### PR TITLE
Hotfix - Federal Account links in Safari behave as expected

### DIFF
--- a/src/_scss/pages/search/results/visualizations/rank/rankVisualization.scss
+++ b/src/_scss/pages/search/results/visualizations/rank/rankVisualization.scss
@@ -8,6 +8,17 @@
         .visualization-tooltip {
             @import "../../../../../components/visualizations/tooltip/_tooltip";
         }
+
+        .chart-groups a {
+            display: block;
+            position: relative;
+            z-index: 1;
+            pointer-events: all;
+
+            &:hover {
+                cursor: pointer;
+            }
+        }
     }
     .results-visualization-message {
         margin-top: rem(10);

--- a/src/js/components/search/visualizations/rank/chart/ChartGroup.jsx
+++ b/src/js/components/search/visualizations/rank/chart/ChartGroup.jsx
@@ -103,8 +103,8 @@ export default class ChartGroup extends React.Component {
     }
 
     clickedLabel() {
-        if (this.props.clickedGroup) {
-            this.props.clickedGroup(this.props.index);
+        if (this.props.linkID !== '') {
+            window.location = `${this.props.urlRoot}${this.props.linkID}`;
         }
     }
 


### PR DESCRIPTION
Fixes Safari SVG issue by adding a redirect when clicking/tapping the SVG text element, and not just the contents of that element. Will require adding `v1/` to `/federal_accounts/${id}/` and `tas/categories/total/` endpoints to test.