### PR TITLE
Fix IBTable Reload after Unmount

### DIFF
--- a/src/js/components/sharedComponents/IBTable/components/Table.jsx
+++ b/src/js/components/sharedComponents/IBTable/components/Table.jsx
@@ -59,7 +59,9 @@ export default class Table extends React.Component {
         // wait for the scroll to complete before changing the row counts (to prevent false
         // pagination)
         window.setTimeout(() => {
-            this._bodyComponent.reloadTable();
+            if (this._bodyComponent) {
+                this._bodyComponent.reloadTable();
+            }
         }, 300);
     }
 


### PR DESCRIPTION
* Fixes a bug where IBTable may respond to a reload method after the table has been scheduled for unmounting, resulting in a JS error