### PR TITLE
Fix - Hide Country Acronym in PoP/Recipient Locations when Place itself is a Country

### DIFF
--- a/src/js/components/search/topFilterBar/filterGroups/LocationFilterGroup.jsx
+++ b/src/js/components/search/topFilterBar/filterGroups/LocationFilterGroup.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import _ from 'lodash';
 
+import * as LocationFormatter from 'helpers/locationFormatter';
 import BaseTopFilterGroup from './BaseTopFilterGroup';
 
 const propTypes = {
@@ -37,19 +38,6 @@ export default class LocationFilterGroup extends React.Component {
         this.props.clearFilterGroup(this.props.toggle);
     }
 
-    generateLabel(item) {
-        // capitalize just the first letter of each word in the place type
-        const placeType = item.place_type.toLowerCase()
-            .replace(/(^|\s|[-_])\S{1}/g, (letter) => (letter.toUpperCase()));
-        let label = `${placeType} | ${item.place}`;
-
-        if (item.parent) {
-            label += `, ${item.parent}`;
-        }
-
-        return label;
-    }
-
     generateTags() {
         const tags = [];
 
@@ -73,7 +61,7 @@ export default class LocationFilterGroup extends React.Component {
         remainingValues.forEach((value) => {
             const tag = {
                 value: value.identifier,
-                title: this.generateLabel(value),
+                title: LocationFormatter.formatLocation(value),
                 isSpecial: false,
                 removeFilter: this.removeFilter
             };

--- a/src/js/containers/search/filters/location/LocationListContainer.jsx
+++ b/src/js/containers/search/filters/location/LocationListContainer.jsx
@@ -50,7 +50,8 @@ class LocationListContainer extends React.Component {
         if (locations.length > 0) {
             locations.forEach((item) => {
                 let placeType = _.upperCase(item.place_type);
-                if (item.parent !== null) {
+                if (item.parent !== null &&
+                    (item.place_type !== null && item.place_type !== 'COUNTRY')) {
                     placeType += ` in ${item.parent}`;
                 }
 

--- a/src/js/containers/search/filters/recipient/RecipientLocationContainer.jsx
+++ b/src/js/containers/search/filters/recipient/RecipientLocationContainer.jsx
@@ -51,7 +51,8 @@ export class RecipientLocationContainer extends React.Component {
         if (recipientLocations.length > 0) {
             recipientLocations.forEach((item) => {
                 let placeType = _.upperCase(item.place_type);
-                if (item.parent !== null) {
+                if (item.parent !== null &&
+                    (item.place_type !== null && item.place_type !== 'COUNTRY')) {
                     placeType += ` in ${item.parent}`;
                 }
 

--- a/src/js/helpers/locationFormatter.js
+++ b/src/js/helpers/locationFormatter.js
@@ -16,7 +16,8 @@ export const formatLocation = (location) => {
 
     displayValue += `${location.place}`;
 
-    if (location.parent !== null) {
+    if (location.parent !== null &&
+        (location.place_type !== null && location.place_type !== 'COUNTRY')) {
         displayValue += `, ${location.parent}`;
     }
 


### PR DESCRIPTION
Removed parent label from all location Autocompletes and Selections when the `place_type` is a country