### PR TITLE
Spending Explorer Limits

### DIFF
--- a/src/_scss/pages/explorer/detail/header/_truncation.scss
+++ b/src/_scss/pages/explorer/detail/header/_truncation.scss
@@ -1,0 +1,29 @@
+.truncation-warning {
+    @include display(flex);
+    @include justify-content(flex-start);
+    @include align-items(flex-start);
+
+    .truncation-warning__icon {
+        @include flex(0 0 rem(15));
+
+        svg {
+            width: rem(15);
+            height: rem(15);
+            margin-top: rem(3);
+            fill: $color-base;
+        }
+    }
+
+    .truncation-warning__message {
+        @include flex(1 1 auto);
+        margin-left: rem(10);
+        font-size: rem(12);
+
+        .truncation-warning__title {
+            font-weight: $font-semibold;
+        }
+        .truncation-warning__detail {
+            margin-top: rem(3);
+        }
+    }
+}

--- a/src/_scss/pages/explorer/detail/header/header.scss
+++ b/src/_scss/pages/explorer/detail/header/header.scss
@@ -91,3 +91,9 @@
         }
     }
 }
+
+.detail-header__truncation {
+    margin-top: rem(20);
+}
+
+@import "./_truncation";

--- a/src/js/components/explorer/detail/DetailContent.jsx
+++ b/src/js/components/explorer/detail/DetailContent.jsx
@@ -16,6 +16,7 @@ import NoAwardsScreen from './NoAwardsScreen';
 const propTypes = {
     isRoot: PropTypes.bool,
     isLoading: PropTypes.bool,
+    isTruncated: PropTypes.bool,
     data: PropTypes.object,
     root: PropTypes.string,
     fy: PropTypes.string,
@@ -175,7 +176,8 @@ export default class DetailContent extends React.Component {
                 fy={this.props.fy}
                 lastUpdate={this.props.lastUpdate}
                 total={this.props.active.total}
-                parent={parentFilter} />);
+                parent={parentFilter}
+                isTruncated={this.props.isTruncated} />);
         }
 
         let fakeScreenAbove = null;

--- a/src/js/components/explorer/detail/header/DetailHeader.jsx
+++ b/src/js/components/explorer/detail/header/DetailHeader.jsx
@@ -13,6 +13,8 @@ import { sidebarTypes } from 'dataMapping/explorer/sidebarStrings';
 import { formatTreemapValues } from 'helpers/moneyFormatter';
 import { generateSingular } from 'helpers/singularityHelper';
 
+import TruncationWarning from './TruncationWarning';
+
 const propTypes = {
     within: PropTypes.string,
     fy: PropTypes.string,
@@ -20,7 +22,8 @@ const propTypes = {
     total: PropTypes.number,
     title: PropTypes.string,
     id: PropTypes.string,
-    parent: PropTypes.string
+    parent: PropTypes.string,
+    isTruncated: PropTypes.bool
 };
 
 const exitExplorer = (target) => {
@@ -91,26 +94,36 @@ const heading = (type, title, id) => {
 const DetailHeader = (props) => {
     const type = sidebarTypes[props.within];
 
+    let truncationWarning = null;
+    if (props.isTruncated) {
+        truncationWarning = (
+            <TruncationWarning />
+        );
+    }
+
     return (
-        <div className="detail-header">
-            <div className="left-side">
-                <div className="you-did-this">
-                    You&apos;ve chosen
+        <div>
+            <div className="detail-header">
+                <div className="left-side">
+                    <div className="you-did-this">
+                        You&apos;ve chosen
+                    </div>
+                    {heading(type, props.title, props.id)}
+                    {dataType(type, props.parent)}
                 </div>
-                {heading(type, props.title, props.id)}
-                {dataType(type, props.parent)}
+                <div className="right-side">
+                    <div className="amount-header">
+                        FY {props.fy} obligated amount
+                    </div>
+                    <div className="amount-value">
+                        {formatTreemapValues(props.total)}
+                    </div>
+                    <div className="update-date">
+                        Data as of {moment(props.lastUpdate, 'YYYY-MM-DD').format('MMMM D, YYYY')}
+                    </div>
+                </div>
             </div>
-            <div className="right-side">
-                <div className="amount-header">
-                    FY {props.fy} obligated amount
-                </div>
-                <div className="amount-value">
-                    {formatTreemapValues(props.total)}
-                </div>
-                <div className="update-date">
-                    Data as of {moment(props.lastUpdate, 'YYYY-MM-DD').format('MMMM D, YYYY')}
-                </div>
-            </div>
+            {truncationWarning}
         </div>
     );
 };

--- a/src/js/components/explorer/detail/header/TruncationWarning.jsx
+++ b/src/js/components/explorer/detail/header/TruncationWarning.jsx
@@ -1,0 +1,25 @@
+/**
+ * TruncationWarning.jsx
+ * Created by Kevin Li 3/2/18
+ */
+
+import React from 'react';
+import { InfoCircle } from 'components/sharedComponents/icons/Icons';
+
+const TruncationWarning = () => (
+    <div className="truncation-warning detail-header__truncation">
+        <div className="truncation-warning__icon">
+            <InfoCircle alt="Information" />
+        </div>
+        <div className="truncation-warning__message">
+            <div className="truncation-warning__title">
+                Award Display Limit
+            </div>
+            <div className="truncation-warning__detail">
+                Only the 500 awards with the highest amounts are shown. For further research on individual awards, visit our <a href="#/search">Advanced Search</a>.
+            </div>
+        </div>
+    </div>
+);
+
+export default TruncationWarning;

--- a/tests/containers/explorer/detail/mockData.js
+++ b/tests/containers/explorer/detail/mockData.js
@@ -32,6 +32,20 @@ export const mockApiResponse = {
     ]
 };
 
+export const mockAwardResponse = {
+    total: 200,
+    results: [
+        {
+            id: 1,
+            type: 'award',
+            name: 'Award',
+            code: '123',
+            amount: 1,
+            total: 1
+        }
+    ]
+};
+
 export const mockReducerRoot = {
     root: 'agency',
     fy: '1984',


### PR DESCRIPTION
* Adds a truncation warning at the award level of the spending explorer when results have limited due to response size