### PR TITLE
Bug fix: Improved Results Table Data Hash

### DIFF
--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -125,7 +125,7 @@ export default class ResultsTable extends React.PureComponent {
         return (
             <div className="award-results-table">
                 <IBTable
-                    dataHash={this.state.dataHash}
+                    dataHash={`${this.state.dataHash}-${this.props.batch.batchId}`}
                     rowHeight={rowHeight}
                     rowCount={this.props.results.length}
                     headerHeight={50}

--- a/src/js/components/sharedComponents/IBTable/components/TableBody.jsx
+++ b/src/js/components/sharedComponents/IBTable/components/TableBody.jsx
@@ -147,8 +147,6 @@ export default class TableBody extends React.Component {
 
         if (this.props.rowCount < 1) {
             // no rows to show
-            // clear the last render
-            this.lastRender = '';
             // set the state to show no rows
             this.setState({
                 visibleRows: []
@@ -197,13 +195,16 @@ export default class TableBody extends React.Component {
         });
 
         // generate a string representation of the visible cell coordinates
-        const renderCoords = `${topRowIndex}-${bottomRowIndex}_${firstCol}-${lastCol}`;
+        const renderCoords =
+            `${topRowIndex}-${bottomRowIndex}_${firstCol}-${lastCol}-${this.props.dataHash}`;
 
+        // don't re-render if the render coords are the same and the underlying data hasn't changed
         if (this.lastRender === renderCoords) {
             return;
         }
 
         this.lastRender = renderCoords;
+
         for (let i = topRowIndex; i <= bottomRowIndex; i++) {
             const row = (<TableRow
                 {...this.props}
@@ -214,7 +215,6 @@ export default class TableBody extends React.Component {
             rows.push(row);
         }
 
-        this.ignoreState = false;
         this.setState({
             visibleRows: rows
         });

--- a/src/js/components/sharedComponents/IBTable/components/TableBody.jsx
+++ b/src/js/components/sharedComponents/IBTable/components/TableBody.jsx
@@ -147,6 +147,9 @@ export default class TableBody extends React.Component {
 
         if (this.props.rowCount < 1) {
             // no rows to show
+            // clear the last render
+            this.lastRender = '';
+            // set the state to show no rows
             this.setState({
                 visibleRows: []
             });
@@ -201,7 +204,6 @@ export default class TableBody extends React.Component {
         }
 
         this.lastRender = renderCoords;
-
         for (let i = topRowIndex; i <= bottomRowIndex; i++) {
             const row = (<TableRow
                 {...this.props}
@@ -241,7 +243,6 @@ export default class TableBody extends React.Component {
                 style={style}
                 onScroll={this.handleScroll}>
                 <div className="ibt-table-body" style={internalStyle}>
-                    <div className="table-cornerstone" />
                     {this.state.visibleRows}
                 </div>
             </div>


### PR DESCRIPTION
* Results table data hash is now a concatenated string of the results batch ID and the award type name
* This addresses a bug where the table would fail to update if the table's award type tabs did not change, but a sidebar filter was applied that that returned no results, then the sidebar filter was changed to something that returned multiple results.
* This also addresses a bug where the table would fail to update if the table's award type tabs did not change and a set of sidebar filters were applied that returned a non-zero number of results, then the sidebar filters were changed again to return different data but the same amount of results.