### PR TITLE
Agency Filter Updates

### DIFF
--- a/src/js/components/search/filters/agency/SelectedAgencies.jsx
+++ b/src/js/components/search/filters/agency/SelectedAgencies.jsx
@@ -21,6 +21,7 @@ export default class SelectedAgencies extends React.Component {
             const key = entry[0];
             const agency = entry[1];
             let label = agency.subtier_agency.name;
+            console.log(agency);
 
             if (agency.agencyType !== '' && agency.agencyType !== null) {
                 if (agency.agencyType === 'subtier' && agency.subtier_agency.abbreviation !== '') {
@@ -31,8 +32,7 @@ export default class SelectedAgencies extends React.Component {
                     label += ` (${agency.toptier_agency.abbreviation})`;
                 }
 
-                if (agency.agencyType === 'subtier' &&
-                    agency.toptier_agency.name === agency.subtier_agency.name) {
+                if (agency.agencyType === 'subtier' && agency.toptier_flag === false) {
                     label += ' | Sub-Agency';
                 }
             }

--- a/src/js/components/search/filters/agency/SelectedAgencies.jsx
+++ b/src/js/components/search/filters/agency/SelectedAgencies.jsx
@@ -21,7 +21,6 @@ export default class SelectedAgencies extends React.Component {
             const key = entry[0];
             const agency = entry[1];
             let label = agency.subtier_agency.name;
-            console.log(agency);
 
             if (agency.agencyType !== '' && agency.agencyType !== null) {
                 if (agency.agencyType === 'subtier' && agency.subtier_agency.abbreviation !== '') {

--- a/src/js/components/search/topFilterBar/filterGroups/AgencyFilterGroup.jsx
+++ b/src/js/components/search/topFilterBar/filterGroups/AgencyFilterGroup.jsx
@@ -51,8 +51,7 @@ export default class AgencyFilterGroup extends React.Component {
             else if (value.agencyType === 'toptier' && value.toptier_agency.abbreviation !== '') {
                 agencyTitle += ` (${value.toptier_agency.abbreviation})`;
             }
-            if (value.agencyType === 'subtier' &&
-                value.toptier_agency.name === value.subtier_agency.name) {
+            if (value.agencyType === 'subtier' && value.toptier_flag === false) {
                 agencyTitle += ' | Sub-Agency';
             }
 

--- a/src/js/containers/search/filters/AgencyListContainer.jsx
+++ b/src/js/containers/search/filters/AgencyListContainer.jsx
@@ -78,9 +78,9 @@ export class AgencyListContainer extends React.Component {
                 if (item.toptier_agency.abbreviation !== '') {
                     topAbbreviation = `(${item.toptier_agency.abbreviation})`;
                 }
-                // Push two items to the autocomplete entries if subtier = toptier
+
                 // Only push items if they are not in selectedAgencies
-                if (item.toptier_agency.name === item.subtier_agency.name) {
+                if (item.toptier_flag) {
                     if (this.props.selectedAgencies.size === 0
                         || !this.props.selectedAgencies.has(`${item.id}_toptier`)) {
                         agencies.push({
@@ -91,8 +91,7 @@ export class AgencyListContainer extends React.Component {
                         });
                     }
                 }
-
-                if (this.props.selectedAgencies.size === 0
+                else if (this.props.selectedAgencies.size === 0
                     || !this.props.selectedAgencies.has(`${item.id}_subtier`)) {
                     agencies.push({
                         title: `${item.subtier_agency.name} ${subAbbreviation}`,
@@ -117,21 +116,7 @@ export class AgencyListContainer extends React.Component {
         toptierAgencies = sortBy(toptierAgencies, 'title');
         subtierAgencies = sortBy(subtierAgencies, 'title');
 
-        if (this.props.agencyType === 'Funding') {
-            // Show an error message if the API results contain exclusively subtier Funding Agencies
-            if (agencies.length > 0 && toptierAgencies.length === 0) {
-                noResults = true;
-            }
-
-            // We don't allow users to filter by subtier Funding Agencies, so we return just
-            // the toptier agencies
-            agencies = toptierAgencies;
-        }
-        else {
-            // Otherwise, for filtering by Awarding Agency, we combine the toptier and subtier
-            // groups, with toptier first, and then return the top 10
-            agencies = slice(concat(toptierAgencies, subtierAgencies), 0, 10);
-        }
+        agencies = slice(concat(toptierAgencies, subtierAgencies), 0, 10);
 
         this.setState({
             autocompleteAgencies: agencies,
@@ -190,9 +175,7 @@ export class AgencyListContainer extends React.Component {
         // create a search index with the API response records
         const search = new Search('id');
         search.addIndex(['toptier_agency', 'name']);
-        if (this.props.agencyType === 'Awarding') {
-            search.addIndex(['subtier_agency', 'name']);
-        }
+        search.addIndex(['subtier_agency', 'name']);
 
         // add the API response as the data source to search within
         search.addDocuments(data);

--- a/src/js/models/search/SearchAwardsOperation.js
+++ b/src/js/models/search/SearchAwardsOperation.js
@@ -121,21 +121,23 @@ class SearchAwardsOperation {
 
             // Funding Agencies are toptier-only
             this.fundingAgencies.forEach((agencyArray) => {
+                const fundingAgencyName = agencyArray[`${agencyArray.agencyType}_agency`].name;
+
                 agencies.push({
                     [agencyKeys.type]: 'funding',
-                    [agencyKeys.tier]: 'toptier',
-                    [agencyKeys.name]: agencyArray.toptier_agency.name
+                    [agencyKeys.tier]: agencyArray.agencyType,
+                    [agencyKeys.name]: fundingAgencyName
                 });
             });
 
             // Awarding Agencies can be both toptier and subtier
             this.awardingAgencies.forEach((agencyArray) => {
-                const agencyName = agencyArray[`${agencyArray.agencyType}_agency`].name;
+                const awardingAgencyName = agencyArray[`${agencyArray.agencyType}_agency`].name;
 
                 agencies.push({
                     [agencyKeys.type]: 'awarding',
                     [agencyKeys.tier]: agencyArray.agencyType,
-                    [agencyKeys.name]: agencyName
+                    [agencyKeys.name]: awardingAgencyName
                 });
             });
 


### PR DESCRIPTION
- Remove the restriction of Funding Agencies to be toptier-only
  - This returns Funding Agency to an "Award Type" filter from the deprecated "Budget Type" filter construct
- Remove the ability to view or select subtier options of toptier Agencies
  - ex. "Treasury" will now return a single option, instead of a toptier and subtier option
- Update queries to reflect Funding Agencies can now be subtier

[Subtask DS-1873](https://federal-spending-transparency.atlassian.net/browse/DS-1873) of [DS-1757](https://federal-spending-transparency.atlassian.net/browse/DS-1757)