### PR TITLE
IDV Business Types/Parent DUNS + Truncated Financial Assistance Descriptions

### DIFF
--- a/src/js/components/award/RecipientInfo.jsx
+++ b/src/js/components/award/RecipientInfo.jsx
@@ -147,6 +147,7 @@ export default class RecipientInfo extends React.Component {
         }
 
         const isContract = includes(awardTypeGroups.contracts, this.props.award.award_type);
+        const isIDV = !this.props.award.award_type;
 
         return (
             <ul className="recipient-information">
@@ -155,8 +156,8 @@ export default class RecipientInfo extends React.Component {
                 <InfoSnippet
                     label="DUNS"
                     value={this.props.award.recipient_duns || 'Not Available'} />
-                {this.buildParentDuns(isContract)}
-                {this.buildBusinessTypes(isContract)}
+                {this.buildParentDuns(isContract || isIDV)}
+                {this.buildBusinessTypes(isContract || isIDV)}
             </ul>
         );
     }

--- a/src/js/components/award/financialAssistance/FinancialAssistanceDetails.jsx
+++ b/src/js/components/award/financialAssistance/FinancialAssistanceDetails.jsx
@@ -34,6 +34,7 @@ export default class FinancialAssistanceDetails extends React.Component {
 
         this.state = {
             description: "",
+            descriptionOverflow: false,
             date: "",
             place: "",
             typeDesc: "",
@@ -151,8 +152,12 @@ export default class FinancialAssistanceDetails extends React.Component {
             popDate = `${formattedStartDate} - ${formattedEndDate} ${timeRange}`;
         }
 
+        let descriptionOverflow = false;
         if (award.description) {
             description = award.description;
+            if (description.length > SummaryPageHelper.maxDescriptionCharacters) {
+                descriptionOverflow = true;
+            }
         }
         else {
             description = "Not Available";
@@ -191,6 +196,7 @@ export default class FinancialAssistanceDetails extends React.Component {
 
         this.setState({
             description,
+            descriptionOverflow,
             programName,
             cfdaOverflow,
             date: popDate,
@@ -215,7 +221,9 @@ export default class FinancialAssistanceDetails extends React.Component {
                         <tbody>
                             <DetailRow
                                 title="Description"
-                                value={this.state.description} />
+                                value={this.state.description}
+                                overflow={this.state.descriptionOverflow}
+                                maxChars={SummaryPageHelper.maxDescriptionCharacters} />
                             <DetailRow
                                 title="Period of Performance"
                                 value={this.state.date} />


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-454
https://federal-spending-transparency.atlassian.net/browse/DEV-514

* Treat IDVs as contracts in the recipient section on the award profile page, allowing correct business types and parent DUNS to appear.
* Implement logic from contract profile to truncate financial assistance award descriptions to be truncated to 160 characters.