### PR TITLE
Show PSC Description in PSC Filter

### DIFF
--- a/src/js/components/search/filters/psc/SelectedPSC.jsx
+++ b/src/js/components/search/filters/psc/SelectedPSC.jsx
@@ -18,12 +18,12 @@ export default class SelectedPSC extends React.Component {
         const shownPSC = [];
 
         this.props.selectedPSC.entrySeq().forEach((entry) => {
-            const pscCode = entry[1].product_or_service_code;
+            const psc = entry[1].product_or_service_code;
             const pscDescription = entry[1].psc_description;
 
             const value = (<ShownValue
-                label={`${pscCode} - ${pscDescription}`}
-                key={pscCode}
+                label={`${psc} - ${pscDescription}`}
+                key={psc}
                 removeValue={this.props.removePSC.bind(null, entry[1])} />);
             shownPSC.push(value);
         });

--- a/src/js/components/search/filters/psc/SelectedPSC.jsx
+++ b/src/js/components/search/filters/psc/SelectedPSC.jsx
@@ -5,7 +5,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
 
 import ShownValue from 'components/search/filters/otherFilters/ShownValue';
 
@@ -17,11 +16,14 @@ const propTypes = {
 export default class SelectedPSC extends React.Component {
     render() {
         const shownPSC = [];
+
         this.props.selectedPSC.entrySeq().forEach((entry) => {
-            const psc = entry[1].product_or_service_code;
+            const pscCode = entry[1].product_or_service_code;
+            const pscDescription = entry[1].psc_description;
+
             const value = (<ShownValue
-                label={_.toString(psc)}
-                key={psc}
+                label={`${pscCode} - ${pscDescription}`}
+                key={pscCode}
                 removeValue={this.props.removePSC.bind(null, entry[1])} />);
             shownPSC.push(value);
         });

--- a/src/js/components/search/topFilterBar/filterGroups/PSCFilterGroup.jsx
+++ b/src/js/components/search/topFilterBar/filterGroups/PSCFilterGroup.jsx
@@ -44,7 +44,7 @@ export default class PSCFilterGroup extends React.Component {
         PSC.forEach((value) => {
             const tag = {
                 value: `${value.identifier}`,
-                title: `${value.product_or_service_code}`,
+                title: `${value.product_or_service_code} - ${value.psc_description}`,
                 isSpecial: false,
                 removeFilter: this.removeFilter
             };

--- a/src/js/containers/search/filters/psc/PSCListContainer.jsx
+++ b/src/js/containers/search/filters/psc/PSCListContainer.jsx
@@ -52,7 +52,7 @@ export class PSCListContainer extends React.Component {
         if (psc && psc.length > 0) {
             psc.forEach((item) => {
                 values.push({
-                    title: item.product_or_service_code,
+                    title: `${item.product_or_service_code} - ${item.psc_description}`,
                     subtitle: '',
                     data: item
                 });


### PR DESCRIPTION
- Surfacing PSC description in the PSC autocomplete results, PSC selection, and PSC section of the top filter bar

[Subtask DS-1870](https://federal-spending-transparency.atlassian.net/browse/DS-1870) of [DS-1757](https://federal-spending-transparency.atlassian.net/browse/DS-1757), as the updated autocomplete endpoint now returns the PSC description, in addition to the code itself, for the first time