### PR TITLE
Program Activity filter on Federal Account page

### DIFF
--- a/src/_scss/pages/account/filters/filters.scss
+++ b/src/_scss/pages/account/filters/filters.scss
@@ -1,0 +1,4 @@
+.search-filters-wrapper {
+    @import "./objectClass/objectClass";
+    @import "./programActivity/programActivity";
+}

--- a/src/_scss/pages/account/filters/objectClass/objectClass.scss
+++ b/src/_scss/pages/account/filters/objectClass/objectClass.scss
@@ -1,5 +1,6 @@
 @import "pages/search/filters/budgetCategory/budgetCategory";
-.account-object-class-filter {
+
+.account-object-class-filter{
     @extend .budget-category-filter;
-    margin: 0 2.0rem 3rem;
+    margin: 0.75rem 2.0rem 1rem;
 }

--- a/src/_scss/pages/account/filters/programActivity/programActivity.scss
+++ b/src/_scss/pages/account/filters/programActivity/programActivity.scss
@@ -18,4 +18,12 @@
             @include sharedAwardStyle;
         }
     }
+
+    .account-program-activity-toggle-button {
+        background-color: $color-white;
+        color: $color-focus;
+        padding: 0.7rem 0 0;
+        margin-bottom: 0;
+        font-weight: normal;
+    }
 }

--- a/src/_scss/pages/account/filters/programActivity/programActivity.scss
+++ b/src/_scss/pages/account/filters/programActivity/programActivity.scss
@@ -18,7 +18,7 @@
             @include sharedAwardStyle;
         }
 
-        div {
+        div.account-program-activity-loading {
             font-size: $small-font-size;
             line-height: $small-font-size;
             margin: 2rem 0 0.7rem;

--- a/src/_scss/pages/account/filters/programActivity/programActivity.scss
+++ b/src/_scss/pages/account/filters/programActivity/programActivity.scss
@@ -1,0 +1,21 @@
+.account-program-activity-filter {
+    padding-left: 0;
+    margin: 0.75rem 2.0rem 1rem;
+
+    > div {
+        padding-left: 0rem;
+    }
+
+    .shown {
+        min-height: 18rem;
+    }
+
+    ul.program-activities {
+        @include unstyled-list;
+
+        .program-activity-set {
+            @import "../../../search/filters/awardType/_sharedAwardStyle";
+            @include sharedAwardStyle;
+        }
+    }
+}

--- a/src/_scss/pages/account/filters/programActivity/programActivity.scss
+++ b/src/_scss/pages/account/filters/programActivity/programActivity.scss
@@ -19,11 +19,13 @@
         }
     }
 
-    .account-program-activity-toggle-button {
+    @import './pages/award/_moreButton';
+
+    button.account-program-activity-toggle-button {
         background-color: $color-white;
         color: $color-focus;
         padding: 0.7rem 0 0;
-        margin-bottom: 0;
+        margin: 0.7rem 0 0 0;
         font-weight: normal;
     }
 }

--- a/src/_scss/pages/account/filters/programActivity/programActivity.scss
+++ b/src/_scss/pages/account/filters/programActivity/programActivity.scss
@@ -17,6 +17,12 @@
             @import "../../../search/filters/awardType/_sharedAwardStyle";
             @include sharedAwardStyle;
         }
+
+        div {
+            font-size: $small-font-size;
+            line-height: $small-font-size;
+            margin: 2rem 0 0.7rem;
+        }
     }
 
     @import './pages/award/_moreButton';

--- a/src/_scss/pages/account/results/searchResults.scss
+++ b/src/_scss/pages/account/results/searchResults.scss
@@ -10,7 +10,7 @@
             @include span-columns(4);
         }
 
-        @import "./_filters";
+        @import "../filters/filters";
     }
 
     .search-results-wrapper {

--- a/src/_scss/pages/search/filters/awardType/_sharedAwardStyle.scss
+++ b/src/_scss/pages/search/filters/awardType/_sharedAwardStyle.scss
@@ -4,10 +4,14 @@
 
     .award-type-item-wrapper {
         display: table-cell;
+        clear:both;
+        overflow:hidden;
 
         input[type=checkbox] {
             @include usa-input-checkbox;
             margin-right: 6px;
+            float: left;
+            margin-top: 1.1rem;
         }
 
         span {

--- a/src/js/components/account/SearchSidebar.jsx
+++ b/src/js/components/account/SearchSidebar.jsx
@@ -9,6 +9,8 @@ import FilterSidebar from 'components/sharedComponents/filterSidebar/FilterSideb
 
 import AccountTimePeriodContainer from 'containers/account/filters/AccountTimePeriodContainer';
 import AccountObjectClassContainer from 'containers/account/filters/AccountObjectClassContainer';
+import AccountProgramActivityContainer
+    from 'containers/account/filters/AccountProgramActivityContainer';
 
 const filters = {
     options: [
@@ -20,7 +22,7 @@ const filters = {
     components: [
         AccountTimePeriodContainer,
         AccountObjectClassContainer,
-        null,
+        AccountProgramActivityContainer,
         null
     ]
 };

--- a/src/js/components/account/filters/programActivity/ProgramActivityFilter.jsx
+++ b/src/js/components/account/filters/programActivity/ProgramActivityFilter.jsx
@@ -30,6 +30,7 @@ export default class ProgramActivityFilter extends React.Component {
         this.state = defaultState;
 
         this.toggleValue = this.toggleValue.bind(this);
+        this.toggleShownAmount = this.toggleShownAmount.bind(this);
     }
 
     toggleShownAmount() {
@@ -95,7 +96,7 @@ export default class ProgramActivityFilter extends React.Component {
 
             toggleButton = (<button
                 className="see-more account-program-activity-toggle-button"
-                onClick={this.toggleShownAmount.bind(this)}
+                onClick={this.toggleShownAmount}
                 title={`See ${shownStatement}`}>
                 See {shownStatement}
                 &nbsp; {arrow}

--- a/src/js/components/account/filters/programActivity/ProgramActivityFilter.jsx
+++ b/src/js/components/account/filters/programActivity/ProgramActivityFilter.jsx
@@ -85,16 +85,12 @@ export default class ProgramActivityFilter extends React.Component {
 
         if (programActivities && Object.keys(programActivities).length > 10) {
             const remaining = Object.keys(programActivities).length - this.state.shown;
-            let shownStatement = '';
-            let arrow = '';
+            let shownStatement = `${remaining} ${this.state.shownType}`;
+            let arrow = (<Icons.AngleDown alt={`See ${shownStatement}`} />);
 
             if (remaining === 0) {
                 shownStatement = this.state.shownType;
                 arrow = (<Icons.AngleUp alt={`See ${shownStatement}`} />);
-            }
-            else {
-                shownStatement = `${remaining} ${this.state.shownType}`;
-                arrow = (<Icons.AngleDown alt={`See ${shownStatement}`} />);
             }
 
             toggleButton = (<button

--- a/src/js/components/account/filters/programActivity/ProgramActivityFilter.jsx
+++ b/src/js/components/account/filters/programActivity/ProgramActivityFilter.jsx
@@ -1,0 +1,86 @@
+/**
+ * ProgramActivityFilter.jsx
+ * Created by michaelbray on 4/14/17.
+ */
+
+import React from 'react';
+import { OrderedSet } from 'immutable';
+
+
+import ProgramActivityItem from './ProgramActivityItem';
+
+const propTypes = {
+    selectedProgramActivities: React.PropTypes.instanceOf(OrderedSet),
+    programActivities: React.PropTypes.array,
+    updateFilter: React.PropTypes.func,
+    shown: React.PropTypes.number
+};
+
+export default class ProgramActivityFilter extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            shown: 10,
+            shownType: 'more'
+        };
+
+        this.toggleValue = this.toggleValue.bind(this);
+    }
+
+    generateShownStatement() {
+        const remaining = Object.keys(this.props.programActivities).length - this.state.shown;
+
+        if (remaining === 0) {
+            return `See ${this.state.shownType}`;
+        }
+
+        return `See ${remaining} ${this.state.shownType}`;
+    }
+
+    toggleShownAmount(showType) {
+        if (showType === 'more') {
+            this.setState({
+                shown: Object.keys(this.state.programActivities).length,
+                shownType: 'fewer'
+            });
+        }
+    }
+
+    toggleValue(event) {
+        const code = event.target.value;
+        this.props.updateFilter(code);
+    }
+
+    render() {
+        let itemCounter = 0;
+        const items = [];
+
+        this.props.programActivities.forEach((programActivity) => {
+            if (itemCounter < this.state.shown) {
+                const label = programActivity.name;
+                const checked = this.props.programActivities.includes(programActivity.code);
+                itemCounter += 1;
+
+                items.push(
+                    <ProgramActivityItem
+                        key={programActivity.code}
+                        code={programActivity.code}
+                        label={label}
+                        checked={checked}
+                        toggleValue={this.toggleValue} />);
+            }
+        });
+
+        return (
+            <div className="account-program-activity-filter search-filter">
+                <ul className="program-activities">
+                    { items }
+                </ul>
+                <div>{this.generateShownStatement}</div>
+            </div>
+        );
+    }
+}
+
+ProgramActivityFilter.propTypes = propTypes;

--- a/src/js/components/account/filters/programActivity/ProgramActivityFilter.jsx
+++ b/src/js/components/account/filters/programActivity/ProgramActivityFilter.jsx
@@ -14,7 +14,7 @@ const propTypes = {
     availableProgramActivities: React.PropTypes.array,
     updateFilter: React.PropTypes.func,
     noResults: React.PropTypes.bool,
-    inFlight: React.PropTypes.bool,
+    inFlight: React.PropTypes.bool
 };
 
 const defaultShown = 10;

--- a/src/js/components/account/filters/programActivity/ProgramActivityFilter.jsx
+++ b/src/js/components/account/filters/programActivity/ProgramActivityFilter.jsx
@@ -112,7 +112,9 @@ export default class ProgramActivityFilter extends React.Component {
         const toggleButton = this.generateToggleButton();
 
         if (this.props.inFlight) {
-            items = (<div>Loading data...</div>);
+            items = (<div className="account-program-activity-loading">
+                Loading data...
+            </div>);
         }
 
         return (

--- a/src/js/components/account/filters/programActivity/ProgramActivityFilter.jsx
+++ b/src/js/components/account/filters/programActivity/ProgramActivityFilter.jsx
@@ -11,7 +11,7 @@ import ProgramActivityItem from './ProgramActivityItem';
 
 const propTypes = {
     selectedProgramActivities: React.PropTypes.instanceOf(OrderedSet),
-    programActivities: React.PropTypes.array,
+    availableProgramActivities: React.PropTypes.array,
     updateFilter: React.PropTypes.func,
     noResults: React.PropTypes.bool
 };
@@ -33,7 +33,7 @@ export default class ProgramActivityFilter extends React.Component {
     }
 
     toggleShownAmount() {
-        const programActivities = this.props.programActivities;
+        const programActivities = this.props.availableProgramActivities;
 
         let updatedState = defaultState;
 
@@ -80,7 +80,7 @@ export default class ProgramActivityFilter extends React.Component {
     }
 
     generateToggleButton() {
-        const programActivities = this.props.programActivities;
+        const programActivities = this.props.availableProgramActivities;
         let toggleButton = null;
 
         if (programActivities && Object.keys(programActivities).length > 10) {
@@ -110,7 +110,7 @@ export default class ProgramActivityFilter extends React.Component {
     }
 
     render() {
-        const items = this.generateProgramActivityItems(this.props.programActivities);
+        const items = this.generateProgramActivityItems(this.props.availableProgramActivities);
         const toggleButton = this.generateToggleButton();
 
         return (

--- a/src/js/components/account/filters/programActivity/ProgramActivityFilter.jsx
+++ b/src/js/components/account/filters/programActivity/ProgramActivityFilter.jsx
@@ -13,7 +13,8 @@ const propTypes = {
     selectedProgramActivities: React.PropTypes.instanceOf(OrderedSet),
     availableProgramActivities: React.PropTypes.array,
     updateFilter: React.PropTypes.func,
-    noResults: React.PropTypes.bool
+    noResults: React.PropTypes.bool,
+    inFlight: React.PropTypes.bool,
 };
 
 const defaultShown = 10;
@@ -107,8 +108,12 @@ export default class ProgramActivityFilter extends React.Component {
     }
 
     render() {
-        const items = this.generateProgramActivityItems(this.props.availableProgramActivities);
+        let items = this.generateProgramActivityItems(this.props.availableProgramActivities);
         const toggleButton = this.generateToggleButton();
+
+        if (this.props.inFlight) {
+            items = (<div>Loading data...</div>);
+        }
 
         return (
             <div className="account-program-activity-filter search-filter">

--- a/src/js/components/account/filters/programActivity/ProgramActivityFilter.jsx
+++ b/src/js/components/account/filters/programActivity/ProgramActivityFilter.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { OrderedSet } from 'immutable';
 
-
+import * as Icons from 'components/sharedComponents/icons/Icons';
 import ProgramActivityItem from './ProgramActivityItem';
 
 const propTypes = {
@@ -86,18 +86,23 @@ export default class ProgramActivityFilter extends React.Component {
         if (programActivities && Object.keys(programActivities).length > 10) {
             const remaining = Object.keys(programActivities).length - this.state.shown;
             let shownStatement = '';
+            let arrow = '';
 
             if (remaining === 0) {
                 shownStatement = this.state.shownType;
+                arrow = (<Icons.AngleUp alt={`See ${shownStatement}`} />);
             }
             else {
                 shownStatement = `${remaining} ${this.state.shownType}`;
+                arrow = (<Icons.AngleDown alt={`See ${shownStatement}`} />);
             }
 
             toggleButton = (<button
-                className="account-program-activity-toggle-button"
-                onClick={this.toggleShownAmount.bind(this)}>
+                className="see-more account-program-activity-toggle-button"
+                onClick={this.toggleShownAmount.bind(this)}
+                title={`See ${shownStatement}`}>
                 See {shownStatement}
+                &nbsp; {arrow}
             </button>);
         }
 

--- a/src/js/components/account/filters/programActivity/ProgramActivityItem.jsx
+++ b/src/js/components/account/filters/programActivity/ProgramActivityItem.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 
 const propTypes = {
-    code: React.PropTypes.string,
+    programActivityID: React.PropTypes.string,
     label: React.PropTypes.string,
     checked: React.PropTypes.bool,
     toggleValue: React.PropTypes.func
@@ -19,11 +19,11 @@ export default class ProgramActivityItem extends React.Component {
                 <div className="award-type-item-wrapper">
                     <input
                         type="checkbox"
-                        id={`program-activity-${this.props.code}`}
-                        value={this.props.code}
+                        id={`program-activity-${this.props.programActivityID}`}
+                        value={this.props.programActivityID}
                         checked={this.props.checked}
                         onChange={this.props.toggleValue} />
-                    <label htmlFor={`program-activity-${this.props.code}`}>
+                    <label htmlFor={`program-activity-${this.props.programActivityID}`}>
                         {this.props.label}</label>
                 </div>
             </li>

--- a/src/js/components/account/filters/programActivity/ProgramActivityItem.jsx
+++ b/src/js/components/account/filters/programActivity/ProgramActivityItem.jsx
@@ -1,0 +1,34 @@
+/**
+ * ProgramActivityItem.jsx
+ * Created by michaelbray on 4/14/17.
+ */
+
+import React from 'react';
+
+const propTypes = {
+    code: React.PropTypes.string,
+    label: React.PropTypes.string,
+    checked: React.PropTypes.bool,
+    toggleValue: React.PropTypes.func
+};
+
+export default class ProgramActivityItem extends React.Component {
+    render() {
+        return (
+            <li className="program-activity-set">
+                <div className="award-type-item-wrapper">
+                    <input
+                        type="checkbox"
+                        id={`program-activity-${this.props.code}`}
+                        value={this.props.code}
+                        checked={this.props.checked}
+                        onChange={this.props.toggleValue} />
+                    <label htmlFor={`program-activity-${this.props.code}`}>
+                        {this.props.label}</label>
+                </div>
+            </li>
+        );
+    }
+}
+
+ProgramActivityItem.propTypes = propTypes;

--- a/src/js/components/account/filters/programActivity/ProgramActivityItem.jsx
+++ b/src/js/components/account/filters/programActivity/ProgramActivityItem.jsx
@@ -24,7 +24,8 @@ export default class ProgramActivityItem extends React.Component {
                         checked={this.props.checked}
                         onChange={this.props.toggleValue} />
                     <label htmlFor={`program-activity-${this.props.programActivityID}`}>
-                        {this.props.label}</label>
+                        {this.props.label}
+                    </label>
                 </div>
             </li>
         );

--- a/src/js/components/account/topFilterBar/filterGroups/AccountTopFilterGroupGenerator.jsx
+++ b/src/js/components/account/topFilterBar/filterGroups/AccountTopFilterGroupGenerator.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 import TimePeriodFYFilterGroup from './TimePeriodFYFilterGroup';
 import TimePeriodDRFilterGroup from './TimePeriodDRFilterGroup';
 import ObjectClassFilterGroup from './ObjectClassFilterGroup';
+import ProgramActivityFilterGroup from './ProgramActivityFilterGroup';
 
 export const topFilterGroupGenerator = (config = {
     filter: {
@@ -24,6 +25,8 @@ export const topFilterGroupGenerator = (config = {
             return <TimePeriodDRFilterGroup key={groupKey} {...config} />;
         case 'objectClass':
             return <ObjectClassFilterGroup key={groupKey} {...config} />;
+        case 'programActivity':
+            return <ProgramActivityFilterGroup key={groupKey} {...config} />;
         default:
             return null;
     }

--- a/src/js/components/account/topFilterBar/filterGroups/ProgramActivityFilterGroup.jsx
+++ b/src/js/components/account/topFilterBar/filterGroups/ProgramActivityFilterGroup.jsx
@@ -1,0 +1,69 @@
+/**
+ * ProgramActivityFilterGroup.jsx
+ * Created by michaelbray on 4/17/17.
+ */
+
+import React from 'react';
+import _ from 'lodash';
+
+import BaseTopFilterGroup from 'components/search/topFilterBar/filterGroups/BaseTopFilterGroup';
+
+const propTypes = {
+    filter: React.PropTypes.object,
+    redux: React.PropTypes.object
+};
+
+export default class ProgramActivityFilterGroup extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.removeFilter = this.removeFilter.bind(this);
+        this.clearGroup = this.clearGroup.bind(this);
+    }
+
+    removeFilter(value) {
+        // remove a single filter item
+        this.props.redux.toggleProgramActivity(value);
+    }
+
+    clearGroup() {
+        this.props.redux.resetProgramActivity();
+    }
+
+    generateTags() {
+        const tags = [];
+        const selectedValues = this.props.filter.values;
+        const availableProgramActivities = this.props.redux.filterOptions.programActivity;
+
+        selectedValues.forEach((value) => {
+            const programActivity = _.find(availableProgramActivities, { id: `${value}` });
+
+            let label = value;
+            if (programActivity) {
+                label = programActivity.name;
+            }
+
+            const tag = {
+                value,
+                title: label,
+                isSpecial: false,
+                removeFilter: this.removeFilter
+            };
+
+            tags.push(tag);
+        });
+
+        return tags;
+    }
+
+    render() {
+        const tags = this.generateTags();
+
+        return (<BaseTopFilterGroup
+            tags={tags}
+            filter={this.props.filter}
+            clearFilterGroup={this.clearGroup} />);
+    }
+}
+
+ProgramActivityFilterGroup.propTypes = propTypes;

--- a/src/js/containers/account/filters/AccountProgramActivityContainer.jsx
+++ b/src/js/containers/account/filters/AccountProgramActivityContainer.jsx
@@ -16,7 +16,6 @@ import ProgramActivityFilter from
 
 const propTypes = {
     toggleProgramActivity: React.PropTypes.func,
-    setProgramActivities: React.PropTypes.func,
     account: React.PropTypes.object
 };
 
@@ -25,7 +24,8 @@ export class AccountProgramActivityContainer extends React.Component {
         super(props);
 
         this.state = {
-            programActivities: []
+            programActivities: [],
+            noResults: false
         };
 
         // bind functions
@@ -60,8 +60,7 @@ export class AccountProgramActivityContainer extends React.Component {
             group: [
                 "program_activity__program_activity_name",
                 "program_activity__program_activity_code",
-                "treasury_account__agency_id",
-                "treasury_account__main_account_code"],
+                "program_activity__id"],
             field: "ussgl480100_undelivered_orders_obligations_unpaid_fyb",
             aggregate: "count",
             filters: [
@@ -69,16 +68,6 @@ export class AccountProgramActivityContainer extends React.Component {
                     field: "treasury_account__federal_account",
                     operation: "equals",
                     value: this.props.account.id
-                },
-                {
-                    field: "treasury_account__agency_id",
-                    operation: "equals",
-                    value: this.props.account.agency_identifier
-                },
-                {
-                    field: "treasury_account__main_account_code",
-                    operation: "equals",
-                    value: this.props.account.main_account_code
                 }
             ]
         };
@@ -92,14 +81,21 @@ export class AccountProgramActivityContainer extends React.Component {
 
                 data.forEach((value) => {
                     programActivities.push({
+                        id: value.program_activity__id,
                         code: value.program_activity__program_activity_code,
                         name: value.program_activity__program_activity_name
                     });
                 });
 
+                let noResults = false;
+                if (programActivities.length === 0) {
+                    noResults = true;
+                }
+
                 // Add search results to Redux
                 this.setState({
-                    programActivities
+                    programActivities,
+                    noResults
                 });
             })
             .catch((err) => {

--- a/src/js/containers/account/filters/AccountProgramActivityContainer.jsx
+++ b/src/js/containers/account/filters/AccountProgramActivityContainer.jsx
@@ -1,0 +1,132 @@
+/**
+ * AccountProgramActivityContainer.jsx
+ * Created by michaelbray on 4/14/17.
+ */
+
+import React from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { isCancel } from 'axios';
+
+import * as accountFilterActions from 'redux/actions/account/accountFilterActions';
+import * as AccountHelper from 'helpers/accountHelper';
+
+import ProgramActivityFilter from
+    'components/account/filters/programActivity/ProgramActivityFilter';
+
+const propTypes = {
+    toggleProgramActivity: React.PropTypes.func,
+    setProgramActivities: React.PropTypes.func,
+    account: React.PropTypes.object
+};
+
+export class AccountProgramActivityContainer extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            programActivities: []
+        };
+
+        // bind functions
+        this.updateFilter = this.updateFilter.bind(this);
+    }
+
+    componentWillMount() {
+        this.populateProgramActivities();
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.account !== this.props.account) {
+            this.setState({
+                programActivities: []
+            }, () => {
+                this.populateProgramActivities();
+            });
+        }
+    }
+
+    updateFilter(code) {
+        this.props.toggleProgramActivity(code);
+    }
+
+    populateProgramActivities() {
+        if (this.searchRequest) {
+            // A request is currently in-flight, cancel it
+            this.searchRequest.cancel();
+        }
+
+        const apiSearchParams = {
+            group: [
+                "program_activity__program_activity_name",
+                "program_activity__program_activity_code",
+                "treasury_account__agency_id",
+                "treasury_account__main_account_code"],
+            field: "ussgl480100_undelivered_orders_obligations_unpaid_fyb",
+            aggregate: "count",
+            filters: [
+                {
+                    field: "treasury_account__federal_account",
+                    operation: "equals",
+                    value: this.props.account.id
+                },
+                {
+                    field: "treasury_account__agency_id",
+                    operation: "equals",
+                    value: this.props.account.agency_identifier
+                },
+                {
+                    field: "treasury_account__main_account_code",
+                    operation: "equals",
+                    value: this.props.account.main_account_code
+                }
+            ]
+        };
+
+        this.searchRequest = AccountHelper.fetchProgramActivities(apiSearchParams);
+
+        this.searchRequest.promise
+            .then((res) => {
+                const data = res.data.results;
+                const programActivities = [];
+
+                data.forEach((value) => {
+                    programActivities.push({
+                        code: value.program_activity__program_activity_code,
+                        name: value.program_activity__program_activity_name
+                    });
+                });
+
+                // Add search results to Redux
+                this.setState({
+                    programActivities
+                });
+            })
+            .catch((err) => {
+                if (!isCancel(err)) {
+                    this.setState({
+                        noResults: true
+                    });
+                }
+            });
+    }
+
+    render() {
+        return (
+            <ProgramActivityFilter
+                {...this.props}
+                {...this.state}
+                updateFilter={this.updateFilter} />
+        );
+    }
+}
+
+AccountProgramActivityContainer.propTypes = propTypes;
+
+export default connect(
+    (state) => ({
+        selectedProgramActivities: state.account.filters.programActivity,
+        account: state.account.account
+    }),
+    (dispatch) => bindActionCreators(accountFilterActions, dispatch)
+)(AccountProgramActivityContainer);

--- a/src/js/containers/account/filters/AccountProgramActivityContainer.jsx
+++ b/src/js/containers/account/filters/AccountProgramActivityContainer.jsx
@@ -25,7 +25,8 @@ export class AccountProgramActivityContainer extends React.Component {
         super(props);
 
         this.state = {
-            noResults: false
+            noResults: false,
+            inFlight: false
         };
 
         // bind functions
@@ -70,13 +71,29 @@ export class AccountProgramActivityContainer extends React.Component {
 
         this.searchRequest = AccountHelper.fetchProgramActivities(apiSearchParams);
 
+        this.setState({
+            inFlight: true
+        });
+
         this.searchRequest.promise
             .then((res) => {
+                this.searchRequest = null;
+
+                this.setState({
+                    inFlight: false
+                });
+
                 this.parseResultData(res.data.results);
             })
             .catch((err) => {
-                console.log(err);
+                this.searchRequest = null;
+
+                this.setState({
+                    inFlight: false
+                });
+
                 if (!isCancel(err)) {
+                    console.log(err);
                     this.setState({
                         noResults: true
                     });

--- a/src/js/containers/account/filters/AccountProgramActivityContainer.jsx
+++ b/src/js/containers/account/filters/AccountProgramActivityContainer.jsx
@@ -75,6 +75,7 @@ export class AccountProgramActivityContainer extends React.Component {
                 this.parseResultData(res.data.results);
             })
             .catch((err) => {
+                console.log(err);
                 if (!isCancel(err)) {
                     this.setState({
                         noResults: true

--- a/src/js/containers/account/filters/AccountProgramActivityContainer.jsx
+++ b/src/js/containers/account/filters/AccountProgramActivityContainer.jsx
@@ -72,29 +72,7 @@ export class AccountProgramActivityContainer extends React.Component {
 
         this.searchRequest.promise
             .then((res) => {
-                const data = res.data.results;
-                const programActivities = [];
-
-                data.forEach((value) => {
-                    programActivities.push({
-                        id: value.program_activity__id,
-                        code: value.program_activity__program_activity_code,
-                        name: value.program_activity__program_activity_name
-                    });
-                });
-
-                let noResults = false;
-                if (programActivities.length === 0) {
-                    noResults = true;
-                }
-
-                // Update state
-                this.setState({
-                    noResults
-                });
-
-                // Add search results to Redux
-                this.props.setAvailableProgramActivities(programActivities);
+                this.parseResultData(res.data.results);
             })
             .catch((err) => {
                 if (!isCancel(err)) {
@@ -103,6 +81,31 @@ export class AccountProgramActivityContainer extends React.Component {
                     });
                 }
             });
+    }
+
+    parseResultData(data) {
+        const programActivities = [];
+
+        data.forEach((value) => {
+            programActivities.push({
+                id: value.program_activity__id,
+                code: value.program_activity__program_activity_code,
+                name: value.program_activity__program_activity_name
+            });
+        });
+
+        let noResults = false;
+        if (programActivities.length === 0) {
+            noResults = true;
+        }
+
+        // Update state
+        this.setState({
+            noResults
+        });
+
+        // Add search results to Redux
+        this.props.setAvailableProgramActivities(programActivities);
     }
 
     render() {

--- a/src/js/containers/account/filters/AccountProgramActivityContainer.jsx
+++ b/src/js/containers/account/filters/AccountProgramActivityContainer.jsx
@@ -15,6 +15,7 @@ import ProgramActivityFilter from
     'components/account/filters/programActivity/ProgramActivityFilter';
 
 const propTypes = {
+    setAvailableProgramActivities: React.PropTypes.func,
     toggleProgramActivity: React.PropTypes.func,
     account: React.PropTypes.object
 };
@@ -24,7 +25,6 @@ export class AccountProgramActivityContainer extends React.Component {
         super(props);
 
         this.state = {
-            programActivities: [],
             noResults: false
         };
 
@@ -38,11 +38,7 @@ export class AccountProgramActivityContainer extends React.Component {
 
     componentWillReceiveProps(nextProps) {
         if (nextProps.account !== this.props.account) {
-            this.setState({
-                programActivities: []
-            }, () => {
-                this.populateProgramActivities();
-            });
+            this.populateProgramActivities();
         }
     }
 
@@ -92,11 +88,13 @@ export class AccountProgramActivityContainer extends React.Component {
                     noResults = true;
                 }
 
-                // Add search results to Redux
+                // Update state
                 this.setState({
-                    programActivities,
                     noResults
                 });
+
+                // Add search results to Redux
+                this.props.setAvailableProgramActivities(programActivities);
             })
             .catch((err) => {
                 if (!isCancel(err)) {
@@ -121,6 +119,7 @@ AccountProgramActivityContainer.propTypes = propTypes;
 
 export default connect(
     (state) => ({
+        availableProgramActivities: state.account.filterOptions.programActivity,
         selectedProgramActivities: state.account.filters.programActivity,
         account: state.account.account
     }),

--- a/src/js/containers/account/topFilterBar/AccountTopFilterBarContainer.jsx
+++ b/src/js/containers/account/topFilterBar/AccountTopFilterBarContainer.jsx
@@ -60,6 +60,11 @@ export class AccountTopFilterBarContainer extends React.Component {
             filters.push(objectClass);
         }
 
+        const programActivity = this.prepareProgramActivity(props);
+        if (programActivity) {
+            filters.push(programActivity);
+        }
+
         this.setState({
             filters
         });
@@ -125,6 +130,25 @@ export class AccountTopFilterBarContainer extends React.Component {
         return null;
     }
 
+    prepareProgramActivity(props) {
+        let selected = false;
+
+        const filter = {
+            code: 'programActivity',
+            name: 'Program Activity',
+            values: props.programActivity.toArray()
+        };
+
+        if (props.programActivity.count() > 0) {
+            selected = true;
+        }
+
+        if (selected) {
+            return filter;
+        }
+        return null;
+    }
+
     clearAllFilters() {
         this.props.resetAccountFilters();
     }
@@ -146,6 +170,9 @@ export class AccountTopFilterBarContainer extends React.Component {
 AccountTopFilterBarContainer.propTypes = propTypes;
 
 export default connect(
-    (state) => ({ reduxFilters: state.account.filters }),
+    (state) => ({
+        reduxFilters: state.account.filters,
+        filterOptions: state.account.filterOptions
+    }),
     (dispatch) => bindActionCreators(accountFilterActions, dispatch)
 )(AccountTopFilterBarContainer);

--- a/src/js/helpers/accountHelper.js
+++ b/src/js/helpers/accountHelper.js
@@ -53,3 +53,19 @@ export const fetchTasBalanceTotals = (data) => {
         }
     };
 };
+
+export const fetchProgramActivities = (data) => {
+    const source = CancelToken.source();
+    return {
+        promise: Axios.request({
+            data,
+            url: '/tas/categories/total/',
+            baseURL: kGlobalConstants.API,
+            method: 'post',
+            cancelToken: source.token
+        }),
+        cancel() {
+            source.cancel();
+        }
+    };
+};

--- a/src/js/models/account/queries/AccountAwardSearchOperation.js
+++ b/src/js/models/account/queries/AccountAwardSearchOperation.js
@@ -8,6 +8,7 @@ import _ from 'lodash';
 import * as AwardTypeQuery from 'models/search/queryBuilders/AwardTypeQuery';
 import * as TimePeriodQuery from './queryBuilders/TimePeriodQuery';
 import * as ObjectClassQuery from './queryBuilders/ObjectClassQuery';
+import * as ProgramActivityQuery from './queryBuilders/ProgramActivityQuery';
 
 class AccountAwardSearchOperation {
     constructor(id = null) {
@@ -21,6 +22,7 @@ class AccountAwardSearchOperation {
         this.dateRange = [];
 
         this.objectClass = [];
+        this.programActivity = [];
 
         this.awardType = [];
     }
@@ -37,6 +39,7 @@ class AccountAwardSearchOperation {
         }
 
         this.objectClass = state.objectClass.toArray();
+        this.programActivity = state.programActivity.toArray();
     }
 
     commonParams() {
@@ -54,6 +57,10 @@ class AccountAwardSearchOperation {
         // add object class to the filter
         if (this.objectClass.length > 0) {
             filters.push(ObjectClassQuery.buildAwardObjectClassQuery(this.objectClass));
+        }
+
+        if (this.programActivity.length > 0) {
+            filters.push(ProgramActivityQuery.buildAwardProgramActivityQuery(this.programActivity));
         }
 
         // add award type to the filters

--- a/src/js/models/account/queries/AccountAwardSearchOperation.js
+++ b/src/js/models/account/queries/AccountAwardSearchOperation.js
@@ -56,11 +56,12 @@ class AccountAwardSearchOperation {
 
         // add object class to the filter
         if (this.objectClass.length > 0) {
-            filters.push(ObjectClassQuery.buildAwardObjectClassQuery(this.objectClass));
+            filters.push(ObjectClassQuery.buildAwardsObjectClassQuery(this.objectClass));
         }
 
         if (this.programActivity.length > 0) {
-            filters.push(ProgramActivityQuery.buildAwardProgramActivityQuery(this.programActivity));
+            filters.push(ProgramActivityQuery
+                .buildAwardsProgramActivityQuery(this.programActivity));
         }
 
         // add award type to the filters

--- a/src/js/models/account/queries/AccountSearchBalanceOperation.js
+++ b/src/js/models/account/queries/AccountSearchBalanceOperation.js
@@ -21,12 +21,12 @@ class AccountSearchBalanceOperation extends AccountSearchOperation {
 
         if (this.objectClass.length > 0) {
             filters.push(ObjectClassQuery
-                .buildSpendingOverTimeObjectClassQuery(this.objectClass));
+                .buildBalancesObjectClassQuery(this.objectClass));
         }
 
         if (this.programActivity.length > 0) {
             filters.push(ProgramActivityQuery
-                .buildSpendingOverTimeProgramActivityQuery(this.programActivity));
+                .buildBalancesProgramActivityQuery(this.programActivity));
         }
 
         return filters;

--- a/src/js/models/account/queries/AccountSearchBalanceOperation.js
+++ b/src/js/models/account/queries/AccountSearchBalanceOperation.js
@@ -4,6 +4,8 @@
  */
 
 import AccountSearchOperation from './AccountSearchOperation';
+import * as ObjectClassQuery from './queryBuilders/ObjectClassQuery';
+import * as ProgramActivityQuery from './queryBuilders/ProgramActivityQuery';
 
 class AccountSearchBalanceOperation extends AccountSearchOperation {
     uniqueParams() {
@@ -15,6 +17,16 @@ class AccountSearchBalanceOperation extends AccountSearchOperation {
                 operation: 'equals',
                 value: this.accountId
             });
+        }
+
+        if (this.objectClass.length > 0) {
+            filters.push(ObjectClassQuery
+                .buildSpendingOverTimeObjectClassQuery(this.objectClass));
+        }
+
+        if (this.programActivity.length > 0) {
+            filters.push(ProgramActivityQuery
+                .buildSpendingOverTimeProgramActivityQuery(this.programActivity));
         }
 
         return filters;

--- a/src/js/models/account/queries/AccountSearchOperation.js
+++ b/src/js/models/account/queries/AccountSearchOperation.js
@@ -7,6 +7,7 @@ import _ from 'lodash';
 
 import * as TimePeriodQuery from './queryBuilders/TimePeriodQuery';
 import * as ObjectClassQuery from './queryBuilders/ObjectClassQuery';
+import * as ProgramActivityQuery from './queryBuilders/ProgramActivityQuery';
 
 class AccountSearchOperation {
     constructor(id = null) {
@@ -20,6 +21,7 @@ class AccountSearchOperation {
         this.dateRange = [];
 
         this.objectClass = [];
+        this.programActivity = [];
     }
 
     fromState(state) {
@@ -40,6 +42,13 @@ class AccountSearchOperation {
         }
         else {
             this.objectClass = [];
+        }
+
+        if (state.programActivity.count() > 0) {
+            this.programActivity = state.programActivity.toArray();
+        }
+        else {
+            this.programActivity = [];
         }
     }
 
@@ -73,6 +82,11 @@ class AccountSearchOperation {
         if (this.objectClass.length > 0) {
             const ocFilter = ObjectClassQuery.buildObjectClassQuery(this.objectClass);
             filters.push(ocFilter);
+        }
+
+        if (this.programActivity.length > 0) {
+            const paFilter = ProgramActivityQuery.buildProgramActivityQuery(this.programActivity);
+            filters.push(paFilter);
         }
 
         return filters;

--- a/src/js/models/account/queries/AccountSearchOperation.js
+++ b/src/js/models/account/queries/AccountSearchOperation.js
@@ -80,13 +80,13 @@ class AccountSearchOperation {
         }
 
         if (this.objectClass.length > 0) {
-            const ocFilter = ObjectClassQuery.buildObjectClassQuery(this.objectClass);
-            filters.push(ocFilter);
+            filters.push(ObjectClassQuery
+                .buildSpendingByCategoryObjectClassQuery(this.objectClass));
         }
 
         if (this.programActivity.length > 0) {
-            const paFilter = ProgramActivityQuery.buildProgramActivityQuery(this.programActivity);
-            filters.push(paFilter);
+            filters.push(ProgramActivityQuery
+                .buildSpendingByCategoryProgramActivityQuery(this.programActivity));
         }
 
         return filters;

--- a/src/js/models/account/queries/AccountSearchOperation.js
+++ b/src/js/models/account/queries/AccountSearchOperation.js
@@ -81,12 +81,12 @@ class AccountSearchOperation {
 
         if (this.objectClass.length > 0) {
             filters.push(ObjectClassQuery
-                .buildSpendingByCategoryObjectClassQuery(this.objectClass));
+                .buildCategoriesObjectClassQuery(this.objectClass));
         }
 
         if (this.programActivity.length > 0) {
             filters.push(ProgramActivityQuery
-                .buildSpendingByCategoryProgramActivityQuery(this.programActivity));
+                .buildCategoriesProgramActivityQuery(this.programActivity));
         }
 
         return filters;

--- a/src/js/models/account/queries/queryBuilders/ObjectClassQuery.js
+++ b/src/js/models/account/queries/queryBuilders/ObjectClassQuery.js
@@ -4,7 +4,10 @@
   **/
 
 const objectClassField = 'object_class__major_object_class';
-const awardObjectClassField = 'financial_set__object_class__major_object_class';
+
+const spendingOverTimeField = `treasury_account_identifier__program_balances__${objectClassField}`;
+const spendingByCategoryField = objectClassField;
+const awardField = `financial_set__${objectClassField}`;
 
 const commonQuery = (field, values) => ({
     field,
@@ -12,6 +15,11 @@ const commonQuery = (field, values) => ({
     value: values
 });
 
-export const buildObjectClassQuery = (values) => commonQuery(objectClassField, values);
+export const buildSpendingOverTimeObjectClassQuery = (values) =>
+    commonQuery(spendingOverTimeField, values);
 
-export const buildAwardObjectClassQuery = (values) => commonQuery(awardObjectClassField, values);
+export const buildSpendingByCategoryObjectClassQuery = (values) =>
+    commonQuery(spendingByCategoryField, values);
+
+export const buildAwardObjectClassQuery = (values) =>
+    commonQuery(awardField, values);

--- a/src/js/models/account/queries/queryBuilders/ObjectClassQuery.js
+++ b/src/js/models/account/queries/queryBuilders/ObjectClassQuery.js
@@ -15,11 +15,11 @@ const commonQuery = (field, values) => ({
     value: values
 });
 
-export const buildSpendingOverTimeObjectClassQuery = (values) =>
+export const buildBalancesObjectClassQuery = (values) =>
     commonQuery(spendingOverTimeField, values);
 
-export const buildSpendingByCategoryObjectClassQuery = (values) =>
+export const buildCategoriesObjectClassQuery = (values) =>
     commonQuery(spendingByCategoryField, values);
 
-export const buildAwardObjectClassQuery = (values) =>
+export const buildAwardsObjectClassQuery = (values) =>
     commonQuery(awardField, values);

--- a/src/js/models/account/queries/queryBuilders/ProgramActivityQuery.js
+++ b/src/js/models/account/queries/queryBuilders/ProgramActivityQuery.js
@@ -5,11 +5,22 @@
 
 const programActivityField = 'program_activity__id';
 
-/* eslint-disable import/prefer-default-export */
-// We only have one export but want to maintain consistency with other functions
-export const buildProgramActivityQuery = (values) => ({
-    field: programActivityField,
+const spendingOverTimeField =
+    `treasury_account_identifier__program_balances__${programActivityField}`;
+const spendingByCategoryField = programActivityField;
+const awardField = `financial_set__${programActivityField}`;
+
+export const commonQuery = (field, values) => ({
+    field,
     operation: 'in',
     value: values
 });
-/* eslint-enable import/prefer-default-export */
+
+export const buildSpendingOverTimeProgramActivityQuery = (values) =>
+    commonQuery(spendingOverTimeField, values);
+
+export const buildSpendingByCategoryProgramActivityQuery = (values) =>
+    commonQuery(spendingByCategoryField, values);
+
+export const buildAwardProgramActivityQuery = (values) =>
+    commonQuery(awardField, values);

--- a/src/js/models/account/queries/queryBuilders/ProgramActivityQuery.js
+++ b/src/js/models/account/queries/queryBuilders/ProgramActivityQuery.js
@@ -16,11 +16,11 @@ export const commonQuery = (field, values) => ({
     value: values
 });
 
-export const buildSpendingOverTimeProgramActivityQuery = (values) =>
+export const buildBalancesProgramActivityQuery = (values) =>
     commonQuery(spendingOverTimeField, values);
 
-export const buildSpendingByCategoryProgramActivityQuery = (values) =>
+export const buildCategoriesProgramActivityQuery = (values) =>
     commonQuery(spendingByCategoryField, values);
 
-export const buildAwardProgramActivityQuery = (values) =>
+export const buildAwardsProgramActivityQuery = (values) =>
     commonQuery(awardField, values);

--- a/src/js/models/account/queries/queryBuilders/ProgramActivityQuery.js
+++ b/src/js/models/account/queries/queryBuilders/ProgramActivityQuery.js
@@ -1,0 +1,15 @@
+/**
+ * ProgramActivityQuery.jsx
+ * Created by michaelbray on 4/17/17.
+ */
+
+const programActivityField = 'program_activity__id';
+
+/* eslint-disable import/prefer-default-export */
+// We only have one export but want to maintain consistency with other functions
+export const buildProgramActivityQuery = (values) => ({
+    field: programActivityField,
+    operation: 'in',
+    value: values
+});
+/* eslint-enable import/prefer-default-export */

--- a/src/js/redux/actions/account/accountFilterActions.js
+++ b/src/js/redux/actions/account/accountFilterActions.js
@@ -24,6 +24,15 @@ export const resetObjectClass = () => ({
     type: 'RESET_ACCOUNT_OBJECT_CLASS'
 });
 
+export const toggleProgramActivity = (state) => ({
+    type: 'TOGGLE_ACCOUNT_PROGRAM_ACTIVITY',
+    item: state
+});
+
+export const resetProgramActivity = () => ({
+    type: 'RESET_ACCOUNT_PROGRAM_ACTIVITY'
+});
+
 export const resetAccountFilters = () => ({
     type: 'RESET_ACCOUNT_FILTERS'
 });

--- a/src/js/redux/actions/account/accountFilterActions.js
+++ b/src/js/redux/actions/account/accountFilterActions.js
@@ -24,6 +24,11 @@ export const resetObjectClass = () => ({
     type: 'RESET_ACCOUNT_OBJECT_CLASS'
 });
 
+export const setAvailableProgramActivities = (state) => ({
+    type: 'SET_AVAILABLE_PROGRAM_ACTIVITIES',
+    programActivities: state
+});
+
 export const toggleProgramActivity = (state) => ({
     type: 'TOGGLE_ACCOUNT_PROGRAM_ACTIVITY',
     item: state

--- a/src/js/redux/reducers/account/accountReducer.js
+++ b/src/js/redux/reducers/account/accountReducer.js
@@ -130,6 +130,8 @@ const accountReducer = (state = initialState, action) => {
                 filters
             });
         }
+
+        // Object Classes
         case 'TOGGLE_ACCOUNT_OBJECT_CLASS': {
             const updatedOC = ObjectClassFuncs.toggleItem(state.filters.objectClass, action.item);
             const updatedFilters = Object.assign({}, state.filters, {
@@ -149,6 +151,8 @@ const accountReducer = (state = initialState, action) => {
                 filters: updatedFilters
             });
         }
+
+        // Program Activities
         case 'SET_AVAILABLE_PROGRAM_ACTIVITIES': {
             const updatedFilterOptions = Object.assign({}, state.filterOptions, {
                 programActivity: action.programActivities
@@ -178,6 +182,7 @@ const accountReducer = (state = initialState, action) => {
                 filters: updatedFilters
             });
         }
+
         case 'RESET_ACCOUNT_FILTERS': {
             return Object.assign({}, state, {
                 filters: initialState.filters

--- a/src/js/redux/reducers/account/accountReducer.js
+++ b/src/js/redux/reducers/account/accountReducer.js
@@ -8,6 +8,7 @@ import _ from 'lodash';
 import { Set, OrderedSet } from 'immutable';
 
 import * as ObjectClassFuncs from './filters/accountObjectClassFunctions';
+import * as ProgramActivityFuncs from './filters/accountProgramActivityFunctions';
 
 const initialState = {
     filters: {
@@ -16,7 +17,7 @@ const initialState = {
         startDate: null,
         endDate: null,
         objectClass: new OrderedSet(),
-        programActivity: [],
+        programActivity: new OrderedSet(),
         tas: []
     },
     filterOptions: {
@@ -89,6 +90,26 @@ const accountReducer = (state = initialState, action) => {
         case 'RESET_ACCOUNT_OBJECT_CLASS': {
             const updatedFilters = Object.assign({}, state.filters, {
                 objectClass: initialState.filters.objectClass
+            });
+
+            return Object.assign({}, state, {
+                filters: updatedFilters
+            });
+        }
+        case 'TOGGLE_ACCOUNT_PROGRAM_ACTIVITY': {
+            const updatedPA = ProgramActivityFuncs.toggleItem(
+                state.filters.programActivity, action.item);
+            const updatedFilters = Object.assign({}, state.filters, {
+                programActivity: updatedPA
+            });
+
+            return Object.assign({}, state, {
+                filters: updatedFilters
+            });
+        }
+        case 'RESET_ACCOUNT_PROGRAM_ACTIVITY': {
+            const updatedFilters = Object.assign({}, state.filters, {
+                programActivity: initialState.filters.programActivity
             });
 
             return Object.assign({}, state, {

--- a/src/js/redux/reducers/account/accountReducer.js
+++ b/src/js/redux/reducers/account/accountReducer.js
@@ -96,6 +96,15 @@ const accountReducer = (state = initialState, action) => {
                 filters: updatedFilters
             });
         }
+        case 'SET_AVAILABLE_PROGRAM_ACTIVITIES': {
+            const updatedFilterOptions = Object.assign({}, state.filterOptions, {
+                programActivity: action.programActivities
+            });
+
+            return Object.assign({}, state, {
+                filterOptions: updatedFilterOptions
+            });
+        }
         case 'TOGGLE_ACCOUNT_PROGRAM_ACTIVITY': {
             const updatedPA = ProgramActivityFuncs.toggleItem(
                 state.filters.programActivity, action.item);

--- a/src/js/redux/reducers/account/filters/accountProgramActivityFunctions.js
+++ b/src/js/redux/reducers/account/filters/accountProgramActivityFunctions.js
@@ -1,0 +1,12 @@
+/**
+ * accountProgramActivityFunctions.js
+ * Created by michaelbray on 4/14/17.
+ */
+
+export const toggleItem = (selected, item) => {
+    if (selected.includes(item)) {
+        return selected.delete(item);
+    }
+
+    return selected.add(item);
+};

--- a/tests/containers/account/defaultFilters.js
+++ b/tests/containers/account/defaultFilters.js
@@ -10,5 +10,6 @@ export const defaultFilters = {
     fy: new Set(),
     startDate: null,
     endDate: null,
-    objectClass: new OrderedSet()
+    objectClass: new OrderedSet(),
+    programActivity: new OrderedSet()
 };

--- a/tests/containers/account/filters/AccountProgramActivityContainer-test.jsx
+++ b/tests/containers/account/filters/AccountProgramActivityContainer-test.jsx
@@ -1,0 +1,134 @@
+/**
+ * AccountProgramActivityContainer-test.jsx
+ * Created by michaelbray on 4/19/17.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import { OrderedSet } from 'immutable';
+
+import { AccountProgramActivityContainer } from
+    'containers/account/filters/AccountProgramActivityContainer';
+
+const initialFilters = {
+    selectedProgramActivities: new OrderedSet(),
+    availableProgramActivities: [],
+    account: {
+        id: 2525
+    }
+};
+
+const account = {
+    id: 2525
+};
+
+describe('AccountProgramActivityContainer', () => {
+    describe('updateFilter', () => {
+        it('should add a Program Activity that has been selected to Redux', () => {
+            const mockReduxAction = jest.fn((args) => {
+                expect(args).toEqual('810');
+            });
+
+            // Set up container with mocked Program Activity action
+            const accountProgramActivityContainer = shallow(
+                <AccountProgramActivityContainer
+                    reduxFilters={initialFilters}
+                    toggleProgramActivity={mockReduxAction}
+                    account={account} />);
+
+            const updateFilterSpy = sinon.spy(accountProgramActivityContainer.instance(),
+                'updateFilter');
+
+            // Add Program Activity to redux
+            accountProgramActivityContainer.instance().updateFilter('810');
+
+            // everything should be updated now
+            expect(updateFilterSpy.callCount).toEqual(1);
+            expect(mockReduxAction).toHaveBeenCalled();
+
+            // reset the spy
+            updateFilterSpy.reset();
+        });
+
+        it('should should a Program Activity that has been deselected from Redux', () => {
+            const mockReduxAction = jest.fn((args) => {
+                expect(args).toEqual('810');
+            });
+
+            // Set up container with mocked Program Activity action
+            const accountProgramActivityContainer = shallow(
+                <AccountProgramActivityContainer
+                    reduxFilters={initialFilters}
+                    toggleProgramActivity={mockReduxAction}
+                    account={account} />);
+
+            const updateFilterSpy = sinon.spy(accountProgramActivityContainer.instance(),
+                'updateFilter');
+
+            // Add Program Activity to redux
+            accountProgramActivityContainer.instance().updateFilter('810');
+
+            // Remove Program Activity from redux
+            accountProgramActivityContainer.instance().updateFilter('810');
+
+            // everything should be updated now
+            expect(updateFilterSpy.callCount).toEqual(2);
+            expect(mockReduxAction).toHaveBeenCalledTimes(2);
+
+            // reset the spy
+            updateFilterSpy.reset();
+        });
+    });
+
+    describe('populateProgramActivities', () => {
+        it('should fetch program activities on load', () => {
+            jest.useFakeTimers();
+
+            const container = shallow(<AccountProgramActivityContainer
+                {...initialFilters} />);
+
+            // set up spy
+            const populateProgramActivitiesSpy = sinon.spy(
+                container.instance(), 'populateProgramActivities');
+
+            container.instance().componentWillMount();
+
+            // Run fake timer for input delay
+            jest.runAllTicks();
+
+            // everything should be updated now
+            expect(populateProgramActivitiesSpy.callCount).toEqual(1);
+
+            // Reset spy
+            populateProgramActivitiesSpy.reset();
+        });
+    });
+
+    describe('parseResultData', () => {
+        it('should parse retrieved program activities', () => {
+            jest.useFakeTimers();
+
+            const container = shallow(<AccountProgramActivityContainer
+                {...initialFilters} />);
+
+            // set up spy
+            const populateProgramActivitiesSpy = sinon.spy(
+                container.instance(), 'populateProgramActivities');
+            const parseResultDataSpy = sinon.spy(
+                container.instance(), 'parseResultData');
+
+            container.instance().populateProgramActivities();
+
+            // Run fake timer for input delay
+            jest.runAllTicks();
+
+            // everything should be updated now
+            expect(populateProgramActivitiesSpy.callCount).toEqual(1);
+            expect(parseResultDataSpy.calledWith(populateProgramActivitiesSpy));
+
+            // Reset spy
+            populateProgramActivitiesSpy.reset();
+        });
+    });
+});

--- a/tests/containers/account/topFilterBar/AccountTopFilterBarContainer-test.jsx
+++ b/tests/containers/account/topFilterBar/AccountTopFilterBarContainer-test.jsx
@@ -111,7 +111,7 @@ describe('AccountTopFilterBarContainer', () => {
         });
     });
 
-    describe('parseObjectClass', () => {
+    describe('prepareObjectClass', () => {
         it('should update the container state with the selected object classes', () => {
             const filters = Object.assign({}, defaultFilters, {
                 objectClass: new OrderedSet(['10', '20'])
@@ -127,9 +127,33 @@ describe('AccountTopFilterBarContainer', () => {
             });
         });
 
-        it('should not return anything when no date filters are supplied', () => {
+        it('should not return anything when no object classes are supplied', () => {
             const container = shallow(<AccountTopFilterBarContainer />);
             const parsed = container.instance().prepareObjectClass(defaultFilters);
+
+            expect(parsed).toBeNull();
+        });
+    });
+
+    describe('prepareProgramActivity', () => {
+        it('should update the container state with the selected program activities', () => {
+            const filters = Object.assign({}, defaultFilters, {
+                programActivity: new OrderedSet(['810', '161'])
+            });
+
+            const container = shallow(<AccountTopFilterBarContainer />);
+            const parsed = container.instance().prepareProgramActivity(filters);
+
+            expect(parsed).toEqual({
+                code: 'programActivity',
+                name: 'Program Activity',
+                values: ['810', '161']
+            });
+        });
+
+        it('should not return anything when no program activities are supplied', () => {
+            const container = shallow(<AccountTopFilterBarContainer />);
+            const parsed = container.instance().prepareProgramActivity(defaultFilters);
 
             expect(parsed).toBeNull();
         });

--- a/tests/redux/reducers/account/accountReducer-test.js
+++ b/tests/redux/reducers/account/accountReducer-test.js
@@ -14,7 +14,7 @@ const initialState = {
         startDate: null,
         endDate: null,
         objectClass: new OrderedSet(),
-        programActivity: [],
+        programActivity: new OrderedSet(),
         tas: []
     },
     filterOptions: {
@@ -104,7 +104,7 @@ describe('accountReducer', () => {
                 fy: new Set(['2017']),
                 startDate: null,
                 endDate: null,
-                programActivity: [],
+                programActivity: new OrderedSet(),
                 tas: [],
                 objectClass: new OrderedSet()
             };
@@ -129,7 +129,7 @@ describe('accountReducer', () => {
                 fy: new Set([]),
                 startDate: '2015-01-01',
                 endDate: '2015-12-31',
-                programActivity: [],
+                programActivity: new OrderedSet(),
                 tas: [],
                 objectClass: new OrderedSet()
             };
@@ -156,7 +156,7 @@ describe('accountReducer', () => {
                 fy: new Set(['2017']),
                 startDate: '2015-01-01',
                 endDate: '2015-12-31',
-                programActivity: [],
+                programActivity: new OrderedSet(),
                 tas: [],
                 objectClass: new OrderedSet()
             };
@@ -173,7 +173,7 @@ describe('accountReducer', () => {
                 fy: new Set([]),
                 startDate: null,
                 endDate: null,
-                programActivity: [],
+                programActivity: new OrderedSet(),
                 tas: [],
                 objectClass: new OrderedSet()
             };
@@ -236,7 +236,7 @@ describe('accountReducer', () => {
                 fy: new Set(['2017']),
                 startDate: '2015-01-01',
                 endDate: '2015-12-31',
-                programActivity: [],
+                programActivity: new OrderedSet(),
                 tas: [],
                 objectClass: new OrderedSet()
             };
@@ -298,7 +298,7 @@ describe('accountReducer', () => {
                 fy: new Set(['2017']),
                 startDate: '2015-01-01',
                 endDate: '2015-12-31',
-                programActivity: [],
+                programActivity: new OrderedSet(),
                 tas: [],
                 objectClass: new OrderedSet()
             };
@@ -424,6 +424,108 @@ describe('accountReducer', () => {
             state = accountReducer(state, action);
             expect(state.awardsOrder.field).toEqual('fake_field');
             expect(state.awardsOrder.direction).toEqual('asc');
+        });
+    });
+
+    describe('SET_AVAILABLE_PROGRAM_ACTIVITIES', () => {
+        it('should set the program activities of the filter options object', () => {
+            let state = accountReducer(initialState, {});
+
+            const action = {
+                type: 'SET_AVAILABLE_PROGRAM_ACTIVITIES',
+                programActivities: [{
+                    id: '810',
+                    code: '0002',
+                    name: 'Child support incentive payments'
+                },
+                {
+                    id: '161',
+                    code: '0001',
+                    name: 'Court of Appeals for Veterans Claims Retirement Fund'
+                }]
+            };
+
+            state = accountReducer(state, action);
+            expect(state.filterOptions.programActivity).toEqual(action.programActivities);
+        });
+    });
+
+    describe('TOGGLE_ACCOUNT_PROGRAM_ACTIVITY', () => {
+        it('should add the provided program activity if it is not already selected', () => {
+            let state = accountReducer(undefined, {});
+
+            const action = {
+                type: 'TOGGLE_ACCOUNT_PROGRAM_ACTIVITY',
+                item: '810'
+            };
+
+            state = accountReducer(state, action);
+
+            const expected = new OrderedSet(['810']);
+            expect(state.filters.programActivity).toEqual(expected);
+        });
+
+        it('should remove the provided program activity if it is already selected', () => {
+            const startingFilters = Object.assign({}, initialState.filters, {
+                programActivity: new OrderedSet(['810', '161'])
+            });
+
+            const startingState = Object.assign({}, initialState, {
+                filters: startingFilters
+            });
+
+            let state = accountReducer(startingState, {});
+
+            const action = {
+                type: 'TOGGLE_ACCOUNT_PROGRAM_ACTIVITY',
+                item: '810'
+            };
+
+            state = accountReducer(state, action);
+
+            const expected = new OrderedSet(['161']);
+            expect(state.filters.programActivity).toEqual(expected);
+        });
+    });
+
+    describe('RESET_ACCOUNT_PROGRAM_ACTIVITY', () => {
+        it('should reset the selected program activities', () => {
+            let state = accountReducer(initialState, {});
+
+            const firstAction = {
+                type: 'TOGGLE_ACCOUNT_PROGRAM_ACTIVITY',
+                item: '810'
+            };
+
+            const firstState = {
+                dateType: 'fy',
+                fy: new Set(),
+                startDate: null,
+                endDate: null,
+                objectClass: new OrderedSet(),
+                programActivity: new OrderedSet(["810"]),
+                tas: []
+            };
+
+            state = accountReducer(state, firstAction);
+            expect(state.filters).toEqual(firstState);
+
+            const secondAction = {
+                type: 'RESET_ACCOUNT_PROGRAM_ACTIVITY'
+            };
+
+            const secondState = {
+                dateType: 'fy',
+                fy: new Set([]),
+                startDate: null,
+                endDate: null,
+                programActivity: new OrderedSet(),
+                tas: [],
+                objectClass: new OrderedSet()
+            };
+
+            state = accountReducer(state, secondAction);
+            expect(state.filters).toEqual(secondState);
         });
     });
 });


### PR DESCRIPTION
- User is able to filter data by Program Activity on Federal Account page
- Program Activities are populated when filter is expanded
- Program Activity list shows up to 10 Program Activities by default
- Program Activity list gives the option to show all remaining Program Activities, as well as hide the subsequently expanded list