### PR TITLE
Homepage Information Icon

### DIFF
--- a/src/_scss/layouts/default/header/nav/_glossaryLink.scss
+++ b/src/_scss/layouts/default/header/nav/_glossaryLink.scss
@@ -11,7 +11,7 @@
     }
 
     .glossary-nav__icon {
-        @include flex(0 0 auto)
+        @include flex(0 0 auto);
         width: rem(15);
         height: rem(15);
         margin-right: rem(10);

--- a/src/_scss/pages/account/header/_options.scss
+++ b/src/_scss/pages/account/header/_options.scss
@@ -1,7 +1,7 @@
 .summary-status {
     @import "../../../mixins/moreOptionsBtn";
     @include display(flex);
-    @include justify-content(space-between);
+    @include justify-content(flex-end);
 
     @include flex(1 1 auto);
 
@@ -12,6 +12,7 @@
         li {
             @include display(flex);
             @include justify-content(flex-start);
+            padding: 0 0 rem(4);
             width: 100%;
 
             .format-item {
@@ -66,13 +67,20 @@
         width: auto;
         ul.summary-status-items {
             @include display(flex);
+            @include flex(0 0 auto);
+            @include align-items(flex-end);
+
             li {
                 border-right: 1px solid rgba($color-white, .3);
+                min-width: rem(150);
+                padding: 0;
+
                 .format-item {
                     @include display(flex);
                     @include flex-direction(column);
-                    padding: 0 $global-pad * 2;
+                    @include flex(1 0 rem(180));
 
+                    padding: 0 $global-pad * 2;
                     .item-label {
                         text-align: center;
                         width: 100%;

--- a/src/_scss/pages/award/_summaryStatus.scss
+++ b/src/_scss/pages/award/_summaryStatus.scss
@@ -1,7 +1,7 @@
 .summary-status {
     @import "../../mixins/moreOptionsBtn";
     @include display(flex);
-    @include justify-content(space-between);
+    @include justify-content(flex-end);
 
     @include flex(1 1 auto);
 
@@ -66,14 +66,21 @@
         width: auto;
         ul.summary-status-items {
             @include display(flex);
+            @include flex(0 0 auto);
+            @include align-items(flex-end);
+
             li {
                 border-right: 1px solid rgba($color-white, .3);
+                min-width: rem(150);
+
                 .format-item {
                     @include display(flex);
                     @include flex-direction(column);
-                    padding: 0 $global-pad * 2;
+                    @include flex(1 0 rem(180));
 
+                    padding: 0 $global-pad * 2;
                     .item-label {
+
                         text-align: center;
                         width: 100%;
                         &:after {

--- a/src/_scss/pages/homepage/hero/_heroTooltip.scss
+++ b/src/_scss/pages/homepage/hero/_heroTooltip.scss
@@ -1,0 +1,61 @@
+.homepage-hero-tooltip {
+    position: absolute;
+    z-index: $z-modal;
+    background-color: $color-white;
+    border-radius: $border-radius;
+    padding: rem(6);
+    width: rem(160);
+    box-shadow: 0 2px 4px 0 rgba(0,0,0,0.5);
+
+    .homepage-hero-tooltip__info_icon {
+        position: absolute;
+        top: rem(6);
+        left: rem(6);
+        height: rem(15);
+        width: rem(15);
+
+        svg {
+            height: rem(15);
+            width: rem(15);
+            fill: $color-gray-medium;
+            vertical-align: top;
+        }
+    }
+
+    .homepage-hero-tooltip__text_holder {
+        height: rem(93);
+        padding-left: rem(21);
+        line-height: $base-line-height;
+        text-align: left;
+    }
+
+    .homepage-hero-tooltip__tooltip_title,
+    .homepage-hero-tooltip__tooltip_text {
+        font-size: rem(12);
+        color: $color-gray-medium;
+    }
+
+    .homepage-hero-tooltip__tooltip_title {
+        font-weight: $font-semibold;
+    }
+
+    .homepage-hero-tooltip__tooltip_text {
+        font-weight: $font-normal;
+    }
+
+    .homepage-hero-tooltip__close_icon {
+        @include button-unstyled;
+
+        position: absolute;
+        top: rem(4);
+        right: rem(6);
+        height: rem(10);
+        width: rem(10);
+
+        svg {
+            height: rem(10);
+            width: rem(10);
+            fill: $color-gray-medium;
+        }
+    }
+}

--- a/src/_scss/pages/homepage/hero/_heroTooltip.scss
+++ b/src/_scss/pages/homepage/hero/_heroTooltip.scss
@@ -49,8 +49,8 @@
         position: absolute;
         top: rem(4);
         right: rem(6);
-        height: rem(10);
-        width: rem(10);
+        height: rem(12);
+        width: rem(12);
 
         svg {
             height: rem(10);

--- a/src/_scss/pages/homepage/hero/hero.scss
+++ b/src/_scss/pages/homepage/hero/hero.scss
@@ -58,7 +58,9 @@
             display: inline;
             height: rem(25);
             width: rem(15);
-            padding-bottom: 10px;
+            padding-bottom: rem(10);
+            top: rem(6);
+            margin-left: rem(-6);
 
             .homepage-hero__info_icon {
                 @include button-unstyled;
@@ -68,7 +70,7 @@
                 svg {
                     height: rem(15);
                     width: rem(15);
-                    fill: #98c8e4;
+                    fill: $color-cool-blue-lightest;
                     position: relative;
                     top: rem(0);
                     vertical-align: top;

--- a/src/_scss/pages/homepage/hero/hero.scss
+++ b/src/_scss/pages/homepage/hero/hero.scss
@@ -53,18 +53,26 @@
             font-weight: $font-normal;
         }
 
-        .homepage-hero__info_icon {
-            height: rem(15);
+        .homepage-hero__info_icon_holder {
+            position: relative;
+            display: inline;
+            height: rem(25);
             width: rem(15);
+            padding-bottom: 10px;
 
-            svg {
-                height: rem(15);
-                width: rem(15);
-                fill: #98C8E4;
-                position: relative;
-                top: rem(10);
-                left: rem(-6);
-                vertical-align: top;
+            .homepage-hero__info_icon {
+                @include button-unstyled;
+
+                position: absolute;
+
+                svg {
+                    height: rem(15);
+                    width: rem(15);
+                    fill: #98c8e4;
+                    position: relative;
+                    top: rem(0);
+                    vertical-align: top;
+                }
             }
         }
     }

--- a/src/_scss/pages/homepage/hero/hero.scss
+++ b/src/_scss/pages/homepage/hero/hero.scss
@@ -55,7 +55,6 @@
 
         .homepage-hero__info_icon_holder {
             position: relative;
-            display: inline;
             height: rem(25);
             width: rem(15);
             padding-bottom: rem(10);

--- a/src/_scss/pages/homepage/hero/hero.scss
+++ b/src/_scss/pages/homepage/hero/hero.scss
@@ -56,15 +56,14 @@
         .homepage-hero__info_icon_holder {
             position: relative;
             height: rem(25);
-            width: rem(15);
             padding-bottom: rem(10);
             top: rem(6);
-            margin-left: rem(-6);
 
             .homepage-hero__info_icon {
                 @include button-unstyled;
 
                 position: absolute;
+                left: rem(-6);
 
                 svg {
                     height: rem(15);

--- a/src/_scss/pages/homepage/hero/hero.scss
+++ b/src/_scss/pages/homepage/hero/hero.scss
@@ -52,6 +52,21 @@
         strong.homepage-hero__headline_weight_bold {
             font-weight: $font-normal;
         }
+
+        .homepage-hero__info_icon {
+            height: rem(15);
+            width: rem(15);
+
+            svg {
+                height: rem(15);
+                width: rem(15);
+                fill: #98C8E4;
+                position: relative;
+                top: rem(10);
+                left: rem(-6);
+                vertical-align: top;
+            }
+        }
     }
 
     hr.homepage-hero__divider {
@@ -86,4 +101,5 @@
     }
 
     @import "./_heroButton";
+    @import "./_heroTooltip";
 }

--- a/src/js/components/homepage/hero/Hero.jsx
+++ b/src/js/components/homepage/hero/Hero.jsx
@@ -50,7 +50,7 @@ export default class Hero extends React.Component {
                     <div className="homepage-hero__content">
                         <h1 className="homepage-hero__headline" tabIndex={-1}>
                             In 2017, the government spent <strong className="homepage-hero__headline homepage-hero__headline_weight_bold">$3.98 trillion.</strong>
-                            <div className="homepage-hero__info_icon_holder">
+                            <span className="homepage-hero__info_icon_holder">
                                 <button
                                     id="homepage-hero__info_icon"
                                     className="homepage-hero__info_icon"
@@ -59,7 +59,7 @@ export default class Hero extends React.Component {
                                     onClick={this.showTooltip}>
                                     <Icons.InfoCircle />
                                 </button>
-                            </div>
+                            </span>
                         </h1>
                         {tooltip}
                         <hr className="homepage-hero__divider" />

--- a/src/js/components/homepage/hero/Hero.jsx
+++ b/src/js/components/homepage/hero/Hero.jsx
@@ -50,14 +50,16 @@ export default class Hero extends React.Component {
                     <div className="homepage-hero__content">
                         <h1 className="homepage-hero__headline" tabIndex={-1}>
                             In 2017, the government spent <strong className="homepage-hero__headline homepage-hero__headline_weight_bold">$3.98 trillion.</strong>
-                            <span
-                                id="homepage-hero__info_icon"
-                                className="homepage-hero__info_icon"
-                                onFocus={this.showTooltip}
-                                onMouseEnter={this.showTooltip}
-                                onClick={this.showTooltip}>
-                                <Icons.InfoCircle />
-                            </span>
+                            <div className="homepage-hero__info_icon_holder">
+                                <button
+                                    id="homepage-hero__info_icon"
+                                    className="homepage-hero__info_icon"
+                                    onFocus={this.showTooltip}
+                                    onMouseEnter={this.showTooltip}
+                                    onClick={this.showTooltip}>
+                                    <Icons.InfoCircle />
+                                </button>
+                            </div>
                         </h1>
                         {tooltip}
                         <hr className="homepage-hero__divider" />

--- a/src/js/components/homepage/hero/Hero.jsx
+++ b/src/js/components/homepage/hero/Hero.jsx
@@ -54,7 +54,8 @@ export default class Hero extends React.Component {
                                 id="homepage-hero__info_icon"
                                 className="homepage-hero__info_icon"
                                 onFocus={this.showTooltip}
-                                onMouseEnter={this.showTooltip}>
+                                onMouseEnter={this.showTooltip}
+                                onClick={this.showTooltip}>
                                 <Icons.InfoCircle />
                             </span>
                         </h1>

--- a/src/js/components/homepage/hero/Hero.jsx
+++ b/src/js/components/homepage/hero/Hero.jsx
@@ -5,27 +5,68 @@
 
 import React from 'react';
 
+import * as Icons from 'components/sharedComponents/icons/Icons';
 import HeroButton from './HeroButton';
+import HeroTooltip from './HeroTooltip';
 
-const Hero = () => (
-    <section
-        className="homepage-hero"
-        aria-label="Introduction">
-        <div className="homepage-hero__wrapper">
-            <div className="homepage-hero__content">
-                <h1
-                    className="homepage-hero__headline"
-                    tabIndex={-1}>
-                    In 2017, the government spent <strong className="homepage-hero__headline homepage-hero__headline_weight_bold">$3.98 trillion.</strong>
-                </h1>
-                <hr className="homepage-hero__divider" />
-                <div className="homepage-hero__description">
-                    <strong className="homepage-hero__description homepage-hero__description_weight_bold">Curious to see how this money was spent?</strong> We hope so &mdash; we&apos;ve opened the conversation around federal spending and provide the tools to help you navigate the budget from top to bottom.
+export default class Hero extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showInfoTooltip: false
+        };
+
+        this.showTooltip = this.showTooltip.bind(this);
+        this.closeTooltip = this.closeTooltip.bind(this);
+    }
+
+    showTooltip() {
+        this.setState({
+            showInfoTooltip: true
+        });
+    }
+
+    closeTooltip() {
+        this.setState({
+            showInfoTooltip: false
+        });
+    }
+
+    render() {
+        let tooltip = null;
+        if (this.state.showInfoTooltip) {
+            tooltip = (
+                <HeroTooltip
+                    closeTooltip={this.closeTooltip} />
+            );
+        }
+
+        return (
+            <section className="homepage-hero" aria-label="Introduction">
+                <div
+                    id="homepage-hero__wrapper"
+                    className="homepage-hero__wrapper">
+                    <div className="homepage-hero__content">
+                        <h1 className="homepage-hero__headline" tabIndex={-1}>
+                            In 2017, the government spent <strong className="homepage-hero__headline homepage-hero__headline_weight_bold">$3.98 trillion.</strong>
+                            <span
+                                id="homepage-hero__info_icon"
+                                className="homepage-hero__info_icon"
+                                onFocus={this.showTooltip}
+                                onMouseEnter={this.showTooltip}>
+                                <Icons.InfoCircle />
+                            </span>
+                        </h1>
+                        {tooltip}
+                        <hr className="homepage-hero__divider" />
+                        <div className="homepage-hero__description">
+                            <strong className="homepage-hero__description homepage-hero__description_weight_bold">Curious to see how this money was spent?</strong> We hope so &mdash; we&apos;ve opened the conversation around federal spending and provide the tools to help you navigate the budget from top to bottom.
+                        </div>
+                    </div>
+                    <HeroButton />
                 </div>
-            </div>
-            <HeroButton />
-        </div>
-    </section>
-);
-
-export default Hero;
+            </section>
+        );
+    }
+};

--- a/src/js/components/homepage/hero/Hero.jsx
+++ b/src/js/components/homepage/hero/Hero.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 
-import * as Icons from 'components/sharedComponents/icons/Icons';
+import { InfoCircle } from 'components/sharedComponents/icons/Icons';
 import HeroButton from './HeroButton';
 import HeroTooltip from './HeroTooltip';
 
@@ -57,7 +57,7 @@ export default class Hero extends React.Component {
                                     onFocus={this.showTooltip}
                                     onMouseEnter={this.showTooltip}
                                     onClick={this.showTooltip}>
-                                    <Icons.InfoCircle />
+                                    <InfoCircle />
                                 </button>
                             </span>
                         </h1>

--- a/src/js/components/homepage/hero/HeroTooltip.jsx
+++ b/src/js/components/homepage/hero/HeroTooltip.jsx
@@ -14,6 +14,7 @@ const propTypes = {
 
 const tooltipWidth = 160;
 const margin = 15;
+const tooltipPadding = 6;
 
 export default class HeroTooltip extends React.Component {
     getPosition() {
@@ -21,8 +22,8 @@ export default class HeroTooltip extends React.Component {
         const conatinerOffsetY = container.getBoundingClientRect().top;
 
         const icon = document.getElementById('homepage-hero__info_icon');
-        const iconTop = icon.getBoundingClientRect().top - conatinerOffsetY;
-        let iconLeft = icon.getBoundingClientRect().left - 12;
+        const iconTop = icon.getBoundingClientRect().top - conatinerOffsetY - tooltipPadding;
+        let iconLeft = icon.getBoundingClientRect().left - tooltipPadding;
 
         const windowWidth = window.innerWidth;
         if ((iconLeft + tooltipWidth) > windowWidth) {

--- a/src/js/components/homepage/hero/HeroTooltip.jsx
+++ b/src/js/components/homepage/hero/HeroTooltip.jsx
@@ -53,7 +53,7 @@ export default class HeroTooltip extends React.Component {
                 </button>
                 <div className="homepage-hero-tooltip__text_holder">
                     <div className="homepage-hero-tooltip__tooltip_title">
-                        Data Source
+                        Data Source:
                     </div>
                     <div className="homepage-hero-tooltip__tooltip_text">
                         Fiscal Year 2017 net outlays as reported on the&nbsp;

--- a/src/js/components/homepage/hero/HeroTooltip.jsx
+++ b/src/js/components/homepage/hero/HeroTooltip.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { throttle } from 'lodash';
 
 import * as Icons from 'components/sharedComponents/icons/Icons';
 
@@ -17,6 +18,27 @@ const margin = 15;
 const tooltipPadding = 6;
 
 export default class HeroTooltip extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            windowWidth: 0,
+            iconTop: 0,
+            iconLeft: 0
+        };
+
+        this.handleWindowResize = throttle(this.handleWindowResize.bind(this), 50);
+    }
+
+    componentDidMount() {
+        this.handleWindowResize();
+        window.addEventListener('resize', this.handleWindowResize);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.handleWindowResize);
+    }
+
     getPosition() {
         const container = document.getElementById('homepage-hero__wrapper');
         const conatinerOffsetY = container.getBoundingClientRect().top;
@@ -33,15 +55,28 @@ export default class HeroTooltip extends React.Component {
         return { iconTop, iconLeft };
     }
 
-    render() {
-        const position = this.getPosition();
+    handleWindowResize() {
+        // determine if the width changed
+        const windowWidth = window.innerWidth;
+        if (this.state.windowWidth !== windowWidth) {
+            // width changed, update the visualization width
+            const position = this.getPosition();
 
+            this.setState({
+                windowWidth,
+                iconTop: position.iconTop,
+                iconLeft: position.iconLeft
+            });
+        }
+    }
+
+    render() {
         return (
             <div
                 className="homepage-hero-tooltip"
                 style={{
-                    top: position.iconTop,
-                    left: position.iconLeft
+                    top: this.state.iconTop,
+                    left: this.state.iconLeft
                 }}>
                 <div className="homepage-hero-tooltip__info_icon">
                     <Icons.InfoCircle />

--- a/src/js/components/homepage/hero/HeroTooltip.jsx
+++ b/src/js/components/homepage/hero/HeroTooltip.jsx
@@ -1,0 +1,72 @@
+/**
+ * HeroTooltip.jsx
+ * Created by michaelbray on 2/28/18.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import * as Icons from 'components/sharedComponents/icons/Icons';
+
+const propTypes = {
+    closeTooltip: PropTypes.func
+};
+
+const tooltipWidth = 160;
+const margin = 15;
+
+export default class HeroTooltip extends React.Component {
+    getPosition() {
+        const container = document.getElementById('homepage-hero__wrapper');
+        const conatinerOffsetY = container.getBoundingClientRect().top;
+
+        const icon = document.getElementById('homepage-hero__info_icon');
+        const iconTop = icon.getBoundingClientRect().top - conatinerOffsetY;
+        let iconLeft = icon.getBoundingClientRect().left - 12;
+
+        const windowWidth = window.innerWidth;
+        if ((iconLeft + tooltipWidth) > windowWidth) {
+            iconLeft = windowWidth - tooltipWidth - margin;
+        }
+
+        return { iconTop, iconLeft };
+    }
+
+    render() {
+        const position = this.getPosition();
+
+        return (
+            <div
+                className="homepage-hero-tooltip"
+                style={{
+                    top: position.iconTop,
+                    left: position.iconLeft
+                }}>
+                <div className="homepage-hero-tooltip__info_icon">
+                    <Icons.InfoCircle />
+                </div>
+                <button
+                    className="homepage-hero-tooltip__close_icon"
+                    onClick={this.props.closeTooltip}>
+                    <Icons.Close />
+                </button>
+                <div className="homepage-hero-tooltip__text_holder">
+                    <div className="homepage-hero-tooltip__tooltip_title">
+                        Data Source
+                    </div>
+                    <div className="homepage-hero-tooltip__tooltip_text">
+                        Fiscal Year 2017 net outlays as reported on the&nbsp;
+                        <a
+                            href="https://www.fiscal.treasury.gov/fsreports/rpt/mthTreasStmt/current.htm"
+                            target="_blank"
+                            rel="noopener noreferrer">
+                            Monthly Treasury Statement
+                        </a>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+};
+
+HeroTooltip.propTypes = propTypes;


### PR DESCRIPTION
- Adds an information icon to the homepage
- Adds a tooltip to the information icon that activates on hover or tap
  - Tooltip can be closed through clicking/tapping an X button at the top right of the tooltip
- Fixes the Header bar CSS for Firefox

Issue: https://federal-spending-transparency.atlassian.net/browse/DEV-553

- [x] Code Review
- [x] Design Review