### PR TITLE
Additional 508 Color Contrast Fixes

### DIFF
--- a/src/_scss/core/_variables.scss
+++ b/src/_scss/core/_variables.scss
@@ -94,6 +94,8 @@ $color-shadow:               rgba(#000, 0.3);
 $color-tab-inactive:		 #f1f1f1; // color for inactive tab
 $color-gray-border:          #D8D8D8;
 
+$color-placeholder:          #747474;
+
 
 // Global Paadding and Margins
 // (example usage {padding: ($global-pad * 4);} = 60px of padding.)

--- a/src/_scss/elements/filters/_typeahead.scss
+++ b/src/_scss/elements/filters/_typeahead.scss
@@ -13,7 +13,7 @@
         width: 100%;
 
         @include placeholder {
-            color: $color-gray-light;
+            color: $color-placeholder;
         }
     }
 

--- a/src/_scss/pages/explorer/detail/visualization/treemap/_cell.scss
+++ b/src/_scss/pages/explorer/detail/visualization/treemap/_cell.scss
@@ -3,7 +3,6 @@
 
     .explorer-cell-title {
         transition: fill 0.2s;
-        fill: $color-white;
         font-size: rem(16);
 
         &.active {
@@ -13,7 +12,6 @@
 
     .explorer-cell-value {
         transition: fill 0.2s;
-        fill: $color-white;
         font-size: rem(18);
         font-weight: $font-semibold;
 

--- a/src/_scss/pages/keyword/_searchBar.scss
+++ b/src/_scss/pages/keyword/_searchBar.scss
@@ -33,6 +33,10 @@
                 font-size: rem(28);
                 line-height: rem(36);
             }
+
+            @include placeholder {
+                color: $color-placeholder;
+            }
         }
         .keyword-search-bar__button {
             @include flex(0 0 auto);

--- a/src/_scss/pages/search/filters/awardAmount/_specificAwardAmount.scss
+++ b/src/_scss/pages/search/filters/awardAmount/_specificAwardAmount.scss
@@ -24,7 +24,7 @@
 
         input {
             @include placeholder {
-                color: $color-gray-light;
+                color: $color-placeholder;
             }
         }
 

--- a/src/_scss/pages/search/filters/awardID/awardID.scss
+++ b/src/_scss/pages/search/filters/awardID/awardID.scss
@@ -30,7 +30,7 @@
             height: rem(40);
 
             @include placeholder {
-                color: $color-gray-light;
+                color: $color-placeholder;
             }
         }
 

--- a/src/_scss/pages/search/filters/keyword/keyword.scss
+++ b/src/_scss/pages/search/filters/keyword/keyword.scss
@@ -21,7 +21,7 @@
         line-height: rem(36);
         height: rem(40);
         @include placeholder {
-            color: $color-gray-light;
+            color: $color-placeholder;
         }
     }
     .keyword-submit {

--- a/src/_scss/pages/search/filters/location/_dropdown.scss
+++ b/src/_scss/pages/search/filters/location/_dropdown.scss
@@ -37,7 +37,7 @@
 
         &.placeholder {
             .label {
-                color: $color-gray-light;
+                color: $color-placeholder;
             }
         }
     }

--- a/src/_scss/pages/search/filters/location/location.scss
+++ b/src/_scss/pages/search/filters/location/location.scss
@@ -65,7 +65,7 @@
                     height: rem(40);
 
                     @include placeholder {
-                        color: $color-gray-light;
+                        color: $color-placeholder;
                     }
                 }
 

--- a/src/js/components/agency/visualizations/objectClass/MajorObjectClasses.jsx
+++ b/src/js/components/agency/visualizations/objectClass/MajorObjectClasses.jsx
@@ -10,6 +10,7 @@ import { throttle, remove, orderBy, find } from 'lodash';
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 import * as TreemapHelper from 'helpers/treemapHelper';
 import { objectClassDefinitions } from 'dataMapping/agency/objectClassDefinitions';
+import { labelColorFromBackground } from 'helpers/colorHelper';
 
 import ObjectClassCell from './ObjectClassCell';
 import ObjectClassTooltip from './ObjectClassTooltip';
@@ -111,7 +112,7 @@ export default class MajorObjectClasses extends React.Component {
         const nodes = objectClassTreemap.map((n, i) => {
             let cell = '';
             let cellColor = TreemapHelper.treemapColors[i];
-            let textColor = TreemapHelper.tooltipStyles.defaultStyle.textColor;
+            let textColor = labelColorFromBackground(TreemapHelper.treemapColors[i]);
             let textClass = '';
 
             // Set highlighted state for hovered object class

--- a/src/js/components/agency/visualizations/objectClass/MinorObjectClasses.jsx
+++ b/src/js/components/agency/visualizations/objectClass/MinorObjectClasses.jsx
@@ -5,13 +5,12 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import tinycolor from 'tinycolor2';
 import { hierarchy, treemap, treemapBinary, treemapSlice } from 'd3-hierarchy';
 import { throttle, remove, orderBy, find } from 'lodash';
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 import * as TreemapHelper from 'helpers/treemapHelper';
 import { objectClassDefinitions } from 'dataMapping/agency/objectClassDefinitions';
-import { labelColorFromBackground, isContrastCompliant } from 'helpers/colorHelper';
+import { labelColorFromBackground } from 'helpers/colorHelper';
 
 import ObjectClassCell from './ObjectClassCell';
 import ObjectClassTooltip from './ObjectClassTooltip';

--- a/src/js/components/agency/visualizations/objectClass/MinorObjectClasses.jsx
+++ b/src/js/components/agency/visualizations/objectClass/MinorObjectClasses.jsx
@@ -5,11 +5,13 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import tinycolor from 'tinycolor2';
 import { hierarchy, treemap, treemapBinary, treemapSlice } from 'd3-hierarchy';
 import { throttle, remove, orderBy, find } from 'lodash';
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 import * as TreemapHelper from 'helpers/treemapHelper';
 import { objectClassDefinitions } from 'dataMapping/agency/objectClassDefinitions';
+import { labelColorFromBackground, isContrastCompliant } from 'helpers/colorHelper';
 
 import ObjectClassCell from './ObjectClassCell';
 import ObjectClassTooltip from './ObjectClassTooltip';
@@ -119,7 +121,7 @@ export default class MinorObjectClasses extends React.Component {
         const nodes = budgetFunctionTreemap.map((n, i) => {
             let cell = '';
             let cellColor = TreemapHelper.treemapColors[i];
-            let textColor = TreemapHelper.tooltipStyles.defaultStyle.textColor;
+            let textColor = labelColorFromBackground(TreemapHelper.treemapColors[i]);
             let textClass = '';
 
             // Set highlighted state for hovered object class

--- a/src/js/components/explorer/detail/visualization/treemap/TreemapCell.jsx
+++ b/src/js/components/explorer/detail/visualization/treemap/TreemapCell.jsx
@@ -6,6 +6,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { labelColorFromBackground } from 'helpers/colorHelper';
+
 const propTypes = {
     width: PropTypes.number,
     height: PropTypes.number,
@@ -28,7 +30,8 @@ export default class TreemapCell extends React.Component {
 
         this.state = {
             backgroundColor: '',
-            active: ''
+            active: '',
+            textColor: '#ffffff'
         };
 
         this.clickedCell = this.clickedCell.bind(this);
@@ -37,14 +40,18 @@ export default class TreemapCell extends React.Component {
     }
 
     componentWillMount() {
+        const textColor = labelColorFromBackground(this.props.color);
         this.setState({
+            textColor,
             backgroundColor: this.props.color
         });
     }
 
     componentWillReceiveProps(nextProps) {
         if (nextProps.color !== this.props.color) {
+            const textColor = labelColorFromBackground(nextProps.color);
             this.setState({
+                textColor,
                 backgroundColor: nextProps.color
             });
         }
@@ -89,15 +96,18 @@ export default class TreemapCell extends React.Component {
             <text
                 className={`explorer-cell-title ${this.state.active}`}
                 textAnchor="middle"
+                fill={this.state.textColor}
                 x={this.props.title.x}
                 y={this.props.title.y}>
                 {this.props.title.text}
             </text>
         );
+
         let cellValue = (
             <text
                 className={`explorer-cell-value ${this.state.active}`}
                 textAnchor="middle"
+                fill={this.state.textColor}
                 x={this.props.subtitle.x}
                 y={this.props.subtitle.y}>
                 {this.props.subtitle.text}

--- a/src/js/helpers/colorHelper.js
+++ b/src/js/helpers/colorHelper.js
@@ -1,0 +1,43 @@
+/**
+ * colorHelper.js
+ * Created by Kevin Li 3/12/18
+ */
+
+
+import tinycolor from 'tinycolor2';
+
+// generate an RGB hex code for a label given any background color
+export const labelColorFromBackground = (backgroundColor) => {
+    const background = tinycolor(backgroundColor);
+    if (background.isDark()) {
+        // dark backgrounds will always have white text
+        return '#ffffff';
+    }
+
+    // otherwise, the background is light and needs a darker text color
+    // calculate the relative luminance of the background color
+    const backLume = background.getLuminance();
+    // determine what the foreground luminance must be to achieve a 4.6:1 contrast ratio
+    // refer to https://www.w3.org/TR/WCAG/#dfn-contrast-ratio
+    const foreLume = ((backLume + 0.05) / 4.6) - 0.05;
+
+    // given this luminance, determine what a grey RGB code must be
+    // we know that the R, G, and B values must be equal to each other because grey colors have
+    // the same R, G, and B values. Given this and the foreground luminance, we can calculate what
+    // their adjusted inputs are.
+    // refer to https://www.w3.org/TR/WCAG/#dfn-relative-luminance
+    const sRGB = foreLume / (0.2126 + 0.7152 + 0.0722);
+
+    // from this we can determine the original, unadjusted R value
+    let rawR = sRGB * 12.92;
+    if (rawR > 0.03928) {
+        rawR = ((sRGB ** (1 / 2.4)) * 1.055) - 0.055;
+    }
+
+    const foreground = tinycolor({
+        r: rawR * 255,
+        g: rawR * 255,
+        b: rawR * 255
+    });
+    return foreground.toHexString();
+};

--- a/tests/helpers/colorHelper-test.js
+++ b/tests/helpers/colorHelper-test.js
@@ -2,13 +2,50 @@ import tinycolor from 'tinycolor2';
 import * as colorHelper from 'helpers/colorHelper';
 
 describe('colorHelper', () => {
+    describe('isContrastCompliant', () => {
+        it('should return true when the color contrast is greater than or equal to 4.5', () => {
+            const firstCompliant = colorHelper.isContrastCompliant('#000000', '#767676');
+            expect(firstCompliant).toBeTruthy();
+
+            const secondCompliant = colorHelper.isContrastCompliant('#0000FF', '#ABBAFF');
+            expect(secondCompliant).toBeTruthy();
+        });
+        it('should return false when the color contrast is less than 4.5', () => {
+            const firstCompliant = colorHelper.isContrastCompliant('#000000', '#646464');
+            expect(firstCompliant).toBeFalsy();
+
+            const secondCompliant = colorHelper.isContrastCompliant('#0000FF', '#0000FF');
+            expect(secondCompliant).toBeFalsy();
+        });
+    });
+    describe('lightestAcceptableLumeForWhiteText', () => {
+        it('should return a luminance value that, combined with white, will result in a contrast ratio equal to the provided target', () => {
+            const firstLume = colorHelper.lightestAcceptableLumeForWhiteText(3.1);
+            const firstContrast = (1 + 0.05) / (firstLume + 0.05);
+            expect(
+                // round to 1 decimal value
+                Math.round(firstContrast * 10) / 10
+            ).toEqual(3.1);
+
+            const secondLume = colorHelper.lightestAcceptableLumeForWhiteText(6.2);
+            const secondContrast = (1 + 0.05) / (secondLume + 0.05);
+            expect(
+                // round to 1 decimal value
+                Math.round(secondContrast * 10) / 10
+            ).toEqual(6.2);
+        });
+    });
     describe('labelColorFromBackground', () => {
-        it('should return white for dark backgrounds', () => {
-            const color = colorHelper.labelColorFromBackground('#000000');
+        it('should return white when the background lume is less than the lightest acceptable background lume for a white label ata 4.6:1 color contrast', () => {
+            const background = '#000000';
+            const color = colorHelper.labelColorFromBackground(background);
+            expect(tinycolor(background).getLuminance()).toBeLessThan(colorHelper.lightestAcceptableLumeForWhiteText(4.6));
             expect(color).toEqual('#ffffff');
         });
-        it('should return a non-white color for light backgrounds', () => {
-            const color = colorHelper.labelColorFromBackground('#74b9ff');
+        it('should return a non-white color for when the background lume is greater than lightest acceptable background lume for a white label at 4.6:1 color contrast', () => {
+            const background = '#74b9ff';
+            const color = colorHelper.labelColorFromBackground(background);
+            expect(tinycolor(background).getLuminance()).toBeGreaterThan(colorHelper.lightestAcceptableLumeForWhiteText(4.6));
             expect(color).not.toEqual('#ffffff');
         });
         it('should return a color with 4.6:1 color contrast against a light background', () => {

--- a/tests/helpers/colorHelper-test.js
+++ b/tests/helpers/colorHelper-test.js
@@ -1,0 +1,26 @@
+import tinycolor from 'tinycolor2';
+import * as colorHelper from 'helpers/colorHelper';
+
+describe('colorHelper', () => {
+    describe('labelColorFromBackground', () => {
+        it('should return white for dark backgrounds', () => {
+            const color = colorHelper.labelColorFromBackground('#000000');
+            expect(color).toEqual('#ffffff');
+        });
+        it('should return a non-white color for light backgrounds', () => {
+            const color = colorHelper.labelColorFromBackground('#74b9ff');
+            expect(color).not.toEqual('#ffffff');
+        });
+        it('should return a color with 4.6:1 color contrast against a light background', () => {
+            const color = colorHelper.labelColorFromBackground('#74b9ff');
+            const labelColor = tinycolor(color).getLuminance();
+            const backgroundColor = tinycolor('#74b9ff').getLuminance();
+            // see https://www.w3.org/TR/WCAG/#dfn-contrast-ratio
+            const contrastRatio = (backgroundColor + 0.05) / (labelColor + 0.05);
+            expect(
+                // round it to 1 decimal
+                Math.round(contrastRatio * 10) / 10
+            ).toEqual(4.6);
+        });
+    });
+});


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-568
https://federal-spending-transparency.atlassian.net/browse/DEV-575

* Improve contrast of text field placeholders on advanced search page
* Implement a color generator to programmatically generate treemap label colors so treemap labels will always have 508-compliant contrast for any given cell background color

- [ ] Design review
- [ ] Code review