### PR TITLE
Reverting Agency Page - Recipient Visualization Date

### DIFF
--- a/src/js/components/agency/AgencyContent.jsx
+++ b/src/js/components/agency/AgencyContent.jsx
@@ -263,7 +263,7 @@ export default class AgencyContent extends React.Component {
                         <RecipientContainer
                             id={this.props.agency.id}
                             activeFY={this.props.agency.overview.activeFY}
-                            asOfDate={asOfDate} />
+                            lastUpdate={this.props.lastUpdate} />
                         {disclaimer}
                     </div>
                     <AgencyFooterContainer id={this.props.agency.id} />

--- a/src/js/components/agency/visualizations/recipient/RecipientVisualization.jsx
+++ b/src/js/components/agency/visualizations/recipient/RecipientVisualization.jsx
@@ -24,7 +24,7 @@ const propTypes = {
     page: PropTypes.number,
     isLastPage: PropTypes.bool,
     changePage: PropTypes.func,
-    asOfDate: PropTypes.string
+    lastUpdate: PropTypes.string
 };
 
 
@@ -101,7 +101,7 @@ export default class RecipientVisualization extends React.Component {
                         ref={(hr) => {
                             this.sectionHr = hr;
                         }} />
-                    <em>FY {this.props.activeFY} data reported through {this.props.asOfDate}</em>
+                    <em>FY {this.props.activeFY} data reported through {this.props.lastUpdate}</em>
                 </div>
                 <div className="agency-callout-description">
                     {`A primary way agencies implement their programs is by awarding money to \

--- a/src/js/containers/agency/visualizations/RecipientContainer.jsx
+++ b/src/js/containers/agency/visualizations/RecipientContainer.jsx
@@ -17,7 +17,7 @@ import RecipientVisualization from
 const propTypes = {
     id: PropTypes.string,
     activeFY: PropTypes.string,
-    asOfDate: PropTypes.string
+    lastUpdate: PropTypes.string
 };
 
 export default class RecipientContainer extends React.PureComponent {
@@ -177,7 +177,7 @@ ${recipient}`;
                 scope={this.state.scope}
                 changeScope={this.changeScope}
                 changePage={this.changePage}
-                asOfDate={this.props.asOfDate} />
+                lastUpdate={this.props.lastUpdate} />
         );
     }
 }


### PR DESCRIPTION
- Recipient Visualization now shows date from response of `lastUpdate` API call, the last date that awards were pulled, instead of the end date of the last submission period

Corrects a bug in [DS-1777](https://federal-spending-transparency.atlassian.net/browse/DS-1777)