### PR TITLE
Update Award profile page business type checks

### DIFF
--- a/src/js/components/award/RecipientInfo.jsx
+++ b/src/js/components/award/RecipientInfo.jsx
@@ -74,12 +74,12 @@ export default class RecipientInfo extends React.Component {
         const businessTypesArray = [];
         let typesList = '';
 
-        if (isContract && this.props.recipient.recipient_business_type === 'Unknown Types') {
+        if (isContract) {
             businessTypeLabel = "Business Types";
             // Build an array of applicable business type fields
             const allBusinessTypes = BusinessTypesHelper.getBusinessTypes();
             allBusinessTypes.forEach((type) => {
-                if (recipient.latest_transaction.recipient[type.fieldName] === '1') {
+                if (recipient.latest_transaction.recipient[type.fieldName]) {
                     businessTypesArray.push(type);
                 }
             });

--- a/src/js/helpers/businessTypesHelper.js
+++ b/src/js/helpers/businessTypesHelper.js
@@ -211,10 +211,6 @@ export const getBusinessTypes = () => {
                 fieldName: 'hispanic_servicing_institution'
             },
             {
-                displayName: 'Receives Contracts and Grants',
-                fieldName: 'receives_contracts_and_grants'
-            },
-            {
                 displayName: 'Airport Authority',
                 fieldName: 'airport_authority'
             },


### PR DESCRIPTION
Updating business type checks to look for booleans and ignoring unknown business type check for contracts

- [x] Backend data reload completed (only dev)
- [x] [API PR #920](fedspendingtransparency/usaspending-api#920) Merged
- [x] Migrations from [API PR #920](fedspendingtransparency/usaspending-api#920) run