### PR TITLE
Expand filters in Search Results page by default

### DIFF
--- a/src/js/components/sharedComponents/filterSidebar/FilterOption.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterOption.jsx
@@ -31,8 +31,8 @@ export default class FilterOption extends React.Component {
         super(props);
 
         this.state = {
-            showFilter: false,
-            arrowState: 'collapsed'
+            showFilter: true,
+            arrowState: 'expanded'
         };
 
         // bind functions


### PR DESCRIPTION
Expand Search Results page filters by default