### PR TITLE
Fix - Budget Category dropdown alignment

### DIFF
--- a/src/_scss/elements/_titleSelector.scss
+++ b/src/_scss/elements/_titleSelector.scss
@@ -1,6 +1,6 @@
     .field-picker {
-        float: none!important;
-        @include clearfix;
+        float: left;
+        clear: none;
         .selected-button {
             @include button-unstyled;
             @extend h3;


### PR DESCRIPTION
- Aligns dropdown elements under the dropdown selector
- Doesn't break other areas where this class is used