### PR TITLE
Update: API Route-Specific Versioning

### DIFF
--- a/sampleGlobalConstants_dev.js
+++ b/sampleGlobalConstants_dev.js
@@ -1,11 +1,13 @@
 // Development values
 const kGlobalConstants = {
-    API: '',
+    API: 'https://api.usaspending.gov/api/',
     LOCAL_ROOT: '',
     GITHUB: '',
     GA_TRACKING_ID: '',
     LOCAL: false,
-    DEV: true
+    DEV: true,
+    PERF_LOG: false,
+    MAPBOX_TOKEN: ''
 };
 
 export default kGlobalConstants;

--- a/sampleGlobalConstants_prod.js
+++ b/sampleGlobalConstants_prod.js
@@ -1,11 +1,13 @@
 // Production values
 const kGlobalConstants = {
-    API: '',
+    API: 'https://api.usaspending.gov/api/',
     LOCAL_ROOT: '',
     GITHUB: '',
     GA_TRACKING_ID: '',
     LOCAL: false,
-    DEV: false
+    DEV: false,
+    PERF_LOG: false,
+    MAPBOX_TOKEN: ''
 };
 
 export default kGlobalConstants;

--- a/src/js/helpers/accountHelper.js
+++ b/src/js/helpers/accountHelper.js
@@ -11,7 +11,7 @@ export const fetchFederalAccount = (id) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: `federal_accounts/${id}/`,
+            url: `v1/federal_accounts/${id}/`,
             baseURL: kGlobalConstants.API,
             method: 'get',
             cancelToken: source.token
@@ -27,7 +27,7 @@ export const fetchTasCategoryTotals = (data) => {
     return {
         promise: Axios.request({
             data,
-            url: '/tas/categories/total/',
+            url: 'v1/tas/categories/total/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             cancelToken: source.token
@@ -43,7 +43,7 @@ export const fetchTasBalanceTotals = (data) => {
     return {
         promise: Axios.request({
             data,
-            url: '/tas/balances/total/',
+            url: 'v1/tas/balances/total/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             cancelToken: source.token
@@ -59,7 +59,7 @@ export const fetchProgramActivities = (data) => {
     return {
         promise: Axios.request({
             data,
-            url: '/tas/categories/total/',
+            url: 'v1/tas/categories/total/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             cancelToken: source.token

--- a/src/js/helpers/accountQuartersHelper.js
+++ b/src/js/helpers/accountQuartersHelper.js
@@ -11,7 +11,7 @@ export const fetchFederalAccount = (id) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: `federal_accounts/${id}/`,
+            url: `v1/federal_accounts/${id}/`,
             baseURL: kGlobalConstants.API,
             method: 'get',
             cancelToken: source.token
@@ -27,7 +27,7 @@ export const fetchTasCategoryTotals = (data) => {
     return {
         promise: Axios.request({
             data,
-            url: '/tas/categories/quarters/total/',
+            url: 'v1/tas/categories/quarters/total/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             cancelToken: source.token
@@ -43,7 +43,7 @@ export const fetchTasBalanceTotals = (data) => {
     return {
         promise: Axios.request({
             data,
-            url: '/tas/balances/quarters/total/',
+            url: 'v1/tas/balances/quarters/total/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             cancelToken: source.token

--- a/src/js/helpers/downloadHelper.js
+++ b/src/js/helpers/downloadHelper.js
@@ -11,7 +11,7 @@ export const requestAwardTable = (params) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'download/awards/',
+            url: 'v1/download/awards/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             data: params,

--- a/src/js/helpers/guideHelper.js
+++ b/src/js/helpers/guideHelper.js
@@ -12,7 +12,7 @@ export const fetchAllTerms = () => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'references/guide/?limit=500',
+            url: 'v1/references/guide/?limit=500',
             baseURL: kGlobalConstants.API,
             method: 'get',
             cancelToken: source.token
@@ -27,7 +27,7 @@ export const fetchSearchResults = (params) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'references/guide/autocomplete/',
+            url: 'v1/references/guide/autocomplete/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             data: params,

--- a/src/js/helpers/searchHelper.js
+++ b/src/js/helpers/searchHelper.js
@@ -12,7 +12,7 @@ export const performSearch = (searchParams) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'awards/',
+            url: 'v1/awards/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             data: searchParams,
@@ -50,7 +50,7 @@ export const fetchAwardCounts = (params) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'awards/total/',
+            url: 'v1/awards/total/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             data: params,
@@ -67,7 +67,7 @@ export const fetchLocations = (req) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'references/locations/geocomplete/',
+            url: 'v1/references/locations/geocomplete/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             data: req,
@@ -84,7 +84,7 @@ export const fetchBudgetFunctions = (req) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'tas/autocomplete/',
+            url: 'v1/tas/autocomplete/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             data: req,
@@ -100,7 +100,7 @@ export const fetchFederalAccounts = (req) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'federal_accounts/autocomplete/',
+            url: 'v1/federal_accounts/autocomplete/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             data: req,
@@ -117,7 +117,7 @@ export const fetchAgencies = (req) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'references/agency/autocomplete/',
+            url: 'v1/references/agency/autocomplete/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             data: req,
@@ -134,7 +134,7 @@ export const fetchAward = (num) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: `awards/${num}/`,
+            url: `v1/awards/${num}/`,
             baseURL: kGlobalConstants.API,
             method: 'get',
             cancelToken: source.token
@@ -150,7 +150,7 @@ export const fetchAwardTransaction = (params) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: `transactions/`,
+            url: `v1/transactions/`,
             baseURL: kGlobalConstants.API,
             method: 'post',
             data: params,
@@ -167,7 +167,7 @@ export const fetchRecipients = (req) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'references/recipients/autocomplete/',
+            url: 'v1/references/recipients/autocomplete/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             data: req,
@@ -184,7 +184,7 @@ export const fetchAwardIDs = (params) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'awards/autocomplete/',
+            url: 'v1/awards/autocomplete/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             data: params,
@@ -201,7 +201,7 @@ export const performTransactionsTotalSearch = (params) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'transactions/total/',
+            url: 'v1/transactions/total/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             data: params,
@@ -219,7 +219,7 @@ export const performCategorySearch = (params) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'tas/categories/total/',
+            url: 'v1/tas/categories/total/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             data: params,
@@ -237,7 +237,7 @@ export const performBalancesSearch = (params) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'tas/balances/total/',
+            url: 'v1/tas/balances/total/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             data: params,
@@ -253,7 +253,7 @@ export const performFinancialAccountAggregation = (params) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'accounts/awards/total/',
+            url: 'v1/accounts/awards/total/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             data: params,
@@ -270,7 +270,7 @@ export const performFinancialSystemLookup = (params) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'accounts/awards/',
+            url: 'v1/accounts/awards/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             data: params,
@@ -287,7 +287,7 @@ export const performSubawardSearch = (data) => {
     return {
         promise: Axios.request({
             data,
-            url: '/subawards/',
+            url: 'v1/subawards/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             cancelToken: source.token
@@ -303,7 +303,7 @@ export const generateUrlHash = (data) => {
     return {
         promise: Axios.request({
             data,
-            url: '/references/filter/',
+            url: 'v1/references/filter/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             cancelToken: source.token
@@ -319,7 +319,7 @@ export const restoreUrlHash = (data) => {
     return {
         promise: Axios.request({
             data,
-            url: '/references/hash/',
+            url: 'v1/references/hash/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             cancelToken: source.token


### PR DESCRIPTION
* Moved API version number to the helper routes, so different routes can use different API versions while they are migrated to v2
* Update the sample configs with an empty mapbox token entry
* 🚨 YOU MUST update your config files to remove `v1/` from the API endpoint, it should still end with a slash though🚨 