### PR TITLE
Fix - Spending Explorer Styles

### DIFF
--- a/src/_scss/pages/explorer/detail/visualization/table/_table.scss
+++ b/src/_scss/pages/explorer/detail/visualization/table/_table.scss
@@ -3,7 +3,7 @@
     background-color: $color-white;
     position: relative;
     display: block;
-    overflow: scroll;
+    overflow: auto;
 
     &.no-results {
         border: none;

--- a/src/_scss/pages/explorer/detail/visualization/table/_table.scss
+++ b/src/_scss/pages/explorer/detail/visualization/table/_table.scss
@@ -68,6 +68,7 @@
                             @include button-unstyled;
                             color: $color-primary;
                             font-size: rem(16);
+                            line-height: rem(20);
                         }
                     }
                 }


### PR DESCRIPTION
- Removes unnecessary scroll bars on the Spending Explorer in Chrome + IE on Windows
- Increases line height of table rows in the Spending Explorer to avoid cutting off the bottom of letters that descend below the baseline in Safari on Mac

Bug: https://federal-spending-transparency.atlassian.net/browse/DEV-91

- [x] Code Review
- [x] Design Review