### PR TITLE
Fix - Spending Explorer Table with null Award IDs

### DIFF
--- a/src/_scss/pages/explorer/detail/visualization/treemap/_cell.scss
+++ b/src/_scss/pages/explorer/detail/visualization/treemap/_cell.scss
@@ -25,4 +25,8 @@
     .explorer-cell-box {
         transition: fill 0.2s;
     }
+
+    &.link-disabled {
+        cursor: default;
+    }
 }

--- a/src/js/components/agency/overview/AgencyOverview.jsx
+++ b/src/js/components/agency/overview/AgencyOverview.jsx
@@ -193,14 +193,16 @@ export default class AgencyOverview extends React.PureComponent {
                         ref={(div) => {
                             this.containerDiv = div;
                         }}>
-                        <h4>Budgetary Resources
+                        <h4>
+                            Budgetary Resources
                             <a href={`#/agency/${this.props.agency.id}?glossary=budgetary-resources`}>
                                 <Glossary />
                             </a>
                             for FY {this.props.agency.activeFY}
                         </h4>
                         <div className="budget-authority-date">
-                            <em>FY {this.props.agency.activeFY} data reported
+                            <em>
+                                FY {this.props.agency.activeFY} data reported
                                 through {this.state.asOfDate}
                             </em>
                         </div>

--- a/src/js/components/award/AwardAmounts.jsx
+++ b/src/js/components/award/AwardAmounts.jsx
@@ -62,7 +62,8 @@ export default class AwardAmounts extends React.Component {
             percentage = Math.floor((unformattedCurrent / unformattedCeiling) * 1000) / 10;
         }
         let awardNarrative = (
-            <p>This {this.props.typeString} was awarded to&nbsp;
+            <p>
+                This {this.props.typeString} was awarded to&nbsp;
                 <b className="recipient-name">{recipient}</b> with a ceiling of
                 &nbsp;<b>{ceiling}</b>.&nbsp;
                 Of this amount, <b>{percentage}%</b> (<b>{current}</b>)
@@ -73,7 +74,8 @@ export default class AwardAmounts extends React.Component {
         if (this.props.typeString === 'grant' || this.props.typeString === 'direct payment' ||
         this.props.typeString === 'other') {
             awardNarrative = (
-                <p>This {this.props.typeString} was awarded to&nbsp;
+                <p>
+                    This {this.props.typeString} was awarded to&nbsp;
                     <b className="recipient-name">{recipient}</b>
                     &nbsp;for <b>{current}</b>.
                 </p>
@@ -86,7 +88,8 @@ export default class AwardAmounts extends React.Component {
                 this.props.selectedAward.assistance_data.original_loan_subsidy_cost);
 
             awardNarrative = (
-                <p>A {this.props.typeString} with a face value of&nbsp;
+                <p>
+                    A {this.props.typeString} with a face value of&nbsp;
                     <b>{loanCeiling}</b> was awarded to <b>{recipient}</b>. The agency&#8217;s
                         estimated non-administrative cost to the government for this&nbsp;
                     {this.props.typeString} is <b>{loanSubsidy}</b>. This cost is also known as

--- a/src/js/components/bulkDownload/awards/AwardDataContent.jsx
+++ b/src/js/components/bulkDownload/awards/AwardDataContent.jsx
@@ -108,8 +108,11 @@ export default class AwardDataContent extends React.Component {
                             <InfoCircle />
                         </div>
                         <div className="archive-info">
-                            <div className="archive-info-heading">A faster way to download yearly award data by agency.</div>
-                            <div>Award downloads for entire fiscal years are available for each major agency on our&nbsp;
+                            <div className="archive-info-heading">
+                                A faster way to download yearly award data by agency.
+                            </div>
+                            <div>
+                                Award downloads for entire fiscal years are available for each major agency on our&nbsp;
                                 <a href="/#/bulk_download/award_data_archive">
                                     Award Data Archive
                                 </a>

--- a/src/js/components/explorer/detail/visualization/table/ExplorerTable.jsx
+++ b/src/js/components/explorer/detail/visualization/table/ExplorerTable.jsx
@@ -42,7 +42,7 @@ export default class ExplorerTable extends React.Component {
         const rows = this.props.results.map((item, index) => (
             <TableRow
                 item={item}
-                key={item.id}
+                key={item.name}
                 rowIndex={index}
                 columns={this.props.columns}
                 selectedRow={this.selectedRow} />

--- a/src/js/components/explorer/detail/visualization/table/TableRow.jsx
+++ b/src/js/components/explorer/detail/visualization/table/TableRow.jsx
@@ -22,7 +22,7 @@ export default class TableRow extends React.PureComponent {
             rowClass = 'row-odd';
         }
         const cells = this.props.columns.map((column) => {
-            if (column.columnName === 'name') {
+            if (column.columnName === 'name' && this.props.item.id) {
                 // show the link cell
                 return (
                     <td
@@ -41,7 +41,7 @@ export default class TableRow extends React.PureComponent {
             return (
                 <td
                     className={rowClass}
-                    key={`${column.columnName}-${this.props.item.id}`}>
+                    key={`${column.columnName}-${this.props.item.name}`}>
                     <GenericCell
                         rowIndex={this.props.rowIndex}
                         data={this.props.item.display[column.columnName]}

--- a/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
+++ b/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
@@ -196,7 +196,7 @@ export default class ExplorerTreemap extends React.Component {
         const cells = this.state.virtualChart.map((cell) => (
             <TreemapCell
                 {...cell}
-                key={cell.data.id}
+                key={cell.data.name}
                 selectedCell={this.selectedCell}
                 showTooltip={this.props.showTooltip}
                 hideTooltip={this.props.hideTooltip} />

--- a/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
+++ b/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
@@ -196,7 +196,7 @@ export default class ExplorerTreemap extends React.Component {
         const cells = this.state.virtualChart.map((cell) => (
             <TreemapCell
                 {...cell}
-                key={cell.data.name}
+                key={`${cell.data.name}-${cell.data.id}`}
                 selectedCell={this.selectedCell}
                 showTooltip={this.props.showTooltip}
                 hideTooltip={this.props.hideTooltip} />

--- a/src/js/components/explorer/detail/visualization/treemap/TreemapCell.jsx
+++ b/src/js/components/explorer/detail/visualization/treemap/TreemapCell.jsx
@@ -51,8 +51,10 @@ export default class TreemapCell extends React.Component {
     }
 
     clickedCell() {
-        this.exitedCell();
-        this.props.selectedCell(this.props.data.id, this.props.data);
+        if (this.props.data.id) {
+            this.exitedCell();
+            this.props.selectedCell(this.props.data.id, this.props.data);
+        }
     }
 
     enteredCell() {
@@ -101,14 +103,21 @@ export default class TreemapCell extends React.Component {
                 {this.props.subtitle.text}
             </text>
         );
+
+        let disabledClass = '';
+        if (this.props.data.id === null) {
+            disabledClass = 'link-disabled';
+        }
+
         if (this.props.width < 75 || this.props.height < 38) {
             cellTitle = '';
             cellValue = '';
         }
         const position = `translate(${this.props.x}, ${this.props.y})`;
+
         return (
             <g
-                className="explorer-cell"
+                className={`explorer-cell ${disabledClass}`}
                 transform={position}
                 onClick={this.clickedCell}
                 onMouseMove={this.enteredCell}


### PR DESCRIPTION
- When an Award ID is `null` due to a missing File C/D linkage, the Spending Explorer table will show a generic table cell that does not attempt to link to the Award page with that `null` ID
- Also fixes React key issues in the Spending Explorer table when encountering `null` Award IDs

Bug: https://federal-spending-transparency.atlassian.net/browse/DEV-284

To test, in the Spending Explorer, select Agency -> DOL -> Click the Table Icon -> Award

- [x] Code Review
- [x] Design Review