### PR TITLE
Fix - Homepage Dropdowns on IE11

### DIFF
--- a/src/_scss/pages/homepage/_searchSectionDropdown.scss
+++ b/src/_scss/pages/homepage/_searchSectionDropdown.scss
@@ -6,7 +6,7 @@
     
     @include media($medium-screen) {
         position: absolute;
-        top: rem(50);
+        top: rem(40);
         left: 0;
     }
 

--- a/src/_scss/pages/homepage/_searchSectionItems.scss
+++ b/src/_scss/pages/homepage/_searchSectionItems.scss
@@ -89,7 +89,7 @@
         }
 
         .action {
-            @include flex(1 1 auto);
+            @include flex(0 0 auto);
             margin-top: rem(30);
             height: rem(40);
             position: relative;


### PR DESCRIPTION
- Removed the gap between the dropdown button and its options so that it doesn't close when the user mouses out from the button
- IE11 users should now be able to select the Agencies option in the dropdown at the bottom of the homepage

Bug: https://federal-spending-transparency.atlassian.net/browse/DS-1972

- [ ] Code Review
- [ ] Design Review