### PR TITLE
Fix - Veteran Owned Business Recipient Type

### DIFF
--- a/src/js/dataMapping/search/recipientType.js
+++ b/src/js/dataMapping/search/recipientType.js
@@ -89,7 +89,7 @@ export const recipientTypeGroups = {
         'joint_venture_economically_disadvantaged_women_owned_small_business'
     ],
     veteran_owned_business: [
-        'service_disabled_veteran_owned_business'
+        'veteran_owned_business'
     ],
     special_designations: [
         '8a_program_participant',


### PR DESCRIPTION
- Updates the top-level Veteran Owned Business Recipient Type to map to `veteran_owned_business` instead of `service_disabled_veteran_owned_business`

Bug: https://federal-spending-transparency.atlassian.net/browse/DS-1930

- [ ] Code Review
- [ ] Wait until https://github.com/fedspendingtransparency/usaspending-api/pull/716 is merged