### PR TITLE
Fix - Federal Account Table Columns

### DIFF
--- a/src/js/components/account/awards/LegacyResultsTable.jsx
+++ b/src/js/components/account/awards/LegacyResultsTable.jsx
@@ -13,9 +13,9 @@ import IBTable from 'components/sharedComponents/IBTable/IBTable';
 import ResultsTableGenericCell from 'components/search/table/cells/ResultsTableGenericCell';
 import ResultsTableAwardIdCell from 'components/search/table/cells/ResultsTableAwardIdCell';
 
-import LegacyTableHeaderCell from './LegacyTableHeaderCell';
-
 import AccountTableSearchFields from 'dataMapping/search/accountTableSearchFields';
+
+import LegacyTableHeaderCell from './LegacyTableHeaderCell';
 
 const propTypes = {
     results: PropTypes.array,

--- a/src/js/components/account/awards/LegacyResultsTable.jsx
+++ b/src/js/components/account/awards/LegacyResultsTable.jsx
@@ -15,7 +15,7 @@ import ResultsTableAwardIdCell from 'components/search/table/cells/ResultsTableA
 
 import LegacyTableHeaderCell from './LegacyTableHeaderCell';
 
-import AccountTableSearchFields from '../../../dataMapping/search/accountTableSearchFields';
+import AccountTableSearchFields from 'dataMapping/search/accountTableSearchFields';
 
 const propTypes = {
     results: PropTypes.array,

--- a/src/js/components/account/awards/LegacyResultsTable.jsx
+++ b/src/js/components/account/awards/LegacyResultsTable.jsx
@@ -15,6 +15,8 @@ import ResultsTableAwardIdCell from 'components/search/table/cells/ResultsTableA
 
 import LegacyTableHeaderCell from './LegacyTableHeaderCell';
 
+import AccountTableSearchFields from '../../../dataMapping/search/accountTableSearchFields';
+
 const propTypes = {
     results: PropTypes.array,
     sort: PropTypes.object,
@@ -55,11 +57,12 @@ export default class LegacyResultsTable extends React.Component {
     headerCellRender(columnIndex) {
         const column = this.props.columns[columnIndex];
         const isLast = columnIndex === this.props.columns.length - 1;
+        const field = AccountTableSearchFields.modelMapping[column.fieldName];
 
         return (
             <LegacyTableHeaderCell
                 title={column.displayName}
-                field={column.fieldName}
+                field={field}
                 defaultDirection={column.defaultDirection}
                 currentSort={this.props.sort}
                 updateSort={this.props.updateSort}

--- a/src/js/components/account/awards/LegacyResultsTable.jsx
+++ b/src/js/components/account/awards/LegacyResultsTable.jsx
@@ -8,9 +8,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import moment from 'moment';
-import { formatMoney } from 'helpers/moneyFormatter';
-
 import IBTable from 'components/sharedComponents/IBTable/IBTable';
 
 import ResultsTableGenericCell from 'components/search/table/cells/ResultsTableGenericCell';
@@ -74,7 +71,8 @@ export default class LegacyResultsTable extends React.Component {
         const column = this.props.columns[columnIndex];
         const isLast = columnIndex === this.props.columns.length - 1;
 
-        if (column.columnName === 'award_id') {
+
+        if (column.columnName === 'awardId') {
             const award = this.props.results[rowIndex];
             let formattedID = award.piid;
             if (!formattedID) {
@@ -94,20 +92,12 @@ export default class LegacyResultsTable extends React.Component {
             );
         }
 
-        const originalData = this.props.results[rowIndex][column.columnName];
-        let displayedData = originalData;
-        if (column.dataType === 'currency') {
-            displayedData = formatMoney(originalData);
-        }
-        else if (column.dataType === 'date') {
-            // format the content as a date
-            displayedData = moment(originalData, 'YYYY-MM-DD').format('M/D/YYYY');
-        }
+        const originalData = this.props.results[rowIndex][column.fieldName];
 
         return (
             <ResultsTableGenericCell
                 rowIndex={rowIndex}
-                data={displayedData}
+                data={originalData}
                 column={column.columnName}
                 isLastColumn={isLast} />
         );

--- a/src/js/containers/account/awards/AccountAwardsContainer.jsx
+++ b/src/js/containers/account/awards/AccountAwardsContainer.jsx
@@ -11,7 +11,7 @@ import { uniqueId } from 'lodash';
 
 import { measureTableHeader } from 'helpers/textMeasurement';
 
-import TableSearchFields from 'dataMapping/search/tableSearchFields';
+import AccountTableSearchFields from 'dataMapping/search/accountTableSearchFields';
 import { awardTypeGroups } from 'dataMapping/search/awardType';
 import { awardTableColumnTypes } from 'dataMapping/search/awardTableColumnTypes';
 import * as SearchHelper from 'helpers/searchHelper';
@@ -170,13 +170,13 @@ export class AccountAwardsContainer extends React.Component {
             // calculate the column metadata to display for each table type
             const tableType = table.internal;
             const typeColumns = [];
-            let sortOrder = TableSearchFields.defaultSortDirection;
+            let sortOrder = AccountTableSearchFields.defaultSortDirection;
 
             if (tableType === 'loans') {
-                sortOrder = TableSearchFields.loans.sortDirection;
+                sortOrder = AccountTableSearchFields.loans.sortDirection;
             }
 
-            const tableSettings = TableSearchFields[tableType];
+            const tableSettings = AccountTableSearchFields[tableType];
 
             tableSettings._order.forEach((col) => {
                 let dataType = awardTableColumnTypes[tableSettings[col]];
@@ -187,7 +187,7 @@ export class AccountAwardsContainer extends React.Component {
                 const column = {
                     dataType,
                     columnName: col,
-                    fieldName: TableSearchFields[tableType]._mapping[col],
+                    fieldName: AccountTableSearchFields[tableType]._mapping[col],
                     displayName: tableSettings[col],
                     width: measureTableHeader(tableSettings[col]),
                     defaultDirection: sortOrder[col]
@@ -291,11 +291,11 @@ export class AccountAwardsContainer extends React.Component {
         const currentSortField = this.state.sort.field;
 
         // check if the current sort field is available in the table type
-        const availableFields = TableSearchFields[tab]._mapping;
+        const availableFields = AccountTableSearchFields[tab]._mapping;
         if (!availableFields[currentSortField]) {
             // the sort field doesn't exist, use the table type's default field
-            const field = TableSearchFields[tab]._defaultSortField;
-            const direction = TableSearchFields.defaultSortDirection[field];
+            const field = AccountTableSearchFields[tab]._defaultSortField;
+            const direction = AccountTableSearchFields.defaultSortDirection[field];
 
             newState.sort = {
                 field,

--- a/src/js/containers/account/awards/AccountAwardsContainer.jsx
+++ b/src/js/containers/account/awards/AccountAwardsContainer.jsx
@@ -17,8 +17,9 @@ import { awardTableColumnTypes } from 'dataMapping/search/awardTableColumnTypes'
 import * as SearchHelper from 'helpers/searchHelper';
 
 import AccountAwardSearchOperation from 'models/account/queries/AccountAwardSearchOperation';
-
 import AccountAwardsSection from 'components/account/awards/AccountAwardsSection';
+
+import BaseFederalAccountAwardRow from '../../../models/v2/BaseFederalAccountAwardRow';
 
 const propTypes = {
     account: PropTypes.object,
@@ -205,6 +206,18 @@ export class AccountAwardsContainer extends React.Component {
         });
     }
 
+    parseAccountAwards(data) {
+        const accountAwards = [];
+
+        data.forEach((accountAward) => {
+            const award = Object.create(BaseFederalAccountAwardRow);
+            award.parse(accountAward);
+            accountAwards.push(award);
+        });
+
+        return accountAwards;
+    }
+
     performSearch(newSearch = false) {
         if (this.searchRequest) {
             // a request is currently in-flight, cancel it
@@ -253,10 +266,10 @@ export class AccountAwardsContainer extends React.Component {
                 // don't clear records if we're appending (not the first page)
                 if (pageNumber <= 1 || newSearch) {
                     newState.tableInstance = `${uniqueId()}`;
-                    newState.results = res.data.results;
+                    newState.results = this.parseAccountAwards(res.data.results);
                 }
                 else {
-                    newState.results = this.state.results.concat(res.data.results);
+                    newState.results = this.state.results.concat(this.parseAccountAwards(res.data.results));
                 }
 
                 // request is done
@@ -341,6 +354,7 @@ export class AccountAwardsContainer extends React.Component {
         if (Object.keys(this.state.columns).length === 0) {
             return null;
         }
+
         return (
             <AccountAwardsSection
                 inFlight={this.state.inFlight}

--- a/src/js/containers/account/awards/AccountAwardsContainer.jsx
+++ b/src/js/containers/account/awards/AccountAwardsContainer.jsx
@@ -19,7 +19,7 @@ import * as SearchHelper from 'helpers/searchHelper';
 import AccountAwardSearchOperation from 'models/account/queries/AccountAwardSearchOperation';
 import AccountAwardsSection from 'components/account/awards/AccountAwardsSection';
 
-import BaseFederalAccountAwardRow from '../../../models/v2/BaseFederalAccountAwardRow';
+import BaseFederalAccountAwardRow from 'models/v2/BaseFederalAccountAwardRow';
 
 const propTypes = {
     account: PropTypes.object,

--- a/src/js/containers/account/awards/AccountAwardsContainer.jsx
+++ b/src/js/containers/account/awards/AccountAwardsContainer.jsx
@@ -64,7 +64,7 @@ export class AccountAwardsContainer extends React.Component {
             counts: {},
             tableType: 'contracts',
             sort: {
-                field: 'Award Amount',
+                field: 'awardAmount',
                 direction: 'desc'
             },
             inFlight: true,

--- a/src/js/dataMapping/search/accountTableSearchFields.js
+++ b/src/js/dataMapping/search/accountTableSearchFields.js
@@ -30,14 +30,14 @@ const accountTableSearchFields = {
             'awarding_subtier_name'
         ],
         _mapping: {
-            award_id: 'piid',
-            recipient_name: 'recipient__recipient_name',
-            period_of_performance_start_date: 'period_of_performance_start_date',
-            period_of_performance_current_end_date: 'period_of_performance_current_end_date',
-            total_obligation: 'total_obligation',
-            type: 'type_description',
-            awarding_agency_name: 'awarding_agency__toptier_agency__name',
-            awarding_subtier_name: 'awarding_agency__subtier_agency__name'
+            award_id: 'awardId',
+            recipient_name: 'recipientName',
+            period_of_performance_start_date: 'startDate',
+            period_of_performance_current_end_date: 'endDate',
+            total_obligation: 'awardAmount',
+            type: 'awardType',
+            awarding_agency_name: 'awardingToptierAgency',
+            awarding_subtier_name: 'awardingSubtierAgency'
         },
         award_id: 'Award ID',
         recipient_name: 'Recipient Name',
@@ -61,14 +61,14 @@ const accountTableSearchFields = {
             'type'
         ],
         _mapping: {
-            award_id: 'fain',
-            recipient_name: 'recipient__recipient_name',
-            period_of_performance_start_date: 'period_of_performance_start_date',
-            period_of_performance_current_end_date: 'period_of_performance_current_end_date',
-            total_obligation: 'total_obligation',
-            type: 'type',
-            awarding_agency_name: 'awarding_agency__toptier_agency__name',
-            awarding_subtier_name: 'awarding_agency__subtier_agency__name'
+            award_id: 'awardId',
+            recipient_name: 'recipientName',
+            period_of_performance_start_date: 'startDate',
+            period_of_performance_current_end_date: 'endDate',
+            total_obligation: 'awardAmount',
+            type: 'awardType',
+            awarding_agency_name: 'awardingToptierAgency',
+            awarding_subtier_name: 'awardingSubtierAgency'
         },
         award_id: 'Award ID',
         recipient_name: 'Recipient Name',
@@ -92,14 +92,14 @@ const accountTableSearchFields = {
             'type'
         ],
         _mapping: {
-            award_id: 'fain',
-            recipient_name: 'recipient__recipient_name',
-            period_of_performance_start_date: 'period_of_performance_start_date',
-            period_of_performance_current_end_date: 'period_of_performance_current_end_date',
-            total_obligation: 'total_obligation',
-            type: 'type',
-            awarding_agency_name: 'awarding_agency__toptier_agency__name',
-            awarding_subtier_name: 'awarding_agency__subtier_agency__name'
+            award_id: 'awardId',
+            recipient_name: 'recipientName',
+            period_of_performance_start_date: 'startDate',
+            period_of_performance_current_end_date: 'endDate',
+            total_obligation: 'awardAmount',
+            type: 'awardType',
+            awarding_agency_name: 'awardingToptierAgency',
+            awarding_subtier_name: 'awardingSubtierAgency'
         },
         award_id: 'Award ID',
         recipient_name: 'Recipient Name',
@@ -131,13 +131,13 @@ const accountTableSearchFields = {
             'awarding_subtier_name'
         ],
         _mapping: {
-            award_id: 'fain',
-            recipient_name: 'recipient__recipient_name',
-            action_date: 'latest_transaction__action_date',
-            face_value_loan_guarantee: 'latest_transaction__assistance_data__face_value_loan_guarantee',
-            original_loan_subsidy_cost: 'latest_transaction__assistance_data__original_loan_subsidy_cost',
-            awarding_agency_name: 'awarding_agency__toptier_agency__name',
-            awarding_subtier_name: 'awarding_agency__subtier_agency__name'
+            award_id: 'awardId',
+            recipient_name: 'recipientName',
+            action_date: 'issuedDate',
+            face_value_loan_guarantee: 'loanValue',
+            original_loan_subsidy_cost: 'subsidyCost',
+            awarding_agency_name: 'awardingToptierAgency',
+            awarding_subtier_name: 'awardingSubtierAgency'
         },
         award_id: 'Award ID',
         recipient_name: 'Recipient Name',
@@ -160,14 +160,14 @@ const accountTableSearchFields = {
             'type'
         ],
         _mapping: {
-            award_id: 'fain',
-            recipient_name: 'recipient__recipient_name',
-            period_of_performance_start_date: 'period_of_performance_start_date',
-            period_of_performance_current_end_date: 'period_of_performance_current_end_date',
-            total_obligation: 'total_obligation',
-            type: 'type',
-            awarding_agency_name: 'awarding_agency__toptier_agency__name',
-            awarding_subtier_name: 'awarding_agency__subtier_agency__name'
+            award_id: 'awardId',
+            recipient_name: 'recipientName',
+            period_of_performance_start_date: 'startDate',
+            period_of_performance_current_end_date: 'endDate',
+            total_obligation: 'awardAmount',
+            type: 'awardType',
+            awarding_agency_name: 'awardingToptierAgency',
+            awarding_subtier_name: 'awardingSubtierAgency'
         },
         award_id: 'Award ID',
         recipient_name: 'Recipient Name',

--- a/src/js/dataMapping/search/accountTableSearchFields.js
+++ b/src/js/dataMapping/search/accountTableSearchFields.js
@@ -15,7 +15,22 @@ const accountTableSearchFields = {
         type: 'asc',
         awarding_agency_name: 'asc',
         awarding_subtier_name: 'asc',
-        face_value_loan_guarantee: 'desc'
+        latest_transaction__action_date: 'desc',
+        latest_transaction__assistance_data__face_value_loan_guarantee: 'desc',
+        latest_transaction__assistance_data__original_loan_subsidy_cost: 'desc'
+    },
+    modelMapping: {
+        awardId: 'id',
+        recipientName: 'recipient__recipient_name',
+        startDate: 'period_of_performance_start_date',
+        endDate: 'period_of_performance_current_end_date',
+        awardAmount: 'total_obligation',
+        awardType: 'type',
+        awardingToptierAgency: 'awarding_agency__toptier_agency__name',
+        awardingSubtierAgency: 'awarding_agency__subtier_agency__name',
+        issuedDate: 'latest_transaction__action_date',
+        loanValue: 'latest_transaction__assistance_data__face_value_loan_guarantee',
+        subsidyCost: 'latest_transaction__assistance_data__original_loan_subsidy_cost'
     },
     contracts: {
         _defaultSortField: 'total_obligation',
@@ -111,7 +126,7 @@ const accountTableSearchFields = {
         type: 'Award Type'
     },
     loans: {
-        _defaultSortField: 'face_value_loan_guarantee',
+        _defaultSortField: 'latest_transaction__assistance_data__face_value_loan_guarantee',
         sortDirection: {
             award_id: 'asc',
             recipient_name: 'asc',

--- a/src/js/dataMapping/search/accountTableSearchFields.js
+++ b/src/js/dataMapping/search/accountTableSearchFields.js
@@ -1,0 +1,184 @@
+/**
+ * accountTableSearchFields.js
+ * Created by michaelbray on 1/16/18.
+ *
+ */
+
+/* eslint-disable max-len */
+const accountTableSearchFields = {
+    defaultSortDirection: {
+        award_id: 'asc',
+        recipient_name: 'asc',
+        period_of_performance_start_date: 'desc',
+        period_of_performance_current_end_date: 'desc',
+        total_obligation: 'desc',
+        type: 'asc',
+        awarding_agency_name: 'asc',
+        awarding_subtier_name: 'asc',
+        face_value_loan_guarantee: 'desc'
+    },
+    contracts: {
+        _defaultSortField: 'total_obligation',
+        _order: [
+            'award_id',
+            'recipient_name',
+            'period_of_performance_start_date',
+            'period_of_performance_current_end_date',
+            'total_obligation',
+            'type',
+            'awarding_agency_name',
+            'awarding_subtier_name'
+        ],
+        _mapping: {
+            award_id: 'piid',
+            recipient_name: 'recipient__recipient_name',
+            period_of_performance_start_date: 'period_of_performance_start_date',
+            period_of_performance_current_end_date: 'period_of_performance_current_end_date',
+            total_obligation: 'total_obligation',
+            type: 'type_description',
+            awarding_agency_name: 'awarding_agency__toptier_agency__name',
+            awarding_subtier_name: 'awarding_agency__subtier_agency__name'
+        },
+        award_id: 'Award ID',
+        recipient_name: 'Recipient Name',
+        period_of_performance_start_date: 'Start Date',
+        period_of_performance_current_end_date: 'End Date',
+        total_obligation: 'Award Amount',
+        type: 'Contract Award Type',
+        awarding_agency_name: 'Awarding Agency',
+        awarding_subtier_name: 'Awarding Sub Agency'
+    },
+    grants: {
+        _defaultSortField: 'total_obligation',
+        _order: [
+            'award_id',
+            'recipient_name',
+            'period_of_performance_start_date',
+            'period_of_performance_current_end_date',
+            'total_obligation',
+            'awarding_agency_name',
+            'awarding_subtier_name',
+            'type'
+        ],
+        _mapping: {
+            award_id: 'fain',
+            recipient_name: 'recipient__recipient_name',
+            period_of_performance_start_date: 'period_of_performance_start_date',
+            period_of_performance_current_end_date: 'period_of_performance_current_end_date',
+            total_obligation: 'total_obligation',
+            type: 'type',
+            awarding_agency_name: 'awarding_agency__toptier_agency__name',
+            awarding_subtier_name: 'awarding_agency__subtier_agency__name'
+        },
+        award_id: 'Award ID',
+        recipient_name: 'Recipient Name',
+        period_of_performance_start_date: 'Start Date',
+        period_of_performance_current_end_date: 'End Date',
+        total_obligation: 'Award Amount',
+        awarding_agency_name: 'Awarding Agency',
+        awarding_subtier_name: 'Awarding Sub Agency',
+        type: 'Award Type'
+    },
+    direct_payments: {
+        _defaultSortField: 'total_obligation',
+        _order: [
+            'award_id',
+            'recipient_name',
+            'period_of_performance_start_date',
+            'period_of_performance_current_end_date',
+            'total_obligation',
+            'awarding_agency_name',
+            'awarding_subtier_name',
+            'type'
+        ],
+        _mapping: {
+            award_id: 'fain',
+            recipient_name: 'recipient__recipient_name',
+            period_of_performance_start_date: 'period_of_performance_start_date',
+            period_of_performance_current_end_date: 'period_of_performance_current_end_date',
+            total_obligation: 'total_obligation',
+            type: 'type',
+            awarding_agency_name: 'awarding_agency__toptier_agency__name',
+            awarding_subtier_name: 'awarding_agency__subtier_agency__name'
+        },
+        award_id: 'Award ID',
+        recipient_name: 'Recipient Name',
+        period_of_performance_start_date: 'Start Date',
+        period_of_performance_current_end_date: 'End Date',
+        total_obligation: 'Award Amount',
+        awarding_agency_name: 'Awarding Agency',
+        awarding_subtier_name: 'Awarding Sub Agency',
+        type: 'Award Type'
+    },
+    loans: {
+        _defaultSortField: 'face_value_loan_guarantee',
+        sortDirection: {
+            award_id: 'asc',
+            recipient_name: 'asc',
+            action_date: 'desc',
+            face_value_loan_guarantee: 'desc',
+            original_loan_subsidy_cost: 'desc',
+            awarding_agency_name: 'asc',
+            awarding_subtier_name: 'asc'
+        },
+        _order: [
+            'award_id',
+            'recipient_name',
+            'action_date',
+            'face_value_loan_guarantee',
+            'original_loan_subsidy_cost',
+            'awarding_agency_name',
+            'awarding_subtier_name'
+        ],
+        _mapping: {
+            award_id: 'fain',
+            recipient_name: 'recipient__recipient_name',
+            action_date: 'latest_transaction__action_date',
+            face_value_loan_guarantee: 'latest_transaction__assistance_data__face_value_loan_guarantee',
+            original_loan_subsidy_cost: 'latest_transaction__assistance_data__original_loan_subsidy_cost',
+            awarding_agency_name: 'awarding_agency__toptier_agency__name',
+            awarding_subtier_name: 'awarding_agency__subtier_agency__name'
+        },
+        award_id: 'Award ID',
+        recipient_name: 'Recipient Name',
+        action_date: 'Issued Date',
+        face_value_loan_guarantee: 'Loan Value',
+        original_loan_subsidy_cost: 'Subsidy Cost',
+        awarding_agency_name: 'Awarding Agency',
+        awarding_subtier_name: 'Awarding Sub Agency'
+    },
+    other: {
+        _defaultSortField: 'total_obligation',
+        _order: [
+            'award_id',
+            'recipient_name',
+            'period_of_performance_start_date',
+            'period_of_performance_current_end_date',
+            'total_obligation',
+            'awarding_agency_name',
+            'awarding_subtier_name',
+            'type'
+        ],
+        _mapping: {
+            award_id: 'fain',
+            recipient_name: 'recipient__recipient_name',
+            period_of_performance_start_date: 'period_of_performance_start_date',
+            period_of_performance_current_end_date: 'period_of_performance_current_end_date',
+            total_obligation: 'total_obligation',
+            type: 'type',
+            awarding_agency_name: 'awarding_agency__toptier_agency__name',
+            awarding_subtier_name: 'awarding_agency__subtier_agency__name'
+        },
+        award_id: 'Award ID',
+        recipient_name: 'Recipient Name',
+        period_of_performance_start_date: 'Start Date',
+        period_of_performance_current_end_date: 'End Date',
+        total_obligation: 'Award Amount',
+        awarding_agency_name: 'Awarding Agency',
+        awarding_subtier_name: 'Awarding Sub Agency',
+        type: 'Award Type'
+    }
+};
+/* eslint-enable max-len */
+
+export default accountTableSearchFields;

--- a/src/js/models/v2/BaseFederalAccountAwardRow.js
+++ b/src/js/models/v2/BaseFederalAccountAwardRow.js
@@ -1,0 +1,58 @@
+/**
+ * BaseFederalAccountAwardRow.js
+ * Created by michaelbray on 1/19/18.
+ */
+
+import { formatMoney } from 'helpers/moneyFormatter';
+import { parseDate } from './utils';
+
+/* eslint-disable object-shorthand */
+const BaseFederalAccountAwardRow = {
+    parse: function (data) {
+        this.awardId = data.id.toString() || null;
+        this.recipientName = data.recipient.recipient_name || '';
+        this._startDate = parseDate(data.period_of_performance_start_date || null);
+        this._endDate = parseDate(data.period_of_performance_current_end_date || null);
+        this._awardAmount = data.total_obligation || 0;
+        this.awardType = data.type || '';
+        this.awardingToptierAgency = data.awarding_agency.toptier_agency.name || '';
+        this.awardingSubtierAgency = data.awarding_agency.subtier_agency.name || '';
+        this._issuedDate = parseDate((data.latest_transaction && data.latest_transaction.action_date));
+        this._loanValue = (data.latest_transaction
+            && data.latest_transaction.assistance_data
+            && data.latest_transaction.assistance_data.face_value_loan_guarantee) || 0;
+        this._subsidyCost = (data.latest_transaction
+            && data.latest_transaction.assistance_data
+            && data.latest_transaction.assistance_data.original_loan_subsidy_cost) || 0;
+    },
+    get startDate() {
+        if (!this._startDate) {
+            return '';
+        }
+        return this._startDate.format('MM/DD/YYYY');
+    },
+    get endDate() {
+        if (!this._endDate) {
+            return '';
+        }
+        return this._endDate.format('MM/DD/YYYY');
+    },
+    get awardAmount() {
+        return formatMoney(this._awardAmount);
+    },
+    get issuedDate() {
+        if (!this._issuedDate) {
+            return '';
+        }
+        return this._issuedDate.format('MM/DD/YYYY');
+    },
+    get loanValue() {
+        return formatMoney(this._endDate);
+    },
+    get subsidyCost() {
+        return formatMoney(this._endDate);
+    }
+};
+/* eslint-enable object-shorthand */
+
+export default BaseFederalAccountAwardRow;

--- a/src/js/models/v2/utils.js
+++ b/src/js/models/v2/utils.js
@@ -1,0 +1,18 @@
+/**
+ * utils.js
+ * Created by michaelbray on 1/19/18.
+ */
+
+import moment from 'moment';
+
+export const parseDate = (dateString, format = 'YYYY-MM-DD') => {
+    if (dateString) {
+        const date = moment(dateString, format);
+
+        if (date.isValid()) {
+            return date;
+        }
+    }
+
+    return null;
+};

--- a/tests/containers/account/awards/AccountAwardsContainer-test.jsx
+++ b/tests/containers/account/awards/AccountAwardsContainer-test.jsx
@@ -32,7 +32,7 @@ jest.mock('helpers/textMeasurement', () => (
 ));
 
 jest.mock('helpers/searchHelper', () => require('./mockSearchHelper'));
-jest.mock('dataMapping/search/tableSearchFields', () => require('./mockSearchFields'));
+jest.mock('dataMapping/search/accountTableSearchFields', () => require('./mockSearchFields'));
 
 describe('AccountAwardsContainer', () => {
     it('should pick a default tab when the Redux filters change', () => {
@@ -82,6 +82,7 @@ describe('AccountAwardsContainer', () => {
                 account: mockReduxAccount,
                 filters: defaultFilters    
             };
+
             const container = shallow(<AccountAwardsContainer {...props} />);
             container.instance().loadColumns();
 
@@ -178,8 +179,11 @@ describe('AccountAwardsContainer', () => {
                 account: mockReduxAccount,
                 filters: defaultFilters    
             };
+
             const container = shallow(<AccountAwardsContainer {...props} />);
+
             container.instance().switchTab('loans');
+
             expect(container.state().sort).toEqual({
                 field: 'loanfield',
                 direction: 'desc'

--- a/tests/containers/account/awards/mockSearchFields.js
+++ b/tests/containers/account/awards/mockSearchFields.js
@@ -2,45 +2,45 @@ const tableSearchFields = {
     defaultSortDirection: {
         field1: 'asc',
         field2: 'desc',
-        loanfield: 'desc',
+        loanfield: 'desc'
     },
     contracts: {
         _defaultSortField: 'field1',
         _order: [
-            'field1',
+            'field1'
         ],
         _mapping: {
-            field1: 'f1',
+            field1: 'f1'
         },
         field1: 'Field 1'
     },
     grants: {
-       _defaultSortField: 'field1',
+        _defaultSortField: 'field1',
         _order: [
-            'field1',
+            'field1'
         ],
         _mapping: {
-            field1: 'f1',
+            field1: 'f1'
         },
         field1: 'Field 1'
     },
     direct_payments: {
         _defaultSortField: 'field1',
         _order: [
-            'field1',
+            'field1'
         ],
         _mapping: {
-            field1: 'f1',
+            field1: 'f1'
         },
         field1: 'Field 1'
     },
     loans: {
         _defaultSortField: 'loanfield',
         _order: [
-            'loanfield',
+            'loanfield'
         ],
         _mapping: {
-            loanfield: 'lf',
+            loanfield: 'lf'
         },
         loanfield: 'Loan Field',
         sortDirection: {
@@ -50,10 +50,10 @@ const tableSearchFields = {
     other: {
         _defaultSortField: 'field1',
         _order: [
-            'field1',
+            'field1'
         ],
         _mapping: {
-            field1: 'f1',
+            field1: 'f1'
         },
         field1: 'Field 1'
     }


### PR DESCRIPTION
Does not need to go in this deploy.

- Columns in the Federal Account table now match those in the Award Search table for each Award Type

Bug: https://federal-spending-transparency.atlassian.net/browse/DEV-116

Note: For full testing, @michaeldhess is looking into finding a Federal Account in the dev database that has corresponding awards to display in the table. However, even without result data in the table (which allows the user to scroll through the column headers), the visible column headers can be seen updating on each tab change.

Use 2421