### PR TITLE
Fix: Allow forced overrides of map measurement diff

### DIFF
--- a/src/_scss/pages/search/results/table/resultsTable.scss
+++ b/src/_scss/pages/search/results/table/resultsTable.scss
@@ -7,6 +7,7 @@
     .loading-table {
         opacity: 0.5;
         @include transition(opacity 0.25s ease-in);
+        margin-top: rem(15);
     }
     .loaded-table {
         opacity: 1;

--- a/src/js/components/search/visualizations/geo/MapWrapper.jsx
+++ b/src/js/components/search/visualizations/geo/MapWrapper.jsx
@@ -302,8 +302,8 @@ export default class MapWrapper extends React.Component {
         });
     }
 
-    measureMap() {
-         // determine which entities (state, counties, etc based on current scope) are in view
+    measureMap(forced = false) {
+        // determine which entities (state, counties, etc based on current scope) are in view
         // use Mapbox SDK to determine the currently rendered shapes in the base layer
         const mapLoaded = this.mapRef.map.loaded();
         // wait for the map to load before continuing
@@ -326,7 +326,7 @@ export default class MapWrapper extends React.Component {
         // remove the duplicates values and pass them to the parent
         const uniqueEntities = uniq(visibleEntities);
 
-        MapBroadcaster.emit('mapMeasureDone', uniqueEntities);
+        MapBroadcaster.emit('mapMeasureDone', uniqueEntities, forced);
     }
 
     prepareChangeListeners() {

--- a/src/js/containers/search/visualizations/geo/GeoVisualizationSectionContainer.jsx
+++ b/src/js/containers/search/visualizations/geo/GeoVisualizationSectionContainer.jsx
@@ -91,7 +91,7 @@ export class GeoVisualizationSectionContainer extends React.Component {
         this.setState({
             scope
         }, () => {
-            this.prepareFetch();
+            this.prepareFetch(true);
         });
     }
 
@@ -108,13 +108,13 @@ export class GeoVisualizationSectionContainer extends React.Component {
         });
     }
 
-    prepareFetch() {
+    prepareFetch(forced = false) {
         if (this.state.loadingTiles) {
             // we can't measure visible entities if the tiles aren't loaded yet, so stop
             return;
         }
 
-        MapBroadcaster.emit('measureMap');
+        MapBroadcaster.emit('measureMap', forced);
     }
 
     compareEntities(entities) {
@@ -139,11 +139,14 @@ export class GeoVisualizationSectionContainer extends React.Component {
         return false;
     }
 
-    receivedEntities(entities) {
-        const changed = this.compareEntities(entities);
-        if (!changed) {
-            // nothing changed
-            return;
+    receivedEntities(entities, forced) {
+        if (!forced) {
+            // only check if the returned entities list has changed if this is not a forced update
+            const changed = this.compareEntities(entities);
+            if (!changed) {
+                // nothing changed
+                return;
+            }
         }
 
         this.setState({

--- a/src/js/helpers/mapBroadcaster.js
+++ b/src/js/helpers/mapBroadcaster.js
@@ -34,7 +34,7 @@ class MapBroadcaster {
         this._events[eventName].splice(index, 1);
     }
 
-    emit(eventName, args) {
+    emit(eventName, ...args) {
         if (!this._events[eventName]) {
             // no such event
             return;
@@ -42,10 +42,9 @@ class MapBroadcaster {
 
         const listeners = this._events[eventName];
         listeners.forEach((listener) => {
-            listener.apply(null, [args]);
+            listener(...args);
         });
     }
-
 }
 
 const singleton = new MapBroadcaster();


### PR DESCRIPTION
* Recipient Location/Place of Performance toggle works on map visualization again
* Restored vertical spacing between award search table's type tabs and header in the table's loading state