### PR TITLE
Visited links color fix

### DIFF
--- a/src/_scss/pages/search/results/visualizations/rank/chart/_item.scss
+++ b/src/_scss/pages/search/results/visualizations/rank/chart/_item.scss
@@ -12,6 +12,9 @@
     }
     .group-label-link {
 	    fill: $color-link;
+	    a:visited {
+		    fill: $color-link;
+	    }
     }
 }
 


### PR DESCRIPTION
- Visited profile links in rank charts are blue instead of black