### PR TITLE
[DS-1147] Multiple Recipients

### DIFF
--- a/src/_scss/pages/award/_recipientInfo.scss
+++ b/src/_scss/pages/award/_recipientInfo.scss
@@ -43,6 +43,11 @@
                 font-size: rem(12);
             }
         }
+        &.single {
+            li {
+                @include span-columns(16);
+            }
+        }
     }
     @include media($tablet-screen) {
         @include span-columns(9);

--- a/src/js/components/award/RecipientInfo.jsx
+++ b/src/js/components/award/RecipientInfo.jsx
@@ -16,8 +16,34 @@ const propTypes = {
 
 export default class RecipientInfo extends React.Component {
 
-    render() {
+    constructor(props) {
+        super(props);
+        this.buildSnippets = this.buildSnippets.bind(this);
+        this.buildName = this.buildName.bind(this);
+    }
+
+    buildName() {
         const recipient = this.props.recipient;
+        const isMultiple = this.props.recipient.recipient_name === 'Multiple Recipients';
+        let recipientName = this.props.recipient.recipient_name;
+        let address = null;
+        if (isMultiple) {
+            if (recipient.recipient_county && recipient.recipient_state_province) {
+                address = ` in ${recipient.recipient_county},
+                ${recipient.recipient_state_province}`;
+            }
+            recipientName = `Multiple Recipients${address}`;
+        }
+        return recipientName;
+    }
+
+    buildSnippets() {
+        const recipient = this.props.recipient;
+        const isMultiple = this.props.recipient.recipient_name === 'Multiple Recipients';
+        const multiDescription = `An award with multiple recipients indicates an aggregate award.
+        Aggregate awards exist to protect recipient Personally Identifiable Information (PII).
+        Agencies are currently required to aggregate these awards on a county level.`;
+
         let duns = "Not Available";
         let parentDuns = "Not Available";
         let businessType = "Not Available";
@@ -41,23 +67,38 @@ export default class RecipientInfo extends React.Component {
             parentDunsSnippet = '';
         }
 
+        let infoSnippets = (
+            <ul className="recipient-information">
+                <RecipientAddress
+                    recipient={recipient} />
+                <InfoSnippet
+                    label="DUNS"
+                    value={duns} />
+                {parentDunsSnippet}
+                <InfoSnippet
+                    label="Business Type"
+                    value={businessType} />
+            </ul>);
+
+        if (isMultiple) {
+            infoSnippets = (
+                <ul className="recipient-information single">
+                    <InfoSnippet
+                        label=""
+                        value={multiDescription} />
+                </ul>);
+        }
+        return infoSnippets;
+    }
+
+    render() {
         return (
             <div className="recipient-info">
                 <h4>Recipient</h4>
                 <div className="recipient-name">
-                    {recipient.recipient_name}
+                    {this.buildName()}
                 </div>
-                <ul className="recipient-information">
-                    <RecipientAddress
-                        recipient={recipient} />
-                    <InfoSnippet
-                        label="DUNS"
-                        value={duns} />
-                    {parentDunsSnippet}
-                    <InfoSnippet
-                        label="Business Type"
-                        value={businessType} />
-                </ul>
+                {this.buildSnippets()}
             </div>
         );
     }

--- a/src/js/models/results/award/AwardSummary.js
+++ b/src/js/models/results/award/AwardSummary.js
@@ -31,6 +31,7 @@ const fields = [
     'funding_office_name',
     'recipient_street',
     'recipient_city',
+    'recipient_county',
     'recipient_state_province',
     'recipient_zip_postal',
     'recipient_country',
@@ -75,6 +76,7 @@ const remapData = (data, idField) => {
     let recipientName = '';
     let recipientStreet = '';
     let recipientCity = '';
+    let recipientCounty = '';
     let recipientStateProvince = '';
     let recipientZipPostal = '';
     let recipientCountry = '';
@@ -258,6 +260,10 @@ const remapData = (data, idField) => {
             recipientCity = loc.city_name;
         }
 
+        if (loc.county_name) {
+            recipientCounty = loc.county_name;
+        }
+
         if (loc.state_code) {
             recipientStateProvince = loc.state_code;
         }
@@ -291,6 +297,7 @@ const remapData = (data, idField) => {
     remappedData.recipient_name = recipientName;
     remappedData.recipient_street = recipientStreet;
     remappedData.recipient_city = recipientCity;
+    remappedData.recipient_county = recipientCounty;
     remappedData.recipient_state_province = recipientStateProvince;
     remappedData.recipient_zip_postal = recipientZipPostal;
     remappedData.recipient_country = recipientCountry;


### PR DESCRIPTION
- Not displaying address/parent/duns InfoSnippets for a Multiple Recipients award, displaying explanatory text instead
- Adding SCSS class to handle display of single InfoSnippet
- Converting name and snippet builds to functions to keep them out of render
- Displaying `Multiple Recipients in [County], [State/Province]` in name field, but only showing `in [County], [State/Province]` if both are available