### PR TITLE
Agency Filter Sorting

### DIFF
--- a/src/js/containers/search/filters/AgencyListContainer.jsx
+++ b/src/js/containers/search/filters/AgencyListContainer.jsx
@@ -61,6 +61,10 @@ export class AgencyListContainer extends React.Component {
 
     parseAutocompleteAgencies(results) {
         const agencies = [];
+        const agencyOrder = {
+            toptier: 0,
+            subtier: 1
+        };
 
         // Format results of search for use in Autocomplete component
         if (results && results.length > 0) {
@@ -97,6 +101,12 @@ export class AgencyListContainer extends React.Component {
                 });
             }
         }
+
+        agencies.sort((a, b) => {
+            const ap = agencyOrder[a.data.agencyType];
+            const bp = agencyOrder[b.data.agencyType];
+            return ap - bp;
+        });
 
         this.setState({
             autocompleteAgencies: agencies

--- a/src/js/containers/search/filters/AgencyListContainer.jsx
+++ b/src/js/containers/search/filters/AgencyListContainer.jsx
@@ -132,6 +132,7 @@ export class AgencyListContainer extends React.Component {
             const agencySearchParams = {
                 fields: ['subtier_agency__name'],
                 value: this.state.agencySearchString,
+                order: ["-toptier_flag"],
                 mode: "contains",
                 matched_objects: true,
                 limit: 10

--- a/src/js/models/search/SearchOperation.js
+++ b/src/js/models/search/SearchOperation.js
@@ -146,22 +146,6 @@ class SearchOperation {
             }
         }
 
-        // Add Budget Category queries
-        if (this.budgetFunctions.length > 0) {
-            filters.push(BudgetCategoryQuery.buildBudgetFunctionQuery(
-                this.budgetFunctions, this.searchContext));
-        }
-
-        if (this.federalAccounts.length > 0) {
-            filters.push(BudgetCategoryQuery.buildFederalAccountQuery(
-                this.federalAccounts, this.searchContext));
-        }
-
-        if (Object.keys(this.objectClasses).length > 0) {
-            filters.push(BudgetCategoryQuery.buildObjectClassQuery(
-                this.objectClasses, this.searchContext));
-        }
-
         return filters;
     }
 

--- a/src/js/models/search/SearchOperation.js
+++ b/src/js/models/search/SearchOperation.js
@@ -13,7 +13,6 @@ import * as RecipientQuery from './queryBuilders/RecipientQuery';
 import * as KeywordQuery from './queryBuilders/KeywordQuery';
 import * as AwardIDQuery from './queryBuilders/AwardIDQuery';
 import * as AwardAmountQuery from './queryBuilders/AwardAmountQuery';
-import * as BudgetCategoryQuery from './queryBuilders/BudgetCategoryQuery';
 
 class SearchOperation {
     constructor() {


### PR DESCRIPTION
- [x] https://github.com/fedspendingtransparency/usaspending-api/pull/329 is merged
- User will see toptier agencies listed before subtier agencies in both Agency Filter autocompletes
- Flag in API request will prioritize agency objects in which subtier agency name matches toptier agency name to ensure that no toptier agencies are being left out of the `limit`ed response (currently 10)