### PR TITLE
Show offices in award detail page header

### DIFF
--- a/src/_scss/pages/award/_agencyInfo.scss
+++ b/src/_scss/pages/award/_agencyInfo.scss
@@ -1,7 +1,7 @@
 .agency-info {
     @include span-columns(16);
     background-color: $color-blue-background;
-    padding: 2.4rem 1rem 4rem 3rem;
+    padding: 2.4rem 1rem 2.4rem 3rem;
     .static-title {
         float: left;
     }
@@ -29,14 +29,14 @@
         text-align: left;
         padding-left: rem(1);
         li {
-            display: inline-block;
+            display: block;
             font-size: $small-font-size;
-            &:last-child {
-                margin-left: rem(50);
+            margin-top: rem(10);
+
+            &:first-child {
+                margin-top: 0;
             }
-            &:only-child {
-                margin-left: 0;
-            }
+
             .title {
                 font-weight: bold;
             }

--- a/src/js/components/award/AgencyInfo.jsx
+++ b/src/js/components/award/AgencyInfo.jsx
@@ -68,10 +68,16 @@ export default class AgencyInfo extends React.Component {
         const award = this.props.selectedAward;
         const toptierAgency = `${this.state.agencyType}_agency_name`;
         const subtierAgency = `${this.state.agencyType}_subtier_name`;
-        const officeAgency = `${this.state.agencyType}_office_name`;
         let office = "";
         let subtier = "";
         let toptier = "Not Available";
+
+        let officeKey = `${this.state.agencyType}_office_code`;
+        let transactionData = award.latest_transaction.assistance_data;
+        if (award.category === 'contract') {
+            transactionData = award.latest_transaction.contract_data;
+            officeKey = `${this.state.agencyType}_office_name`;
+        }
 
         const options = this.props.awardTypes.map((label, index) => (
             <li
@@ -128,11 +134,12 @@ export default class AgencyInfo extends React.Component {
                     value={award[subtierAgency]} />
             );
         }
-        if (award[officeAgency]) {
+
+        if (transactionData && transactionData[officeKey]) {
             office = (
                 <InfoSnippet
                     label="Office"
-                    value={award[officeAgency]} />
+                    value={transactionData[officeKey]} />
             );
         }
         return (

--- a/src/js/models/results/award/AwardSummary.js
+++ b/src/js/models/results/award/AwardSummary.js
@@ -21,6 +21,7 @@ const fields = [
     'period_of_performance_current_end_date',
     'award_type',
     'internal_general_type',
+    'category',
     'type',
     'type_description',
     'awarding_agency_name',
@@ -115,6 +116,7 @@ const remapData = (data, idField) => {
     let parentId = 0;
     let awardType = '';
     let internalGeneralType = 'unknown';
+    let category = '';
     let actionDate = '';
     let awardTypeDescription = '';
     let awardDescription = '';
@@ -207,6 +209,10 @@ const remapData = (data, idField) => {
     if (data.type) {
         awardType = data.type;
         internalGeneralType = SummaryPageHelper.awardType(data.type);
+    }
+
+    if (data.category) {
+        category = data.category;
     }
 
     if (data.type_description) {
@@ -443,6 +449,7 @@ const remapData = (data, idField) => {
     remappedData.parent_id = parentId;
     remappedData.award_type = awardType;
     remappedData.internal_general_type = internalGeneralType;
+    remappedData.category = category;
     remappedData.type_description = awardTypeDescription;
     remappedData.description = awardDescription;
     remappedData.awarding_agency_name = awardingAgencyName;


### PR DESCRIPTION
* Adds awarding and funding office names for contracts and codes for assistance awards in the award detail page header bar 

https://federal-spending-transparency.atlassian.net/browse/DS-1785
https://projects.invisionapp.com/d/main#/console/8586929/260271850/comments/88635986

* Contract example: 52276483
* Assistance example: 8623108