### PR TITLE
Fixes: Federal Account - Sankey Error Handling & Multiple FYs in Spending Over Time 

### DIFF
--- a/src/js/components/account/AccountOverview.jsx
+++ b/src/js/components/account/AccountOverview.jsx
@@ -75,32 +75,34 @@ export default class AccountOverview extends React.Component {
     generateSummary(account) {
         // determine the current fiscal year and get the associated values
         const fy = FiscalYearHelper.defaultFiscalYear();
-        let fiscalYearAvailable = true;
-        let authorityValue = 0;
-        let obligatedValue = 0;
-        let balanceBroughtForwardValue = 0;
-        let otherValue = 0;
-        let appropriationsValue = 0;
+        const fiscalYearAvailable = account.totals.available;
+        const summary = {
+            flow: `No data is available for the current fiscal year (FY ${fy}).`,
+            toDate: ''
+        };
+        let amounts = {};
 
-        if (account.totals.budgetAuthority) {
-            authorityValue = account.totals.budgetAuthority;
-        }
-        else {
-            fiscalYearAvailable = false;
+        if (!fiscalYearAvailable) {
+            amounts = {
+                budgetAuthority: 0,
+                out: {
+                    obligated: 0,
+                    unobligated: 0
+                }
+            };
+            this.setState({
+                summary,
+                amounts,
+                fyAvailable: fiscalYearAvailable
+            });
+            return;
         }
 
-        if (account.totals.obligated) {
-            obligatedValue = account.totals.obligated;
-        }
-        else {
-            fiscalYearAvailable = false;
-        }
-
-        if (fiscalYearAvailable) {
-            balanceBroughtForwardValue = (account.totals.balanceBroughtForward);
-            otherValue = parseFloat(account.totals.otherBudgetaryResources);
-            appropriationsValue = parseFloat(account.totals.appropriations);
-        }
+        const authorityValue = account.totals.budgetAuthority || 0;
+        const obligatedValue = account.totals.obligated || 0;
+        const balanceBroughtForwardValue = account.totals.balanceBroughtForward || 0;
+        const otherValue = account.totals.otherBudgetaryResources || 0;
+        const appropriationsValue = account.totals.appropriations || 0;
 
         const authUnits = MoneyFormatter.calculateUnitForSingleValue(authorityValue);
         const authority = `${MoneyFormatter.formatMoney(authorityValue / authUnits.unit)}\
@@ -127,16 +129,14 @@ ${appropUnits.unitLabel}`;
         const otherString = `${MoneyFormatter.formatMoney(otherValue / otherUnits.unit)}\
 ${otherUnits.unitLabel}`;
 
-        const summary = {
-            flow: `For this current fiscal year, this agency has been granted authority to spend \
+        summary.flow = `For this current fiscal year, this agency has been granted authority to spend \
 ${authority} out of this federal account. They carried over a balance of ${bbfString} from last \
 year, were given ${appropString} in new appropriations, and have authority to use ${otherString} \
-of other budgetary resources.`,
-            toDate: `To date, ${percentObligated}% (${amountObligated}) of the total \
-${authority} has been obligated.`
-        };
+of other budgetary resources.`;
+        summary.toDate = `To date, ${percentObligated}% (${amountObligated}) of the total \
+${authority} has been obligated.`;
 
-        let amounts = {
+        amounts = {
             budgetAuthority: authorityValue,
             out: {
                 obligated: obligatedValue,
@@ -148,19 +148,6 @@ ${authority} has been obligated.`
                 appropriations: appropriationsValue
             }
         };
-
-        if (!fiscalYearAvailable) {
-            summary.flow = `No data is available for the current fiscal year (FY ${fy}).`;
-            summary.toDate = '';
-
-            amounts = {
-                budgetAuthority: 0,
-                out: {
-                    obligated: 0,
-                    unobligated: 0
-                }
-            };
-        }
 
         this.setState({
             summary,

--- a/src/js/containers/account/AccountContainer.jsx
+++ b/src/js/containers/account/AccountContainer.jsx
@@ -140,11 +140,16 @@ export class AccountContainer extends React.Component {
     }
 
     parseFYSnapshot(data) {
-        const balances = {};
+        const balances = {
+            available: false
+        };
 
-        Object.keys(fiscalYearSnapshotFields).forEach((key) => {
-            balances[fiscalYearSnapshotFields[key]] = data.results[key];
-        });
+        if (Object.keys(data).length > 0 && data.results) {
+            Object.keys(fiscalYearSnapshotFields).forEach((key) => {
+                balances[fiscalYearSnapshotFields[key]] = data.results[key];
+            });
+            balances.available = true;
+        }
 
         // update the Redux account model with balances
         const account = Object.assign({}, this.props.account);

--- a/src/js/containers/account/visualizations/AccountTimeVisualizationContainer.jsx
+++ b/src/js/containers/account/visualizations/AccountTimeVisualizationContainer.jsx
@@ -167,8 +167,7 @@ export class AccountTimeVisualizationSectionContainer extends React.PureComponen
                         group: ['submission__reporting_fiscal_year', 'submission__reporting_fiscal_quarter'],
                         field: balanceFieldsFiltered[balanceType],
                         aggregate: '',
-                        order: ['-submission__reporting_fiscal_quarter'],
-                        limit: 1,
+                        order: ['submission__reporting_fiscal_year', 'submission__reporting_fiscal_quarter'],
                         auditTrail: `Spending over Time (years) - obligated filter - ${balanceType}`
                     });
                     request.type = balanceType;
@@ -183,8 +182,7 @@ export class AccountTimeVisualizationSectionContainer extends React.PureComponen
                         group: ['submission__reporting_fiscal_year', 'submission__reporting_fiscal_quarter'],
                         field: balanceFieldsNonfiltered[balanceType],
                         aggregate: '',
-                        order: ['-submission__reporting_fiscal_quarter'],
-                        limit: 1,
+                        order: ['submission__reporting_fiscal_year', 'submission__reporting_fiscal_quarter'],
                         auditTrail: `Spending over Time (years) - obligated filter - ${balanceType}`
                     });
                     request.type = balanceType;
@@ -200,8 +198,7 @@ export class AccountTimeVisualizationSectionContainer extends React.PureComponen
                         group: ['submission__reporting_fiscal_year', 'submission__reporting_fiscal_quarter'],
                         field: balanceFields[balanceType],
                         aggregate: '',
-                        order: ['-submission__reporting_fiscal_quarter'],
-                        limit: 1,
+                        order: ['submission__reporting_fiscal_year', 'submission__reporting_fiscal_quarter'],
                         auditTrail: `Spending over Time (years) - non-obligated filter - ${balanceType}`
                     });
 

--- a/src/js/models/account/FederalAccount.js
+++ b/src/js/models/account/FederalAccount.js
@@ -23,6 +23,7 @@ const defaultValues = [
     '',
     'Not available',
     {
+        available: false,
         obligated: 0,
         unobligated: 0,
         budgetAuthority: 0,

--- a/src/js/redux/reducers/account/accountReducer.js
+++ b/src/js/redux/reducers/account/accountReducer.js
@@ -32,6 +32,7 @@ export const initialState = {
         title: '',
         description: '',
         totals: {
+            available: false,
             obligated: 0,
             unobligated: 0,
             budgetAuthority: 0,

--- a/tests/containers/account/mockAccount.js
+++ b/tests/containers/account/mockAccount.js
@@ -17,6 +17,7 @@ export const mockReduxAccount = {
     main_account_code: '0208',
     description: 'Not available',
     totals: {
+        available: true,
         appropriations: 0,
         balanceBroughtForward: 49394224538.76,
         budgetAuthority: 84734289679.5,


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-528

* More robust logic in the federal account sankey to determine if there is data for the current FY which to build the sankey and summary
* Support for showing multiple FYs at the same time in federal account Spending Over Time visualization
* Reversed the order of bars in Spending Over Time so later periods appear going left-to-right, matching Advanced Search's Spending Over Time
* Refactored federal account container test's function mocking to be in line with our standard approach