### PR TITLE
NPM command to display only linting errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "./node_modules/.bin/webpack-dev-server --progress --config ./webpack/webpack.dev.config.js",
     "test": "./node_modules/.bin/jest; exit 0;",
     "lint": "./node_modules/.bin/eslint --config .eslintrc --ext .jsx,.js \"src/js/**\"; exit 0;",
+    "errors": "./node_modules/.bin/eslint --config .eslintrc --ext .jsx,.js \"src/js/**\" --quiet; exit 0;",
     "dev": "./node_modules/.bin/webpack --progress --config ./webpack/webpack.dev.config.js",
     "prod": "./node_modules/.bin/webpack -p --progress --config ./webpack/webpack.prod.config.js",
     "travis": "./node_modules/.bin/eslint --config .eslintrc --ext .jsx,.js \"src/js/**\" && ./node_modules/.bin/jest --runInBand;",


### PR DESCRIPTION
* Ever have just 1 linter error buried in the middle of 280 warnings?
* Now you can run `npm run errors` to only display linter errors without warnings