### PR TITLE
Hotfix agency accounts pagination

### DIFF
--- a/src/_scss/pages/agency/visualizations/federalAccount/federalAccount.scss
+++ b/src/_scss/pages/agency/visualizations/federalAccount/federalAccount.scss
@@ -27,6 +27,26 @@
 		    }
 	    }
 
+	    @import "pages/search/results/visualizations/rank/_pager";
+	    .visualization-pager-container {
+		    @include display(flex);
+		    @include align-items(center);
+		    @include justify-content(center);
 
+		    position: relative;
+		    width: 100%;
+
+		    .prev-page {
+			    @include flex(1 1 auto);
+			    @include align-self(flex-start);
+		    }
+		    .next-page {
+			    @include flex(1 1 auto);
+			    @include align-self(flex-end);
+			    button {
+				    float: right;
+			    }
+		    }
+	    }
     }
 }

--- a/src/js/components/agency/visualizations/federalAccount/FederalAccountChart.jsx
+++ b/src/js/components/agency/visualizations/federalAccount/FederalAccountChart.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { AngleLeft, AngleRight } from 'components/sharedComponents/icons/Icons';
 import HorizontalChart from 'components/search/visualizations/rank/chart/HorizontalChart';
 import BarChartLegend from 'components/search/visualizations/time/chart/BarChartLegend';
 
@@ -18,7 +19,10 @@ const propTypes = {
     dataSeries: PropTypes.array,
     descriptions: PropTypes.array,
     width: PropTypes.number,
-    labelWidth: PropTypes.number
+    labelWidth: PropTypes.number,
+    page: PropTypes.number,
+    changePage: PropTypes.func,
+    isLastPage: PropTypes.bool
 };
 
 const rowHeight = 60;
@@ -41,6 +45,9 @@ export default class FederalAccountChart extends React.Component {
 
         this.showTooltip = this.showTooltip.bind(this);
         this.hideTooltip = this.hideTooltip.bind(this);
+
+        this.clickedNext = this.clickedNext.bind(this);
+        this.clickedPrev = this.clickedPrev.bind(this);
     }
 
     showTooltip(data) {
@@ -56,12 +63,39 @@ export default class FederalAccountChart extends React.Component {
         });
     }
 
+    clickedNext() {
+        if (this.props.loading || this.props.isLastPage) {
+            return;
+        }
+
+        const nextPage = this.props.page + 1;
+        this.props.changePage(nextPage);
+    }
+
+    clickedPrev() {
+        if (this.props.loading) {
+            return;
+        }
+
+        const nextPage = Math.max(1, this.props.page - 1);
+        this.props.changePage(nextPage);
+    }
+
     render() {
         let hideTooltip = '';
         if (!this.state.showTooltip) {
             hideTooltip = 'hide';
         }
 
+        let hidePrevious = '';
+        if (this.props.page === 1) {
+            hidePrevious = 'hide';
+        }
+
+        let hideNext = '';
+        if (this.props.isLastPage) {
+            hideNext = 'hide';
+        }
 
         let isLoading = '';
         if (this.props.loading) {
@@ -96,6 +130,43 @@ export default class FederalAccountChart extends React.Component {
                         <BarChartLegend legend={legend} />
                     </g>
                 </svg>
+
+                <div className="visualization-pager-container">
+                    <div className="prev-page">
+                        <button
+                            className={`visualization-pager ${hidePrevious}`}
+                            title="Show previous ten"
+                            aria-label="Show previous ten"
+                            onClick={this.clickedPrev}
+                            disabled={this.props.loading || this.props.page === 1}>
+                            <div className="pager-content">
+                                <div className="icon">
+                                    <AngleLeft alt="Show previous ten" />
+                                </div>
+                                <div className="pager-label">
+                                    Show previous ten
+                                </div>
+                            </div>
+                        </button>
+                    </div>
+                    <div className="next-page">
+                        <button
+                            className={`visualization-pager ${hideNext}`}
+                            title="Show next ten"
+                            aria-label="Show next ten"
+                            onClick={this.clickedNext}
+                            disabled={this.props.loading || this.props.isLastPage}>
+                            <div className="pager-content">
+                                <div className="pager-label next">
+                                    Show next ten
+                                </div>
+                                <div className="icon">
+                                    <AngleRight alt="Show next ten" />
+                                </div>
+                            </div>
+                        </button>
+                    </div>
+                </div>
 
                 <div className={`tooltip-wrapper ${hideTooltip}`}>
                     <FederalAccountTooltip

--- a/src/js/components/agency/visualizations/federalAccount/FederalAccountVisualization.jsx
+++ b/src/js/components/agency/visualizations/federalAccount/FederalAccountVisualization.jsx
@@ -7,17 +7,23 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 
+import ChartMessage from 'components/search/visualizations/rank/RankVisualizationChartMessage';
+
 import FederalAccountChart from './FederalAccountChart';
 
 const propTypes = {
     obligatedAmount: PropTypes.number,
     loading: PropTypes.bool,
     error: PropTypes.bool,
+    isInitialLoad: PropTypes.bool,
     linkSeries: PropTypes.array,
     labelSeries: PropTypes.array,
     dataSeries: PropTypes.array,
     descriptions: PropTypes.array,
-    asOfDate: PropTypes.string
+    asOfDate: PropTypes.string,
+    page: PropTypes.number,
+    isLastPage: PropTypes.bool,
+    changePage: PropTypes.func
 };
 
 export default class FederalAccountVisualization extends React.Component {
@@ -59,6 +65,33 @@ export default class FederalAccountVisualization extends React.Component {
         const formattedObligation = `${MoneyFormatter.formatMoneyWithPrecision(this.props.obligatedAmount / obUnits.unit, 1)}
          ${obUnits.longLabel}`;
 
+        let chart = null;
+        if (this.props.loading && this.props.isInitialLoad) {
+            // initial load
+            chart = (<ChartMessage message="Loading data..." />);
+        }
+        else if (this.props.error) {
+            // error
+            chart = (<ChartMessage message="An error occurred." />);
+        }
+        else if (this.props.dataSeries.length === 0) {
+            // no data
+            chart = (<ChartMessage message="No data to display." />);
+        }
+        else {
+            chart = (<FederalAccountChart
+                loading={this.props.loading}
+                linkSeries={this.props.linkSeries}
+                labelSeries={this.props.labelSeries}
+                dataSeries={this.props.dataSeries}
+                descriptions={this.props.descriptions}
+                width={this.state.visualizationWidth}
+                labelWidth={this.state.labelWidth}
+                page={this.props.page}
+                isLastPage={this.props.isLastPage}
+                changePage={this.props.changePage} />);
+        }
+
         return (
             <div
                 className="agency-section-wrapper"
@@ -79,14 +112,7 @@ export default class FederalAccountVisualization extends React.Component {
                 </div>
                 <div className="agency-section-content">
                     <div className="chart-wrapper">
-                        <FederalAccountChart
-                            loading={this.props.loading}
-                            linkSeries={this.props.linkSeries}
-                            labelSeries={this.props.labelSeries}
-                            dataSeries={this.props.dataSeries}
-                            descriptions={this.props.descriptions}
-                            width={this.state.visualizationWidth}
-                            labelWidth={this.state.labelWidth} />
+                        {chart}
                     </div>
                 </div>
             </div>

--- a/src/js/containers/agency/visualizations/FederalAccountContainer.jsx
+++ b/src/js/containers/agency/visualizations/FederalAccountContainer.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { isCancel } from 'axios';
+import { slice } from 'lodash';
 
 import * as AgencyHelper from 'helpers/agencyHelper';
 import * as MoneyFormatter from 'helpers/moneyFormatter';
@@ -28,13 +29,18 @@ export default class FederalAccountContainer extends React.PureComponent {
         this.state = {
             loading: true,
             error: false,
+            isInitialLoad: true,
             linkSeries: [],
             labelSeries: [],
             dataSeries: [],
-            descriptions: []
+            descriptions: [],
+            page: 1,
+            isLastPage: true
         };
 
         this.request = null;
+
+        this.changePage = this.changePage.bind(this);
     }
 
     componentWillMount() {
@@ -43,11 +49,15 @@ export default class FederalAccountContainer extends React.PureComponent {
 
     componentWillReceiveProps(nextProps) {
         if (this.props.id !== nextProps.id || this.props.activeFY !== nextProps.activeFY) {
-            this.loadData(nextProps.id, nextProps.activeFY);
+            this.setState({
+                isInitialLoad: true
+            }, () => {
+                this.loadData(nextProps.id, nextProps.activeFY, 1);
+            });
         }
     }
 
-    loadData(id, fy) {
+    loadData(id, fy, pageNumber = 1) {
         if (!id || id === '' || !fy || fy === '') {
             // invalid ID or fiscal year
             return;
@@ -65,14 +75,18 @@ export default class FederalAccountContainer extends React.PureComponent {
         this.request = AgencyHelper.fetchAgencyFederalAccounts({
             fiscal_year: fy,
             funding_agency_id: id,
-            limit: 10
+            limit: 10,
+            page: pageNumber
         });
 
         this.request.promise
             .then((res) => {
                 this.setState({
                     loading: false,
-                    error: false
+                    error: false,
+                    isInitialLoad: false,
+                    page: pageNumber,
+                    isLastPage: !res.data.page_metadata.has_next_page
                 });
 
                 this.parseData(res.data.results);
@@ -91,14 +105,28 @@ export default class FederalAccountContainer extends React.PureComponent {
             });
     }
 
+    changePage(pageNumber) {
+        if (pageNumber < 1 || (this.state.isLastPage && pageNumber > this.state.page)) {
+            // don't do anything
+            return;
+        }
+
+        this.setState({
+            page: pageNumber
+        }, () => {
+            this.loadData(this.props.id, this.props.activeFY, pageNumber);
+        });
+    }
+
     parseData(data) {
         // keep only the top 10 in descending order
+        const results = slice(data, 0, 10);
         const linkSeries = [];
         const dataSeries = [];
         const labelSeries = [];
         const descriptions = [];
 
-        data.forEach((result) => {
+        results.forEach((result) => {
             let parsedValue = parseFloat(result.obligated_amount);
             if (isNaN(parsedValue)) {
                 // the aggregate value is invalid (most likely null)
@@ -134,7 +162,11 @@ ${account}`;
                 descriptions={this.state.descriptions}
                 loading={this.state.loading}
                 error={this.state.error}
-                asOfDate={this.props.asOfDate} />
+                isInitialLoad={this.state.isInitialLoad}
+                asOfDate={this.props.asOfDate}
+                page={this.state.page}
+                isLastPage={this.state.isLastPage}
+                changePage={this.changePage} />
         );
     }
 }

--- a/src/js/containers/agency/visualizations/RecipientContainer.jsx
+++ b/src/js/containers/agency/visualizations/RecipientContainer.jsx
@@ -111,8 +111,8 @@ export default class RecipientContainer extends React.PureComponent {
     }
 
     changePage(pageNumber) {
-        if (this.state.isLastPage || pageNumber < 1) {
-            // last page, don't do anything
+        if (pageNumber < 1 || (this.state.isLastPage && pageNumber > this.state.page)) {
+            // Requested page number is out of range; don't do anything
             return;
         }
 

--- a/tests/containers/agency/agencyHelper.js
+++ b/tests/containers/agency/agencyHelper.js
@@ -3,6 +3,8 @@ import { mockObligatedAmounts }
 
 import { mockRecipient } from './visualizations/mocks/mockRecipient';
 
+import { mockAccount } from './visualizations/mocks/mockFederalAccount';
+
 import { mockMajorObjectClasses, mockMinorObjectClasses } from './visualizations/mocks/mockObjectClasses';
 
 // Fetch Agency Obligated Amounts
@@ -12,6 +14,19 @@ export const fetchAgencyObligatedAmounts = () => (
             process.nextTick(() => {
                 resolve({
                     data: mockObligatedAmounts
+                });
+            });
+        }),
+        cancel: jest.fn()
+    }
+);
+
+export const fetchAgencyFederalAccounts = () => (
+    {
+        promise: new Promise((resolve) => {
+            process.nextTick(() => {
+                resolve({
+                    data: mockAccount
                 });
             });
         }),

--- a/tests/containers/agency/visualizations/FederalAccountContainer-test.jsx
+++ b/tests/containers/agency/visualizations/FederalAccountContainer-test.jsx
@@ -100,7 +100,7 @@ describe('FederalAccountContainer', () => {
 
         jest.runAllTicks();
 
-        expect(loadDataMock).toHaveBeenCalledWith('555', inboundProps.activeFY);
+        expect(loadDataMock).toHaveBeenCalledWith('555', inboundProps.activeFY, 1);
         loadDataSpy.reset();
 
         unmockAgencyHelper();

--- a/tests/containers/agency/visualizations/FederalAccountContainer-test.jsx
+++ b/tests/containers/agency/visualizations/FederalAccountContainer-test.jsx
@@ -8,13 +8,11 @@ import { mount, shallow } from 'enzyme';
 import sinon from 'sinon';
 
 import FederalAccountContainer from 'containers/agency/visualizations/FederalAccountContainer';
-import * as AgencyHelper from 'helpers/agencyHelper';
 
 import { mockAccount, parsedSeries } from './mocks/mockFederalAccount';
 
-// force Jest to use native Node promises
-// see: https://facebook.github.io/jest/docs/troubleshooting.html#unresolved-promises
-global.Promise = require.requireActual('promise');
+jest.mock('helpers/agencyHelper', () => require('./../agencyHelper'));
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
 
 // spy on specific functions inside the component
 const loadDataSpy = sinon.spy(FederalAccountContainer.prototype, 'loadData');
@@ -37,56 +35,19 @@ jest.mock('containers/glossary/GlossaryButtonWrapperContainer', () =>
 jest.mock('containers/glossary/GlossaryContainer', () =>
     jest.fn(() => null));
 
-const mockAgencyHelper = (functionName, event, expectedResponse) => {
-    jest.useFakeTimers();
-    // override the specified function
-    AgencyHelper[functionName] = jest.fn(() => {
-        // Axios normally returns a promise, replicate this, but return the expected result
-        const networkCall = new Promise((resolve, reject) => {
-            process.nextTick(() => {
-                if (event === 'resolve') {
-                    resolve({
-                        data: expectedResponse
-                    });
-                }
-                else {
-                    reject({
-                        data: expectedResponse
-                    });
-                }
-            });
-        });
-
-        return {
-            promise: networkCall,
-            cancel: jest.fn()
-        };
-    });
-};
-
-const unmockAgencyHelper = () => {
-    jest.useRealTimers();
-    jest.unmock('helpers/agencyHelper');
-};
 
 describe('FederalAccountContainer', () => {
-    it('should make an API call for the selected agency on mount', () => {
-        mockAgencyHelper('fetchAgencyFederalAccounts', 'resolve', mockAccount);
-
-        mount(<FederalAccountContainer
+    it('should make an API call for the selected agency on mount', async () => {
+        const container = mount(<FederalAccountContainer
             {...inboundProps} />);
 
-        jest.runAllTicks();
+        await container.instance().request.promise;
 
         expect(loadDataSpy.callCount).toEqual(1);
         loadDataSpy.reset();
-
-        unmockAgencyHelper();
     });
 
-    it('should make a new API call when the inbound agency ID prop changes', () => {
-        mockAgencyHelper('fetchAgencyFederalAccounts', 'resolve', mockAccount);
-
+    it('should make a new API call when the inbound agency ID prop changes', async () => {
         const container = mount(<FederalAccountContainer
             {...inboundProps} />);
 
@@ -98,17 +59,14 @@ describe('FederalAccountContainer', () => {
             id: '555'
         });
 
-        jest.runAllTicks();
+        await container.instance().request.promise;
 
         expect(loadDataMock).toHaveBeenCalledWith('555', inboundProps.activeFY, 1);
         loadDataSpy.reset();
-
-        unmockAgencyHelper();
     });
 
     describe('parseData', () => {
         it('should parse the returned API response', () => {
-            mockAgencyHelper('fetchAgencyFederalAccounts', 'resolve', mockAccount);
             const container = shallow(<FederalAccountContainer
                 {...inboundProps} />);
 
@@ -117,6 +75,53 @@ describe('FederalAccountContainer', () => {
             expect(container.state().dataSeries).toEqual(parsedSeries.dataSeries);
             expect(container.state().labelSeries).toEqual(parsedSeries.labelSeries);
             expect(container.state().linkSeries).toEqual(parsedSeries.linkSeries);
+        });
+    });
+
+    describe('changePage', () => {
+        it('should update the page number in state', () => {
+            const container = shallow(<FederalAccountContainer
+                {...inboundProps} />);
+
+            container.setState({
+                isLastPage: false
+            });
+
+            expect(container.state().page).toEqual(1);
+
+            container.instance().changePage(2);
+            expect(container.state().page).toEqual(2);
+        });
+        it('should make an API call with the new page number', () => {
+            const container = shallow(<FederalAccountContainer
+                {...inboundProps} />);
+
+            container.setState({
+                isLastPage: false
+            });
+
+            const loadDataMock = jest.fn();
+            container.instance().loadData = loadDataMock;
+
+            container.instance().changePage(2);
+            expect(loadDataMock).toHaveBeenCalledWith(inboundProps.id, inboundProps.activeFY, 2);
+        });
+
+        it('should not do anything if there are no more pages', () => {
+            const container = shallow(<FederalAccountContainer
+                {...inboundProps} />);
+
+            container.setState({
+                isLastPage: true
+            });
+
+            const loadDataMock = jest.fn();
+            container.instance().loadData = loadDataMock;
+
+            expect(container.state().page).toEqual(1);
+
+            container.instance().changePage(2);
+            expect(container.state().page).toEqual(1);
         });
     });
 });


### PR DESCRIPTION
- Adds pagination to the Federal Accounts visualization on the Agency Profile Page so that users can see more than just the top 10 accounts
- Updated tests