### PR TITLE
Spending Explorer Updates

### DIFF
--- a/src/_scss/pages/explorer/detail/_noAwardsScreen.scss
+++ b/src/_scss/pages/explorer/detail/_noAwardsScreen.scss
@@ -1,0 +1,31 @@
+.explorer-no-awards {
+	text-align: center;
+	.no-awards-message {
+		font-weight: 600;
+		font-size: rem(30);
+		margin: 20vh 0 rem(30) 0;
+		.info-icon-circle {
+			@include align-self(center);
+			display: inline-block;
+			fill: $color-primary-alt;
+			height: rem(27);
+			right: rem(5);
+			position: relative;
+			top: rem(3);
+			width: rem(25);
+			svg {
+				float: none;
+			}
+		}
+	}
+	.go-back {
+		background-color: transparent;
+		font-size: rem(24);
+		font-weight: normal;
+		color: $color-primary-alt-darkest;
+		text-decoration: underline;
+		&:hover {
+			color: $color-primary-alt-dark;
+		}
+	}
+}

--- a/src/_scss/pages/explorer/detail/explorerDetail.scss
+++ b/src/_scss/pages/explorer/detail/explorerDetail.scss
@@ -1,5 +1,6 @@
 .explorer-detail-wrap {
     @import "./_tooltip";
+	@import "./_noAwardsScreen";
 
     background: url(#{$image-path}/explorer-background.jpg) no-repeat top center fixed;
     background-size: cover;

--- a/src/js/components/explorer/detail/DetailContent.jsx
+++ b/src/js/components/explorer/detail/DetailContent.jsx
@@ -11,6 +11,7 @@ import DetailHeader from './header/DetailHeader';
 
 import ExplorerVisualization from './visualization/ExplorerVisualization';
 import FakeScreens from './FakeScreens';
+import NoAwardsScreen from './NoAwardsScreen';
 
 const propTypes = {
     isRoot: PropTypes.bool,
@@ -27,7 +28,8 @@ const propTypes = {
     goDeeper: PropTypes.func,
     changeSubdivisionType: PropTypes.func,
     showTooltip: PropTypes.func,
-    hideTooltip: PropTypes.func
+    hideTooltip: PropTypes.func,
+    rewindToFilter: PropTypes.func
 };
 
 export default class DetailContent extends React.Component {
@@ -189,6 +191,30 @@ export default class DetailContent extends React.Component {
                 transitionSteps={this.props.transitionSteps} />);
         }
 
+        let visualizationSection = (
+            <ExplorerVisualization
+                isRoot={this.props.isRoot}
+                isLoading={this.props.isLoading}
+                lastFilter={lastFilter}
+                root={this.props.root}
+                fy={this.props.fy}
+                active={this.props.active}
+                trail={this.props.trail}
+                total={this.props.total}
+                data={this.props.data}
+                goDeeper={this.props.goDeeper}
+                changeSubdivisionType={this.props.changeSubdivisionType}
+                showTooltip={this.props.showTooltip}
+                hideTooltip={this.props.hideTooltip} />
+        );
+        if (this.props.total === 0 || this.props.total === null) {
+            const currentIndex = this.props.trail.length - 1;
+            visualizationSection = (
+                <NoAwardsScreen
+                    rewindToFilter={this.props.rewindToFilter}
+                    currentIndex={currentIndex} />);
+        }
+
         return (
             <div
                 className="explorer-detail-content"
@@ -199,20 +225,8 @@ export default class DetailContent extends React.Component {
                 {fakeScreenAbove}
 
                 {header}
-                <ExplorerVisualization
-                    isRoot={this.props.isRoot}
-                    isLoading={this.props.isLoading}
-                    lastFilter={lastFilter}
-                    root={this.props.root}
-                    fy={this.props.fy}
-                    active={this.props.active}
-                    trail={this.props.trail}
-                    total={this.props.total}
-                    data={this.props.data}
-                    goDeeper={this.props.goDeeper}
-                    changeSubdivisionType={this.props.changeSubdivisionType}
-                    showTooltip={this.props.showTooltip}
-                    hideTooltip={this.props.hideTooltip} />
+
+                {visualizationSection}
 
                 {fakeScreenBelow}
             </div>

--- a/src/js/components/explorer/detail/NoAwardsScreen.jsx
+++ b/src/js/components/explorer/detail/NoAwardsScreen.jsx
@@ -1,0 +1,45 @@
+/**
+ * NoAwardsScreen.jsx
+ * Created by Lizzie Salita 9/21/17
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import * as Icons from 'components/sharedComponents/icons/Icons';
+
+const propTypes = {
+    rewindToFilter: PropTypes.func,
+    currentIndex: PropTypes.number
+};
+
+export default class NoAwardsScreen extends React.Component {
+    constructor(props) {
+        super(props);
+        this.clickedLink = this.clickedLink.bind(this);
+    }
+
+    clickedLink() {
+        const previousIndex = this.props.currentIndex - 1;
+        console.log(previousIndex);
+        this.props.rewindToFilter(previousIndex);
+    };
+
+    render() {
+        return (
+            <div className="explorer-no-awards">
+                <div className="no-awards-message">
+                    <span className="info-icon-circle">
+                        <Icons.InfoCircle />
+                    </span>
+                    You&#8217;ve reached a point with no associated awards.
+                </div>
+                <button className="go-back" onClick={this.clickedLink}>
+                    Click here to go back.
+                </button>
+            </div>
+        );
+    }
+}
+
+NoAwardsScreen.propTypes = propTypes;

--- a/src/js/components/explorer/detail/NoAwardsScreen.jsx
+++ b/src/js/components/explorer/detail/NoAwardsScreen.jsx
@@ -21,7 +21,6 @@ export default class NoAwardsScreen extends React.Component {
 
     clickedLink() {
         const previousIndex = this.props.currentIndex - 1;
-        console.log(previousIndex);
         this.props.rewindToFilter(previousIndex);
     };
 

--- a/src/js/components/explorer/detail/visualization/toolbar/BreakdownDropdown.jsx
+++ b/src/js/components/explorer/detail/visualization/toolbar/BreakdownDropdown.jsx
@@ -42,10 +42,6 @@ export default class BreakdownDropdown extends React.Component {
         this.prepareOptions(this.props);
     }
 
-    componentDidMount() {
-        document.addEventListener('mousedown', this.handleClickOutside);
-    }
-
     componentWillReceiveProps(nextProps) {
         if (nextProps.active !== this.props.active) {
             this.prepareOptions(nextProps);
@@ -56,10 +52,6 @@ export default class BreakdownDropdown extends React.Component {
         else if (nextProps.isRoot !== this.props.isRoot) {
             this.prepareOptions(nextProps);
         }
-    }
-
-    componentWillUnmount() {
-        document.removeEventListener('mousedown', this.handleClickOutside);
     }
 
     setWrapperRef(node) {
@@ -114,6 +106,13 @@ export default class BreakdownDropdown extends React.Component {
     toggleMenu() {
         this.setState({
             expanded: !this.state.expanded
+        }, () => {
+            if (this.state.expanded) {
+                document.addEventListener('mousedown', this.handleClickOutside);
+            }
+            else {
+                document.removeEventListener('mousedown', this.handleClickOutside);
+            }
         });
     }
 

--- a/src/js/components/explorer/detail/visualization/toolbar/BreakdownDropdown.jsx
+++ b/src/js/components/explorer/detail/visualization/toolbar/BreakdownDropdown.jsx
@@ -54,6 +54,10 @@ export default class BreakdownDropdown extends React.Component {
         }
     }
 
+    componentWillUnmount() {
+        document.removeEventListener('mousedown', this.handleClickOutside);
+    }
+
     setWrapperRef(node) {
         this.wrapperRef = node;
     }

--- a/src/js/components/explorer/detail/visualization/toolbar/BreakdownDropdown.jsx
+++ b/src/js/components/explorer/detail/visualization/toolbar/BreakdownDropdown.jsx
@@ -34,10 +34,16 @@ export default class BreakdownDropdown extends React.Component {
 
         this.toggleMenu = this.toggleMenu.bind(this);
         this.pickItem = this.pickItem.bind(this);
+        this.setWrapperRef = this.setWrapperRef.bind(this);
+        this.handleClickOutside = this.handleClickOutside.bind(this);
     }
 
     componentWillMount() {
         this.prepareOptions(this.props);
+    }
+
+    componentDidMount() {
+        document.addEventListener('mousedown', this.handleClickOutside);
     }
 
     componentWillReceiveProps(nextProps) {
@@ -49,6 +55,22 @@ export default class BreakdownDropdown extends React.Component {
         }
         else if (nextProps.isRoot !== this.props.isRoot) {
             this.prepareOptions(nextProps);
+        }
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('mousedown', this.handleClickOutside);
+    }
+
+    setWrapperRef(node) {
+        this.wrapperRef = node;
+    }
+
+    handleClickOutside(event) {
+        if (this.state.expanded && this.wrapperRef && !this.wrapperRef.contains(event.target)) {
+            this.setState({
+                expanded: false
+            });
         }
     }
 
@@ -131,26 +153,28 @@ export default class BreakdownDropdown extends React.Component {
         }
 
         return (
-            <div className="breakdown-menu">
-                <div className="breakdown-label">
-                    See the breakdown by:
-                </div>
-                <div className="breakdown-dropdown">
-                    <button
-                        className="dropdown-selector"
-                        onClick={this.toggleMenu}>
-                        <div className="item-icon">
-                            {icon}
-                        </div>
-                        <div className="item-label">
-                            {sidebarTypes[this.state.active]}
-                        </div>
-                        <div className="arrow">
-                            <AngleDown />
-                        </div>
-                    </button>
+            <div ref={this.setWrapperRef}>
+                <div className="breakdown-menu" >
+                    <div className="breakdown-label">
+                        See the breakdown by:
+                    </div>
+                    <div className="breakdown-dropdown">
+                        <button
+                            className="dropdown-selector"
+                            onClick={this.toggleMenu}>
+                            <div className="item-icon">
+                                {icon}
+                            </div>
+                            <div className="item-label">
+                                {sidebarTypes[this.state.active]}
+                            </div>
+                            <div className="arrow">
+                                <AngleDown />
+                            </div>
+                        </button>
 
-                    {dropdown}
+                        {dropdown}
+                    </div>
                 </div>
             </div>
         );

--- a/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
+++ b/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
@@ -76,7 +76,7 @@ export default class ExplorerTreemap extends React.Component {
         // generate the treemap and calculate the individual boxes
         const treeItems = tree(treemapData).leaves();
 
-        if (treeItems.length === 0) {
+        if (treeItems.length === 0 || data.length === 0) {
             // we have no data, so don't draw a chart
             this.setState({
                 virtualChart: []

--- a/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
+++ b/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 
 import { hierarchy, treemap, treemapBinary } from 'd3-hierarchy';
 import { scaleLinear } from 'd3-scale';
+import { remove } from 'lodash';
 
 import { measureTreemapHeader, measureTreemapValue } from 'helpers/textMeasurement';
 
@@ -52,6 +53,10 @@ export default class ExplorerTreemap extends React.Component {
 
     buildVirtualChart(props) {
         const data = props.data.toJS();
+
+        // remove the negative values from the data because they can't be displayed in the treemap
+        remove(data, (v) => v.amount <= 0);
+
         const total = props.total;
 
         // parse the inbound data into D3's treemap hierarchy structure
@@ -97,11 +102,8 @@ export default class ExplorerTreemap extends React.Component {
         // we can now begin creating the individual treemap cells
         const cells = [];
         treeItems.forEach((item) => {
-            if (item.value > 0) {
-                // Don't display cells with zero or negative amounts
-                const cell = this.buildVirtualCell(item, scale, total);
-                cells.push(cell);
-            }
+            const cell = this.buildVirtualCell(item, scale, total);
+            cells.push(cell);
         });
 
         this.setState({

--- a/src/js/containers/explorer/detail/DetailContentContainer.jsx
+++ b/src/js/containers/explorer/detail/DetailContentContainer.jsx
@@ -409,7 +409,8 @@ export class DetailContentContainer extends React.Component {
                     goDeeper={this.goDeeper}
                     changeSubdivisionType={this.changeSubdivisionType}
                     showTooltip={this.props.showTooltip}
-                    hideTooltip={this.props.hideTooltip} />
+                    hideTooltip={this.props.hideTooltip}
+                    rewindToFilter={this.rewindToFilter} />
             </div>
         );
     }


### PR DESCRIPTION
- Prevents treemap cells from getting cut off when there are negative obligations
- Shows a message when a user clicks on an option and there are no associated awards at the next step/ total is $0
- Closes the dropdown when user clicks outside it