### PR TITLE
Add Sub-Agency and Funding Agency/Sub-Agency to Results Table

### DIFF
--- a/src/_scss/pages/search/results/table/_tableStyle.scss
+++ b/src/_scss/pages/search/results/table/_tableStyle.scss
@@ -24,7 +24,7 @@
         @import "cells/_genericCell";
         @include genericCell();
 
-        &.column-awarding_agency_name {
+        &.last-column {
             border-right: none;
         }
     }
@@ -33,7 +33,7 @@
         @import "cells/_genericHeader";
         @include genericHeader();
 
-         &.column-awarding_agency_name {
+         &.last-column {
             border-right: none;
         }
     }

--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -93,8 +93,10 @@ export default class ResultsTable extends React.PureComponent {
     prepareTable() {
         let totalWidth = 0;
 
-        const columns = this.props.columns.map((column) => {
+        const columns = this.props.columns.map((column, i) => {
             totalWidth += column.width;
+            const isLast = i === this.props.columns.length - 1;
+
             return {
                 width: column.width,
                 name: column.columnName,
@@ -104,7 +106,8 @@ export default class ResultsTable extends React.PureComponent {
                     <ResultsTableHeaderCellContainer
                         label={column.displayName}
                         column={column.columnName}
-                        defaultDirection={column.defaultDirection} />
+                        defaultDirection={column.defaultDirection}
+                        isLastColumn={isLast} />
                 ),
                 cell: (index) => (
                     <ResultsTableGenericCell
@@ -112,7 +115,8 @@ export default class ResultsTable extends React.PureComponent {
                         rowIndex={index}
                         data={this.props.results[index][column.columnName]}
                         dataHash={this.state.dataHash}
-                        column={column.columnName} />
+                        column={column.columnName}
+                        isLastColumn={isLast} />
                 )
             };
         });

--- a/src/js/components/search/table/cells/ResultsTableGenericCell.jsx
+++ b/src/js/components/search/table/cells/ResultsTableGenericCell.jsx
@@ -8,7 +8,8 @@ import React from 'react';
 const propTypes = {
     data: React.PropTypes.string,
     rowIndex: React.PropTypes.number,
-    column: React.PropTypes.string
+    column: React.PropTypes.string,
+    isLastColumn: React.PropTypes.bool
 };
 
 export default class ResultsTableGenericCell extends React.Component {
@@ -21,10 +22,14 @@ export default class ResultsTableGenericCell extends React.Component {
         }
 
         // calculate even-odd class names
-        let rowClass = "row-even";
+        let rowClass = 'row-even';
         if (this.props.rowIndex % 2 === 0) {
             // row index is zero-based
-            rowClass = "row-odd";
+            rowClass = 'row-odd';
+        }
+
+        if (this.props.isLastColumn) {
+            rowClass += ' last-column';
         }
 
         return (

--- a/src/js/components/search/table/cells/ResultsTableHeaderCell.jsx
+++ b/src/js/components/search/table/cells/ResultsTableHeaderCell.jsx
@@ -11,7 +11,8 @@ const propTypes = {
     column: React.PropTypes.string,
     defaultDirection: React.PropTypes.string,
     order: React.PropTypes.object,
-    setSearchOrder: React.PropTypes.func
+    setSearchOrder: React.PropTypes.func,
+    isLastColumn: React.PropTypes.bool
 };
 
 export default class ResultsTableHeaderCell extends React.Component {
@@ -61,6 +62,11 @@ export default class ResultsTableHeaderCell extends React.Component {
             }
         }
 
+        let lastClass = '';
+        if (this.props.isLastColumn) {
+            lastClass = ' last-column';
+        }
+
         /* eslint-disable jsx-a11y/no-static-element-interactions */
         // we need to allow the outer div to take an onClick event because there are nested
         // buttons within the div for specific ascending/descending sort actions
@@ -68,7 +74,7 @@ export default class ResultsTableHeaderCell extends React.Component {
         // convenience, screen-reader users are expected to use the button elements instead as
         // they are presented as interactive clickable targets
         return (
-            <div className={`award-result-header-cell column-${this.props.column}`}>
+            <div className={`award-result-header-cell column-${this.props.column}${lastClass}`}>
                 <div className="cell-content" onClick={this.clickedHeader}>
                     <div className="header-sort">
                         <div className="header-label">

--- a/src/js/dataMapping/search/tableSearchFields.js
+++ b/src/js/dataMapping/search/tableSearchFields.js
@@ -6,7 +6,10 @@ const tableSearchFields = {
         period_of_performance_current_end_date: 120,
         total_obligation: 190,
         type: 200,
-        awarding_agency_name: 250
+        awarding_agency_name: 250,
+        awarding_subtier_name: 250,
+        funding_agency_name: 250,
+        funding_subtier_name: 250
     },
     defaultSortDirection: {
         id: 'asc',
@@ -15,7 +18,10 @@ const tableSearchFields = {
         period_of_performance_current_end_date: 'desc',
         total_obligation: 'desc',
         type: 'asc',
-        awarding_agency_name: 'asc'
+        awarding_agency_name: 'asc',
+        awarding_subtier_name: 'asc',
+        funding_agency_name: 'asc',
+        funding_subtier_name: 'asc'
     },
     contracts: {
         _order: [
@@ -25,7 +31,10 @@ const tableSearchFields = {
             'period_of_performance_current_end_date',
             'total_obligation',
             'type',
-            'awarding_agency_name'
+            'awarding_agency_name',
+            'awarding_subtier_name',
+            'funding_agency_name',
+            'funding_subtier_name'
         ],
         _requestFields: [
             'piid',
@@ -35,8 +44,9 @@ const tableSearchFields = {
             'period_of_performance_start_date',
             'period_of_performance_current_end_date',
             'total_obligation',
-            'type',
-            'awarding_agency'
+            'type_description',
+            'awarding_agency',
+            'funding_agency'
         ],
         _mapping: {
             id: 'piid',
@@ -45,7 +55,10 @@ const tableSearchFields = {
             period_of_performance_current_end_date: 'period_of_performance_current_end_date',
             total_obligation: 'total_obligation',
             type: 'type',
-            awarding_agency_name: 'awarding_agency__toptier_agency__name'
+            awarding_agency_name: 'awarding_agency__toptier_agency__name',
+            awarding_subtier_name: 'awarding_agency__subtier_agency__name',
+            funding_agency_name: 'funding_agency__toptier_agency__name',
+            funding_subtier_name: 'funding_agency__subtier_agency__name'
         },
         id: 'Award ID',
         recipient_name: 'Recipient Name',
@@ -53,7 +66,10 @@ const tableSearchFields = {
         period_of_performance_current_end_date: 'End Date',
         total_obligation: 'Total Funded To-Date',
         type: 'Award Type',
-        awarding_agency_name: 'Awarding Agency'
+        awarding_agency_name: 'Awarding Agency',
+        awarding_subtier_name: 'Awarding Sub-Agency',
+        funding_agency_name: 'Funding Agency',
+        funding_subtier_name: 'Funding Sub-Agency'
     },
     grants: {
         _order: [
@@ -63,7 +79,10 @@ const tableSearchFields = {
             'period_of_performance_current_end_date',
             'total_obligation',
             'type',
-            'awarding_agency_name'
+            'awarding_agency_name',
+            'awarding_subtier_name',
+            'funding_agency_name',
+            'funding_subtier_name'
         ],
         _requestFields: [
             'piid',
@@ -73,8 +92,9 @@ const tableSearchFields = {
             'period_of_performance_start_date',
             'period_of_performance_current_end_date',
             'total_obligation',
-            'type',
-            'awarding_agency'
+            'type_description',
+            'awarding_agency',
+            'funding_agency'
         ],
         _mapping: {
             id: 'fain',
@@ -83,7 +103,10 @@ const tableSearchFields = {
             period_of_performance_current_end_date: 'period_of_performance_current_end_date',
             total_obligation: 'total_obligation',
             type: 'type',
-            awarding_agency_name: 'awarding_agency__toptier_agency__name'
+            awarding_agency_name: 'awarding_agency__toptier_agency__name',
+            awarding_subtier_name: 'awarding_agency__subtier_agency__name',
+            funding_agency_name: 'funding_agency__toptier_agency__name',
+            funding_subtier_name: 'funding_agency__subtier_agency__name'
         },
         id: 'Award ID',
         recipient_name: 'Recipient Name',
@@ -91,7 +114,10 @@ const tableSearchFields = {
         period_of_performance_current_end_date: 'End Date',
         total_obligation: 'Total Funded To-Date',
         type: 'Award Type',
-        awarding_agency_name: 'Awarding Agency'
+        awarding_agency_name: 'Awarding Agency',
+        awarding_subtier_name: 'Awarding Sub-Agency',
+        funding_agency_name: 'Funding Agency',
+        funding_subtier_name: 'Funding Sub-Agency'
     },
     direct_payments: {
         _order: [
@@ -101,7 +127,10 @@ const tableSearchFields = {
             'period_of_performance_current_end_date',
             'total_obligation',
             'type',
-            'awarding_agency_name'
+            'awarding_agency_name',
+            'awarding_subtier_name',
+            'funding_agency_name',
+            'funding_subtier_name'
         ],
         _requestFields: [
             'piid',
@@ -111,8 +140,9 @@ const tableSearchFields = {
             'period_of_performance_start_date',
             'period_of_performance_current_end_date',
             'total_obligation',
-            'type',
-            'awarding_agency'
+            'type_description',
+            'awarding_agency',
+            'funding_agency'
         ],
         _mapping: {
             id: 'fain',
@@ -121,7 +151,10 @@ const tableSearchFields = {
             period_of_performance_current_end_date: 'period_of_performance_current_end_date',
             total_obligation: 'total_obligation',
             type: 'type',
-            awarding_agency_name: 'awarding_agency__toptier_agency__name'
+            awarding_agency_name: 'awarding_agency__toptier_agency__name',
+            awarding_subtier_name: 'awarding_agency__subtier_agency__name',
+            funding_agency_name: 'funding_agency__toptier_agency__name',
+            funding_subtier_name: 'funding_agency__subtier_agency__name'
         },
         id: 'Award ID',
         recipient_name: 'Recipient Name',
@@ -129,7 +162,10 @@ const tableSearchFields = {
         period_of_performance_current_end_date: 'End Date',
         total_obligation: 'Total Funded To-Date',
         type: 'Award Type',
-        awarding_agency_name: 'Awarding Agency'
+        awarding_agency_name: 'Awarding Agency',
+        awarding_subtier_name: 'Awarding Sub-Agency',
+        funding_agency_name: 'Funding Agency',
+        funding_subtier_name: 'Funding Sub-Agency'
     },
     loans: {
         _order: [
@@ -138,7 +174,10 @@ const tableSearchFields = {
             'period_of_performance_start_date',
             'period_of_performance_current_end_date',
             'type',
-            'awarding_agency_name'
+            'awarding_agency_name',
+            'awarding_subtier_name',
+            'funding_agency_name',
+            'funding_subtier_name'
         ],
         _requestFields: [
             'piid',
@@ -148,8 +187,9 @@ const tableSearchFields = {
             'period_of_performance_start_date',
             'period_of_performance_current_end_date',
             'total_obligation',
-            'type',
-            'awarding_agency'
+            'type_description',
+            'awarding_agency',
+            'funding_agency'
         ],
         _mapping: {
             id: 'fain',
@@ -158,14 +198,20 @@ const tableSearchFields = {
             period_of_performance_current_end_date: 'period_of_performance_current_end_date',
             total_obligation: 'total_obligation',
             type: 'type',
-            awarding_agency_name: 'awarding_agency__toptier_agency__name'
+            awarding_agency_name: 'awarding_agency__toptier_agency__name',
+            awarding_subtier_name: 'awarding_agency__subtier_agency__name',
+            funding_agency_name: 'funding_agency__toptier_agency__name',
+            funding_subtier_name: 'funding_agency__subtier_agency__name'
         },
         id: 'Award ID',
         recipient_name: 'Recipient Name',
         period_of_performance_start_date: 'Start Date',
         period_of_performance_current_end_date: 'End Date',
         type: 'Award Type',
-        awarding_agency_name: 'Awarding Agency'
+        awarding_agency_name: 'Awarding Agency',
+        awarding_subtier_name: 'Awarding Sub-Agency',
+        funding_agency_name: 'Funding Agency',
+        funding_subtier_name: 'Funding Sub-Agency'
     },
     insurance: {
         _order: [
@@ -175,7 +221,10 @@ const tableSearchFields = {
             'period_of_performance_current_end_date',
             'total_obligation',
             'type',
-            'awarding_agency_name'
+            'awarding_agency_name',
+            'awarding_subtier_name',
+            'funding_agency_name',
+            'funding_subtier_name'
         ],
         _requestFields: [
             'piid',
@@ -185,8 +234,9 @@ const tableSearchFields = {
             'period_of_performance_start_date',
             'period_of_performance_current_end_date',
             'total_obligation',
-            'type',
-            'awarding_agency'
+            'type_description',
+            'awarding_agency',
+            'funding_agency'
         ],
         _mapping: {
             id: 'fain',
@@ -195,7 +245,10 @@ const tableSearchFields = {
             period_of_performance_current_end_date: 'period_of_performance_current_end_date',
             total_obligation: 'total_obligation',
             type: 'type',
-            awarding_agency_name: 'awarding_agency__toptier_agency__name'
+            awarding_agency_name: 'awarding_agency__toptier_agency__name',
+            awarding_subtier_name: 'awarding_agency__subtier_agency__name',
+            funding_agency_name: 'funding_agency__toptier_agency__name',
+            funding_subtier_name: 'funding_agency__subtier_agency__name'
         },
         id: 'Award ID',
         recipient_name: 'Recipient Name',
@@ -203,7 +256,10 @@ const tableSearchFields = {
         period_of_performance_current_end_date: 'End Date',
         total_obligation: 'Total Funded To-Date',
         type: 'Award Type',
-        awarding_agency_name: 'Awarding Agency'
+        awarding_agency_name: 'Awarding Agency',
+        awarding_subtier_name: 'Awarding Sub-Agency',
+        funding_agency_name: 'Funding Agency',
+        funding_subtier_name: 'Funding Sub-Agency'
     }
 };
 

--- a/src/js/models/results/award/AwardSummary.js
+++ b/src/js/models/results/award/AwardSummary.js
@@ -5,7 +5,6 @@
 
 import moment from 'moment';
 
-import { awardTypeCodes } from 'dataMapping/search/awardType';
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 
 import GenericRecord from '../GenericRecord';
@@ -18,21 +17,38 @@ const fields = [
     'period_of_performance_current_end_date',
     'total_obligation',
     'type',
-    'awarding_agency_name'
+    'awarding_agency_name',
+    'awarding_subtier_name',
+    'funding_agency_name',
+    'funding_subtier_name'
 ];
 
 const remapData = (data, idField) => {
     // remap expected child fields to top-level fields
     const remappedData = data;
-    let agencyName = '';
+    let awardingAgencyName = '';
+    let awardingSubtierName = '';
+    let fundingAgencyName = '';
+    let fundingSubtierName = '';
     let recipientName = '';
+
     if (data.awarding_agency) {
-        agencyName = data.awarding_agency.toptier_agency.name;
+        awardingAgencyName = data.awarding_agency.toptier_agency.name;
+        awardingSubtierName = data.awarding_agency.subtier_agency.name;
     }
+
+    if (data.funding_agency) {
+        fundingAgencyName = data.funding_agency.toptier_agency.name;
+        fundingSubtierName = data.funding_agency.subtier_agency.name;
+    }
+
     if (data.recipient) {
         recipientName = data.recipient.recipient_name;
     }
-    remappedData.awarding_agency_name = agencyName;
+    remappedData.awarding_agency_name = awardingAgencyName;
+    remappedData.awarding_subtier_name = awardingSubtierName;
+    remappedData.funding_agency_name = fundingAgencyName;
+    remappedData.funding_subtier_name = fundingSubtierName;
     remappedData.recipient_name = recipientName;
 
     // set the ID to the relevant field
@@ -55,7 +71,11 @@ const remapData = (data, idField) => {
     remappedData.id = id;
 
     // convert the award type code to a user-readable string
-    remappedData.type = awardTypeCodes[data.type];
+    let serverType = '';
+    if (data.type_description) {
+        serverType = data.type_description;
+    }
+    remappedData.type = serverType;
 
     const moneyCells = ['total_obligation'];
     moneyCells.forEach((cell) => {


### PR DESCRIPTION
* Adds awarding sub-agency, funding agency, and funding sub-agency columns to the search results table
* Updates the results table styling to be able to dynamically apply correct final column styling to any arbitrary final column
* Awards JS model updated to reflect new fields
* Results table/awards JS model now populates Award Type value using the `type_description` server value instead of mapping it client-side. This also ensures correct alphabetical sorting of the Type column in the results table