### PR TITLE
Remove award status label

### DIFF
--- a/src/js/components/award/SummaryBar.jsx
+++ b/src/js/components/award/SummaryBar.jsx
@@ -11,7 +11,6 @@ import * as SummaryPageHelper from 'helpers/summaryPageHelper';
 import { awardTypeGroups } from 'dataMapping/search/awardType';
 
 import InfoSnippet from './InfoSnippet';
-import MoreHeaderOptions from './MoreHeaderOptions';
 
 const propTypes = {
     selectedAward: PropTypes.object
@@ -92,7 +91,6 @@ export default class SummaryBar extends React.Component {
                                 value={this.props.selectedAward.award_id} />
                             { parentAwardId }
                         </ul>
-                        <MoreHeaderOptions />
                     </div>
                 </div>
             </div>

--- a/src/js/components/award/SummaryBar.jsx
+++ b/src/js/components/award/SummaryBar.jsx
@@ -91,9 +91,6 @@ export default class SummaryBar extends React.Component {
                                 label="Award ID"
                                 value={this.props.selectedAward.award_id} />
                             { parentAwardId }
-                            <InfoSnippet
-                                label="Status"
-                                value={this.state.status} />
                         </ul>
                         <MoreHeaderOptions />
                     </div>


### PR DESCRIPTION
* Removes award status section from header bar on individual award page

https://federal-spending-transparency.atlassian.net/browse/DS-1956