### PR TITLE
Hotfix - Autocomplete error incorrectly showing / not showing in Agency Filter

### DIFF
--- a/src/js/containers/search/filters/AgencyListContainer.jsx
+++ b/src/js/containers/search/filters/AgencyListContainer.jsx
@@ -132,7 +132,7 @@ export class AgencyListContainer extends React.Component {
             this.agencySearchRequest.promise
                 .then((res) => {
                     this.setState({
-                        noResults: !res.data.matched_objects.subtier_agency__name.length
+                        noResults: res.data.matched_objects.subtier_agency__name.length === 0
                     });
 
                     // Add search results to Redux

--- a/src/js/containers/search/filters/AgencyListContainer.jsx
+++ b/src/js/containers/search/filters/AgencyListContainer.jsx
@@ -90,6 +90,12 @@ export class AgencyListContainer extends React.Component {
                     });
                 }
             });
+
+            if (agencies.length === 0) {
+                this.setState({
+                    noResults: true
+                });
+            }
         }
 
         this.setState({
@@ -126,7 +132,7 @@ export class AgencyListContainer extends React.Component {
             this.agencySearchRequest.promise
                 .then((res) => {
                     this.setState({
-                        noResults: !res.data.matched_objects.length
+                        noResults: !res.data.matched_objects.subtier_agency__name.length
                     });
 
                     // Add search results to Redux

--- a/src/js/containers/search/filters/location/LocationListContainer.jsx
+++ b/src/js/containers/search/filters/location/LocationListContainer.jsx
@@ -112,7 +112,7 @@ class LocationListContainer extends React.Component {
                     }
 
                     this.setState({
-                        noResults: !autocompleteData.length
+                        noResults: autocompleteData.length === 0
                     });
 
                     // Add search results to Redux

--- a/src/js/containers/search/filters/recipient/RecipientLocationContainer.jsx
+++ b/src/js/containers/search/filters/recipient/RecipientLocationContainer.jsx
@@ -115,7 +115,7 @@ export class RecipientLocationContainer extends React.Component {
                     }
 
                     this.setState({
-                        noResults: !autocompleteData.length
+                        noResults: autocompleteData.length === 0
                     });
 
                     // Add search results to Redux


### PR DESCRIPTION
Fixes an issue on showing the Autocomplete error on the Agency filter when it shouldn't be there / when it should be there. We're checking for previously-selected agencies in this class' `parseAutocomplete` function and not `queryAutocomplete` function, like in the others, so we need to check if all the agencies that match the search term have been selected in the `parseAutocomplete` function in addition to `queryAutocomplete`.