### PR TITLE
Fix - Spending Explorer Table Key Names

### DIFF
--- a/src/js/components/explorer/detail/visualization/table/ExplorerTable.jsx
+++ b/src/js/components/explorer/detail/visualization/table/ExplorerTable.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { uniqueId } from 'lodash';
 
 import Pagination from 'components/sharedComponents/Pagination';
 import LegacyTableHeaderCell from 'components/account/awards/LegacyTableHeaderCell';
@@ -42,7 +43,7 @@ export default class ExplorerTable extends React.Component {
         const rows = this.props.results.map((item, index) => (
             <TableRow
                 item={item}
-                key={item.name}
+                key={`${uniqueId(item.name)}`}
                 rowIndex={index}
                 columns={this.props.columns}
                 selectedRow={this.selectedRow} />

--- a/src/js/helpers/moneyFormatter.js
+++ b/src/js/helpers/moneyFormatter.js
@@ -156,7 +156,7 @@ export const calculateUnitForSingleValue = (value) => {
 export const formatTreemapValues = (value) => {
     // Format the ceiling and current values to be friendly strings
     const units = calculateUnitForSingleValue(value);
-    const useCents = (units.unit === unitValues.THOUSAND || units.unit === 1);
+    const useCents = units.unit <= unitValues.THOUSAND;
 
     // Only reformat at a million or higher
     if (units.unit < unitValues.MILLION) {

--- a/src/js/helpers/moneyFormatter.js
+++ b/src/js/helpers/moneyFormatter.js
@@ -156,6 +156,8 @@ export const calculateUnitForSingleValue = (value) => {
 export const formatTreemapValues = (value) => {
     // Format the ceiling and current values to be friendly strings
     const units = calculateUnitForSingleValue(value);
+    const isThousand = units.unit === unitValues.THOUSAND;
+
     // Only reformat at a million or higher
     if (units.unit < unitValues.MILLION) {
         units.unit = 1;
@@ -163,10 +165,14 @@ export const formatTreemapValues = (value) => {
         units.longLabel = '';
     }
     const formattedValue = value / units.unit;
+
     let precision = 1;
     if (formattedValue % 1 === 0) {
         // Whole number
         precision = 0;
+    }
+    else if (isThousand) {
+        precision = 2;
     }
 
     const formattedCurrency = formatMoneyWithPrecision(formattedValue, precision);

--- a/src/js/helpers/moneyFormatter.js
+++ b/src/js/helpers/moneyFormatter.js
@@ -156,7 +156,7 @@ export const calculateUnitForSingleValue = (value) => {
 export const formatTreemapValues = (value) => {
     // Format the ceiling and current values to be friendly strings
     const units = calculateUnitForSingleValue(value);
-    const isThousand = units.unit === unitValues.THOUSAND;
+    const useCents = (units.unit === unitValues.THOUSAND || units.unit === 1);
 
     // Only reformat at a million or higher
     if (units.unit < unitValues.MILLION) {
@@ -171,7 +171,7 @@ export const formatTreemapValues = (value) => {
         // Whole number
         precision = 0;
     }
-    else if (isThousand) {
+    else if (useCents) {
         precision = 2;
     }
 


### PR DESCRIPTION
- Fixes Spending Explorer table unique key issue with duplicate names
- Fixes bug in showing cents in treemap tooltips for awards in the THOUSANDS range