### PR TITLE
Fix filter removal icons on IE

### DIFF
--- a/src/_scss/elements/filters/_selectedFilterBtn.scss
+++ b/src/_scss/elements/filters/_selectedFilterBtn.scss
@@ -38,6 +38,9 @@
             cursor: pointer;
             @include transition(all 0.25s $ease-in-out-sine);
             & .close {
+                cursor: pointer;
+                fill: $color-cool-blue;
+                
                 & svg,
                 & path {
                     cursor: pointer;

--- a/src/_scss/elements/filters/_selectedFilterBtn.scss
+++ b/src/_scss/elements/filters/_selectedFilterBtn.scss
@@ -38,7 +38,8 @@
             cursor: pointer;
             @include transition(all 0.25s $ease-in-out-sine);
             & .close {
-                & svg {
+                & svg,
+                & path {
                     cursor: pointer;
                     fill: $color-cool-blue;
                 }

--- a/src/_scss/elements/filters/_selectedFilterBtn.scss
+++ b/src/_scss/elements/filters/_selectedFilterBtn.scss
@@ -28,6 +28,7 @@
             vertical-align: middle;
             & svg {
                 width: rem(8);
+                height: rem(8);
                 fill: $color-gray;
             }
         }

--- a/src/_scss/pages/search/topFilterBar/_tag.scss
+++ b/src/_scss/pages/search/topFilterBar/_tag.scss
@@ -3,6 +3,7 @@
     margin-right: 6px;
 
     .filter-item {
+        @include button-unstyled();
         display: table;
         margin-top: 0.5rem;
         margin-bottom: 0.5rem;
@@ -12,9 +13,16 @@
         @include border-top-radius(4px);
         @include border-bottom-radius(4px);
 
+        font-size: $smallest-font-size;
+
+        &:hover, &:active {
+            background-color: $color-white;
+        }
+
         .filter-item-title {
             color: $color-gray;
             display: table-cell;
+            vertical-align: middle;
         }
 
         .filter-item-remove-container {
@@ -22,15 +30,14 @@
             vertical-align: middle;
 
             .filter-remove {
-                @include button-unstyled();
                 margin-left: 10px;
-                width: 10px;
-                height: 14px;
+                width: rem(8);
+                height: rem(8);
                 
                 .close-icon {
                     svg {
-                        height: 8px;
-                        width: 8px;
+                        height: rem(8);
+                        width: rem(8);
                         fill: $color-gray;
                     }
                 }

--- a/src/js/components/search/topFilterBar/TopFilterItem.jsx
+++ b/src/js/components/search/topFilterBar/TopFilterItem.jsx
@@ -33,25 +33,25 @@ export default class TopFilterItem extends React.Component {
 
         return (
             <div className="filter-item-container">
-                <div className="filter-item">
+                <button
+                    className="filter-item"
+                    aria-label={accessibleLabel}
+                    title={accessibleLabel}
+                    onClick={this.clickedButton}>
                     <div className="filter-item-title">
                         {this.props.title}
                     </div>
                     <div className="filter-item-remove-container">
-                        <button
-                            className="filter-remove"
-                            aria-label={accessibleLabel}
-                            title={accessibleLabel}
-                            onClick={this.clickedButton}>
+                        <div className="filter-remove">
                             <span className="sr-only">
                                 {accessibleLabel}
                             </span>
                             <span className="close-icon">
                                 <Icons.Close alt={accessibleLabel} />
                             </span>
-                        </button>
+                        </div>
                     </div>
-                </div>
+                </button>
             </div>
         );
     }


### PR DESCRIPTION
* Also standardizes behavior of the filter badges between top filter bar and sidebar (previously, top bar required clicking the X to remove while the entire badge removed the filter in the sidebar; both now will remove if the badge is clicked due to the small size of the X)


![screen shot 2017-08-01 at 4 04 37 pm](https://user-images.githubusercontent.com/3594363/28844676-721218c6-76d3-11e7-9ffe-744c467b7905.png)
