### PR TITLE
Sidebar Remix

### DIFF
--- a/src/js/components/search/SearchPage.jsx
+++ b/src/js/components/search/SearchPage.jsx
@@ -17,7 +17,8 @@ import SearchSidebar from './SearchSidebar';
 import SearchResults from './SearchResults';
 
 const propTypes = {
-    clearAllFilters: PropTypes.func
+    clearAllFilters: PropTypes.func,
+    filters: PropTypes.object
 };
 
 export default class SearchPage extends React.Component {
@@ -219,7 +220,7 @@ export default class SearchPage extends React.Component {
     }
 
     render() {
-        let fullSidebar = (<SearchSidebar />);
+        let fullSidebar = (<SearchSidebar filters={this.props.filters} />);
         if (this.state.isMobile) {
             fullSidebar = null;
         }

--- a/src/js/components/search/SearchSidebar.jsx
+++ b/src/js/components/search/SearchSidebar.jsx
@@ -10,8 +10,6 @@ import AwardTypeContainer from 'containers/search/filters/AwardTypeContainer';
 import TimePeriodContainer from 'containers/search/filters/TimePeriodContainer';
 import AgencyContainer from 'containers/search/filters/AgencyContainer';
 import LocationSearchContainer from 'containers/search/filters/location/LocationSearchContainer';
-import BudgetCategorySearchContainer
-    from 'containers/search/filters/budgetCategory/BudgetCategorySearchContainer';
 import RecipientSearchContainer from 'containers/search/filters/recipient/RecipientSearchContainer';
 import KeywordContainer from 'containers/search/filters/KeywordContainer';
 import AwardIDSearchContainer from 'containers/search/filters/awardID/AwardIDSearchContainer';
@@ -27,25 +25,23 @@ const filters = {
     options: [
         'Search',
         'Time Period',
-        'Place of Performance',
-        'Budget Categories',
+        'Award Type',
         'Agencies',
         'Recipients',
-        'Award Type',
-        'Award ID',
+        'Place of Performance',
         'Award Amount',
+        'Award ID',
         'Other Award Items'
     ],
     components: [
         KeywordContainer,
         TimePeriodContainer,
-        LocationSearchContainer,
-        BudgetCategorySearchContainer,
+        AwardTypeContainer,
         AgencyContainer,
         RecipientSearchContainer,
-        AwardTypeContainer,
-        AwardIDSearchContainer,
+        LocationSearchContainer,
         AwardAmountSearchContainer,
+        AwardIDSearchContainer,
         OtherFilters
     ]
 };
@@ -62,13 +58,8 @@ export default class SearchSidebar extends React.Component {
     render() {
         const expanded = [];
         filters.options.forEach(() => {
-            // collapse if mobile, otherwise expand
-            if (this.props.mobile) {
-                expanded.push(false);
-            }
-            else {
-                expanded.push(true);
-            }
+            // Collapse all by default
+            expanded.push(false);
         });
 
         let mobileHeader = null;

--- a/src/js/components/search/SearchSidebar.jsx
+++ b/src/js/components/search/SearchSidebar.jsx
@@ -20,6 +20,7 @@ import OtherFilters from 'components/search/filters/otherFilters/OtherFilters';
 import { Filter as FilterIcon } from 'components/sharedComponents/icons/Icons';
 import FilterSidebar from 'components/sharedComponents/filterSidebar/FilterSidebar';
 import MobileFilterHeader from 'components/search/mobile/MobileFilterHeader';
+import * as SidebarHelper from 'helpers/sidebarHelper';
 
 const filters = {
     options: [
@@ -56,82 +57,11 @@ const defaultProps = {
 };
 
 export default class SearchSidebar extends React.Component {
-    constructor(props) {
-        super(props);
-
-        this.filterHasSelections.bind(this);
-    }
-
-    filterHasSelections(filter) {
-        switch (filter) {
-            case 'Search':
-                if (this.props.filters.keyword !== '') {
-                    return true;
-                }
-                return false;
-            case 'Time Period':
-                if (this.props.filters.timePeriodFY.toArray().length > 0
-                    || (this.props.filters.timePeriodRange
-                        && this.props.filters.timePeriodRange.toArray().length === 2)) {
-                    return true;
-                }
-                return false;
-            case 'Award Type':
-                if (this.props.filters.awardType.toArray().length > 0) {
-                    return true;
-                }
-                return false;
-            case 'Agencies':
-                if (this.props.filters.selectedFundingAgencies.toArray().length > 0
-                    || this.props.filters.selectedAwardingAgencies.toArray().length > 0) {
-                    return true;
-                }
-                return false;
-            case 'Recipients':
-                if (this.props.filters.selectedRecipients.toArray().length > 0
-                    || (this.props.filters.recipientDomesticForeign !== ''
-                        && this.props.filters.recipientDomesticForeign !== 'all')
-                    || this.props.filters.selectedRecipientLocations.toArray().length > 0
-                    || this.props.filters.recipientType.toArray().length > 0) {
-                    return true;
-                }
-                return false;
-            case 'Place of Performance':
-                if (this.props.filters.selectedLocations.toArray().length > 0
-                    || (this.props.filters.locationDomesticForeign !== ''
-                    && this.props.filters.locationDomesticForeign !== 'all')) {
-                    return true;
-                }
-                return false;
-            case 'Award Amount':
-                if (this.props.filters.awardAmounts.toArray().length > 0) {
-                    return true;
-                }
-                return false;
-            case 'Award ID':
-                if (this.props.filters.selectedAwardIDs.toArray().length > 0) {
-                    return true;
-                }
-                return false;
-                // Todo - Mike Bray - Add remaining Other Award Items and convert to individual
-                // statements when available
-            case 'Other Award Items':
-                if (this.props.filters.selectedCFDA.toArray().length > 0
-                    || this.props.filters.selectedNAICS.toArray().length > 0
-                    || this.props.filters.selectedPSC.toArray().length > 0) {
-                    return true;
-                }
-                return false;
-            default:
-                return false;
-        }
-    }
-
     render() {
         const expanded = [];
         filters.options.forEach((filter) => {
             // Collapse all by default, unless the filter has a selection made
-            expanded.push(this.filterHasSelections(filter));
+            expanded.push(SidebarHelper.filterHasSelections(this.props.filters, filter));
         });
 
         let mobileHeader = null;

--- a/src/js/components/search/SearchSidebar.jsx
+++ b/src/js/components/search/SearchSidebar.jsx
@@ -47,7 +47,8 @@ const filters = {
 };
 
 const propTypes = {
-    mobile: PropTypes.bool
+    mobile: PropTypes.bool,
+    filters: PropTypes.object
 };
 
 const defaultProps = {
@@ -55,11 +56,82 @@ const defaultProps = {
 };
 
 export default class SearchSidebar extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.filterHasSelections.bind(this);
+    }
+
+    filterHasSelections(filter) {
+        switch (filter) {
+            case 'Search':
+                if (this.props.filters.keyword !== '') {
+                    return true;
+                }
+                return false;
+            case 'Time Period':
+                if (this.props.filters.timePeriodFY.toArray().length > 0
+                    || (this.props.filters.timePeriodRange
+                        && this.props.filters.timePeriodRange.toArray().length === 2)) {
+                    return true;
+                }
+                return false;
+            case 'Award Type':
+                if (this.props.filters.awardType.toArray().length > 0) {
+                    return true;
+                }
+                return false;
+            case 'Agencies':
+                if (this.props.filters.selectedFundingAgencies.toArray().length > 0
+                    || this.props.filters.selectedAwardingAgencies.toArray().length > 0) {
+                    return true;
+                }
+                return false;
+            case 'Recipients':
+                if (this.props.filters.selectedRecipients.toArray().length > 0
+                    || (this.props.filters.recipientDomesticForeign !== ''
+                        && this.props.filters.recipientDomesticForeign !== 'all')
+                    || this.props.filters.selectedRecipientLocations.toArray().length > 0
+                    || this.props.filters.recipientType.toArray().length > 0) {
+                    return true;
+                }
+                return false;
+            case 'Place of Performance':
+                if (this.props.filters.selectedLocations.toArray().length > 0
+                    || (this.props.filters.locationDomesticForeign !== ''
+                    && this.props.filters.locationDomesticForeign !== 'all')) {
+                    return true;
+                }
+                return false;
+            case 'Award Amount':
+                if (this.props.filters.awardAmounts.toArray().length > 0) {
+                    return true;
+                }
+                return false;
+            case 'Award ID':
+                if (this.props.filters.selectedAwardIDs.toArray().length > 0) {
+                    return true;
+                }
+                return false;
+                // Todo - Mike Bray - Add remaining Other Award Items and convert to individual
+                // statements when available
+            case 'Other Award Items':
+                if (this.props.filters.selectedCFDA.toArray().length > 0
+                    || this.props.filters.selectedNAICS.toArray().length > 0
+                    || this.props.filters.selectedPSC.toArray().length > 0) {
+                    return true;
+                }
+                return false;
+            default:
+                return false;
+        }
+    }
+
     render() {
         const expanded = [];
-        filters.options.forEach(() => {
-            // Collapse all by default
-            expanded.push(false);
+        filters.options.forEach((filter) => {
+            // Collapse all by default, unless the filter has a selection made
+            expanded.push(this.filterHasSelections(filter));
         });
 
         let mobileHeader = null;

--- a/src/js/components/sharedComponents/filterSidebar/FilterOption.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterOption.jsx
@@ -55,6 +55,23 @@ export default class FilterOption extends React.Component {
         }
     }
 
+    componentWillUpdate(nextProps) {
+        if (nextProps.defaultExpand !== this.props.defaultExpand) {
+            if (nextProps.defaultExpand) {
+                this.setState({
+                    showFilter: true,
+                    arrowState: 'expanded'
+                });
+            }
+            else {
+                this.setState({
+                    showFilter: false,
+                    arrowState: 'collapsed'
+                });
+            }
+        }
+    }
+
     toggleFilter(e) {
         e.preventDefault();
 

--- a/src/js/containers/search/SearchContainer.jsx
+++ b/src/js/containers/search/SearchContainer.jsx
@@ -294,7 +294,8 @@ export class SearchContainer extends React.Component {
         return (
             <SearchPage
                 hash={this.props.params.hash}
-                clearAllFilters={this.props.clearAllFilters} />
+                clearAllFilters={this.props.clearAllFilters}
+                filters={this.props.filters} />
         );
     }
 }

--- a/src/js/helpers/sidebarHelper.js
+++ b/src/js/helpers/sidebarHelper.js
@@ -1,0 +1,70 @@
+/**
+ * Created by michaelbray on 8/9/17.
+ */
+
+/* eslint-disable default-export */
+export const filterHasSelections = (reduxFilters, filter) => {
+    switch (filter) {
+        case 'Search':
+            if (reduxFilters.keyword !== '') {
+                return true;
+            }
+            return false;
+        case 'Time Period':
+            if (reduxFilters.timePeriodFY.toArray().length > 0
+                || (reduxFilters.timePeriodRange
+                && reduxFilters.timePeriodRange.toArray().length === 2)) {
+                return true;
+            }
+            return false;
+        case 'Award Type':
+            if (reduxFilters.awardType.toArray().length > 0) {
+                return true;
+            }
+            return false;
+        case 'Agencies':
+            if (reduxFilters.selectedFundingAgencies.toArray().length > 0
+                || reduxFilters.selectedAwardingAgencies.toArray().length > 0) {
+                return true;
+            }
+            return false;
+        case 'Recipients':
+            if (reduxFilters.selectedRecipients.toArray().length > 0
+                || (reduxFilters.recipientDomesticForeign !== ''
+                && reduxFilters.recipientDomesticForeign !== 'all')
+                || reduxFilters.selectedRecipientLocations.toArray().length > 0
+                || reduxFilters.recipientType.toArray().length > 0) {
+                return true;
+            }
+            return false;
+        case 'Place of Performance':
+            if (reduxFilters.selectedLocations.toArray().length > 0
+                || (reduxFilters.locationDomesticForeign !== ''
+                && reduxFilters.locationDomesticForeign !== 'all')) {
+                return true;
+            }
+            return false;
+        case 'Award Amount':
+            if (reduxFilters.awardAmounts.toArray().length > 0) {
+                return true;
+            }
+            return false;
+        case 'Award ID':
+            if (reduxFilters.selectedAwardIDs.toArray().length > 0) {
+                return true;
+            }
+            return false;
+        // Todo - Mike Bray - Add remaining Other Award Items and convert to individual
+        // statements when available
+        case 'Other Award Items':
+            if (reduxFilters.selectedCFDA.toArray().length > 0
+                || reduxFilters.selectedNAICS.toArray().length > 0
+                || reduxFilters.selectedPSC.toArray().length > 0) {
+                return true;
+            }
+            return false;
+        default:
+            return false;
+    }
+};
+/* eslint-enable default-export */


### PR DESCRIPTION
- Sidebar filters are now collapsed by default on *both* desktop and mobile
- Removed Budget Categories sidebar filter, reclassifying Funding Agency and Fiscal Year as Award-type filters, leaving only Award-type filters in the Sidebar
- Reorders the Sidebar filters in the order of most-used:
  - Keywords
  - Time Period
  - Award Types
  - Agencies
  - Recipients
  - Place of Performance
  - Award Amount
  - Award ID
  - [Other Awards Items]
- Other Award Items will be broken out into individual top-level sidebar containers in a following PR from @ejgullo 