### PR TITLE
Remove Subtier Funding Agency Filtering

### DIFF
--- a/src/js/containers/search/filters/AgencyListContainer.jsx
+++ b/src/js/containers/search/filters/AgencyListContainer.jsx
@@ -1,5 +1,5 @@
 /**
-* AgenciesListContainer.jsx
+* AgencyListContainer.jsx
 * Created by Emily Gullo 12/23/2016
 **/
 
@@ -107,8 +107,16 @@ export class AgencyListContainer extends React.Component {
         toptierAgencies = _.sortBy(toptierAgencies, 'title');
         subtierAgencies = _.sortBy(subtierAgencies, 'title');
 
-        // Combine groups, with toptier first, and select the top 10
-        agencies = _.slice(_.concat(toptierAgencies, subtierAgencies), 0, 10);
+        if (this.props.agencyType === 'Funding') {
+            // We don't allow users to filter by subtier Funding Agencies, so we return just
+            // the toptier agencies
+            agencies = toptierAgencies;
+        }
+        else {
+            // Otherwise, for filtering by Awarding Agency, we combine the toptier and subtier
+            // groups, with toptier first, and then return the top 10
+            agencies = _.slice(_.concat(toptierAgencies, subtierAgencies), 0, 10);
+        }
 
         this.setState({
             autocompleteAgencies: agencies


### PR DESCRIPTION
Within the Agency Filter:
- Removes the ability to filter on subtier **Funding** Agencies, only showing toptier Funding Agencies
- Leaves intact the ability to filter on subtier **Awarding** Agencies, showing both subtier and toptier Awarding Agencies