### PR TITLE
Performance Option: Fewer Rows

### DIFF
--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -289,7 +289,7 @@ export class ResultsTableContainer extends React.Component {
             // the page number
             pageNumber = 1;
         }
-        const resultLimit = 60;
+        const resultLimit = 30;
 
         const requestFields = ['Award ID'];
 


### PR DESCRIPTION
* Award search table requests 30 rows at a time instead of 60
* Can optionally be merged *in addition* to column changes