### PR TITLE
Spending Over Time Fixes

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -115,7 +115,7 @@ gulp.task('criticalVersionCheck', () => {
         misalignedLibs.forEach((lib) => {
             message += `\n- ${lib}`;
         });
-        message += `\n\nPerform a clean install by deleting your ${chalk.bold('node_modules')} folder and then running ${chalk.bold('npm install')}\n${emoji.get(':warning:')}  ${chalk.white.bgRed('WARNING WARNING WARNING')} ${emoji.get(':warning:')}`;
+        message += `\n\nUpdate your node packages by running ${chalk.bold('npm install')}\n${emoji.get(':warning:')}  ${chalk.white.bgRed('WARNING WARNING WARNING')} ${emoji.get(':warning:')}`;
 
         gutil.log(message);
 

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "awesomplete": "^1.1.0",
     "axios": "^0.15.2",
     "babel-polyfill": "^6.20.0",
+    "d3-array": "^1.0.2",
     "d3-scale": "^1.0.4",
     "fixed-data-table": "0.6.3",
     "immutable": "^3.8.1",

--- a/src/js/components/search/visualizations/time/TimeVisualizationTooltip.jsx
+++ b/src/js/components/search/visualizations/time/TimeVisualizationTooltip.jsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import Accounting from 'accounting';
+import * as MoneyFormatter from 'helpers/moneyFormatter';
 
 const propTypes = {
     y: React.PropTypes.number,
@@ -43,23 +43,7 @@ export default class TimeVisualizationTooltip extends React.Component {
     }
 
     render() {
-        const accountingOptions = {
-            symbol: '$',
-            precision: 0,
-            format: {
-                pos: '%s%v',
-                neg: '-%s%v'
-            }
-        };
-
-        const dollarValue = Accounting.formatMoney(this.props.data.yValue, accountingOptions);
-
-        // calculate round the percentage of total to 1 decimal value
-        let percentageValue = Math.round(this.props.data.percentage * 1000) / 10;
-        if (percentageValue % 1 === 0) {
-            // add a trailing .0 for whole numbers
-            percentageValue += '.0';
-        }
+        const dollarValue = MoneyFormatter.formatMoney(this.props.data.yValue);
 
         return (
             <div className="visualization-tooltip">
@@ -87,7 +71,7 @@ export default class TimeVisualizationTooltip extends React.Component {
                         </div>
                         <div className="tooltip-right">
                             <div className="tooltip-value">
-                                {percentageValue}%
+                                {this.props.data.percentage}%
                             </div>
                             <div className="tooltip-label">
                                 Percent of Total Spending

--- a/src/js/components/search/visualizations/time/chart/BarItem.jsx
+++ b/src/js/components/search/visualizations/time/chart/BarItem.jsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import Accounting from 'accounting';
+import * as MoneyFormatter from 'helpers/moneyFormatter';
 
 const defaultProps = {
     active: false
@@ -61,14 +61,7 @@ export default class BarItem extends React.Component {
     }
 
     render() {
-        const formattedValue = Accounting.formatMoney(this.props.dataY, {
-            symbol: '$',
-            precision: 0,
-            format: {
-                pos: '%s%v',
-                neg: '-%s%v'
-            }
-        });
+        const formattedValue = MoneyFormatter.formatMoney(this.props.dataY);
 
         // generate an invisible hitbox that spans the full height of the graph and matches the
         // width of the data point bar to trigger hover events anywhere along the Y axis for the

--- a/src/js/components/search/visualizations/time/chart/BarYAxis.jsx
+++ b/src/js/components/search/visualizations/time/chart/BarYAxis.jsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import Accounting from 'accounting';
+import * as MoneyFormatter from 'helpers/moneyFormatter';
 import _ from 'lodash';
 
 import BarYAxisItem from './BarYAxisItem';
@@ -125,15 +125,6 @@ export default class BarYAxis extends React.Component {
         }
 
         // generate the labels
-        const accountingOptions = {
-            precision,
-            symbol: '$',
-            format: {
-                pos: '%s%v',
-                neg: '-%s%v'
-            }
-        };
-
         const tickLabels = props.ticks.map((tick) => {
             let formattedTick = tick;
 
@@ -142,10 +133,11 @@ export default class BarYAxis extends React.Component {
                 formattedTick = '$0';
             }
             else if (unit > 1) {
-                formattedTick = Accounting.formatMoney(tick / unit, accountingOptions) + unitString;
+                formattedTick = MoneyFormatter.formatMoneyWithPrecision(tick / unit, precision)
+                    + unitString;
             }
             else {
-                formattedTick = Accounting.formatMoney(tick, accountingOptions);
+                formattedTick = MoneyFormatter.formatMoneyWithPrecision(tick, precision);
             }
 
             return formattedTick;

--- a/src/js/helpers/moneyFormatter.js
+++ b/src/js/helpers/moneyFormatter.js
@@ -17,3 +17,10 @@ const accountingOptions = {
 };
 
 export const formatMoney = (value) => Accounting.formatMoney(value, accountingOptions);
+
+export const formatMoneyWithPrecision = (value, precision) => {
+    const modifiedOptions = Object.assign({}, accountingOptions, {
+        precision
+    });
+    return Accounting.formatMoney(value, modifiedOptions);
+};


### PR DESCRIPTION
* Y axis now displays labels when only one data point is shown and it is negative or zero
* No longer errors out when data points are exactly $0
* Now displays N/A as the percent of total spending for $0 data points instead of NaN
* Centralized all money formatting to the MoneyFormatter helper