### PR TITLE
Add federal account column to award detail pages

### DIFF
--- a/src/js/components/award/table/FinancialSystemTable.jsx
+++ b/src/js/components/award/table/FinancialSystemTable.jsx
@@ -14,6 +14,7 @@ import tableMapping from 'dataMapping/contracts/financialSystem';
 
 import FinSysHeaderCellContainer from 'containers/award/table/cells/FinSysHeaderCellContainer';
 import FinSysGenericCell from './cells/FinSysGenericCell';
+import FinSysAccountCell from './cells/FinSysAccountCell';
 import SummaryPageTableMessage from './SummaryPageTableMessage';
 
 const rowHeight = 40;
@@ -94,6 +95,11 @@ export default class FinancialSystemTable extends React.Component {
             const apiKey = tableMapping.table._mapping[column];
             const defaultSort = tableMapping.defaultSortDirection[column];
 
+            let CellComponent = FinSysGenericCell;
+            if (column === 'fedAccount') {
+                CellComponent = FinSysAccountCell;
+            }
+
             return {
                 width: columnWidth,
                 name: column,
@@ -106,7 +112,7 @@ export default class FinancialSystemTable extends React.Component {
                     isLastColumn={isLast} />),
                 cell: (index) => {
                     const item = this.props.award.finSysData[index];
-                    return (<FinSysGenericCell
+                    return (<CellComponent
                         key={`cell-transaction-${column}-${index}`}
                         rowIndex={index}
                         id={item.id}

--- a/src/js/components/award/table/cells/FinSysAccountCell.jsx
+++ b/src/js/components/award/table/cells/FinSysAccountCell.jsx
@@ -1,0 +1,48 @@
+/**
+ * FinSysAccountCell.jsx
+ * Created by Kevin Li 3/7/17
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+    data: PropTypes.object,
+    rowIndex: PropTypes.number,
+    column: PropTypes.string,
+    isLastColumn: PropTypes.bool
+};
+
+export default class FinSysAccountCell extends React.Component {
+    render() {
+        // cell needs to have some content or it will collapse
+        // replace with a &nbsp; if there's no data
+        let content = (<a href={`#/federal_account/${this.props.data.id}`}>
+            {this.props.data.title}
+        </a>);
+        if (!content) {
+            content = "\u00A0";
+        }
+
+        // calculate even-odd class names
+        let rowClass = 'row-even';
+        if (this.props.rowIndex % 2 === 0) {
+            // row index is zero-based
+            rowClass = 'row-odd';
+        }
+
+        if (this.props.isLastColumn) {
+            rowClass += ' last-column';
+        }
+
+        return (
+            <div className={`financial-system-generic-cell column-${this.props.column} ${rowClass}`}>
+                <div className="cell-content">
+                    {content}
+                </div>
+            </div>
+        );
+    }
+}
+
+FinSysAccountCell.propTypes = propTypes;

--- a/src/js/dataMapping/contracts/financialSystem.js
+++ b/src/js/dataMapping/contracts/financialSystem.js
@@ -6,6 +6,7 @@
 const tableFields = {
     columnWidths: {
         submissionDate: 0,
+        fedAccount: 0,
         tas: 0,
         programActivity: 300,
         objectClass: 300,
@@ -13,6 +14,7 @@ const tableFields = {
     },
     defaultSortDirection: {
         submissionDate: 'desc',
+        fedAccount: 'asc',
         tas: 'desc',
         programActivity: 'asc',
         objectClass: 'asc',
@@ -29,6 +31,7 @@ const tableFields = {
         ],
         _order: [
             'submissionDate',
+            'fedAccount',
             'tas',
             'programActivity',
             'objectClass',
@@ -36,6 +39,7 @@ const tableFields = {
         ],
         _sortFields: {
             submissionDate: 'certified_date',
+            fedAccount: 'treasury_account__federal_account__account_title',
             tas: 'treasury_account__tas_rendering_label',
             programActivity: 'program_activity__program_activity_name',
             objectClass: 'object_class__object_class_name',
@@ -43,13 +47,15 @@ const tableFields = {
         },
         _mapping: {
             submissionDate: 'submissionDate',
+            fedAccount: 'fedAccount',
             tas: 'tas',
             programActivity: 'programActivity',
             objectClass: 'objectClass',
             fundingObligated: 'fundingObligated'
         },
         submissionDate: 'Submission Date',
-        tas: 'TAS',
+        fedAccount: 'Federal Account Name',
+        tas: 'Treasury Account Symbol',
         programActivity: 'Program Activity',
         objectClass: 'Object Class',
         fundingObligated: 'Funding Obligated'

--- a/src/js/models/results/other/FinancialSystemItem.js
+++ b/src/js/models/results/other/FinancialSystemItem.js
@@ -13,6 +13,7 @@ const recordType = 'finsys';
 const fields = [
     'id',
     'submissionDate',
+    'fedAccount',
     'tas',
     'objectClass',
     'programActivity',
@@ -26,6 +27,10 @@ const remapData = (data) => {
     const remappedData = data;
 
     remappedData.submissionDate = '';
+    remappedData.fedAccount = {
+        title: '',
+        id: 0
+    };
     remappedData.tas = '';
     remappedData.objectClass = '';
     remappedData.programActivity = '';
@@ -43,6 +48,12 @@ const remapData = (data) => {
         const tAccount = data.treasury_account;
         if (tAccount.tas_rendering_label) {
             remappedData.tas = tAccount.tas_rendering_label;
+            if (tAccount.federal_account) {
+                remappedData.fedAccount = {
+                    title: tAccount.federal_account.account_title,
+                    id: tAccount.federal_account.id
+                };
+            }
         }
 
         if (tAccount.budget_function_title && tAccount.budget_function_code) {


### PR DESCRIPTION
* Financial System Details table on individual award pages now has a federal account column
* Federal account column shows the name of the column and links to the federal account page