### PR TITLE
Revert hard coded total budget authority amount

### DIFF
--- a/src/js/components/agency/overview/AgencyOverview.jsx
+++ b/src/js/components/agency/overview/AgencyOverview.jsx
@@ -13,9 +13,6 @@ import * as MoneyFormatter from 'helpers/moneyFormatter';
 
 import HorizontalBarItem from '../visualizations/obligated/HorizontalBarItem';
 
-// Temporarily use a hardcoded total budget authority
-const federalBudget = 8361447130497.72;
-
 const propTypes = {
     agency: PropTypes.object
 };
@@ -85,7 +82,7 @@ export default class AgencyOverview extends React.PureComponent {
         // Move props to variables for readability
         const budgetAuthority = props.agency.budgetAuthority;
 
-        // const federalBudget = props.agency.federalBudget;
+        const federalBudget = props.agency.federalBudget;
 
         const fy = parseInt(props.agency.activeFY, 10);
         const quarter = parseInt(props.agency.activeFQ, 10);
@@ -132,17 +129,11 @@ export default class AgencyOverview extends React.PureComponent {
         // Generate visualization parameters
         let obligatedWidth = 0;
 
-        // Temporarily use hardcoded Federal Budget
-        if (props.agency.budgetAuthority !== 0) {
-            const percentageNumber = props.agency.budgetAuthority / federalBudget;
+        // Only check the percentage width if the data is available
+        if (props.agency.budgetAuthority !== 0 && props.agency.federalBudget !== 0) {
+            const percentageNumber = props.agency.budgetAuthority / props.agency.federalBudget;
             obligatedWidth = visualizationWidth * percentageNumber;
         }
-
-        // Only check the percentage width if the data is available
-        // if (props.agency.budgetAuthority !== 0 && props.agency.federalBudget !== 0) {
-        //     const percentageNumber = props.agency.budgetAuthority / props.agency.federalBudget;
-        //     obligatedWidth = visualizationWidth * percentageNumber;
-        // }
 
         // Account for 10 pixels of left padding
         const padding = 10;

--- a/src/js/containers/agencyLanding/AgencyLandingContainer.jsx
+++ b/src/js/containers/agencyLanding/AgencyLandingContainer.jsx
@@ -135,18 +135,14 @@ export class AgencyLandingContainer extends React.Component {
 
     parseAgencies(data) {
         const agencies = [];
-        // Temporarily hardcode the total budget authority to calculate accurate percentages
-        const totalBudgetAuthority = 8361447130497.72;
 
         data.results.forEach((item) => {
             // Format budget authority amount
             const formattedCurrency =
                 MoneyFormatter.formatMoneyWithPrecision(item.budget_authority_amount, 0);
 
-            const percentage = item.budget_authority_amount / totalBudgetAuthority;
-
             // Convert from decimal value to percentage and round to 2 decimal places
-            const formattedPercentage = (percentage * 100).toFixed(2);
+            const formattedPercentage = (item.percentage_of_total_budget_authority * 100).toFixed(2);
 
             let percent = `${formattedPercentage}%`;
             if (percent === '0.00%') {
@@ -162,7 +158,7 @@ export class AgencyLandingContainer extends React.Component {
                 agency_id: item.agency_id,
                 agency_name: `${item.agency_name} ${abbreviation}`,
                 budget_authority_amount: item.budget_authority_amount,
-                percentage_of_total_budget_authority: percentage,
+                percentage_of_total_budget_authority: item.percentage_of_total_budget_authority,
                 display: {
                     agency_name: `${item.agency_name} (${item.abbreviation})`,
                     budget_authority_amount: formattedCurrency,

--- a/tests/containers/agencyLanding/mockToptierAgencies.js
+++ b/tests/containers/agencyLanding/mockToptierAgencies.js
@@ -45,38 +45,32 @@ export const mockAgenciesOrder = {
 };
 
 export const mockPopulated = [
-    // Temporarily calculate percentage of budget authority using the
-    // hardcoded total budget authority value
     {
         agency_id: 1,
         agency_name: "Agency 1 (ABC)",
-        // percentage_of_total_budget_authority: 0.655,
-        percentage_of_total_budget_authority: (123.0 / 8361447130497.72),
+        percentage_of_total_budget_authority: 0.655,
         budget_authority_amount: 123.0,
         display: {
             agency_name: "Agency 1 (ABC)",
             budget_authority_amount: "$123",
-            //percentage_of_total_budget_authority: "65.50%"
-            percentage_of_total_budget_authority: "Less than 0.01%"
+            percentage_of_total_budget_authority: "65.50%"
         }
     },
     {
         agency_id: 2,
         agency_name: "Agency 2 (XYZ)",
-        // percentage_of_total_budget_authority: 0.345,
-        percentage_of_total_budget_authority: (23400000000.0 / 8361447130497.72),
+        percentage_of_total_budget_authority: 0.345,
         budget_authority_amount: 23400000000.0,
         display: {
             agency_name: "Agency 2 (XYZ)",
             budget_authority_amount: "$23,400,000,000",
-            percentage_of_total_budget_authority: "0.28%"
+            percentage_of_total_budget_authority: "34.50%"
         }
     },
     {
         agency_id: 3,
         agency_name: "Agency 3 (FFF)",
-        // percentage_of_total_budget_authority: 0.00003,
-        percentage_of_total_budget_authority: (0.10 / 8361447130497.72),
+        percentage_of_total_budget_authority: 0.00003,
         budget_authority_amount: 0.10,
         display: {
             agency_name: "Agency 3 (FFF)",


### PR DESCRIPTION
Removes hard coded total budget from:
- Agency landing page
- Agency overview visualization 
- Tests