### PR TITLE
Hotfix: Top Filter Bar

### DIFF
--- a/src/_scss/pages/search/topFilterBar/_clearAllButton.scss
+++ b/src/_scss/pages/search/topFilterBar/_clearAllButton.scss
@@ -16,7 +16,7 @@
         padding: 0px 15px;
 
         .close-icon {
-            margin-left: 10px;
+            margin-left: 5px;
             height: 2rem;
             width: 2rem;
             

--- a/src/_scss/pages/search/topFilterBar/_clearAllButton.scss
+++ b/src/_scss/pages/search/topFilterBar/_clearAllButton.scss
@@ -16,7 +16,7 @@
         padding: 0px 15px;
 
         .close-icon {
-            margin-left: 5px;
+            margin-left: 10px;
             height: 2rem;
             width: 2rem;
             
@@ -24,11 +24,12 @@
 
             svg {
                 fill: $top-clear-button-color;
-                height: 2rem;
-                width: 2rem;
+                height: 1.2rem;
+                width: 1.2rem;
 
                 position: absolute;
-                top: -3px;
+                top: 2px;
+                left: 5px;
             }
         }
 

--- a/src/_scss/pages/search/topFilterBar/_tag.scss
+++ b/src/_scss/pages/search/topFilterBar/_tag.scss
@@ -32,6 +32,8 @@
                 
                 .close-icon {
                     svg {
+                        height: 10px;
+                        width: 10px;
                         fill: #ADAFB4;
                     }
                 }

--- a/src/js/components/search/topFilterBar/TopFilterBar.jsx
+++ b/src/js/components/search/topFilterBar/TopFilterBar.jsx
@@ -138,7 +138,7 @@ export default class TopFilterBar extends React.Component {
                                 Clear all filters
                             </span>
                             <span className="close-icon">
-                                <Icons.Times alt="Clear all filters" />
+                                <Icons.Close alt="Clear all filters" />
                             </span>
                         </button>
                     </div>

--- a/src/js/components/search/topFilterBar/TopFilterItem.jsx
+++ b/src/js/components/search/topFilterBar/TopFilterItem.jsx
@@ -47,7 +47,7 @@ export default class TopFilterItem extends React.Component {
                                 {accessibleLabel}
                             </span>
                             <span className="close-icon">
-                                <Icons.Times alt={accessibleLabel} />
+                                <Icons.Close alt={accessibleLabel} />
                             </span>
                         </button>
                     </div>

--- a/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
+++ b/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
@@ -34,6 +34,12 @@ class TopFilterBarContainer extends React.Component {
         this.removeFilter = this.removeFilter.bind(this);
     }
 
+    componentDidMount() {
+        // prepare filters on initial mount to handle pre-populated filters (such as a back
+        // button event or a provided URL param)
+        this.prepareFilters(this.props.reduxFilters);
+    }
+
     componentWillReceiveProps(nextProps) {
         if (!Object.is(nextProps.reduxFilters, this.props.reduxFilters)) {
             this.prepareFilters(nextProps.reduxFilters);


### PR DESCRIPTION
* Fixes a bug where scrolling JS would break because the close icon was previously replaced in the SVG file with a different name.
* Adds functionality to automatically display/populate the top filter bar when filters are pre-selected, either by pressing the back button to the search page or via future URL parameter functionality.