### PR TITLE
Fix Duplicate Program Activity Filters on Federal Account Profile

### DIFF
--- a/src/js/containers/account/filters/AccountProgramActivityContainer.jsx
+++ b/src/js/containers/account/filters/AccountProgramActivityContainer.jsx
@@ -12,12 +12,15 @@ import { isCancel } from 'axios';
 import * as accountFilterActions from 'redux/actions/account/accountFilterActions';
 import * as AccountHelper from 'helpers/accountHelper';
 
+import { _resetExchange, _convertToFrontendFilter } from 'models/account/queries/queryBuilders/_programActivityTranslator';
+
 import ProgramActivityFilter from
     'components/account/filters/programActivity/ProgramActivityFilter';
 
 const propTypes = {
     setAvailableProgramActivities: PropTypes.func,
     toggleProgramActivity: PropTypes.func,
+    resetProgramActivity: PropTypes.func,
     account: PropTypes.object
 };
 
@@ -35,11 +38,15 @@ export class AccountProgramActivityContainer extends React.Component {
     }
 
     componentWillMount() {
+        // clear out any previously selected program activities
+        this.props.resetProgramActivity();
         this.populateProgramActivities();
     }
 
     componentWillReceiveProps(nextProps) {
         if (nextProps.account !== this.props.account) {
+            // clear out any previously selected program activities
+            this.props.resetProgramActivity();
             this.populateProgramActivities();
         }
     }
@@ -103,15 +110,24 @@ export class AccountProgramActivityContainer extends React.Component {
     }
 
     parseResultData(data) {
-        const programActivities = [];
+        _resetExchange();
+        const programActivities = data.reduce((parsed, activity) => {
+            const code = activity.program_activity__program_activity_code;
+            const name = activity.program_activity__program_activity_name;
+            const id = activity.program_activity__id;
 
-        data.forEach((value) => {
-            programActivities.push({
-                id: value.program_activity__id,
-                code: value.program_activity__program_activity_code,
-                name: value.program_activity__program_activity_name
+            // exchange the API response for a frontend version
+            const filter = _convertToFrontendFilter({
+                id,
+                code,
+                name
             });
-        });
+
+            if (filter) {
+                parsed.push(filter);
+            }
+            return parsed;
+        }, []);
 
         let noResults = false;
         if (programActivities.length === 0) {

--- a/src/js/containers/account/filters/AccountProgramActivityContainer.jsx
+++ b/src/js/containers/account/filters/AccountProgramActivityContainer.jsx
@@ -123,6 +123,9 @@ export class AccountProgramActivityContainer extends React.Component {
                 name
             });
 
+            // if the frontend exchange returns a falsy item, that means it appended the API ID
+            // to an existing frontend filter object; pretend this item wasn't in the response
+            // otherwise, if it does return an actual object, add it to the parsed output
             if (filter) {
                 parsed.push(filter);
             }

--- a/src/js/models/account/queries/queryBuilders/ProgramActivityQuery.js
+++ b/src/js/models/account/queries/queryBuilders/ProgramActivityQuery.js
@@ -3,6 +3,8 @@
  * Created by michaelbray on 4/17/17.
  */
 
+import { _translateFrontendIDToPrimaryKeys } from './_programActivityTranslator';
+
 const programActivityField = 'program_activity__id';
 
 const spendingOverTimeField =
@@ -17,10 +19,10 @@ export const commonQuery = (field, values) => ({
 });
 
 export const buildBalancesProgramActivityQuery = (values) =>
-    commonQuery(spendingOverTimeField, values);
+    commonQuery(spendingOverTimeField, _translateFrontendIDToPrimaryKeys(values));
 
 export const buildCategoriesProgramActivityQuery = (values) =>
-    commonQuery(spendingByCategoryField, values);
+    commonQuery(spendingByCategoryField, _translateFrontendIDToPrimaryKeys(values));
 
 export const buildAwardsProgramActivityQuery = (values) =>
-    commonQuery(awardField, values);
+    commonQuery(awardField, _translateFrontendIDToPrimaryKeys(values));

--- a/src/js/models/account/queries/queryBuilders/_programActivityTranslator.js
+++ b/src/js/models/account/queries/queryBuilders/_programActivityTranslator.js
@@ -1,0 +1,48 @@
+/**
+ * _programActivityTranslator.js
+ * Created by Kevin Li 2/27/18
+ * This is EXTREMELY TEMPORARY - DO NOT DEPEND ON THIS
+ */
+
+import { uniqueId } from 'lodash';
+
+const exchangeTemplate = {
+    labelsToAPI: {},
+    frontendToAPI: {}
+};
+
+let _frontendAPIExchange = Object.assign({}, exchangeTemplate);
+
+export const _resetExchange = () => {
+    _frontendAPIExchange = Object.assign({}, exchangeTemplate);
+};
+
+const _exchangeForAPIValue = (frontendId) => _frontendAPIExchange.frontendToAPI[frontendId] || [];
+export const _convertToFrontendFilter = (filter) => {
+    const label = `${filter.code} - ${filter.name}`;
+    const frontendId = _frontendAPIExchange.labelsToAPI[label];
+    if (frontendId) {
+        // it already exists, append the ID
+        // don't return anything because the container already has a copy of the adapted filter object
+        _frontendAPIExchange.frontendToAPI[frontendId].push(filter.id);
+        return null;
+    }
+
+    // it doesn't exist yet in the exchange, add it
+    const generatedId = `pa-${uniqueId()}`;
+    _frontendAPIExchange.labelsToAPI[label] = generatedId;
+    _frontendAPIExchange.frontendToAPI[generatedId] = [filter.id];
+    return Object.assign({}, filter, {
+        id: generatedId
+    });
+};
+
+export const _translateFrontendIDToPrimaryKeys = (frontendIds) => (
+    frontendIds.reduce((ids, frontendId) => {
+        const apiIDs = _exchangeForAPIValue(frontendId);
+        if (apiIDs) {
+            return ids.concat(apiIDs);
+        }
+        return ids;
+    }, [])
+);

--- a/src/js/models/account/queries/queryBuilders/_programActivityTranslator.js
+++ b/src/js/models/account/queries/queryBuilders/_programActivityTranslator.js
@@ -7,7 +7,7 @@
 import { uniqueId } from 'lodash';
 
 const exchangeTemplate = {
-    labelsToAPI: {},
+    labelsToFrontend: {},
     frontendToAPI: {}
 };
 
@@ -20,18 +20,21 @@ export const _resetExchange = () => {
 const _exchangeForAPIValue = (frontendId) => _frontendAPIExchange.frontendToAPI[frontendId] || [];
 export const _convertToFrontendFilter = (filter) => {
     const label = `${filter.code} - ${filter.name}`;
-    const frontendId = _frontendAPIExchange.labelsToAPI[label];
+    // get the frontend-generated ID from the exchange
+    const frontendId = _frontendAPIExchange.labelsToFrontend[label];
     if (frontendId) {
-        // it already exists, append the ID
+        // the filter already exists in the exchange, so append the API ID to the existing record
         // don't return anything because the container already has a copy of the adapted filter object
         _frontendAPIExchange.frontendToAPI[frontendId].push(filter.id);
         return null;
     }
 
-    // it doesn't exist yet in the exchange, add it
+    // the filter doesn't exist yet in the exchange, add it and generate a new frontend ID
     const generatedId = `pa-${uniqueId()}`;
-    _frontendAPIExchange.labelsToAPI[label] = generatedId;
+    _frontendAPIExchange.labelsToFrontend[label] = generatedId;
     _frontendAPIExchange.frontendToAPI[generatedId] = [filter.id];
+    // replace the API ID with the frontend ID and return it to container to continue parsing as
+    // normal
     return Object.assign({}, filter, {
         id: generatedId
     });

--- a/tests/containers/account/filters/AccountProgramActivityContainer-test.jsx
+++ b/tests/containers/account/filters/AccountProgramActivityContainer-test.jsx
@@ -38,6 +38,7 @@ describe('AccountProgramActivityContainer', () => {
                 <AccountProgramActivityContainer
                     reduxFilters={initialFilters}
                     toggleProgramActivity={mockReduxAction}
+                    resetProgramActivity={jest.fn()}
                     setAvailableProgramActivities={jest.fn()}
                     account={account} />);
 
@@ -67,6 +68,7 @@ describe('AccountProgramActivityContainer', () => {
                 <AccountProgramActivityContainer
                     reduxFilters={initialFilters}
                     toggleProgramActivity={mockReduxAction}
+                    resetProgramActivity={jest.fn()}
                     setAvailableProgramActivities={jest.fn()}
                     account={account} />);
 
@@ -96,6 +98,7 @@ describe('AccountProgramActivityContainer', () => {
                 <AccountProgramActivityContainer
                     reduxFilters={initialFilters}
                     toggleProgramActivity={jest.fn()}
+                    resetProgramActivity={jest.fn()}
                     setAvailableProgramActivities={jest.fn()}
                     account={account} />);
 
@@ -121,6 +124,7 @@ describe('AccountProgramActivityContainer', () => {
                 <AccountProgramActivityContainer
                     reduxFilters={initialFilters}
                     toggleProgramActivity={jest.fn()}
+                    resetProgramActivity={jest.fn()}
                     setAvailableProgramActivities={jest.fn()}
                     account={account} />);
 


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-540

* Temporary patch to combine program activity filters on the federal account profile page that have the same code and name into a single option