### PR TITLE
Reset the sort order when the subdivision type changes

### DIFF
--- a/src/js/containers/explorer/detail/DetailContentContainer.jsx
+++ b/src/js/containers/explorer/detail/DetailContentContainer.jsx
@@ -28,7 +28,7 @@ const propTypes = {
     addExplorerTrail: PropTypes.func,
     showTooltip: PropTypes.func,
     hideTooltip: PropTypes.func,
-    setExplorerTablePage: PropTypes.func
+    resetExplorerTable: PropTypes.func
 };
 
 export class DetailContentContainer extends React.Component {
@@ -142,6 +142,8 @@ export class DetailContentContainer extends React.Component {
         ];
 
         this.props.overwriteExplorerTrail(trail);
+
+        this.props.resetExplorerTable();
 
         if (this.state.transitionSteps !== 0) {
             // there is going to be a transition, so trigger the exit animation
@@ -302,8 +304,7 @@ export class DetailContentContainer extends React.Component {
             id: data.id
         };
 
-        // reset to page 1
-        this.props.setExplorerTablePage(1);
+        this.props.resetExplorerTable();
 
         this.setState({
             transitionSteps: 1,
@@ -326,8 +327,7 @@ export class DetailContentContainer extends React.Component {
             subdivision: type
         });
 
-        // reset to page 1
-        this.props.setExplorerTablePage(1);
+        this.props.resetExplorerTable();
 
         this.setState({
             transitionSteps: 0
@@ -385,8 +385,7 @@ export class DetailContentContainer extends React.Component {
 
         this.props.overwriteExplorerTrail(newTrail);
 
-        // reset to page 1
-        this.props.setExplorerTablePage(1);
+        this.props.resetExplorerTable();
 
         this.setState({
             transitionSteps: steps,

--- a/src/js/redux/actions/explorer/explorerActions.js
+++ b/src/js/redux/actions/explorer/explorerActions.js
@@ -38,6 +38,10 @@ export const setExplorerTablePage = (state) => ({
     number: state
 });
 
+export const resetExplorerTable = () => ({
+    type: 'RESET_EXPLORER_TABLE'
+});
+
 export const resetExplorer = () => ({
     type: 'RESET_EXPLORER'
 });

--- a/src/js/redux/reducers/explorer/explorerReducer.js
+++ b/src/js/redux/reducers/explorer/explorerReducer.js
@@ -70,6 +70,13 @@ const explorerReducer = (state = initialState, action) => {
                 table
             });
         }
+        case 'RESET_EXPLORER_TABLE': {
+            const table = Object.assign({}, initialState.table);
+
+            return Object.assign({}, state, {
+                table
+            });
+        }
         case 'RESET_EXPLORER': {
             return Object.assign({}, initialState);
         }

--- a/tests/containers/explorer/detail/mockData.js
+++ b/tests/containers/explorer/detail/mockData.js
@@ -185,6 +185,7 @@ export const mockActions = {
     overwriteExplorerTrail: jest.fn(),
     setExplorerTableOrder: jest.fn(),
     setExplorerTablePage: jest.fn(),
+    resetExplorerTable: jest.fn(),
     resetExplorer: jest.fn()
 };
 

--- a/tests/redux/reducers/explorer/explorerReducer-test.js
+++ b/tests/redux/reducers/explorer/explorerReducer-test.js
@@ -113,6 +113,38 @@ describe('explorerReducer', () => {
         });
     });
 
+    describe('RESET_EXPLORER_TABLE', () => {
+        it('should reset the table to its initial state', () => {
+            const state = {
+                root: 'agency',
+                active: new ActiveScreen({
+                    within: 'agency',
+                    subdivision: 'federal_account',
+                    total: 12345
+                }),
+                fy: '1984',
+                trail: new List(['a', 'b', 'c']),
+                table: {
+                    order: {
+                        field: 'fake_field',
+                        direction: 'dir'
+                    },
+                    pageNumber: 4
+                }
+            };
+
+            const action = {
+                type: 'RESET_EXPLORER_TABLE'
+            };
+
+            const newState = explorerReducer(state, action);
+
+            expect(newState.table.order.field).toEqual('obligated_amount');
+            expect(newState.table.order.direction).toEqual('desc');
+            expect(newState.table.pageNumber).toEqual(1);
+        });
+    });
+
     describe('RESET_EXPLORER', () => {
         it('should reset the explorer state to its initial state', () => {
             const state = {


### PR DESCRIPTION
- Resets the table to page 1 and the default sort order in Redux when changing level or subdivision