### PR TITLE
Fix: Parent Recipient Type Filter API Integration

### DIFF
--- a/src/js/components/search/filters/recipient/RecipientType.jsx
+++ b/src/js/components/search/filters/recipient/RecipientType.jsx
@@ -24,7 +24,7 @@ const defaultProps = {
         {
             id: 'recipient-women-owned-business',
             name: 'Women Owned Business',
-            filters: recipientTypeGroups.women_owned_business
+            filters: recipientTypeGroups.woman_owned_business
         },
         {
             id: 'recipient-veteran-owned-business',

--- a/src/js/components/search/filters/recipient/RecipientType.jsx
+++ b/src/js/components/search/filters/recipient/RecipientType.jsx
@@ -62,11 +62,10 @@ const defaultProps = {
 
 const propTypes = {
     recipientTypeMapping: PropTypes.arrayOf(PropTypes.object),
-    recipientType: PropTypes.object
+    selectedTypes: PropTypes.object
 };
 
 export default class RecipientType extends React.Component {
-
     render() {
         const checkboxTypes = (
             this.props.recipientTypeMapping.map((type, index) =>
@@ -76,7 +75,7 @@ export default class RecipientType extends React.Component {
                     key={index}
                     types={recipientTypes}
                     filterType="Recipient"
-                    selectedCheckboxes={this.props.recipientType}
+                    selectedCheckboxes={this.props.selectedTypes}
                     enableAnalytics />
             ));
 

--- a/src/js/components/search/topFilterBar/filterGroups/RecipientTypeFilterGroup.jsx
+++ b/src/js/components/search/topFilterBar/filterGroups/RecipientTypeFilterGroup.jsx
@@ -5,9 +5,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { indexOf, difference, concat } from 'lodash';
-
-import { Set } from 'immutable';
 
 import * as RecipientType from 'dataMapping/search/recipientType';
 
@@ -24,7 +21,6 @@ export default class RecipientTypeFilterGroup extends React.Component {
         super(props);
 
         this.removeFilter = this.removeFilter.bind(this);
-        this.removeGroup = this.removeGroup.bind(this);
         this.clearGroup = this.clearGroup.bind(this);
     }
 
@@ -37,22 +33,6 @@ export default class RecipientTypeFilterGroup extends React.Component {
         });
     }
 
-    removeGroup(value) {
-        // remove a group of filter items
-        // let's actually fake the removal by just overwriting the the filter value with everything
-        // except for the values in the specified group
-        let updatedValues = new Set(this.props.filter.values);
-
-        // remove the current group's values
-        const recipientValues = RecipientType.recipientTypeGroups[value];
-        updatedValues = updatedValues.filterNot((x) => indexOf(recipientValues, x) > -1);
-
-        this.props.redux.updateGenericFilter({
-            type: 'recipientType',
-            value: updatedValues
-        });
-    }
-
     clearGroup() {
         this.props.redux.clearFilterType('recipientType');
     }
@@ -62,36 +42,6 @@ export default class RecipientTypeFilterGroup extends React.Component {
 
         // check to see if any type groups are fully selected
         const selectedValues = this.props.filter.values;
-        const fullGroups = [];
-        RecipientType.groupKeys.forEach((key) => {
-            const fullMembership = RecipientType.recipientTypeGroups[key];
-
-            // quick way of checking for full group membership is to return an array of missing
-            // values; it'll be empty if all the values are selected
-            const missingValues = difference(fullMembership, selectedValues);
-
-            if (missingValues.length === 0) {
-                // this group is complete
-                fullGroups.push(key);
-            }
-        });
-
-        // add full groups to the beginning of the tag list
-        let excludedValues = [];
-        fullGroups.forEach((group) => {
-            const tag = {
-                value: group,
-                title: `All ${RecipientType.groupLabels[group]}`,
-                isSpecial: true,
-                removeFilter: this.removeGroup
-            };
-
-            tags.push(tag);
-
-            // exclude these values from the remaining tags
-            excludedValues = concat(excludedValues, RecipientType.recipientTypeGroups[group]);
-        });
-
         selectedValues.forEach((value) => {
             const tag = {
                 value,
@@ -100,12 +50,13 @@ export default class RecipientTypeFilterGroup extends React.Component {
                 removeFilter: this.removeFilter
             };
 
-            if (indexOf(excludedValues, value) < 0) {
-                // only insert individual tags that aren't part of a fully-selected group
-                // excluded values is an array of values that are already included in a full group,
-                // so if this value isn't in that array, it can be shown individually
-                tags.push(tag);
+            // check if this is a parent group
+            if (RecipientType.groupLabels[value]) {
+                // this is a a parent
+                tag.title = `All ${RecipientType.groupLabels[value]}`;
             }
+
+            tags.push(tag);
         });
 
         return tags;

--- a/src/js/dataMapping/search/recipientType.js
+++ b/src/js/dataMapping/search/recipientType.js
@@ -82,7 +82,7 @@ export const recipientTypeGroups = {
         'tribally_owned_business',
         'other_minority_owned_business'
     ],
-    women_owned_business: [
+    woman_owned_business: [
         'women_owned_small_business',
         'economically_disadvantaged_women_owned_small_business',
         'joint_venture_women_owned_small_business',
@@ -135,7 +135,7 @@ export const recipientTypeGroups = {
 export const groupKeys = [
     'business',
     'minority_owned_business',
-    'women_owned_business',
+    'woman_owned_business',
     'veteran_owned_business',
     'special_designations',
     'nonprofit',
@@ -146,7 +146,7 @@ export const groupKeys = [
 export const groupLabels = {
     business: 'Business',
     minority_owned_business: 'Minority Owned Business',
-    women_owned_business: 'Women Owned Business',
+    woman_owned_business: 'Women Owned Business',
     veteran_owned_business: 'Veteran Owned Business',
     special_designations: 'Special Designations',
     nonprofit: 'Nonprofit',

--- a/src/js/redux/reducers/search/searchFiltersReducer.js
+++ b/src/js/redux/reducers/search/searchFiltersReducer.js
@@ -18,7 +18,7 @@ import * as ContractFilterFunctions from './filters/contractFilterFunctions';
 // update this version when changes to the reducer structure are made
 // frontend will reject inbound hashed search filter sets with different versions because the
 // data structures may have changed
-export const filterStoreVersion = '2017-10-31';
+export const filterStoreVersion = '2017-11-21';
 
 export const requiredTypes = {
     timePeriodFY: Set,

--- a/tests/containers/search/filters/recipientFilter/RecipientTypeContainer-test.jsx
+++ b/tests/containers/search/filters/recipientFilter/RecipientTypeContainer-test.jsx
@@ -1,0 +1,87 @@
+/**
+ * RecipientTypeContainer-test.jsx
+ * Created by Kevin Li 11/21/17
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import { Set } from 'immutable';
+
+import { recipientTypeGroups } from 'dataMapping/search/recipientType';
+
+import { RecipientTypeContainer } from 'containers/search/filters/recipient/RecipientTypeContainer';
+import { mockTypeRedux } from './mockRecipients';
+
+jest.mock('helpers/searchHelper', () => require('../searchHelper'));
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+
+// mock the child component by replacing it with a function that returns a null element
+jest.mock('components/search/filters/recipient/RecipientType', () =>
+    jest.fn(() => null));
+
+describe('RecipientTypeContainer', () => {
+    describe('ungroupSelectedTypes', () => {
+        it('should split filter values associated with parent recipient type items into their child values', () => {
+            const container = shallow(<RecipientTypeContainer {...mockTypeRedux} />);
+            container.instance().ungroupSelectedTypes(new Set(['business']));
+
+            expect(container.state().selectedTypes).toEqual(new Set(recipientTypeGroups.business));
+        });
+
+        it('should pass the filter values into state as-is when the filter value is not a parent recipient type', () => {
+            const container = shallow(<RecipientTypeContainer {...mockTypeRedux} />);
+            container.instance().ungroupSelectedTypes(new Set(['pizza']));
+
+            expect(container.state().selectedTypes).toEqual(new Set(['pizza']));
+        });
+    });
+
+    describe('determineParentType', () => {
+        it('should return the parent value when the input matches any recipient type group value', () => {
+            const container = shallow(<RecipientTypeContainer {...mockTypeRedux} />);
+            const parentType = container.instance().determineParentType(recipientTypeGroups.business);
+
+            expect(parentType).toEqual('business');
+        });
+        it('should return the null when the input is not a member of any recipient type group', () => {
+            const container = shallow(<RecipientTypeContainer {...mockTypeRedux} />);
+            const parentType = container.instance().determineParentType(['xyz']);
+
+            expect(parentType).toEqual(null);
+        });
+    });
+
+    describe('toggleRecipientType', () => {
+        it('should just pass the argument on Redux', () => {
+            const mockRedux = Object.assign({}, mockTypeRedux, {
+                toggleRecipientType: jest.fn()
+            });
+            const container = shallow(<RecipientTypeContainer {...mockRedux} />);
+
+            container.instance().toggleRecipientType('abc');
+
+            expect(mockRedux.toggleRecipientType).toHaveBeenCalledTimes(1);
+            expect(mockRedux.toggleRecipientType).toHaveBeenCalledWith('abc');
+        });
+    });
+
+    describe('bulkRecipientTypeChange', () => {
+        it('should return call Redux with a bulk change event equal to just the parent type group', () => {
+            const mockRedux = Object.assign({}, mockTypeRedux, {
+                bulkRecipientTypeChange: jest.fn()
+            });
+            const container = shallow(<RecipientTypeContainer {...mockRedux} />);
+
+            container.instance().bulkRecipientTypeChange({
+                types: recipientTypeGroups.business,
+                direction: 'add'
+            });
+
+            expect(mockRedux.bulkRecipientTypeChange).toHaveBeenCalledTimes(1);
+            expect(mockRedux.bulkRecipientTypeChange).toHaveBeenCalledWith({
+                types: ['business'],
+                direction: 'add'
+            });
+        });
+    });
+});

--- a/tests/containers/search/filters/recipientFilter/mockRecipients.js
+++ b/tests/containers/search/filters/recipientFilter/mockRecipients.js
@@ -1,3 +1,5 @@
+import { Set } from 'immutable';
+
 export const mockRecipientLocation = [{
     place_type: "CITY",
     matched_ids: [22516, 23056],
@@ -13,4 +15,10 @@ export const mockRecipientDUNS = {
             2260
         ]
     }
+};
+
+export const mockTypeRedux = {
+    toggleRecipientType: jest.fn(),
+    bulkRecipientTypeChange: jest.fn(),
+    recipientType: new Set()
 };

--- a/tests/containers/search/mockSearchHashes.js
+++ b/tests/containers/search/mockSearchHashes.js
@@ -1,4 +1,4 @@
-import { initialState } from 'redux/reducers/search/searchFiltersReducer';
+import { initialState, filterStoreVersion } from 'redux/reducers/search/searchFiltersReducer';
 import * as FiscalYearHelper from 'helpers/fiscalYearHelper';
 
 export const mockHash = {
@@ -7,7 +7,7 @@ export const mockHash = {
 
 export const mockFilters = {
     filter: {
-        version: '2017-10-31',
+        version: filterStoreVersion,
         filters: {
             locationDomesticForeign: "all",
             selectedAwardIDs: {},


### PR DESCRIPTION
* Passes a single filter value when an entire group of recipient types is selected
* **Note:** This will invalidate any existing search hash URLs once deployed.