### PR TITLE
Spending by Funding Agency Endpoint Fix

### DIFF
--- a/src/js/components/search/visualizations/rank/RankVisualizationTitle.jsx
+++ b/src/js/components/search/visualizations/rank/RankVisualizationTitle.jsx
@@ -14,6 +14,7 @@ const propTypes = {
     currentSpendingBy: React.PropTypes.string
 };
 
+// TODO: Mike Bray - Add Funding Agency (funding_agency) as the 3rd item when backend ready
 const defaultProps = {
     fieldTypes: [
         {
@@ -23,10 +24,6 @@ const defaultProps = {
         {
             label: 'Awarding Agency',
             value: 'awarding_agency'
-        },
-        {
-            label: 'Funding Agency',
-            value: 'funding_agency'
         },
         {
             label: 'Recipient',

--- a/src/js/components/search/visualizations/rank/sections/SpendingByAgencySection.jsx
+++ b/src/js/components/search/visualizations/rank/sections/SpendingByAgencySection.jsx
@@ -13,7 +13,12 @@ import RankVisualizationSection from './RankVisualizationSection';
 const propTypes = {
     agencyScope: React.PropTypes.string,
     changeScope: React.PropTypes.func,
-    agencyType: React.PropTypes.string
+    agencyType: React.PropTypes.string,
+    hideSuboptionBar: React.PropTypes.string
+};
+
+const defaultProps = {
+    hideSuboptionBar: ""
 };
 
 export default class SpendingByAgencySection extends React.Component {
@@ -28,7 +33,7 @@ export default class SpendingByAgencySection extends React.Component {
                             update automatically. View your results in a bar graph or a tree map.
                         </div>
                     </div>
-                    <div className="visualization-period">
+                    <div className={`visualization-period ${this.props.hideSuboptionBar}`}>
                         <div className="content">
                             <ul>
                                 <li>
@@ -64,3 +69,4 @@ export default class SpendingByAgencySection extends React.Component {
 }
 
 SpendingByAgencySection.propTypes = propTypes;
+SpendingByAgencySection.defaultProps = defaultProps;

--- a/src/js/containers/search/visualizations/rank/SpendingByFundingAgencyVisualizationContainer.jsx
+++ b/src/js/containers/search/visualizations/rank/SpendingByFundingAgencyVisualizationContainer.jsx
@@ -17,7 +17,6 @@ import * as searchFilterActions from 'redux/actions/search/searchFilterActions';
 import * as SearchHelper from 'helpers/searchHelper';
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 
-import SearchTransactionOperation from 'models/search/SearchTransactionOperation';
 import SearchAccountAwardsOperation from 'models/search/SearchAccountAwardsOperation';
 
 const propTypes = {
@@ -125,7 +124,7 @@ export class SpendingByFundingAgencyVisualizationContainer extends React.Compone
 
 
     fetchUnfilteredRequest() {
-        this.fetchTransactions('Funding agency vis - unfiltered');
+        this.fetchAccountAwards('Funding agency vis - unfiltered');
     }
 
     fetchBudgetRequest() {
@@ -134,45 +133,12 @@ export class SpendingByFundingAgencyVisualizationContainer extends React.Compone
 
     fetchAwardRequest() {
         // only award filters have been selected
-        this.fetchTransactions('Funding agency vis - award filters');
+        this.fetchAccountAwards('Funding agency vis - award filters');
     }
 
     fetchComboRequest() {
         // a combination of budget and award filters have been selected
         this.fetchAccountAwards('Funding agency vis - combination');
-    }
-
-    fetchTransactions(auditTrail = null) {
-        // Create Search Operation
-        const operation = new SearchTransactionOperation();
-
-        operation.fromState(this.props.reduxFilters);
-        const searchParams = operation.toParams();
-
-        // generate the API parameters
-        const apiParams = {
-            field: 'federal_action_obligation',
-            group: `funding_agency__${this.state.agencyScope}_agency__name`,
-            order: ['-aggregate'],
-            aggregate: 'sum',
-            filters: searchParams,
-            limit: 5,
-            page: this.state.page
-        };
-
-        if (auditTrail) {
-            apiParams.auditTrail = auditTrail;
-        }
-
-        this.apiRequest = SearchHelper.performTransactionsTotalSearch(apiParams);
-        this.apiRequest.promise
-            .then((res) => {
-                this.parseData(res.data);
-                this.apiRequest = null;
-            })
-            .catch(() => {
-                this.apiRequest = null;
-            });
     }
 
     fetchAccountAwards(auditTrail = null) {

--- a/tests/containers/search/visualizations/rank/SpendingByFundingAgencyVisualizationContainer-test.jsx
+++ b/tests/containers/search/visualizations/rank/SpendingByFundingAgencyVisualizationContainer-test.jsx
@@ -135,7 +135,7 @@ describe('SpendingByFundingAgencyVisualizationContainer', () => {
         };
 
         // mock the search helper to resolve with the mocked response
-        mockSearchHelper('performTransactionsTotalSearch', 'resolve', apiResponse);
+        mockSearchHelper('performFinancialAccountAggregation', 'resolve', apiResponse);
 
         const initialFilters = Object.assign({}, defaultFilters);
         const secondFilters = Object.assign({}, defaultFilters, {
@@ -200,7 +200,7 @@ describe('SpendingByFundingAgencyVisualizationContainer', () => {
             };
 
             // mock the search helper to resolve with the mocked response
-            mockSearchHelper('performTransactionsTotalSearch', 'resolve', apiResponse);
+            mockSearchHelper('performFinancialAccountAggregation', 'resolve', apiResponse);
             // mount the container
             const container =
                 mount(<SpendingByFundingAgencyVisualizationContainer
@@ -250,7 +250,7 @@ describe('SpendingByFundingAgencyVisualizationContainer', () => {
             };
 
             // mock the search helper to resolve with the mocked response
-            mockSearchHelper('performTransactionsTotalSearch', 'resolve', apiResponse);
+            mockSearchHelper('performFinancialAccountAggregation', 'resolve', apiResponse);
 
             // mount the container
             const container =
@@ -296,7 +296,7 @@ describe('SpendingByFundingAgencyVisualizationContainer', () => {
             };
 
             // mock the search helper to resolve with the mocked response
-            mockSearchHelper('performTransactionsTotalSearch', 'resolve', apiResponse);
+            mockSearchHelper('performFinancialAccountAggregation', 'resolve', apiResponse);
             // mount the container
             const container =
                 mount(<SpendingByFundingAgencyVisualizationContainer
@@ -342,7 +342,7 @@ describe('SpendingByFundingAgencyVisualizationContainer', () => {
             };
 
             // mock the search helper to resolve with the mocked response
-            mockSearchHelper('performTransactionsTotalSearch', 'resolve', apiResponse);
+            mockSearchHelper('performFinancialAccountAggregation', 'resolve', apiResponse);
             // mount the container
             const container =
                 mount(<SpendingByFundingAgencyVisualizationContainer

--- a/tests/containers/search/visualizations/rank/SpendingByFundingAgencyVisualizationContainer-test.jsx
+++ b/tests/containers/search/visualizations/rank/SpendingByFundingAgencyVisualizationContainer-test.jsx
@@ -135,7 +135,7 @@ describe('SpendingByFundingAgencyVisualizationContainer', () => {
         };
 
         // mock the search helper to resolve with the mocked response
-        mockSearchHelper('performFinancialAccountAggregation', 'resolve', apiResponse);
+        mockSearchHelper('performCategorySearch', 'resolve', apiResponse);
 
         const initialFilters = Object.assign({}, defaultFilters);
         const secondFilters = Object.assign({}, defaultFilters, {
@@ -200,7 +200,7 @@ describe('SpendingByFundingAgencyVisualizationContainer', () => {
             };
 
             // mock the search helper to resolve with the mocked response
-            mockSearchHelper('performFinancialAccountAggregation', 'resolve', apiResponse);
+            mockSearchHelper('performCategorySearch', 'resolve', apiResponse);
             // mount the container
             const container =
                 mount(<SpendingByFundingAgencyVisualizationContainer
@@ -250,7 +250,7 @@ describe('SpendingByFundingAgencyVisualizationContainer', () => {
             };
 
             // mock the search helper to resolve with the mocked response
-            mockSearchHelper('performFinancialAccountAggregation', 'resolve', apiResponse);
+            mockSearchHelper('performCategorySearch', 'resolve', apiResponse);
 
             // mount the container
             const container =
@@ -296,7 +296,7 @@ describe('SpendingByFundingAgencyVisualizationContainer', () => {
             };
 
             // mock the search helper to resolve with the mocked response
-            mockSearchHelper('performFinancialAccountAggregation', 'resolve', apiResponse);
+            mockSearchHelper('performCategorySearch', 'resolve', apiResponse);
             // mount the container
             const container =
                 mount(<SpendingByFundingAgencyVisualizationContainer
@@ -342,7 +342,7 @@ describe('SpendingByFundingAgencyVisualizationContainer', () => {
             };
 
             // mock the search helper to resolve with the mocked response
-            mockSearchHelper('performFinancialAccountAggregation', 'resolve', apiResponse);
+            mockSearchHelper('performCategorySearch', 'resolve', apiResponse);
             // mount the container
             const container =
                 mount(<SpendingByFundingAgencyVisualizationContainer


### PR DESCRIPTION
"Spending by Funding Agency" rank visualization will always use `/accounts/awards/total/` endpoint