### PR TITLE
Fix: Default transactions table sorting

### DIFF
--- a/src/js/redux/reducers/award/awardReducer.js
+++ b/src/js/redux/reducers/award/awardReducer.js
@@ -15,8 +15,8 @@ const initialState = {
     renderHash: null,
     groupHash: null,
     transactionSort: {
-        field: "modification_number",
-        direction: "asc"
+        field: "action_date",
+        direction: "desc"
     },
     finSysData: [],
     finSysMeta: {

--- a/tests/redux/reducers/award/awardReducer-test.js
+++ b/tests/redux/reducers/award/awardReducer-test.js
@@ -13,8 +13,8 @@ const initialState = {
     renderHash: null,
     groupHash: null,
     transactionSort: {
-        field: "modification_number",
-        direction: "asc"
+        field: "action_date",
+        direction: "desc"
     },
     finSysData: [],
     finSysMeta: {


### PR DESCRIPTION
* Change transactions table default sort to action date descending

https://federal-spending-transparency.atlassian.net/browse/DS-1789