### PR TITLE
Agency Page Design Updates

### DIFF
--- a/src/_scss/pages/agency/_contentWrap.scss
+++ b/src/_scss/pages/agency/_contentWrap.scss
@@ -9,10 +9,6 @@
     .agency-padded-content {
         padding: rem(30);
 
-        &.overview {
-            border-bottom: 1px solid $color-gray-border;
-        }
-
         &.data {
             padding-top: 0;
         }

--- a/src/_scss/pages/agency/_contentWrap.scss
+++ b/src/_scss/pages/agency/_contentWrap.scss
@@ -8,9 +8,5 @@
 
     .agency-padded-content {
         padding: rem(30);
-
-        &.data {
-            padding-top: 0;
-        }
     }
 }

--- a/src/_scss/pages/agency/_overview.scss
+++ b/src/_scss/pages/agency/_overview.scss
@@ -105,6 +105,25 @@
                 height: rem(20);
                 width: 100%;
             }
+
+            h4 {
+                position: relative;
+
+                a {
+                    height: rem(14);
+                    width: rem(14);
+                    margin: 0 rem(4);
+                    display: inline-block;
+
+                    svg {
+                        position: absolute;
+                        top: rem(6);
+                        height: rem(14);
+                        width: rem(14);
+                        fill: $color-gray;
+                    }
+                }
+            }
         }
 
 

--- a/src/_scss/pages/agency/_overview.scss
+++ b/src/_scss/pages/agency/_overview.scss
@@ -110,17 +110,17 @@
                 position: relative;
 
                 a {
-                    height: rem(14);
-                    width: rem(14);
-                    margin: 0 rem(4);
+                    height: rem(16);
+                    width: rem(16);
+                    margin: 0 rem(6) 0 rem(2);
                     display: inline-block;
 
                     svg {
                         position: absolute;
                         top: rem(6);
-                        height: rem(14);
-                        width: rem(14);
-                        fill: $color-gray;
+                        height: rem(16);
+                        width: rem(16);
+                        fill: $color-gray-lighter;
                     }
                 }
             }

--- a/src/_scss/pages/agency/_overview.scss
+++ b/src/_scss/pages/agency/_overview.scss
@@ -120,7 +120,7 @@
                         top: rem(6);
                         height: rem(16);
                         width: rem(16);
-                        fill: $color-gray-lighter;
+                        fill: $color-gray-light;
                     }
                 }
             }

--- a/src/_scss/pages/agency/_section.scss
+++ b/src/_scss/pages/agency/_section.scss
@@ -3,18 +3,22 @@
 
     .agency-callout-description {
         @include display(flex);
-        @include align-items(center);
-        @include justify-content(center);
+        @include align-items(left);
+        @include justify-content(left);
         width: 100%;
         position: relative;
-        margin: rem(60) 0 rem(60);
-        padding: 0 rem(63);
+        margin: rem(24) 0 rem(32);
+        padding: 0;
         color: $color-base;
         font-family: $font-sans;
         font-size: $lead-font-size;
         font-weight: 300;
         line-height: 35px;
-        text-align: center;
+        text-align: left;
+
+        p {
+            margin: 0;
+        }
     }
 
     .agency-section-title {
@@ -23,6 +27,12 @@
             line-height: rem(47);
             margin: rem(5) 0;
         }
+
+        hr {
+            width: 100%;
+            margin: 0 0 rem(4);
+        }
+
 	    em {
 		    font-size: rem(12);
 	    }
@@ -32,7 +42,7 @@
         @import "pages/homepage/treemapSection";
 
 	    .agency-viz-description {
-		    margin-top: rem(10);
+		    margin: rem(10) 0 rem(85);
 		    font-size: rem(12);
 	    }
 

--- a/src/_scss/pages/agency/_sidebar.scss
+++ b/src/_scss/pages/agency/_sidebar.scss
@@ -17,13 +17,13 @@
     border-top: 1px solid $color-gray-border;
     border-right: 1px solid $color-gray-border;
     border-bottom: 1px solid $color-gray-border;
-    padding: rem(30);
+    padding: rem(40) rem(46);
 
     ul {
         @include unstyled-list;
 
         li {
-            margin-bottom: rem(20);
+            margin-bottom: rem(24);
 
             &:last-child {
                 margin-bottom: rem(0);
@@ -32,7 +32,7 @@
 
         a.sidebar-link {
             color: $color-primary;
-            font-size: rem(16);
+            font-size: rem(19);
             line-height: rem(20);
             padding-bottom: rem(5);
 
@@ -45,7 +45,7 @@
             }
 
             &.active {
-                font-weight: $font-semibold;
+                font-weight: $font-bold;
                 border-bottom: 5px solid $color-gold;
             }
         }

--- a/src/_scss/pages/agency/_sidebar.scss
+++ b/src/_scss/pages/agency/_sidebar.scss
@@ -31,7 +31,7 @@
         }
 
         a.sidebar-link {
-            color: $color-primary;
+            color: $color-base;
             font-size: rem(19);
             line-height: rem(20);
             padding-bottom: rem(5);

--- a/src/_scss/pages/agency/agencyPage.scss
+++ b/src/_scss/pages/agency/agencyPage.scss
@@ -8,7 +8,7 @@
 
     .main-content {
         @import "../../mixins/fullSectionWrap";
-        @include fullSectionWrap(($global-mrg * 4), ($global-mrg * 4));
+        @include fullSectionWrap(($global-mrg * 2), ($global-mrg * 2));
         padding:  0;
 
         @import "./_positioning";

--- a/src/_scss/pages/agency/visualizations/_obligated.scss
+++ b/src/_scss/pages/agency/visualizations/_obligated.scss
@@ -16,8 +16,8 @@
 
         .horizontal-bar {
             width: 100%;
-            height: rem(70);
-	        padding-top: rem(15);
+            height: rem(40);
+	        margin: rem(15) 0 rem(10);
 
             .legend-container {
                 color: $color-gray-medium;

--- a/src/_scss/pages/agency/visualizations/_obligated.scss
+++ b/src/_scss/pages/agency/visualizations/_obligated.scss
@@ -1,37 +1,59 @@
 .agency-section-wrapper {
     .agency-obligated-content {
-        text-align: center;
+        text-align: left;
+
         .fy-text {
-            margin-top: rem(76);
+            margin: rem(32) 0 0;
             font-style: italic;
+            font-size: rem(18);
         }
+
         .against-auth-text {
-            font-size: rem(20);
+            font-size: rem(24);
             font-weight: 300;
-            .number {
-                font-weight: normal;
-                color: $color-vis-dark;
-                font-size: rem(30);
-                letter-spacing: -1px;
-                line-height: rem(38);
-                &.number-bolder {
-                    font-weight: 600;
-                }
-            }
+            margin: rem(8) 0 0;
         }
+
         .horizontal-bar {
             width: 100%;
-            height: rem(100);
+            height: rem(70);
 	        padding-top: rem(15);
+
             .legend-container {
                 color: $color-gray-medium;
+
                 .key-label {
                     font-size: rem(12);
                 }
             }
         }
+
+        .outlay-text {
+            font-size: rem(20);
+            font-weight: 300;
+            line-height: rem(25);
+            margin: 0 0 rem(80);
+        }
+
         .object-class-text {
             margin: rem(100) rem(50) rem(78) rem(50);
+        }
+    }
+}
+
+.number {
+    font-weight: normal;
+    color: $color-vis-dark;
+    font-size: rem(30);
+    letter-spacing: -1px;
+    line-height: rem(38);
+
+    &.number-bolder {
+        font-weight: 600;
+
+        &.outlay {
+            font-size: rem(20);
+            color: #fdb81e;
         }
     }
 }

--- a/src/js/components/agency/AgencyContent.jsx
+++ b/src/js/components/agency/AgencyContent.jsx
@@ -10,6 +10,8 @@ import { scrollToY } from 'helpers/scrollToHelper';
 import moment from 'moment';
 import { convertQuarterToDate } from 'helpers/fiscalYearHelper';
 
+import GlossaryButtonWrapperContainer from 'containers/glossary/GlossaryButtonWrapperContainer';
+
 import ObjectClassContainer from 'containers/agency/visualizations/ObjectClassContainer';
 import RecipientContainer from 'containers/agency/visualizations/RecipientContainer';
 import ObligatedContainer from 'containers/agency/visualizations/ObligatedContainer';
@@ -237,7 +239,9 @@ export default class AgencyContent extends React.Component {
                 </div>
                 <div className="agency-content">
                     <div className="agency-padded-content overview">
-                        <AgencyOverview agency={this.props.agency.overview} />
+                        <GlossaryButtonWrapperContainer
+                            child={AgencyOverview}
+                            agency={this.props.agency.overview} />
                     </div>
                     <div className="agency-padded-content data">
                         <ObligatedContainer
@@ -259,7 +263,7 @@ export default class AgencyContent extends React.Component {
                         <RecipientContainer
                             id={this.props.agency.id}
                             activeFY={this.props.agency.overview.activeFY}
-                            lastUpdate={this.props.lastUpdate} />
+                            asOfDate={asOfDate} />
                         {disclaimer}
                     </div>
                     <AgencyFooterContainer id={this.props.agency.id} />

--- a/src/js/components/agency/overview/AgencyOverview.jsx
+++ b/src/js/components/agency/overview/AgencyOverview.jsx
@@ -11,6 +11,8 @@ import { convertQuarterToDate } from 'helpers/fiscalYearHelper';
 
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 
+import { Glossary } from 'components/sharedComponents/icons/Icons';
+
 import HorizontalBarItem from '../visualizations/obligated/HorizontalBarItem';
 
 const propTypes = {
@@ -189,9 +191,14 @@ export default class AgencyOverview extends React.PureComponent {
                         ref={(div) => {
                             this.containerDiv = div;
                         }}>
-                        <h4>Budgetary Resources for FY {this.props.agency.activeFY}</h4>
+                        <h4>Budgetary Resources
+                            <a href={`#/agency/${this.props.agency.id}?glossary=other-budgetary-resources`}>
+                                <Glossary />
+                            </a>
+                            for FY {this.props.agency.activeFY}</h4>
                         <div className="budget-authority-date">
-                            <em>Data as of {this.state.asOfDate}</em>
+                            <em>FY {this.props.agency.activeFY} data reported
+                                through {this.state.asOfDate}</em>
                         </div>
                         <div className="authority-amount">
                             {this.state.formattedBudgetAuthority}

--- a/src/js/components/agency/overview/AgencyOverview.jsx
+++ b/src/js/components/agency/overview/AgencyOverview.jsx
@@ -192,7 +192,7 @@ export default class AgencyOverview extends React.PureComponent {
                             this.containerDiv = div;
                         }}>
                         <h4>Budgetary Resources
-                            <a href={`#/agency/${this.props.agency.id}?glossary=other-budgetary-resources`}>
+                            <a href={`#/agency/${this.props.agency.id}?glossary=budgetary-resources`}>
                                 <Glossary />
                             </a>
                             for FY {this.props.agency.activeFY}</h4>

--- a/src/js/components/agency/visualizations/federalAccount/FederalAccountVisualization.jsx
+++ b/src/js/components/agency/visualizations/federalAccount/FederalAccountVisualization.jsx
@@ -12,6 +12,7 @@ import ChartMessage from 'components/search/visualizations/rank/RankVisualizatio
 import FederalAccountChart from './FederalAccountChart';
 
 const propTypes = {
+    activeFY: PropTypes.string,
     obligatedAmount: PropTypes.number,
     loading: PropTypes.bool,
     error: PropTypes.bool,
@@ -96,19 +97,19 @@ export default class FederalAccountVisualization extends React.Component {
             <div
                 className="agency-section-wrapper"
                 id="agency-federal-accounts">
-                <div className="agency-callout-description">
-                    <p>
-                        This {formattedObligation} in obligations is broken out in multiple <strong>federal accounts</strong> that are helpful in understanding what the agency broadly spends its money on. You can drill-down further into a federal account to view its program activities, which are at a more granular level.
-                    </p>
-                </div>
                 <div className="agency-section-title">
                     <h4>Federal Accounts</h4>
-                    <em>Data as of {this.props.asOfDate}</em>
                     <hr
                         className="results-divider"
                         ref={(hr) => {
                             this.sectionHr = hr;
                         }} />
+                    <em>FY {this.props.activeFY} data reported through {this.props.asOfDate}</em>
+                </div>
+                <div className="agency-callout-description">
+                    <p>
+                        This {formattedObligation} in obligations is broken out in multiple <strong>federal accounts</strong> that are helpful in understanding what the agency broadly spends its money on. You can drill-down further into a federal account to view its program activities, which are at a more granular level.
+                    </p>
                 </div>
                 <div className="agency-section-content">
                     <div className="chart-wrapper">

--- a/src/js/components/agency/visualizations/objectClass/ObjectClassTreeMap.jsx
+++ b/src/js/components/agency/visualizations/objectClass/ObjectClassTreeMap.jsx
@@ -14,6 +14,7 @@ import MajorObjectClasses from './MajorObjectClasses';
 import MinorObjectClasses from './MinorObjectClasses';
 
 const propTypes = {
+    activeFY: PropTypes.string,
     majorObjectClasses: PropTypes.object,
     minorObjectClasses: PropTypes.object,
     totalObligation: PropTypes.number,
@@ -115,15 +116,15 @@ export default class ObjectClassTreeMap extends React.Component {
             <div
                 className="agency-section-wrapper"
                 id="agency-object-classes">
-                <div className="agency-callout-description">
-                    <p>This {total} in obligations is divided among categories,
-                    called <strong>object classes</strong>. These groupings can be helpful
-                        for analysis and cross-agency comparison.</p>
-                </div>
                 <div className="agency-section-title">
                     <h4>Object Classes</h4>
-                    <em>Data as of {this.props.asOfDate}</em>
                     <hr className="results-divider" />
+                    <em>FY {this.props.activeFY} data reported through {this.props.asOfDate}</em>
+                </div>
+                <div className="agency-callout-description">
+                    <p>This {total} in obligations is divided among categories,
+                        called <strong>object classes</strong>. These groupings can be helpful
+                        for analysis and cross-agency comparison.</p>
                 </div>
                 <div className="agency-section-content">
                     <div

--- a/src/js/components/agency/visualizations/obligated/ObligatedGraph.jsx
+++ b/src/js/components/agency/visualizations/obligated/ObligatedGraph.jsx
@@ -68,18 +68,14 @@ export default class AgencyObligatedGraph extends React.Component {
                         y={0}
                         width={remainderWidth}
                         color={this.props.legend[2].color} />
-                    <OutlayLine
+                </g>
+                <g>
+                    <HorizontalBarItem
                         description="Outlay Amount"
-                        value={this.props.outlay}
-                        x={outlayWidth}
-                        y={0}
-                        height={20}
+                        x={0}
+                        y={20}
+                        width={outlayWidth}
                         color={this.props.legend[1].color} />
-                    <g
-                        className="legend-container"
-                        transform={`translate(0,52)`}>
-                        <BarChartLegend legend={this.props.legend} />
-                    </g>
                 </g>
             </svg>
         );

--- a/src/js/components/agency/visualizations/obligated/ObligatedGraph.jsx
+++ b/src/js/components/agency/visualizations/obligated/ObligatedGraph.jsx
@@ -6,9 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as MoneyFormatter from 'helpers/moneyFormatter';
-import BarChartLegend from 'components/search/visualizations/time/chart/BarChartLegend';
 import HorizontalBarItem from './HorizontalBarItem';
-import OutlayLine from './OutlayLine';
 
 const propTypes = {
     obligatedAmount: PropTypes.number,

--- a/src/js/components/agency/visualizations/obligated/ObligatedVisualization.jsx
+++ b/src/js/components/agency/visualizations/obligated/ObligatedVisualization.jsx
@@ -56,6 +56,7 @@ export default class AgencyObligatedAmount extends React.Component {
         // Move props to variables for readability
         const obligatedAmount = this.props.obligatedAmount;
         const budgetAuthority = this.props.budgetAuthority;
+        const outlay = this.props.outlay;
 
         // Generate Budget Authority string
         const budgetAuthorityAmount = MoneyFormatter
@@ -71,6 +72,13 @@ export default class AgencyObligatedAmount extends React.Component {
             .formatMoneyWithPrecision(obligatedAmount / obligatedAmountValue.unit, 1)}
         ${capitalize(obligatedAmountValue.longLabel)}`;
 
+        // Generate Outlay Amount string
+        const outlayAmountValue = MoneyFormatter
+            .calculateUnitForSingleValue(outlay);
+        const formattedOutlayAmount = `${MoneyFormatter
+            .formatMoneyWithPrecision(outlay / outlayAmountValue.unit, 1)}
+        ${capitalize(outlayAmountValue.longLabel)}`;
+
         const legend = [
             {
                 color: '#5C7480',
@@ -78,7 +86,7 @@ export default class AgencyObligatedAmount extends React.Component {
                 offset: 0
             },
             {
-                color: '#FBA302',
+                color: '#FDB81E',
                 label: 'Outlay Amount',
                 offset: 130
             },
@@ -94,30 +102,30 @@ export default class AgencyObligatedAmount extends React.Component {
             <div
                 className="agency-section-wrapper"
                 id="agency-obligated-amount">
-                <div className="agency-callout-description">
-                    <p>
-                        Agencies spend their available budgetary resources by making binding
-financial commitments called <strong>obligations</strong>. An agency incurs an obligation, for
-example, when it places an order, signs a contract, awards a grant, purchases a service, or
-takes other actions that require it to make a payment.
-                    </p>
-                </div>
                 <div className="agency-section-wrapper">
                     <div className="agency-section-title">
                         <h4>Obligated Amount</h4>
-                        <em>Data as of {this.props.asOfDate}</em>
                         <hr
                             className="results-divider"
                             ref={(hr) => {
                                 this.sectionHr = hr;
                             }} />
+                        <em>FY {this.props.activeFY} data reported through {this.props.asOfDate}</em>
+                    </div>
+                    <div className="agency-callout-description">
+                        <p>
+                            Agencies spend their available budgetary resources by making binding
+                            financial commitments called <strong>obligations</strong>. An agency incurs an obligation, for
+                            example, when it places an order, signs a contract, awards a grant, purchases a service, or
+                            takes other actions that require it to make a payment.
+                        </p>
                     </div>
                     <div className="agency-obligated-content">
                         <p className="fy-text">
-                            In fiscal year {this.props.activeFY}, {this.props.agencyName} has obligated...
+                            As of {this.props.asOfDate}, the {this.props.agencyName} has...
                         </p>
                         <p className="against-auth-text">
-                            <span className="number number-bolder">{formattedObligatedAmount}</span> against its <span className="number">{formattedBudgetAuthority}</span> in Budgetary Resources
+                            obligated <span className="number number-bolder">{formattedObligatedAmount}</span> against its <span className="number">{formattedBudgetAuthority}</span> in budgetary resources
                         </p>
                         <AgencyObligatedGraph
                             obligatedAmount={this.props.obligatedAmount}
@@ -126,6 +134,9 @@ takes other actions that require it to make a payment.
                             width={this.state.visualizationWidth}
                             obligatedText={formattedObligatedAmount}
                             legend={legend} />
+                        <p className="outlay-text">
+                            ...and outlaid <span className="number number-bolder outlay">{formattedOutlayAmount}</span> in FY {this.props.activeFY}.
+                        </p>
                     </div>
                 </div>
             </div>

--- a/src/js/components/agency/visualizations/recipient/RecipientVisualization.jsx
+++ b/src/js/components/agency/visualizations/recipient/RecipientVisualization.jsx
@@ -12,6 +12,7 @@ import ScopeList from './ScopeList';
 import RecipientChart from './RecipientChart';
 
 const propTypes = {
+    activeFY: PropTypes.string,
     loading: PropTypes.bool,
     isInitialLoad: PropTypes.bool,
     error: PropTypes.bool,
@@ -23,7 +24,7 @@ const propTypes = {
     page: PropTypes.number,
     isLastPage: PropTypes.bool,
     changePage: PropTypes.func,
-    lastUpdate: PropTypes.string
+    asOfDate: PropTypes.string
 };
 
 
@@ -93,19 +94,19 @@ export default class RecipientVisualization extends React.Component {
             <div
                 className="agency-section-wrapper"
                 id="agency-recipients">
-                <div className="agency-callout-description">
-                    {`A primary way agencies implement their programs is by awarding money to \
-companies, organizations, individuals, or government entities (i.e. state, local, tribal, federal, \
-or foreign). Here is a look at who these recipients are and how they rank by award type.`}
-                </div>
                 <div className="agency-section-title">
                     <h4>Recipients</h4>
-                    <em>Data as of {this.props.lastUpdate}</em>
                     <hr
                         className="results-divider"
                         ref={(hr) => {
                             this.sectionHr = hr;
                         }} />
+                    <em>FY {this.props.activeFY} data reported through {this.props.asOfDate}</em>
+                </div>
+                <div className="agency-callout-description">
+                    {`A primary way agencies implement their programs is by awarding money to \
+companies, organizations, individuals, or government entities (i.e. state, local, tribal, federal, \
+or foreign). Here is a look at who these recipients are and how they rank by award type.`}
                 </div>
                 <div className="agency-section-content">
                     <ScopeList

--- a/src/js/containers/agency/visualizations/FederalAccountContainer.jsx
+++ b/src/js/containers/agency/visualizations/FederalAccountContainer.jsx
@@ -155,6 +155,7 @@ ${account}`;
     render() {
         return (
             <FederalAccountVisualization
+                activeFY={this.props.activeFY}
                 obligatedAmount={this.props.obligatedAmount}
                 linkSeries={this.state.linkSeries}
                 dataSeries={this.state.dataSeries}

--- a/src/js/containers/agency/visualizations/ObjectClassContainer.jsx
+++ b/src/js/containers/agency/visualizations/ObjectClassContainer.jsx
@@ -221,6 +221,7 @@ export default class ObjectClassContainer extends React.PureComponent {
     render() {
         return (
             <ObjectClassTreeMap
+                activeFY={this.props.activeFY}
                 displayedTotalObligation={this.props.displayedTotalObligation}
                 majorObjectClasses={this.state.majorObjectClasses}
                 minorObjectClasses={this.state.minorObjectClasses}

--- a/src/js/containers/agency/visualizations/RecipientContainer.jsx
+++ b/src/js/containers/agency/visualizations/RecipientContainer.jsx
@@ -17,7 +17,7 @@ import RecipientVisualization from
 const propTypes = {
     id: PropTypes.string,
     activeFY: PropTypes.string,
-    lastUpdate: PropTypes.string
+    asOfDate: PropTypes.string
 };
 
 export default class RecipientContainer extends React.PureComponent {
@@ -165,6 +165,7 @@ ${recipient}`;
     render() {
         return (
             <RecipientVisualization
+                activeFY={this.props.activeFY}
                 page={this.state.page}
                 isLastPage={this.state.isLastPage}
                 dataSeries={this.state.dataSeries}
@@ -176,7 +177,7 @@ ${recipient}`;
                 scope={this.state.scope}
                 changeScope={this.changeScope}
                 changePage={this.changePage}
-                lastUpdate={this.props.lastUpdate} />
+                asOfDate={this.props.asOfDate} />
         );
     }
 }


### PR DESCRIPTION
- [x] Code Review
- [x] Design Review
- [x] [API 649](https://github.com/fedspendingtransparency/usaspending-api/pull/649) is merged

Updates:
- Change outlay from line to bar
- Add "outlaid" text underneath outlay bar
- Move narrative copy under subtitles, align to the left, and reduce margins
- Change "As of FY [FY]" to "FY [FY] data reported through [date]"
- Update Sidebar typography, colors, spacing
- Add Glossary Trigger to Budgetary Resources
- Replace [FY] with [date] in Obligated Amount description
- Reduce top margin of content