### PR TITLE
Fix: Award type API field change

### DIFF
--- a/src/js/models/search/queryBuilders/AwardTypeQuery.js
+++ b/src/js/models/search/queryBuilders/AwardTypeQuery.js
@@ -3,11 +3,7 @@
   * Created by Kevin Li 11/7/16
   **/
 
-import { awardTypeGroups } from 'dataMapping/search/awardType';
-
-const contractValues = new Set(awardTypeGroups.contracts);
-const contractFieldName = 'procurement__contract_award_type';
-const otherFieldName = 'type';
+const fieldName = 'type';
 
 const buildFieldQuery = (field, values) => ({
     field,
@@ -15,41 +11,11 @@ const buildFieldQuery = (field, values) => ({
     value: values
 });
 
-const buildCompoundQuery = (contracts, other) => ({
-    combine_method: 'OR',
-    filters: [
-        buildFieldQuery(contractFieldName, contracts),
-        buildFieldQuery(otherFieldName, other)
-    ]
-});
 
 export const buildQuery = (awardType) => {
     let awardQuery = {};
 
-    // break the filters into two categories, contract and other
-    // (these use different search fields)
-    const contractFilters = [];
-    const otherFilters = [];
-
-    // iterate through each award type and add it to the appropriate array
-    awardType.forEach((award) => {
-        if (contractValues.has(award)) {
-            contractFilters.push(award);
-        }
-        else {
-            otherFilters.push(award);
-        }
-    });
-
-    if (contractFilters.length > 0 && otherFilters.length > 0) {
-        awardQuery = buildCompoundQuery(contractFilters, otherFilters);
-    }
-    else if (contractFilters.length > 0) {
-        awardQuery = buildFieldQuery(contractFieldName, contractFilters);
-    }
-    else {
-        awardQuery = buildFieldQuery(otherFieldName, otherFilters);
-    }
+    awardQuery = buildFieldQuery(fieldName, awardType);
 
     return awardQuery;
 };


### PR DESCRIPTION
* No longer adds separate filters for `procurement_set` sub-values, all award types are now filtered by the `type` value in the main award object.
* Update required by current API after fedspendingtransparency/usaspending-api#114
