### PR TITLE
Update profile links

### DIFF
--- a/src/_scss/pages/search/results/visualizations/rank/chart/_item.scss
+++ b/src/_scss/pages/search/results/visualizations/rank/chart/_item.scss
@@ -12,6 +12,7 @@
     }
     .group-label-link {
         text-decoration: underline;
+	    fill: $color-link;
     }
 }
 

--- a/src/_scss/pages/search/results/visualizations/rank/chart/_item.scss
+++ b/src/_scss/pages/search/results/visualizations/rank/chart/_item.scss
@@ -11,7 +11,6 @@
         fill: $color-base;
     }
     .group-label-link {
-        text-decoration: underline;
 	    fill: $color-link;
     }
 }


### PR DESCRIPTION
- All links to summary/profile pages should be blue links rather than underlined