### PR TITLE
Hottest Fix - Change FY Rollover Date from 1/31 to 2/15

### DIFF
--- a/tests/containers/account/filters/AccountTimePeriodContainer-test.jsx
+++ b/tests/containers/account/filters/AccountTimePeriodContainer-test.jsx
@@ -36,7 +36,7 @@ describe('AccountTimePeriodContainer', () => {
             expect(container.state().timePeriods).toEqual(expectedYears);
         });
 
-        it('waits on the current fiscal year until after January 31', () => {
+        it('waits on the current fiscal year until February 15', () => {
             const mockedDate = moment('2018-02-14', 'YYYY-MM-DD').toDate();
             moment.now = () => (mockedDate);
 

--- a/tests/containers/account/filters/AccountTimePeriodContainer-test.jsx
+++ b/tests/containers/account/filters/AccountTimePeriodContainer-test.jsx
@@ -24,7 +24,7 @@ const defaultFilters = {
 describe('AccountTimePeriodContainer', () => {
     describe('generateTimePeriods', () => {
         it('generates the current available fiscal years', () => {
-            const mockedDate = moment('2018-02-01', 'YYYY-MM-DD').toDate();
+            const mockedDate = moment('2018-02-15', 'YYYY-MM-DD').toDate();
             moment.now = () => (mockedDate);
 
             const container = shallow(<AccountTimePeriodContainer />);
@@ -37,7 +37,7 @@ describe('AccountTimePeriodContainer', () => {
         });
 
         it('waits on the current fiscal year until after January 31', () => {
-            const mockedDate = moment('2018-01-31', 'YYYY-MM-DD').toDate();
+            const mockedDate = moment('2018-02-14', 'YYYY-MM-DD').toDate();
             moment.now = () => (mockedDate);
 
             const container = shallow(<AccountTimePeriodContainer />);

--- a/tests/helpers/fiscalYearHelper-test.js
+++ b/tests/helpers/fiscalYearHelper-test.js
@@ -42,37 +42,25 @@ describe('Fiscal Year helper functions', () => {
     });
 
     describe('defaultFiscalYear', () => {
-        it('should use the current calendar year as the fiscal year for every month before October but after January', () => {
+        it('should use the previous fiscal year as the fiscal year on February 14', () => {
             // override the moment's library's internal time to a known mocked date
-            const mockedDate = moment('2015-04-01', 'YYYY-MM-DD').toDate();
+            const mockedDate = moment('2018-02-14', 'YYYY-MM-DD').toDate();
             moment.now = () => (mockedDate);
 
             const currentFY = FiscalYearHelper.defaultFiscalYear();
-            expect(currentFY).toEqual(2015);
+            expect(currentFY).toEqual(2017);
 
             // reset moment's date to the current time
             moment.now = () => (new Date());
         });
 
-        it('should use the previous calendar year as the fiscal year for every month before February', () => {
+        it('should use the current fiscal year as the fiscal year on February 15', () => {
             // override the moment's library's internal time to a known mocked date
-            const mockedDate = moment('2015-01-20', 'YYYY-MM-DD').toDate();
+            const mockedDate = moment('2018-02-15', 'YYYY-MM-DD').toDate();
             moment.now = () => (mockedDate);
 
             const currentFY = FiscalYearHelper.defaultFiscalYear();
-            expect(currentFY).toEqual(2014);
-
-            // reset moment's date to the current time
-            moment.now = () => (new Date());
-        });
-
-        it('should use the current calendar year as the fiscal year for months on or after October', () => {
-            // override the moment's library's internal time to a known mocked date
-            const mockedDate = moment('2015-11-01', 'YYYY-MM-DD').toDate();
-            moment.now = () => (mockedDate);
-
-            const currentFY = FiscalYearHelper.defaultFiscalYear();
-            expect(currentFY).toEqual(2015);
+            expect(currentFY).toEqual(2018);
 
             // reset moment's date to the current time
             moment.now = () => (new Date());


### PR DESCRIPTION
**This PR is going directly to master**

- Extends the FY rollover date by 15 days
- Adds configuration to allow for complete override of default fiscal year via global constants
- Adds configuration to dynamically change the number of days of delay between the end of Q1 close and the date we rollover to the new FY

- [x] [usaspending-config update](https://github.com/fedspendingtransparency/usaspending-config/pull/68) is merged
- [x] Code Review