### PR TITLE
Update - Advanced Search Hover

### DIFF
--- a/src/js/components/search/SearchPage.jsx
+++ b/src/js/components/search/SearchPage.jsx
@@ -146,7 +146,8 @@ export default class SearchPage extends React.Component {
                     <div className="sticky-header__options">
                         <DownloadButton
                             downloadAvailable={this.props.downloadAvailable}
-                            onClick={this.showModal} />
+                            onClick={this.showModal}
+                            filterCount={this.state.filterCount} />
                     </div>
                 </StickyHeader>
                 <div id="main-content">

--- a/src/js/components/search/header/DownloadButton.jsx
+++ b/src/js/components/search/header/DownloadButton.jsx
@@ -10,7 +10,8 @@ import NoDownloadHover from './NoDownloadHover';
 
 const propTypes = {
     onClick: PropTypes.func,
-    downloadAvailable: PropTypes.bool
+    downloadAvailable: PropTypes.bool,
+    filterCount: PropTypes.number
 };
 
 export default class DownloadButton extends React.Component {
@@ -49,7 +50,7 @@ export default class DownloadButton extends React.Component {
 
     render() {
         let hover = null;
-        if (this.state.showHover && !this.props.downloadAvailable) {
+        if (this.state.showHover && !this.props.downloadAvailable && this.props.filterCount > 0) {
             hover = (<NoDownloadHover />);
         }
 

--- a/src/js/components/search/header/DownloadButton.jsx
+++ b/src/js/components/search/header/DownloadButton.jsx
@@ -14,6 +14,10 @@ const propTypes = {
     filterCount: PropTypes.number
 };
 
+const defaultProps = {
+    filterCount: 0
+};
+
 export default class DownloadButton extends React.Component {
     constructor(props) {
         super(props);
@@ -84,3 +88,4 @@ export default class DownloadButton extends React.Component {
 }
 
 DownloadButton.propTypes = propTypes;
+DownloadButton.defaultProps = defaultProps;

--- a/src/js/components/search/header/NoDownloadHover.jsx
+++ b/src/js/components/search/header/NoDownloadHover.jsx
@@ -18,8 +18,9 @@ const NoDownloadHover = () => (
                         <ExclamationTriangle alt="Download is not available" />
                     </div>
                     <div className="message">
-                        Please visit the <a href="#/bulk_download">Download Center</a> page to export
-                        more than 500,000 records or limit your results with additional filters.
+                        Our Advanced Search limits downloads to 500,000 records.
+                        Narrow your search using additional filters, or grab larger files from
+                        our <a href="#/bulk_download/award_data_archive">Award Data Archive</a>.
                     </div>
                 </div>
                 <div className="tooltip-pointer right" />


### PR DESCRIPTION
- Updates text and link within the hover on the Advanced Search page Download button when it's in a disabled state
- Only shows the hover if the user has applied filters and there are more than 500,000 results

Issue: https://federal-spending-transparency.atlassian.net/browse/DEV-431

As there are fewer than 500,000 records within the Skinny Dev database, test the hover functionality by changing [this line](https://github.com/fedspendingtransparency/usaspending-website/blob/dev/src/js/containers/search/SearchContainer.jsx#L380) to `downloadAvailable: false`.

- [x] Code Review
- [x] Design Review