### PR TITLE
Fix: Safely handle setState in Mapbox callbacks

### DIFF
--- a/src/js/components/search/visualizations/geo/map/MapBox.jsx
+++ b/src/js/components/search/visualizations/geo/map/MapBox.jsx
@@ -25,10 +25,12 @@ export default class MapBox extends React.Component {
         };
 
         this.map = null;
+        this.componentUnmounted = false;
 
         this.findHoveredLayers = this.findHoveredLayers.bind(this);
     }
     componentDidMount() {
+        this.componentUnmounted = false;
         this.mountMap();
     }
 
@@ -39,6 +41,7 @@ export default class MapBox extends React.Component {
 
     componentWillUnmount() {
         this.props.unloadedMap();
+        this.componentUnmounted = true;
     }
 
 
@@ -70,6 +73,11 @@ export default class MapBox extends React.Component {
 
         // prepare the shapes
         this.map.on('load', () => {
+            if (this.componentUnmounted) {
+                // don't update the state if the map has been unmounted
+                return;
+            }
+
             this.setState({
                 mapReady: true
             }, () => {


### PR DESCRIPTION
* Fixes a bug where unmounting a map component before its Mapbox API calls were complete would trigger a JS error