### PR TITLE
Fix: Handle null recipient names

### DIFF
--- a/src/js/models/results/award/AwardSummary.js
+++ b/src/js/models/results/award/AwardSummary.js
@@ -563,7 +563,7 @@ const remapData = (data, idField) => {
 
     // Format Recipient Info + Address
     if (data.recipient) {
-        recipientName = data.recipient.recipient_name;
+        recipientName = data.recipient.recipient_name || 'Unknown';
 
         const loc = data.recipient.location;
 


### PR DESCRIPTION
* Fixes a bug where page rendering would break on award profile pages with `null` recipient names due to Award Amounts performing a `.toLowerCase()` operation.

Test on award 6797869