### PR TITLE
Fix: Award Page React Errors

### DIFF
--- a/src/_scss/pages/award/table/detailsTable.scss
+++ b/src/_scss/pages/award/table/detailsTable.scss
@@ -25,4 +25,9 @@
     @import "./_subawards";
     @import "pages/search/results/table/_tableTypes";
     @import "pages/search/results/table/_resultsTablePicker";
+
+    .field-picker {
+        float: none;
+        display: block;
+    }
 }

--- a/src/js/components/award/details/DetailsSection.jsx
+++ b/src/js/components/award/details/DetailsSection.jsx
@@ -4,6 +4,7 @@
  **/
 
 import React from 'react';
+import { concat } from 'lodash';
 
 import ContractTransactionsTableContainer from
     'containers/award/table/ContractTransactionsTableContainer';
@@ -25,7 +26,7 @@ const propTypes = {
     clickTab: React.PropTypes.func
 };
 
-const tabs = [
+const commonTabs = [
     {
         label: 'Transaction History',
         internal: 'transaction',
@@ -110,6 +111,8 @@ export default class DetailsSection extends React.Component {
 
     render() {
         const content = this.currentSection();
+
+        const tabs = concat([], commonTabs);
 
         if (this.props.award.selectedAward.internal_general_type === 'contract') {
             tabs.push({


### PR DESCRIPTION
* Resolves React `key` errors on award page and associated memory leak.
    * This was caused by `tabs` array being moved to a scope outside of the component instance, which caused the Additional tab to be appended to the retained array on each render pass rather than re-instantiated each time
* Fixed a styling issue where the responsive mobile tabs floated behind the data tables, which prevented them from being clickable