### PR TITLE
Spending By Funding Agency Visualization

### DIFF
--- a/src/js/components/search/visualizations/rank/RankVisualizationTitle.jsx
+++ b/src/js/components/search/visualizations/rank/RankVisualizationTitle.jsx
@@ -14,7 +14,6 @@ const propTypes = {
     currentSpendingBy: React.PropTypes.string
 };
 
-// TODO: Mike Bray - Add Funding Agency (funding_agency) as the 3rd item when backend ready
 const defaultProps = {
     fieldTypes: [
         {
@@ -24,6 +23,10 @@ const defaultProps = {
         {
             label: 'Awarding Agency',
             value: 'awarding_agency'
+        },
+        {
+            label: 'Funding Agency',
+            value: 'funding_agency'
         },
         {
             label: 'Recipient',

--- a/src/js/containers/search/visualizations/rank/SpendingByFundingAgencyVisualizationContainer.jsx
+++ b/src/js/containers/search/visualizations/rank/SpendingByFundingAgencyVisualizationContainer.jsx
@@ -151,7 +151,7 @@ export class SpendingByFundingAgencyVisualizationContainer extends React.Compone
         // generate the API parameters
         const apiParams = {
             field: 'transaction_obligated_amount',
-            group: `award__funding_agency__toptier_agency__name`,
+            group: 'treasury_account__funding_toptier_agency__name',
             order: ['-aggregate'],
             aggregate: 'sum',
             filters: searchParams,
@@ -181,10 +181,9 @@ export class SpendingByFundingAgencyVisualizationContainer extends React.Compone
         const searchParams = operation.toParams();
 
         // Generate the API parameters
-        // TODO: Mike Bray - Update group to the new Agency name linkage once it's available
         const apiParams = {
             field: 'obligations_incurred_by_program_object_class_cpe',
-            group: 'treasury_account__agency_id',
+            group: 'treasury_account__funding_toptier_agency__name',
             order: ['-aggregate'],
             aggregate: 'sum',
             filters: searchParams,


### PR DESCRIPTION
Re-enables option to view Spending By Funding Agency visualization using updated queries that group by the new `treasury_account__funding_toptier_agency__name` foreign key, linking TAS and Agency.