### PR TITLE
Hotfix - Undefined Homepage Prop

### DIFF
--- a/src/js/components/homepage/Homepage.jsx
+++ b/src/js/components/homepage/Homepage.jsx
@@ -21,7 +21,9 @@ export default class Homepage extends React.Component {
         super(props);
 
         this.state = {
-            categories: {},
+            categories: {
+                children: []
+            },
             breakdown: [],
             colors: [],
             total: ''


### PR DESCRIPTION
Fixing issue of undefined `children` array within `categories` prop of `TreeMap`