### PR TITLE
Location Filter Redux Refactor

### DIFF
--- a/src/js/components/search/filters/location/SelectedLocations.jsx
+++ b/src/js/components/search/filters/location/SelectedLocations.jsx
@@ -36,13 +36,17 @@ export default class SelectedLocations extends React.Component {
     }
 
     render() {
-        const shownLocations = this.props.selectedLocations.map((location, key) => (
-            <ShownLocation
+        const shownLocations = [];
+        this.props.selectedLocations.entrySeq().forEach((entry) => {
+            const key = entry[0];
+            const location = entry[1];
+            const value = (<ShownLocation
                 location={location}
                 label={this.formatLocation(location)}
-                key={key.matched_ids.join(',').concat(`_${key.place}`).concat(`_${key.place_type}`)}
-                removeLocation={this.props.removeLocation.bind(null, location)} />
-        ));
+                key={key}
+                removeLocation={this.props.removeLocation.bind(null, location)} />);
+            shownLocations.push(value);
+        });
 
         return (
             <div className="selected-locations">

--- a/src/js/redux/reducers/search/filters/locationFilterFunctions.js
+++ b/src/js/redux/reducers/search/filters/locationFilterFunctions.js
@@ -2,18 +2,21 @@
  * Created by michaelbray on 12/12/16.
  */
 
-import { Set } from 'immutable';
+import _ from 'lodash';
 
 /* eslint-disable import/prefer-default-export */
 // We only have one export but want to maintain consistency with other query modules
 export const updateSelectedLocations = (state, value) => {
-    let updatedSet = new Set(state);
+    let updatedSet = state;
+    // generate an identifier string based on matched IDs and place name
+    const locationIdentifier =
+        `${_.sortBy(value.matched_ids).join(',')}_${value.place}_${value.place_type}`;
 
-    if (updatedSet.includes(value)) {
-        updatedSet = updatedSet.delete(value);
+    if (updatedSet.has(locationIdentifier)) {
+        updatedSet = updatedSet.delete(locationIdentifier);
     }
     else {
-        updatedSet = updatedSet.add(value);
+        updatedSet = updatedSet.set(locationIdentifier, value);
     }
 
     return updatedSet;

--- a/src/js/redux/reducers/search/searchFiltersReducer.js
+++ b/src/js/redux/reducers/search/searchFiltersReducer.js
@@ -3,7 +3,7 @@
  * Created by Kevin Li 11/1/16
  **/
 
-import { Set } from 'immutable';
+import { Set, OrderedMap } from 'immutable';
 
 import * as AwardFilterFunctions from './filters/awardFilterFunctions';
 import * as LocationFilterFunctions from './filters/locationFilterFunctions';
@@ -14,7 +14,7 @@ const initialState = {
     timePeriodFY: new Set(),
     timePeriodStart: null,
     timePeriodEnd: null,
-    selectedLocations: new Set(),
+    selectedLocations: new OrderedMap(),
     locationDomesticForeign: 'all'
 };
 


### PR DESCRIPTION
* Refactored Redux store for location filter to be an OrderedMap instead of a Set
* This allows us to stop comparing full location objects for each filter add/remove, which may or may not always equal
* This also guarantees return order of location tags is the order in which they were added
* This also allows the Redux actions to pass their future tests

👇
- [x] Merge after 1/18