### PR TITLE
Mild Fix: Show Financial Assistance Award Details

### DIFF
--- a/src/js/components/award/contract/ContractDetails.jsx
+++ b/src/js/components/award/contract/ContractDetails.jsx
@@ -46,7 +46,7 @@ export default class ContractDetails extends React.Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        if (nextProps.selectedAward !== this.props.selectedAward) {
+        if (!Object.is(nextProps.selectedAward, this.props.selectedAward)) {
             this.prepareValues(nextProps.selectedAward);
         }
     }

--- a/src/js/components/award/contract/ContractDetails.jsx
+++ b/src/js/components/award/contract/ContractDetails.jsx
@@ -46,7 +46,9 @@ export default class ContractDetails extends React.Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        this.prepareValues(nextProps.selectedAward);
+        if (nextProps.selectedAward !== this.props.selectedAward) {
+            this.prepareValues(nextProps.selectedAward);
+        }
     }
 
     parsePlaceOfPerformance(award) {

--- a/src/js/components/award/financialAssistance/FinancialAssistanceDetails.jsx
+++ b/src/js/components/award/financialAssistance/FinancialAssistanceDetails.jsx
@@ -48,7 +48,9 @@ export default class FinancialAssistanceDetails extends React.Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        this.prepareValues(nextProps.selectedAward);
+        if (!Object.is(nextProps.selectedAward, this.props.selectedAward)) {
+            this.prepareValues(nextProps.selectedAward);
+        }
     }
 
     parsePlaceOfPerformance(award) {
@@ -98,11 +100,10 @@ export default class FinancialAssistanceDetails extends React.Component {
         return popPlace;
     }
 
-    prepareValues() {
+    prepareValues(award) {
         let yearRangeTotal = "";
         let monthRangeTotal = "";
         let description = null;
-        const award = this.props.selectedAward;
         const latestTransaction = award.latest_transaction;
 
         // Date Range

--- a/src/js/components/award/financialAssistance/FinancialAssistanceDetails.jsx
+++ b/src/js/components/award/financialAssistance/FinancialAssistanceDetails.jsx
@@ -43,8 +43,12 @@ export default class FinancialAssistanceDetails extends React.Component {
         };
     }
 
-    componentWillReceiveProps() {
+    componentDidMount() {
         this.prepareValues(this.props.selectedAward);
+    }
+
+    componentWillReceiveProps(nextProps) {
+        this.prepareValues(nextProps.selectedAward);
     }
 
     parsePlaceOfPerformance(award) {


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DS-2076

* Promote to dev-stable with staging (not prod) as target
* Fixes a bug where financial assistance awards would not initially populate Award Details and, if the URL changed to another financial assistance award, would then populate with the previous award
  