### PR TITLE
Hotfix: Updated obligated amount narrative in agency object class treemap

### DIFF
--- a/src/js/components/agency/AgencyContent.jsx
+++ b/src/js/components/agency/AgencyContent.jsx
@@ -242,6 +242,7 @@ export default class AgencyContent extends React.Component {
                         <ObjectClassContainer
                             id={this.props.agency.id}
                             activeFY={this.props.agency.overview.activeFY}
+                            displayedTotalObligation={this.props.agency.overview.obligatedAmount}
                             asOfDate={asOfDate} />
                         <FederalAccountContainer
                             id={this.props.agency.id}

--- a/src/js/components/agency/visualizations/objectClass/ObjectClassTreeMap.jsx
+++ b/src/js/components/agency/visualizations/objectClass/ObjectClassTreeMap.jsx
@@ -18,6 +18,7 @@ const propTypes = {
     minorObjectClasses: PropTypes.object,
     totalObligation: PropTypes.number,
     totalMinorObligation: PropTypes.number,
+    displayedTotalObligation: PropTypes.number,
     showMinorObjectClasses: PropTypes.func,
     asOfDate: PropTypes.string,
     hasNegatives: PropTypes.bool,
@@ -108,7 +109,7 @@ export default class ObjectClassTreeMap extends React.Component {
     }
 
     render() {
-        const total = MoneyFormatter.formatTreemapValues(this.props.totalObligation);
+        const total = MoneyFormatter.formatTreemapValues(this.props.displayedTotalObligation);
 
         return (
             <div

--- a/src/js/containers/agency/visualizations/ObjectClassContainer.jsx
+++ b/src/js/containers/agency/visualizations/ObjectClassContainer.jsx
@@ -15,7 +15,8 @@ import ObjectClassTreeMap from 'components/agency/visualizations/objectClass/Obj
 const propTypes = {
     id: PropTypes.string,
     activeFY: PropTypes.string,
-    asOfDate: PropTypes.string
+    asOfDate: PropTypes.string,
+    displayedTotalObligation: PropTypes.number
 };
 
 const defaultProps = {
@@ -220,6 +221,7 @@ export default class ObjectClassContainer extends React.PureComponent {
     render() {
         return (
             <ObjectClassTreeMap
+                displayedTotalObligation={this.props.displayedTotalObligation}
                 majorObjectClasses={this.state.majorObjectClasses}
                 minorObjectClasses={this.state.minorObjectClasses}
                 totalObligation={this.state.totalObligation}


### PR DESCRIPTION
* Get the total obligated amount in the object class narrative from File A (via the redux agency overview object)