### PR TITLE
Re-enable subawards tab

### DIFF
--- a/src/js/components/award/details/DetailsSection.jsx
+++ b/src/js/components/award/details/DetailsSection.jsx
@@ -34,6 +34,11 @@ const commonTabs = [
         enabled: true
     },
     {
+        label: 'Sub-Awards',
+        internal: 'subaward',
+        enabled: true
+    },
+    {
         label: 'Financial System Details',
         internal: 'financial',
         enabled: true


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DS-1896

- [x] Backend has finished loading data (in dev)