### PR TITLE
Don't close dirty filters

### DIFF
--- a/src/js/components/sharedComponents/filterSidebar/FilterOption.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterOption.jsx
@@ -37,6 +37,7 @@ export default class FilterOption extends React.Component {
         super(props);
 
         this.state = {
+            isDirty: false,
             showFilter: true,
             arrowState: 'expanded'
         };
@@ -56,7 +57,7 @@ export default class FilterOption extends React.Component {
     }
 
     componentWillUpdate(nextProps) {
-        if (nextProps.defaultExpand !== this.props.defaultExpand) {
+        if (nextProps.defaultExpand !== this.props.defaultExpand && !this.state.isDirty) {
             if (nextProps.defaultExpand) {
                 this.setState({
                     showFilter: true,
@@ -83,6 +84,7 @@ export default class FilterOption extends React.Component {
             FilterOption.logFilterEvent(filterName);
         }
         this.setState({
+            isDirty: true,
             showFilter: newShowState,
             arrowState: newArrowState
         });

--- a/src/js/components/sharedComponents/filterSidebar/FilterOption.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterOption.jsx
@@ -60,6 +60,7 @@ export default class FilterOption extends React.Component {
         if (nextProps.defaultExpand !== this.props.defaultExpand && !this.state.isDirty) {
             if (nextProps.defaultExpand) {
                 this.setState({
+                    isDirty: true,
                     showFilter: true,
                     arrowState: 'expanded'
                 });


### PR DESCRIPTION
* Mark filters as dirty when they are expanded or pre-populated from the search hash
* Don't collapse dirty filters when their values are cleared