### PR TITLE
Federal Account Spending by Category Legend

### DIFF
--- a/src/_scss/pages/account/results/visualizations/rank/rank.scss
+++ b/src/_scss/pages/account/results/visualizations/rank/rank.scss
@@ -14,5 +14,26 @@
         color: $color-base;
         text-align: center;
     }
+
+    .visualization-legend {
+        @include display(flex);
+        @include justify-content(flex-start);
+        @include align-items(center);
+
+        .visualization-legend__circle {
+            @include flex(0 0 rem(12));
+            width: rem(12);
+            height: rem(12);
+            border-radius: rem(6);
+            background-color: $color-vis-dark;
+        }
+        .visualization-legend__label {
+            @include flex(1 1 auto);
+            font-size: rem(12);
+            color: #666;
+            margin-left: rem(8);
+        }
+    }
+
     @import "./_pager";
 }

--- a/src/_scss/pages/search/results/visualizations/rank/rankVisualization.scss
+++ b/src/_scss/pages/search/results/visualizations/rank/rankVisualization.scss
@@ -25,6 +25,27 @@
         color: $color-base;
         text-align: center;
     }
+
+    .visualization-legend {
+        @include display(flex);
+        @include justify-content(flex-start);
+        @include align-items(center);
+
+        .visualization-legend__circle {
+            @include flex(0 0 rem(12));
+            width: rem(12);
+            height: rem(12);
+            border-radius: rem(6);
+            background-color: $color-vis-dark;
+        }
+        .visualization-legend__label {
+            @include flex(1 1 auto);
+            font-size: rem(12);
+            color: #666;
+            margin-left: rem(8);
+        }
+    }
+
     .results-visualization-rank-container {
         min-height: rem(334);
     }

--- a/src/js/components/search/visualizations/rank/RankVisualization.jsx
+++ b/src/js/components/search/visualizations/rank/RankVisualization.jsx
@@ -66,6 +66,7 @@ export default class RankVisualization extends React.Component {
 
     render() {
         let chart = (<ChartMessage message="No data to display" />);
+        let legend = null;
         if (this.props.loading) {
             chart = (<ChartMessage message="Loading data..." />);
         }
@@ -74,6 +75,14 @@ export default class RankVisualization extends React.Component {
                 {...this.props}
                 selectItem={this.selectItem}
                 deselectItem={this.deselectItem} />);
+            legend = (
+                <div className="visualization-legend">
+                    <div className="visualization-legend__circle" />
+                    <div className="visualization-legend__label">
+                        Obligations Incurred
+                    </div>
+                </div>
+            );
         }
 
         let tooltip = null;
@@ -88,6 +97,7 @@ export default class RankVisualization extends React.Component {
                 className="results-visualization-rank-container"
                 aria-label="Spending by Category">
                 {chart}
+                {legend}
                 {tooltip}
             </section>
         );

--- a/src/js/components/search/visualizations/rank/RankVisualizationTooltip.jsx
+++ b/src/js/components/search/visualizations/rank/RankVisualizationTooltip.jsx
@@ -74,7 +74,7 @@ export default class RankVisualizationTooltip extends React.Component {
                                 {MoneyFormatter.formatMoney(this.props.value)}
                             </div>
                             <div className="tooltip-label">
-                                Total Spending
+                                Obligations Incurred
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-545

* Adds a legend to Spending by Category on federal account profile page
* Updates tooltip to use "Obligation Incurred" instead of "Total Spending"