### PR TITLE
Time Period Filter Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "react-aria-modal": "^2.7.0",
     "react-copy-to-clipboard": "^5.0.1",
     "react-custom-scrollbars": "^4.1.2",
-    "react-day-picker": "^6.1.0",
+    "react-day-picker": "^7.0.2",
     "react-dnd": "^2.4.0",
     "react-dnd-html5-backend": "^2.4.1",
     "react-dom": "15.6.1",

--- a/src/_scss/all.scss
+++ b/src/_scss/all.scss
@@ -2,7 +2,6 @@
 @import 'lib/bourbon/bourbon';
 @import 'lib/neat/neat';
 @import 'lib/normalize';
-// @import 'lib/mapbox/mapbox';
 
 // Core -------------- //
 @import 'core/defaults';

--- a/src/_scss/components/datePicker/_datePicker.scss
+++ b/src/_scss/components/datePicker/_datePicker.scss
@@ -101,6 +101,10 @@
                 font-size: 1.3rem;
             }
         }
+        .DayPicker-Day--disabled {
+            opacity: 0.4;
+            pointer-events: none;
+        }
     }
 }
 

--- a/src/js/components/search/filters/timePeriod/DateRange.jsx
+++ b/src/js/components/search/filters/timePeriod/DateRange.jsx
@@ -5,8 +5,10 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 import DatePicker from 'components/sharedComponents/DatePicker';
 import { AngleRight } from 'components/sharedComponents/icons/Icons';
+import * as FiscalYearHelper from 'helpers/fiscalYearHelper';
 
 const defaultProps = {
     startDate: '01/01/2016',
@@ -55,6 +57,9 @@ export default class DateRange extends React.Component {
     }
 
     render() {
+        const earliestDateString =
+            FiscalYearHelper.convertFYToDateRange(FiscalYearHelper.earliestFiscalYear)[0];
+        const earliestDate = moment(earliestDateString, 'YYYY-MM-DD').toDate();
         return (
             <div className="date-range-option">
                 <form
@@ -69,6 +74,9 @@ export default class DateRange extends React.Component {
                         opposite={this.props.endDate}
                         showError={this.props.showError}
                         hideError={this.props.hideError}
+                        disabledDays={[{
+                            before: earliestDate
+                        }]}
                         ref={(component) => {
                             this.startPicker = component;
                         }}
@@ -82,6 +90,9 @@ export default class DateRange extends React.Component {
                         opposite={this.props.startDate}
                         showError={this.props.showError}
                         hideError={this.props.hideError}
+                        disabledDays={[{
+                            before: earliestDate
+                        }]}
                         ref={(component) => {
                             this.endPicker = component;
                         }}

--- a/src/js/components/sharedComponents/DatePicker.jsx
+++ b/src/js/components/sharedComponents/DatePicker.jsx
@@ -12,7 +12,8 @@ import * as Icons from './icons/Icons';
 const defaultProps = {
     type: 'startDate',
     tabIndex: 1,
-    allowClearing: false
+    allowClearing: false,
+    disabledDays: []
 };
 
 const propTypes = {
@@ -24,7 +25,8 @@ const propTypes = {
     opposite: PropTypes.object,
     tabIndex: PropTypes.number,
     title: PropTypes.string,
-    allowClearing: PropTypes.bool
+    allowClearing: PropTypes.bool,
+    disabledDays: PropTypes.array
 };
 
 export default class DatePicker extends React.Component {
@@ -214,18 +216,18 @@ export default class DatePicker extends React.Component {
 
         // handle the cutoff dates (preventing end dates from coming before
         // start dates or vice versa)
-        let cutoffFunc = null;
+        const disabledDays = this.props.disabledDays;
         if (this.props.type === 'startDate' && this.props.opposite) {
             // the cutoff date represents the latest possible date
-            cutoffFunc = (day) => (
-                moment(day).isAfter(this.props.opposite)
-            );
+            disabledDays.push({
+                after: this.props.opposite.toDate()
+            });
         }
         else if (this.props.type === 'endDate' && this.props.opposite) {
             // cutoff date represents the earliest possible date
-            cutoffFunc = (day) => (
-                moment(day).isBefore(this.props.opposite)
-            );
+            disabledDays.push({
+                before: this.props.opposite.toDate()
+            });
         }
 
         return (
@@ -256,7 +258,7 @@ export default class DatePicker extends React.Component {
                             this.datepicker = daypicker;
                         }}
                         initialMonth={pickedDay}
-                        disabledDays={cutoffFunc}
+                        disabledDays={disabledDays}
                         selectedDays={(day) => DateUtils.isSameDay(pickedDay, day)}
                         onDayClick={this.handleDatePick}
                         onFocus={this.handleDateFocus}

--- a/src/js/models/search/SearchAwardsOperation.js
+++ b/src/js/models/search/SearchAwardsOperation.js
@@ -101,10 +101,25 @@ class SearchAwardsOperation {
                 });
             }
             else if (this.timePeriodType === 'dr' && this.timePeriodRange.length > 0) {
+                let start = this.timePeriodRange[0];
+                let end = this.timePeriodRange[1];
+
+                // if no start or end date is provided, use the 2008-present date range to fill out
+                // the missing dates
+                const initialYear = FiscalYearHelper.earliestFiscalYear;
+                const currentYear = FiscalYearHelper.currentFiscalYear();
+
+                if (!start) {
+                    start = FiscalYearHelper.convertFYToDateRange(initialYear)[0];
+                }
+                if (!end) {
+                    end = FiscalYearHelper.convertFYToDateRange(currentYear)[1];
+                }
+
                 filters[rootKeys.timePeriod] = [
                     {
-                        [timePeriodKeys.startDate]: this.timePeriodRange[0],
-                        [timePeriodKeys.endDate]: this.timePeriodRange[1]
+                        [timePeriodKeys.startDate]: start,
+                        [timePeriodKeys.endDate]: end
                     }
                 ];
             }
@@ -115,7 +130,7 @@ class SearchAwardsOperation {
             // the user selected fiscal years but did not specify any years OR
             // the user has selected the date range type but has not entered any dates yet
             // this should default to a period of time from FY 2008 to present
-            const initialYear = 2008;
+            const initialYear = FiscalYearHelper.earliestFiscalYear;
             const currentYear = FiscalYearHelper.currentFiscalYear();
 
             filters[rootKeys.timePeriod] = [{

--- a/src/js/models/search/SearchAwardsOperation.js
+++ b/src/js/models/search/SearchAwardsOperation.js
@@ -110,6 +110,20 @@ class SearchAwardsOperation {
             }
         }
 
+        if ((this.timePeriodType === 'fy' && this.timePeriodFY.length === 0) ||
+        (this.timePeriodType === 'dr' && this.timePeriodRange.length === 0)) {
+            // the user selected fiscal years but did not specify any years OR
+            // the user has selected the date range type but has not entered any dates yet
+            // this should default to a period of time from FY 2008 to present
+            const initialYear = 2008;
+            const currentYear = FiscalYearHelper.currentFiscalYear();
+
+            filters[rootKeys.timePeriod] = [{
+                [timePeriodKeys.startDate]: FiscalYearHelper.convertFYToDateRange(initialYear)[0],
+                [timePeriodKeys.endDate]: FiscalYearHelper.convertFYToDateRange(currentYear)[1]
+            }];
+        }
+
         // Add award types
         if (this.awardType.length > 0) {
             filters[rootKeys.awardType] = this.awardType;


### PR DESCRIPTION
* When a set of FYs are intended but no FYs are selected, request the period of start of FY 2008 to end of current FY from API
* When a date range date is intended but no date is specified, request the period of start of FY 2008 to end of current FY from API
* When an open-ended date range is sent to the API, fill in the missing start or end date with the start of FY 2008 or end of current FY respectively
* Disable dates in date picker before FY 2008 or the populated start date value (whichever is later)
* Upgrade react-day-picker so date picker automatically goes to the pre-populated date
* Style changes to actually disable selection of disabled dates in date picker