### PR TITLE
Fixing Data Mappings on Award Page

### DIFF
--- a/src/js/components/award/contract/ContractDetails.jsx
+++ b/src/js/components/award/contract/ContractDetails.jsx
@@ -137,6 +137,12 @@ export default class ContractDetails extends React.Component {
             description = "Not Available";
         }
 
+        // Award Type
+        let awardType = "Not Available";
+        if (award.latest_transaction.contract_data.contract_award_type_desc) {
+            awardType = award.latest_transaction.contract_data.contract_award_type_desc;
+        }
+
         // Pricing
         let pricing = "Not Available";
         if (award.type_of_contract_pricing_description) {
@@ -154,7 +160,7 @@ export default class ContractDetails extends React.Component {
             overflow: seeMore,
             date: popDate,
             place: this.parsePlaceOfPerformance(award),
-            typeDesc: award.type_description,
+            typeDesc: awardType,
             price: pricing
         });
     }

--- a/src/js/components/award/financialAssistance/FinancialAssistanceDetails.jsx
+++ b/src/js/components/award/financialAssistance/FinancialAssistanceDetails.jsx
@@ -155,6 +155,8 @@ ${latestTransaction.assistance_data.cfda.program_title}`;
             cfdaOverflow = true;
         }
 
+        // Todo - Mike Bray - update typeDesc when available from Broker data
+        // Probably "assistance_type"
         this.setState({
             description,
             programName,

--- a/src/js/components/search/filters/psc/SelectedPSC.jsx
+++ b/src/js/components/search/filters/psc/SelectedPSC.jsx
@@ -20,7 +20,7 @@ export default class SelectedPSC extends React.Component {
         this.props.selectedPSC.entrySeq().forEach((entry) => {
             const psc = entry[1].product_or_service_code;
             const value = (<ShownValue
-                label={psc}
+                label={_.toString(psc)}
                 key={psc}
                 removeValue={this.props.removePSC.bind(null, entry[1])} />);
             shownPSC.push(value);

--- a/src/js/components/search/filters/psc/SelectedPSC.jsx
+++ b/src/js/components/search/filters/psc/SelectedPSC.jsx
@@ -20,7 +20,7 @@ export default class SelectedPSC extends React.Component {
         this.props.selectedPSC.entrySeq().forEach((entry) => {
             const psc = entry[1].product_or_service_code;
             const value = (<ShownValue
-                label={_.toString(psc)}
+                label={psc}
                 key={psc}
                 removeValue={this.props.removePSC.bind(null, entry[1])} />);
             shownPSC.push(value);

--- a/src/js/dataMapping/contracts/additionalDetails.js
+++ b/src/js/dataMapping/contracts/additionalDetails.js
@@ -11,24 +11,38 @@ export const agencyFields = [
         field: 'awarding_agency_name'
     },
     {
-        label: 'Awarding Sub-Tier Agency',
+        label: 'Awarding Sub-Agency',
         field: 'awarding_subtier_name'
     },
     {
         label: 'Awarding Office',
-        field: 'awarding_office_name'
+        field: '__special',
+        parse: (data) => {
+            let output = '';
+            if (data.latest_transaction.contract_data.awarding_office_name) {
+                output = data.latest_transaction.contract_data.awarding_office_name;
+            }
+            return output;
+        }
     },
     {
         label: 'Funding Agency',
         field: 'funding_agency_name'
     },
     {
-        label: 'Funding Sub-Tier Agency',
+        label: 'Funding Sub-Agency',
         field: 'funding_subtier_name'
     },
     {
         label: 'Funding Office',
-        field: 'funding_office_name'
+        field: '__special',
+        parse: (data) => {
+            let output = '';
+            if (data.latest_transaction.contract_data.funding_office_name) {
+                output = data.latest_transaction.contract_data.funding_office_name;
+            }
+            return output;
+        }
     }
 ];
 
@@ -66,10 +80,7 @@ export const competitionFields = [
         field: '__special',
         parse: (data) => {
             let output = '';
-            if (data.solicitation_procedur_desc && data.solicitation_procedures) {
-                output = `${data.solicitation_procedures}: ${data.solicitation_procedur_desc}`;
-            }
-            else if (data.solicitation_procedur_desc) {
+            if (data.solicitation_procedur_desc) {
                 output = data.solicitation_procedur_desc;
             }
             else if (data.solicitation_procedures) {
@@ -88,10 +99,7 @@ export const competitionFields = [
         field: '__special',
         parse: (data) => {
             let output = '';
-            if (data.extent_compete_description && data.extent_competed) {
-                output = `${data.extent_competed}: ${data.extent_compete_description}`;
-            }
-            else if (data.extent_compete_description) {
+            if (data.extent_compete_description) {
                 output = data.extent_compete_description;
             }
             else if (data.extent_competed) {
@@ -107,17 +115,14 @@ export const competitionFields = [
     },
     {
         label: 'Set-Aside Type',
-        field: 'type_set_aside'
+        field: 'type_set_aside_description'
     },
     {
         label: 'Commercial Item Acquisition Procedures',
         field: '__special',
         parse: (data) => {
             let output = '';
-            if (data.commercial_item_acqui_desc && data.commercial_item_acquisitio) {
-                output = `${data.commercial_item_acquisitio}: ${data.commercial_item_acqui_desc}`;
-            }
-            else if (data.commercial_item_acqui_desc) {
+            if (data.commercial_item_acqui_desc) {
                 output = data.commercial_item_acqui_desc;
             }
             else if (data.commercial_item_acquisitio) {
@@ -129,7 +134,7 @@ export const competitionFields = [
     },
     {
         label: 'Commercial Item Test Program',
-        field: 'commercial_item_test_progr'
+        field: 'commercial_item_test_desc'
     },
     {
         label: 'Evaluated Preference',
@@ -329,11 +334,8 @@ export const additionalFields = [
         label: 'Subcontracting Plan',
         field: '__special',
         parse: (data) => {
-            let output = '';
-            if (data.subcontracting_plan_desc && data.subcontracting_plan) {
-                output = `${data.subcontracting_plan}: ${data.subcontracting_plan_desc}`;
-            }
-            else if (data.subcontracting_plan_desc) {
+            let output = 'Not Available';
+            if (data.subcontracting_plan_desc) {
                 output = data.subcontracting_plan_desc;
             }
             else if (data.subcontracting_plan) {


### PR DESCRIPTION
- Shows Award Type as "Not Available" if it doesn't exist
- Rename "Awarding Sub-Tier Agency" to "Awarding Sub-Agency"
- Rename "Funding Sub-Tier Agency" to "Funding Sub-Agency"
- Surface Awarding Office name from contract details in latest transaction
- Surface Funding Office name from contract details in latest transaction
- Show description (or code, if description does not exist) instead of both items for Solicitation Procedures, Extent Competed, Commercial Item Acquisition Procedures, and Subcontracting Plan fields
- Use correct description field for Set-Aside Type and Commercial Item Test Program
- Note a future fix for Financial Assistance Type once the data is available from the Broker