### PR TITLE
Hotfix: Hold off using the new FY until 2/1

### DIFF
--- a/src/js/components/account/AccountOverview.jsx
+++ b/src/js/components/account/AccountOverview.jsx
@@ -74,7 +74,7 @@ export default class AccountOverview extends React.Component {
 
     generateSummary(account) {
         // determine the current fiscal year and get the associated values
-        const fy = FiscalYearHelper.currentFiscalYear();
+        const fy = FiscalYearHelper.defaultFiscalYear();
         let fiscalYearAvailable = true;
         let authorityValue = 0;
         let obligatedValue = 0;

--- a/src/js/components/explorer/detail/sidebar/FYPicker.jsx
+++ b/src/js/components/explorer/detail/sidebar/FYPicker.jsx
@@ -13,7 +13,7 @@ const propTypes = {
 
 const FYPicker = (props) => {
     const fy = [];
-    const currentFY = FiscalYearHelper.currentFiscalYear();
+    const currentFY = FiscalYearHelper.defaultFiscalYear();
     const earliestFY = FiscalYearHelper.earliestExplorerYear;
     for (let year = currentFY; year >= earliestFY; year--) {
         const item = (<li key={year}>

--- a/src/js/components/explorer/landing/ExplorerLanding.jsx
+++ b/src/js/components/explorer/landing/ExplorerLanding.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 
-import { currentFiscalYear } from 'helpers/fiscalYearHelper';
+import { defaultFiscalYear } from 'helpers/fiscalYearHelper';
 
 import ExplorerWrapperPage from '../ExplorerWrapperPage';
 import ExplorerLandingOption from './ExplorerLandingOption';
@@ -14,7 +14,7 @@ const ExplorerLanding = () => (
     <ExplorerWrapperPage>
         <div className="explorer-landing-page">
             <div className="landing-intro">
-                <h2>Explore spending for Fiscal Year {currentFiscalYear()}</h2>
+                <h2>Explore spending for Fiscal Year {defaultFiscalYear()}</h2>
                 <div className="description">
                     <div className="highlight">
                         Choose a starting point to begin.

--- a/src/js/containers/account/AccountContainer.jsx
+++ b/src/js/containers/account/AccountContainer.jsx
@@ -129,7 +129,7 @@ export class AccountContainer extends React.Component {
                     {
                         field: ['reporting_period_start', 'reporting_period_end'],
                         operation: 'range_intersect',
-                        value: FiscalYearHelper.currentFiscalYear(),
+                        value: FiscalYearHelper.defaultFiscalYear(),
                         value_format: 'fy'
                     }
                 ],

--- a/src/js/containers/account/filters/AccountTimePeriodContainer.jsx
+++ b/src/js/containers/account/filters/AccountTimePeriodContainer.jsx
@@ -46,7 +46,7 @@ export class AccountTimePeriodContainer extends React.Component {
         const timePeriods = [];
 
         // determine the current fiscal year
-        const currentFY = FiscalYearHelper.currentFiscalYear();
+        const currentFY = FiscalYearHelper.defaultFiscalYear();
 
         for (let i = currentFY; i >= startYear; i--) {
             timePeriods.push(i.toString());

--- a/src/js/containers/search/filters/TimePeriodContainer.jsx
+++ b/src/js/containers/search/filters/TimePeriodContainer.jsx
@@ -46,7 +46,7 @@ export class TimePeriodContainer extends React.Component {
         const timePeriods = [];
 
         // determine the current fiscal year
-        const currentFY = FiscalYearHelper.currentFiscalYear();
+        const currentFY = FiscalYearHelper.defaultFiscalYear();
 
         for (let i = currentFY; i >= startYear; i--) {
             timePeriods.push(i.toString());

--- a/src/js/helpers/fiscalYearHelper.js
+++ b/src/js/helpers/fiscalYearHelper.js
@@ -21,6 +21,18 @@ export const currentFiscalYear = () => {
     return currentFY;
 };
 
+export const defaultFiscalYear = () => {
+    // wait until after the 1/31 of the new year
+    const currentMonth = moment().month();
+    if (currentMonth >= 1 && currentMonth < 9) {
+        // months are zero-indexed, so 1 is February, 9 is October (start of the next fiscal year)
+        // show the current fiscal year if the month is February or later but before October
+        return currentFiscalYear();
+    }
+    // go to the previous fiscal year
+    return currentFiscalYear() - 1;
+};
+
 export const convertFYToDateRange = (fy) => {
     const startingYear = fy - 1;
     const endingYear = fy;

--- a/src/js/redux/reducers/explorer/explorerReducer.js
+++ b/src/js/redux/reducers/explorer/explorerReducer.js
@@ -4,7 +4,7 @@
  **/
 
 import { List, Record } from 'immutable';
-import { currentFiscalYear } from 'helpers/fiscalYearHelper';
+import { defaultFiscalYear } from 'helpers/fiscalYearHelper';
 
 export const ActiveScreen = new Record({
     within: '', // within is the data type that the total is a slice WITHIN
@@ -14,7 +14,7 @@ export const ActiveScreen = new Record({
 
 export const initialState = {
     root: 'object_class',
-    fy: `${currentFiscalYear()}`,
+    fy: `${defaultFiscalYear()}`,
     active: new ActiveScreen(),
     trail: new List([])
 };

--- a/src/js/redux/reducers/search/searchFiltersReducer.js
+++ b/src/js/redux/reducers/search/searchFiltersReducer.js
@@ -42,7 +42,7 @@ export const requiredTypes = {
 export const initialState = {
     keyword: '',
     timePeriodType: 'fy',
-    timePeriodFY: new Set([`${FiscalYearHelper.currentFiscalYear()}`]),
+    timePeriodFY: new Set([`${FiscalYearHelper.defaultFiscalYear()}`]),
     timePeriodStart: null,
     timePeriodEnd: null,
     selectedLocations: new OrderedMap(),

--- a/tests/containers/search/SearchContainer-test.jsx
+++ b/tests/containers/search/SearchContainer-test.jsx
@@ -27,6 +27,8 @@ jest.mock('components/search/SearchPage', () =>
     jest.fn(() => null));
 
 jest.mock('helpers/searchHelper', () => require('./filters/searchHelper'));
+jest.mock('helpers/fiscalYearHelper', () => require('./filters/fiscalYearHelper'));
+
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
 
 
@@ -260,7 +262,7 @@ describe('SearchContainer', () => {
             container.instance().applyFilters(mockFilters.filter);
 
             const expectedFilters = Object.assign({}, initialState, {
-                timePeriodFY: new Set(['2017'])
+                timePeriodFY: new Set(['1990'])
             });
 
             expect(populateAction).toHaveBeenCalledTimes(1);

--- a/tests/containers/search/filters/fiscalYearHelper.js
+++ b/tests/containers/search/filters/fiscalYearHelper.js
@@ -1,2 +1,3 @@
 export const earliestFiscalYear = 1984;
 export const currentFiscalYear = () => 1990;
+export const defaultFiscalYear = () => 1990;

--- a/tests/helpers/fiscalYearHelper-test.js
+++ b/tests/helpers/fiscalYearHelper-test.js
@@ -41,6 +41,44 @@ describe('Fiscal Year helper functions', () => {
         });
     });
 
+    describe('defaultFiscalYear', () => {
+        it('should use the current calendar year as the fiscal year for every month before October but after January', () => {
+            // override the moment's library's internal time to a known mocked date
+            const mockedDate = moment('2015-04-01', 'YYYY-MM-DD').toDate();
+            moment.now = () => (mockedDate);
+
+            const currentFY = FiscalYearHelper.defaultFiscalYear();
+            expect(currentFY).toEqual(2015);
+
+            // reset moment's date to the current time
+            moment.now = () => (new Date());
+        });
+
+        it('should use the previous calendar year as the fiscal year for every month before February', () => {
+            // override the moment's library's internal time to a known mocked date
+            const mockedDate = moment('2015-01-20', 'YYYY-MM-DD').toDate();
+            moment.now = () => (mockedDate);
+
+            const currentFY = FiscalYearHelper.defaultFiscalYear();
+            expect(currentFY).toEqual(2014);
+
+            // reset moment's date to the current time
+            moment.now = () => (new Date());
+        });
+
+        it('should use the current calendar year as the fiscal year for months on or after October', () => {
+            // override the moment's library's internal time to a known mocked date
+            const mockedDate = moment('2015-11-01', 'YYYY-MM-DD').toDate();
+            moment.now = () => (mockedDate);
+
+            const currentFY = FiscalYearHelper.defaultFiscalYear();
+            expect(currentFY).toEqual(2015);
+
+            // reset moment's date to the current time
+            moment.now = () => (new Date());
+        });
+    });
+
     describe('convertFYtoDateRange', () => {
         it('should convert a given fiscal year to an array of start, end date strings', () => {
             const fy = '2016';

--- a/tests/redux/reducers/explorer/mockCurrentFiscalYear.js
+++ b/tests/redux/reducers/explorer/mockCurrentFiscalYear.js
@@ -1,1 +1,2 @@
 export const currentFiscalYear = () => '1984';
+export const defaultFiscalYear = () => '1984';


### PR DESCRIPTION
* Current FY will not appear as award search and spending explorer filter options until 2/1
* Use previous FY prior to 2/1 for federal account sankey and spending explorer
* Updated tests