### PR TITLE
Update Subtiers Based on Names

### DIFF
--- a/src/js/components/bulkDownload/awards/filters/AgencyFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/AgencyFilter.jsx
@@ -70,8 +70,7 @@ export default class AgencyFilter extends React.Component {
         e.preventDefault();
         const target = e.target;
         this.props.updateFilter('subAgency', {
-            id: target.value,
-            name: target.name
+            name: target.value
         });
 
         this.setState({
@@ -129,16 +128,15 @@ export default class AgencyFilter extends React.Component {
         ));
 
         // Create the sub-agency options
-        const subAgencies = this.props.subAgencies.map((subAgency) => (
+        const subAgencies = this.props.subAgencies.map((subAgency, index) => (
             <li
                 className="field-item"
-                key={`field-${subAgency.subtier_agency_id}`}>
+                key={`field-${index}`}>
                 <button
                     className="item-button"
                     title={subAgency.subtier_agency_name}
                     aria-label={subAgency.subtier_agency_name}
-                    value={subAgency.subtier_agency_id}
-                    name={subAgency.subtier_agency_name}
+                    value={subAgency.subtier_agency_name}
                     onClick={this.handleSubAgencySelect}>
                     {subAgency.subtier_agency_name}
                 </button>

--- a/src/js/components/bulkDownload/awards/filters/AgencyFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/AgencyFilter.jsx
@@ -128,10 +128,10 @@ export default class AgencyFilter extends React.Component {
         ));
 
         // Create the sub-agency options
-        const subAgencies = this.props.subAgencies.map((subAgency, index) => (
+        const subAgencies = this.props.subAgencies.map((subAgency) => (
             <li
                 className="field-item"
-                key={`field-${index}`}>
+                key={`field-${subAgency.subtier_agency_name}`}>
                 <button
                     className="item-button"
                     title={subAgency.subtier_agency_name}

--- a/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
+++ b/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
@@ -95,7 +95,7 @@ export class BulkDownloadPageContainer extends React.Component {
             filters: {
                 award_types: awardTypes,
                 agency: formState.agency.id,
-                sub_agency: formState.subAgency.id,
+                sub_agency: formState.subAgency.name,
                 date_type: formState.dateType,
                 date_range: {
                     start_date: startDate,

--- a/tests/containers/bulkDownload/mockData.js
+++ b/tests/containers/bulkDownload/mockData.js
@@ -40,12 +40,10 @@ export const mockAgencies = {
 
 export const mockSubAgencies = [
     {
-        subtier_agency_name: "Subtier Agency 1",
-        subtier_agency_id: 5
+        subtier_agency_name: "Subtier Agency 1"
     },
     {
-        subtier_agency_name: "Subtier Agency 2",
-        subtier_agency_id: 6
+        subtier_agency_name: "Subtier Agency 2"
     }
 ];
 
@@ -69,7 +67,6 @@ export const mockRedux = {
                 name: 'Mock Agency'
             },
             subAgency: {
-                id: '456',
                 name: 'Mock Sub-Agency'
             },
             dateType: 'action_date',


### PR DESCRIPTION
- [ ] [Backed PR](https://github.com/fedspendingtransparency/usaspending-api/pull/830) merged

- [x] Code review

- Removes the `subtier_agency_id` field, which will no longer be returned by the `/list_agencies` endpoint

- Passes the subtier agency name as a string instead of its id to the `/bulk_download/awards` endpoint

https://federal-spending-transparency.atlassian.net/browse/DS-2065