### PR TITLE
Other Award Types

### DIFF
--- a/src/js/components/agency/visualizations/recipient/ScopeList.jsx
+++ b/src/js/components/agency/visualizations/recipient/ScopeList.jsx
@@ -68,9 +68,9 @@ export default class ScopeList extends React.Component {
                             </li>
                             <li className="coming-soon">
                                 <RankVisualizationScopeButton
-                                    value="insurance"
-                                    label="Insurance"
-                                    active={this.props.scope === 'insurance'}
+                                    value="other"
+                                    label="Other"
+                                    active={this.props.scope === 'other'}
                                     changeScope={this.props.changeScope}
                                     disabled />
                                 <ComingSoonLabel />

--- a/src/js/components/award/AwardAmounts.jsx
+++ b/src/js/components/award/AwardAmounts.jsx
@@ -69,7 +69,7 @@ export default class AwardAmounts extends React.Component {
             has been obligated.</p>);
 
         if (this.props.typeString === 'grant' || this.props.typeString === 'direct payment' ||
-        this.props.typeString === 'insurance') {
+        this.props.typeString === 'other') {
             awardNarrative = (<p>This {this.props.typeString} was awarded to&nbsp;
             <b className="recipient-name">{recipient}</b>
             &nbsp;for <b>{current}</b>.</p>);

--- a/src/js/components/search/filters/awardType/AwardType.jsx
+++ b/src/js/components/search/filters/awardType/AwardType.jsx
@@ -32,10 +32,9 @@ const defaultProps = {
             filters: awardTypeGroups.loans
         },
         {
-            id: 'award-insurance',
-            name: 'Insurance',
-            filters: [],
-            value: awardTypeGroups.insurance[0]
+            id: 'award-other',
+            name: 'Other',
+            filters: awardTypeGroups.other
         }
     ]
 };

--- a/src/js/components/search/topFilterBar/filterGroups/AwardTypeFilterGroup.jsx
+++ b/src/js/components/search/topFilterBar/filterGroups/AwardTypeFilterGroup.jsx
@@ -18,12 +18,13 @@ const propTypes = {
     redux: PropTypes.object
 };
 
-const groupKeys = ['contracts', 'grants', 'direct_payments', 'loans'];
+const groupKeys = ['contracts', 'grants', 'direct_payments', 'loans', 'other'];
 const groupLabels = {
     contracts: 'Contracts',
     grants: 'Grants',
     direct_payments: 'Direct Payments',
-    loans: 'Loans'
+    loans: 'Loans',
+    other: 'Other'
 };
 
 export default class AwardTypeFilterGroup extends React.Component {

--- a/src/js/containers/account/awards/AccountAwardsContainer.jsx
+++ b/src/js/containers/account/awards/AccountAwardsContainer.jsx
@@ -58,8 +58,8 @@ const tableTypes = [
         enabled: true
     },
     {
-        label: 'Insurance',
-        internal: 'insurance',
+        label: 'Other',
+        internal: 'other',
         enabled: true
     }
 ];

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -66,8 +66,8 @@ const tableTypes = [
         enabled: true
     },
     {
-        label: 'Insurance',
-        internal: 'insurance',
+        label: 'Other',
+        internal: 'other',
         enabled: true
     }
 ];

--- a/src/js/dataMapping/search/awardType.js
+++ b/src/js/dataMapping/search/awardType.js
@@ -18,7 +18,8 @@ export const awardTypeCodes = {
     '06': 'Direct Payment for Specified Use',
     '07': 'Direct Loans',
     '08': 'Guaranteed/Insured Loans',
-    '09': 'Insurance'
+    '09': 'Insurance',
+    '11': 'Other Financial Assistance'
 };
 /* eslint-enable quote-props */
 
@@ -27,5 +28,5 @@ export const awardTypeGroups = {
     grants: ['02', '03', '04', '05'],
     direct_payments: ['10', '06'],
     loans: ['07', '08'],
-    insurance: ['09']
+    other: ['09', '11']
 };

--- a/src/js/dataMapping/search/tableSearchFields.js
+++ b/src/js/dataMapping/search/tableSearchFields.js
@@ -423,7 +423,7 @@ const tableSearchFields = {
         funding_agency_name: 'Funding Agency',
         funding_subtier_name: 'Funding Sub-Agency'
     },
-    insurance: {
+    other: {
         _defaultSortField: 'total_obligation',
         _order: [
             'award_id',

--- a/src/js/helpers/summaryPageHelper.js
+++ b/src/js/helpers/summaryPageHelper.js
@@ -21,8 +21,8 @@ export const awardType = (code) => {
     else if (includes(awardTypeGroups.loans, code)) {
         type = "loan";
     }
-    else if (includes(awardTypeGroups.insurance, code)) {
-        type = "insurance";
+    else if (includes(awardTypeGroups.other, code)) {
+        type = "other";
     }
 
     return type;

--- a/src/js/redux/reducers/search/columnVisibilityReducerInitialState.js
+++ b/src/js/redux/reducers/search/columnVisibilityReducerInitialState.js
@@ -149,7 +149,7 @@ const initialState = {
             ]
         )
     },
-    insurance: {
+    other: {
         visibleColumns: new OrderedSet(
             [
                 'award_id',

--- a/tests/redux/reducers/search/columnVisibilityReducer-test.js
+++ b/tests/redux/reducers/search/columnVisibilityReducer-test.js
@@ -368,7 +368,7 @@ describe('columnVisibilityReducer', () => {
                         ]
                     )
                 },
-                insurance: {
+                other: {
                     visibleColumns: new OrderedSet(
                         [
                             'award_id',
@@ -553,7 +553,7 @@ describe('columnVisibilityReducer', () => {
                         ]
                     )
                 },
-                insurance: {
+                other: {
                     visibleColumns: new OrderedSet(
                         [
                             'award_id',


### PR DESCRIPTION
- User can see "Other" is a top-level option in the Award Type filter, with "Insurance" and "Other Financial Assistance" as children (https://projects.invisionapp.com/share/XHB29AYB3#/screens/205404741_USA_Spending_Search)
- User can see "Other" as an option in the tabs above the award table on the Search/Download and Federal Account pages, replacing "Insurance"
- User can see "Other" as a future option in the Agency Page Rank Visualization, replacing "Insurance"