### PR TITLE
Hotfix: Lock moment version

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "keyboardjs": "^2.3.3",
     "lodash": "^4.6.1",
     "mapbox-gl": "^0.39.1",
-    "moment": "^2.12.0",
+    "moment": "2.18.1",
     "moment-timezone": "^0.5.4",
     "mousetrap": "^1.6.1",
     "node-uuid": "^1.4.7",


### PR DESCRIPTION
* A bug in moment 2.19 (released today) will cause builds to fail. Our `package.json` will auto-upgrade to this version on new installs. This change locks the version to 2.18.1, the last known stable version.