### PR TITLE
Agency Page design updates

### DIFF
--- a/src/_scss/pages/agency/_section.scss
+++ b/src/_scss/pages/agency/_section.scss
@@ -7,7 +7,7 @@
         @include justify-content(center);
         width: 100%;
         position: relative;
-        margin: rem(100) 0 rem(60);
+        margin: rem(60) 0 rem(60);
         padding: 0 rem(63);
         color: $color-base;
         font-family: $font-sans;
@@ -23,10 +23,18 @@
             line-height: rem(47);
             margin: rem(5) 0;
         }
+	    em {
+		    font-size: rem(12);
+	    }
     }
 
     .agency-section-content {
         @import "pages/homepage/treemapSection";
+
+	    .agency-viz-description {
+		    margin-top: rem(20);
+		    font-size: rem(12);
+	    }
 
         .usa-da-treemap-section {
             background: white;
@@ -68,6 +76,20 @@
             color: $color-gray;
             font-size: rem(12);
             line-height: $base-line-height;
+
+	        .info-icon-circle {
+		        @include align-self(center);
+		        display: inline-block;
+		        fill: $color-gray;
+		        height: rem(17);
+		        left: rem(5);
+		        position: relative;
+		        top: rem(3);
+		        width: rem(15);
+	        }
+	        span {
+		        margin-left: rem(10);
+	        }
 
             .back {
                 color: $color-gray;

--- a/src/_scss/pages/agency/visualizations/_obligated.scss
+++ b/src/_scss/pages/agency/visualizations/_obligated.scss
@@ -1,14 +1,4 @@
-.agency-obligated-wrapper {
-    margin-top: rem(15);
-
-    .agency-obligated-title {
-        h4 {
-            font-size: rem(38);
-            line-height: rem(47);
-            margin: rem(5) 0;
-        }
-    }
-
+.agency-section-wrapper {
     .agency-obligated-content {
         text-align: center;
         .fy-text {

--- a/src/_scss/pages/agency/visualizations/federalAccount/federalAccount.scss
+++ b/src/_scss/pages/agency/visualizations/federalAccount/federalAccount.scss
@@ -16,5 +16,17 @@
         .visualization-tooltip {
             @import "components/visualizations/tooltip/_tooltip";
         }
+
+	    .horizontal-bar {
+		    height: rem(15);
+		    .legend-container {
+			    color: $color-gray-medium;
+			    .key-label {
+				    font-size: rem(12);
+			    }
+		    }
+	    }
+
+
     }
 }

--- a/src/_scss/pages/agency/visualizations/recipient/recipient.scss
+++ b/src/_scss/pages/agency/visualizations/recipient/recipient.scss
@@ -18,6 +18,16 @@
             @import "components/visualizations/tooltip/_tooltip";
         }
 
+	    .horizontal-bar {
+		    height: rem(15);
+		    .legend-container {
+			    color: $color-gray-medium;
+			    .key-label {
+				    font-size: rem(12);
+			    }
+		    }
+	    }
+
         @import "pages/search/results/visualizations/rank/_pager";
         .visualization-pager-container {
             @include display(flex);

--- a/src/js/components/agency/AgencyContent.jsx
+++ b/src/js/components/agency/AgencyContent.jsx
@@ -43,7 +43,8 @@ const agencySections = [
 ];
 
 const propTypes = {
-    agency: PropTypes.object
+    agency: PropTypes.object,
+    lastUpdate: PropTypes.string
 };
 
 export default class AgencyContent extends React.Component {
@@ -249,7 +250,8 @@ export default class AgencyContent extends React.Component {
                             asOfDate={asOfDate} />
                         <RecipientContainer
                             id={this.props.agency.id}
-                            activeFY={this.props.agency.overview.activeFY} />
+                            activeFY={this.props.agency.overview.activeFY}
+                            lastUpdate={this.props.lastUpdate} />
                     </div>
                     <AgencyFooterContainer id={this.props.agency.id} />
                 </div>

--- a/src/js/components/agency/AgencyContent.jsx
+++ b/src/js/components/agency/AgencyContent.jsx
@@ -7,6 +7,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { find, throttle } from 'lodash';
 import { scrollToY } from 'helpers/scrollToHelper';
+import moment from 'moment';
+import { convertQuarterToDate } from 'helpers/fiscalYearHelper';
 
 import ObjectClassContainer from 'containers/agency/visualizations/ObjectClassContainer';
 import RecipientContainer from 'containers/agency/visualizations/RecipientContainer';
@@ -213,6 +215,10 @@ export default class AgencyContent extends React.Component {
     }
 
     render() {
+        const qtr = parseFloat(this.props.agency.overview.activeFQ);
+        const endOfQuarter = convertQuarterToDate(qtr, this.props.agency.overview.activeFY);
+        const asOfDate = moment(endOfQuarter, "YYYY-MM-DD").format("MMMM D, YYYY");
+
         return (
             <div className="agency-content-wrapper">
                 <div className="agency-sidebar">
@@ -230,14 +236,17 @@ export default class AgencyContent extends React.Component {
                             agencyName={this.props.agency.overview.name}
                             activeFY={this.props.agency.overview.activeFY}
                             activeQuarter={this.props.agency.overview.activeFQ}
-                            id={this.props.agency.id} />
+                            id={this.props.agency.id}
+                            asOfDate={asOfDate} />
                         <ObjectClassContainer
                             id={this.props.agency.id}
-                            activeFY={this.props.agency.overview.activeFY} />
+                            activeFY={this.props.agency.overview.activeFY}
+                            asOfDate={asOfDate} />
                         <FederalAccountContainer
                             id={this.props.agency.id}
                             activeFY={this.props.agency.overview.activeFY}
-                            obligatedAmount={this.props.agency.overview.obligatedAmount} />
+                            obligatedAmount={this.props.agency.overview.obligatedAmount}
+                            asOfDate={asOfDate} />
                         <RecipientContainer
                             id={this.props.agency.id}
                             activeFY={this.props.agency.overview.activeFY} />

--- a/src/js/components/agency/AgencyPage.jsx
+++ b/src/js/components/agency/AgencyPage.jsx
@@ -23,7 +23,8 @@ const propTypes = {
     loading: PropTypes.bool,
     error: PropTypes.bool,
     id: PropTypes.string,
-    agency: PropTypes.object
+    agency: PropTypes.object,
+    lastUpdate: PropTypes.string
 };
 
 export default class AgencyPage extends React.Component {

--- a/src/js/components/agency/visualizations/federalAccount/FederalAccountChart.jsx
+++ b/src/js/components/agency/visualizations/federalAccount/FederalAccountChart.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import HorizontalChart from 'components/search/visualizations/rank/chart/HorizontalChart';
+import BarChartLegend from 'components/search/visualizations/time/chart/BarChartLegend';
 
 import FederalAccountTooltip from './FederalAccountTooltip';
 
@@ -67,7 +68,16 @@ export default class FederalAccountChart extends React.Component {
             isLoading = 'loading-visualization';
         }
 
+        const legend = [
+            {
+                color: '#597785',
+                label: 'Obligated Amounts',
+                offset: 0
+            }
+        ];
+
         return (
+
             <div className={isLoading}>
                 <HorizontalChart
                     labelSeries={this.props.labelSeries}
@@ -81,6 +91,11 @@ export default class FederalAccountChart extends React.Component {
                     selectItem={this.showTooltip}
                     deselectItem={this.hideTooltip}
                     urlRoot="#/federal_account/" />
+                <svg className="horizontal-bar">
+                    <g className="legend-container">
+                        <BarChartLegend legend={legend} />
+                    </g>
+                </svg>
 
                 <div className={`tooltip-wrapper ${hideTooltip}`}>
                     <FederalAccountTooltip

--- a/src/js/components/agency/visualizations/federalAccount/FederalAccountChart.jsx
+++ b/src/js/components/agency/visualizations/federalAccount/FederalAccountChart.jsx
@@ -71,7 +71,7 @@ export default class FederalAccountChart extends React.Component {
         const legend = [
             {
                 color: '#597785',
-                label: 'Obligated Amounts',
+                label: 'Obligated Amount',
                 offset: 0
             }
         ];

--- a/src/js/components/agency/visualizations/federalAccount/FederalAccountVisualization.jsx
+++ b/src/js/components/agency/visualizations/federalAccount/FederalAccountVisualization.jsx
@@ -16,7 +16,8 @@ const propTypes = {
     linkSeries: PropTypes.array,
     labelSeries: PropTypes.array,
     dataSeries: PropTypes.array,
-    descriptions: PropTypes.array
+    descriptions: PropTypes.array,
+    asOfDate: PropTypes.string
 };
 
 export default class FederalAccountVisualization extends React.Component {
@@ -68,6 +69,7 @@ export default class FederalAccountVisualization extends React.Component {
                 </div>
                 <div className="agency-section-title">
                     <h4>Federal Accounts</h4>
+                    <em>Data as of {this.props.asOfDate}</em>
                     <hr
                         className="results-divider"
                         ref={(hr) => {

--- a/src/js/components/agency/visualizations/objectClass/ObjectClassTreeMap.jsx
+++ b/src/js/components/agency/visualizations/objectClass/ObjectClassTreeMap.jsx
@@ -18,7 +18,8 @@ const propTypes = {
     minorObjectClasses: PropTypes.object,
     totalObligation: PropTypes.number,
     totalMinorObligation: PropTypes.number,
-    showMinorObjectClasses: PropTypes.func
+    showMinorObjectClasses: PropTypes.func,
+    asOfDate: PropTypes.string
 };
 
 export default class ObjectClassTreeMap extends React.Component {
@@ -66,7 +67,12 @@ export default class ObjectClassTreeMap extends React.Component {
     }
 
     generateHeader() {
-        let header = "Hover over a segment for more information";
+        let header = (<div>
+            <div className="info-icon-circle">
+                <Icons.InfoCircle />
+            </div>
+            <span>Hover over a segment for more information</span>
+        </div>);
 
         if (this.state.showMinorObjectClass === true) {
             header = (<button
@@ -116,6 +122,7 @@ export default class ObjectClassTreeMap extends React.Component {
                 </div>
                 <div className="agency-section-title">
                     <h4>Object Classes</h4>
+                    <em>Data as of {this.props.asOfDate}</em>
                     <hr className="results-divider" />
                 </div>
                 <div className="agency-section-content">
@@ -129,6 +136,7 @@ export default class ObjectClassTreeMap extends React.Component {
                         </div>
                         {this.generateObjectClasses()}
                     </div>
+                    <div className="agency-viz-description">This visualization represents obligated amount.</div>
                 </div>
             </div>
         );

--- a/src/js/components/agency/visualizations/obligated/ObligatedGraph.jsx
+++ b/src/js/components/agency/visualizations/obligated/ObligatedGraph.jsx
@@ -10,8 +10,6 @@ import BarChartLegend from 'components/search/visualizations/time/chart/BarChart
 import HorizontalBarItem from './HorizontalBarItem';
 
 const propTypes = {
-    activeFY: PropTypes.string,
-    reportingFiscalQuarter: PropTypes.number,
     obligatedAmount: PropTypes.number,
     budgetAuthority: PropTypes.number,
     width: PropTypes.number,

--- a/src/js/components/agency/visualizations/obligated/ObligatedVisualization.jsx
+++ b/src/js/components/agency/visualizations/obligated/ObligatedVisualization.jsx
@@ -5,8 +5,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
-import { convertQuarterToDate } from 'helpers/fiscalYearHelper';
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 import { capitalize, throttle } from 'lodash';
 
@@ -14,10 +12,10 @@ import AgencyObligatedGraph from './ObligatedGraph';
 
 const propTypes = {
     activeFY: PropTypes.string,
-    reportingFiscalQuarter: PropTypes.number,
     agencyName: PropTypes.string,
     obligatedAmount: PropTypes.number,
-    budgetAuthority: PropTypes.number
+    budgetAuthority: PropTypes.number,
+    asOfDate: PropTypes.string
 };
 
 export default class AgencyObligatedAmount extends React.Component {
@@ -72,10 +70,6 @@ export default class AgencyObligatedAmount extends React.Component {
             .formatMoneyWithPrecision(obligatedAmount / obligatedAmountValue.unit, 1)}
         ${capitalize(obligatedAmountValue.longLabel)}`;
 
-
-        const endOfQuarter = convertQuarterToDate(this.props.reportingFiscalQuarter, this.props.activeFY);
-        const asOfDate = moment(endOfQuarter, "YYYY-MM-DD").format("MMMM D, YYYY");
-
         const legend = [
             {
                 color: '#5C7480',
@@ -86,11 +80,6 @@ export default class AgencyObligatedAmount extends React.Component {
                 color: '#D6D7D9',
                 label: 'Budgetary Resources',
                 offset: 100
-            },
-            {
-                color: '#ffffff',
-                label: `*as of ${asOfDate}`,
-                offset: this.state.visualizationWidth - 150
             }
         ];
 
@@ -106,9 +95,10 @@ example, when it places an order, signs a contract, awards a grant, purchases a 
 takes other actions that require it to make a payment.
                     </p>
                 </div>
-                <div className="agency-obligated-wrapper">
-                    <div className="agency-obligated-title">
+                <div className="agency-section-wrapper">
+                    <div className="agency-section-title">
                         <h4>Obligated Amount</h4>
+                        <em>Data as of {this.props.asOfDate}</em>
                         <hr
                             className="results-divider"
                             ref={(hr) => {
@@ -117,14 +107,12 @@ takes other actions that require it to make a payment.
                     </div>
                     <div className="agency-obligated-content">
                         <p className="fy-text">
-                            In fiscal year {this.props.activeFY}*, {this.props.agencyName} has obligated
+                            In fiscal year {this.props.activeFY}, {this.props.agencyName} has obligated...
                         </p>
                         <p className="against-auth-text">
                             <span className="number number-bolder">{formattedObligatedAmount}</span> against its <span className="number">{formattedBudgetAuthority}</span> in Budgetary Resources
                         </p>
                         <AgencyObligatedGraph
-                            activeFY={this.props.activeFY}
-                            reportingFiscalQuarter={this.props.reportingFiscalQuarter}
                             obligatedAmount={this.props.obligatedAmount}
                             budgetAuthority={this.props.budgetAuthority}
                             width={this.state.visualizationWidth}

--- a/src/js/components/agency/visualizations/recipient/RecipientChart.jsx
+++ b/src/js/components/agency/visualizations/recipient/RecipientChart.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 
 import { AngleLeft, AngleRight } from 'components/sharedComponents/icons/Icons';
 import HorizontalChart from 'components/search/visualizations/rank/chart/HorizontalChart';
+import BarChartLegend from 'components/search/visualizations/time/chart/BarChartLegend';
 
 import RecipientTooltip from './RecipientTooltip';
 
@@ -100,6 +101,14 @@ export default class RecipientChart extends React.Component {
             isLoading = 'loading-visualization';
         }
 
+        const legend = [
+            {
+                color: '#597785',
+                label: 'Obligated Amount',
+                offset: 0
+            }
+        ];
+
         return (
             <div className={`${isLoading}`}>
                 <HorizontalChart
@@ -112,6 +121,11 @@ export default class RecipientChart extends React.Component {
                     labelWidth={this.props.labelWidth}
                     selectItem={this.showTooltip}
                     deselectItem={this.hideTooltip} />
+                <svg className="horizontal-bar">
+                    <g className="legend-container">
+                        <BarChartLegend legend={legend} />
+                    </g>
+                </svg>
 
                 <div className="visualization-pager-container">
                     <div className="prev-page">

--- a/src/js/components/agency/visualizations/recipient/RecipientVisualization.jsx
+++ b/src/js/components/agency/visualizations/recipient/RecipientVisualization.jsx
@@ -22,7 +22,8 @@ const propTypes = {
     descriptions: PropTypes.array,
     page: PropTypes.number,
     isLastPage: PropTypes.bool,
-    changePage: PropTypes.func
+    changePage: PropTypes.func,
+    lastUpdate: PropTypes.string
 };
 
 
@@ -99,6 +100,7 @@ or foreign). Here is a look at who these recipients are and how they rank by awa
                 </div>
                 <div className="agency-section-title">
                     <h4>Recipients</h4>
+                    <em>Data as of {this.props.lastUpdate}</em>
                     <hr
                         className="results-divider"
                         ref={(hr) => {

--- a/src/js/containers/agency/visualizations/FederalAccountContainer.jsx
+++ b/src/js/containers/agency/visualizations/FederalAccountContainer.jsx
@@ -17,7 +17,8 @@ import FederalAccountVisualization from
 const propTypes = {
     id: PropTypes.string,
     activeFY: PropTypes.string,
-    obligatedAmount: PropTypes.number
+    obligatedAmount: PropTypes.number,
+    asOfDate: PropTypes.string
 };
 
 export default class FederalAccountContainer extends React.PureComponent {
@@ -132,7 +133,8 @@ ${account}`;
                 labelSeries={this.state.labelSeries}
                 descriptions={this.state.descriptions}
                 loading={this.state.loading}
-                error={this.state.error} />
+                error={this.state.error}
+                asOfDate={this.props.asOfDate} />
         );
     }
 }

--- a/src/js/containers/agency/visualizations/ObjectClassContainer.jsx
+++ b/src/js/containers/agency/visualizations/ObjectClassContainer.jsx
@@ -15,7 +15,8 @@ import ObjectClassTreeMap from 'components/agency/visualizations/objectClass/Obj
 
 const propTypes = {
     id: PropTypes.string,
-    activeFY: PropTypes.string
+    activeFY: PropTypes.string,
+    asOfDate: PropTypes.string
 };
 
 const defaultProps = {
@@ -202,7 +203,8 @@ export default class ObjectClassContainer extends React.PureComponent {
                 minorObjectClasses={this.state.minorObjectClasses}
                 totalObligation={this.state.totalObligation}
                 totalMinorObligation={this.state.totalMinorObligation}
-                showMinorObjectClasses={this.showMinorObjectClasses} />
+                showMinorObjectClasses={this.showMinorObjectClasses}
+                asOfDate={this.props.asOfDate} />
         );
     }
 

--- a/src/js/containers/agency/visualizations/ObligatedContainer.jsx
+++ b/src/js/containers/agency/visualizations/ObligatedContainer.jsx
@@ -17,7 +17,7 @@ const propTypes = {
     id: PropTypes.string,
     activeFY: PropTypes.string,
     agencyName: PropTypes.string,
-    activeQuarter: PropTypes.string
+    asOfDate: PropTypes.string
 };
 
 export class ObligatedContainer extends React.PureComponent {
@@ -83,10 +83,10 @@ export class ObligatedContainer extends React.PureComponent {
         return (
             <ObligatedVisualization
                 activeFY={this.props.activeFY}
-                reportingFiscalQuarter={parseFloat(this.props.activeQuarter)}
                 agencyName={this.props.agencyName}
                 obligatedAmount={this.state.obligatedAmount}
-                budgetAuthority={this.state.budgetAuthority} />
+                budgetAuthority={this.state.budgetAuthority}
+                asOfDate={this.props.asOfDate} />
         );
     }
 }

--- a/src/js/containers/agency/visualizations/RecipientContainer.jsx
+++ b/src/js/containers/agency/visualizations/RecipientContainer.jsx
@@ -16,7 +16,8 @@ import RecipientVisualization from
 
 const propTypes = {
     id: PropTypes.string,
-    activeFY: PropTypes.string
+    activeFY: PropTypes.string,
+    lastUpdate: PropTypes.string
 };
 
 export default class RecipientContainer extends React.PureComponent {
@@ -174,7 +175,8 @@ ${recipient}`;
                 error={this.state.error}
                 scope={this.state.scope}
                 changeScope={this.changeScope}
-                changePage={this.changePage} />
+                changePage={this.changePage}
+                lastUpdate={this.props.lastUpdate} />
         );
     }
 }


### PR DESCRIPTION
- "Data as of X" is added to all sections according to the mock (Date is the same for all visualizations except recipients, which shows the date awards were last uploaded)
- Labels added to each visualization so the users know they are looking at obligated amounts
- Asterisk is removed from obligations section and previous "data as of" note is removed