### PR TITLE
Update: CFDA key change

### DIFF
--- a/src/js/components/award/financialAssistance/FinancialAssistanceDetails.jsx
+++ b/src/js/components/award/financialAssistance/FinancialAssistanceDetails.jsx
@@ -24,7 +24,8 @@ export default class FinancialAssistanceDetails extends React.Component {
             place: "",
             typeDesc: "",
             programName: "",
-            programDesc: ""
+            programDesc: "",
+            cfdaOverflow: false
         };
 
         // bind functions
@@ -91,14 +92,36 @@ export default class FinancialAssistanceDetails extends React.Component {
         }
 
         // CFDA Data
-        // TODO: get program description (objectives) for latest transaction
-        const programName = `${latestTransaction.assistance_data.cfda_number} -
-        ${latestTransaction.assistance_data.cfda_title}`;
-        const programDescription = "Not Available";
+        let programName = 'Not Available';
+        let programDescription = 'Not Available';
+
+        if (latestTransaction.assistance_data.cfda) {
+            const cfda = latestTransaction.assistance_data.cfda;
+            if (cfda.program_number && cfda.program_title) {
+                programName = `${latestTransaction.assistance_data.cfda.program_number} - \
+${latestTransaction.assistance_data.cfda.program_title}`;
+            }
+            else if (cfda.program_number) {
+                programName = cfda.program_number;
+            }
+            else if (cfda.program_title) {
+                programName = cfda.program_title;
+            }
+
+            if (cfda.objectives) {
+                programDescription = cfda.objectives;
+            }
+        }
+
+        let cfdaOverflow = false;
+        if (programDescription.length > SummaryPageHelper.maxDescriptionCharacters) {
+            cfdaOverflow = true;
+        }
 
         this.setState({
             description,
             programName,
+            cfdaOverflow,
             date: popDate,
             place: popPlace,
             typeDesc: award.type_description,
@@ -136,7 +159,9 @@ export default class FinancialAssistanceDetails extends React.Component {
                                 value={this.state.programName} />
                             <DetailRow
                                 title="CFDA Program Description"
-                                value={this.state.programDesc} />
+                                value={this.state.programDesc}
+                                overflow={this.state.cfdaOverflow}
+                                maxChars={SummaryPageHelper.maxDescriptionCharacters} />
                         </tbody>
                     </table>
                 </div>

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -132,7 +132,8 @@ export class ResultsTableContainer extends React.Component {
             aggregate: 'count',
             group: 'type',
             field: 'total_obligation',
-            filters: searchParams.toParams()
+            filters: searchParams.toParams(),
+            auditTrail: 'Award table - tab counts'
         });
 
         this.tabCountRequest.promise

--- a/src/js/dataMapping/search/filterFields.js
+++ b/src/js/dataMapping/search/filterFields.js
@@ -62,8 +62,8 @@ export const transactionFields = {
     budgetFunctionTitle: 'award__financial_set__treasury_account__budget_function_title',
     budgetSubfunctionTitle: 'award__financial_set__treasury_account__budget_subfunction_title',
     federalAccount: 'award__financial_set__treasury_account__federal_account',
-    cfdaNumber: 'assistance_data__cfda_number',
-    cfdaTitle: 'assistance_data__cfda_title',
+    cfdaNumber: 'assistance_data__cfda__program_number',
+    cfdaTitle: 'assistance_data__cfda__program_title',
     naics: 'contract_data__naics',
     naicsDescription: 'contract_data__naics_description',
     psc: 'contract_data__product_or_service_code'
@@ -95,8 +95,8 @@ export const accountAwardsFields = {
     budgetFunctionTitle: 'treasury_account__budget_function_title',
     budgetSubfunctionTitle: 'treasury_account__budget_subfunction_title',
     federalAccount: 'treasury_account__federal_account',
-    cfdaNumber: 'award__transaction__assistance_data__cfda_number',
-    cfdaTitle: 'award__transaction__assistance_data__cfda_title',
+    cfdaNumber: 'award__transaction__assistance_data__cfda__program_number',
+    cfdaTitle: 'award__transaction__assistance_data__cfda__program_title',
     naics: 'award__transaction__contract_data__naics',
     naicsDescription: 'award__transaction__contract_data__naics_description',
     psc: 'award__transaction__contract_data__product_or_service_code'

--- a/tests/containers/search/visualizations/rank/SpendingByCFDAVisualizationContainer-test.jsx
+++ b/tests/containers/search/visualizations/rank/SpendingByCFDAVisualizationContainer-test.jsx
@@ -83,14 +83,14 @@ describe('SpendingByCFDAVisualizationContainer', () => {
                 {
                     item: '93.778',
                     aggregate: '66681011412.00',
-                    assistance_data__cfda_number: '93.778',
-                    assistance_data__cfda_title: 'Medical Assistance Program'
+                    assistance_data__cfda__program_number: '93.778',
+                    assistance_data__cfda__program_title: 'Medical Assistance Program'
                 },
                 {
                     item: '93.774',
                     aggregate: '152',
-                    assistance_data__cfda_number: '93.774',
-                    assistance_data__cfda_title: 'Medicare_Supplementary Medical Insurance'
+                    assistance_data__cfda__program_number: '93.774',
+                    assistance_data__cfda__program_title: 'Medicare_Supplementary Medical Insurance'
                 }
             ]
         };
@@ -131,14 +131,14 @@ describe('SpendingByCFDAVisualizationContainer', () => {
                 {
                     item: '93.778',
                     aggregate: '66681011412.00',
-                    award__transaction__assistance_data__cfda_number: '93.778',
-                    award__transaction__assistance_data__cfda_title: 'Medical Assistance Program'
+                    award__transaction__assistance_data__cfda__program_number: '93.778',
+                    award__transaction__assistance_data__cfda__program_title: 'Medical Assistance Program'
                 },
                 {
                     item: '93.774',
                     aggregate: '152',
-                    award__transaction__assistance_data__cfda_number: '93.774',
-                    award__transaction__assistance_data__cfda_title: 'Medicare_Supplementary Medical Insurance'
+                    award__transaction__assistance_data__cfda__program_number: '93.774',
+                    award__transaction__assistance_data__cfda__program_title: 'Medicare_Supplementary Medical Insurance'
                 }
             ]
         };
@@ -199,14 +199,14 @@ describe('SpendingByCFDAVisualizationContainer', () => {
                     {
                         item: '93.778',
                         aggregate: '66681011412.00',
-                        assistance_data__cfda_number: '93.778',
-                        assistance_data__cfda_title: 'Medical Assistance Program'
+                        assistance_data__cfda__program_number: '93.778',
+                        assistance_data__cfda__program_title: 'Medical Assistance Program'
                     },
                     {
                         item: '93.774',
                         aggregate: '152',
-                        assistance_data__cfda_number: '93.774',
-                        assistance_data__cfda_title: 'Medicare_Supplementary Medical Insurance'
+                        assistance_data__cfda__program_number: '93.774',
+                        assistance_data__cfda__program_title: 'Medicare_Supplementary Medical Insurance'
                     }
                 ]
             };


### PR DESCRIPTION
* Changes references to the API's `cfda_number` and `cfda_title` to `cfda__program_number` and `cfda__program_title`
* Adds in CFDA program description to the federal assistance page and allows the description to overflow as necessary