### PR TITLE
Fix: Pass all the children of a parent recipient type when it is selected

### DIFF
--- a/src/js/containers/search/filters/recipient/RecipientTypeContainer.jsx
+++ b/src/js/containers/search/filters/recipient/RecipientTypeContainer.jsx
@@ -105,11 +105,10 @@ export class RecipientTypeContainer extends React.Component {
         const existingChildren = this.props.recipientType.filter((type) =>
             recipientTypeGroups[parentType].indexOf(type) > -1
         );
-        if (existingChildren.count() > 0) {
+        if (existingChildren.count() > 0 && selection.direction === 'add') {
             // children are already selected
-            // remove these filters first (regardless of whether the parent is being added or removed)
-            // if the parent is being added, this prevents duplicates
-            // if the parent is being removed, this prevents weirdness with the top filter bar, etc
+            // remove these filters before adding anything to prevent duplicates in the Redux store
+            // and subsequent API calls/top filter bar
             this.props.bulkRecipientTypeChange({
                 types: existingChildren.toArray(),
                 direction: 'remove'

--- a/src/js/containers/search/filters/recipient/RecipientTypeContainer.jsx
+++ b/src/js/containers/search/filters/recipient/RecipientTypeContainer.jsx
@@ -101,6 +101,21 @@ export class RecipientTypeContainer extends React.Component {
             return;
         }
 
+        // identify any individual filters within this group that may have already been selected
+        const existingChildren = this.props.recipientType.filter((type) =>
+            recipientTypeGroups[parentType].indexOf(type) > -1
+        );
+        if (existingChildren.count() > 0) {
+            // children are already selected
+            // remove these filters first (regardless of whether the parent is being added or removed)
+            // if the parent is being added, this prevents duplicates
+            // if the parent is being removed, this prevents weirdness with the top filter bar, etc
+            this.props.bulkRecipientTypeChange({
+                types: existingChildren.toArray(),
+                direction: 'remove'
+            });
+        }
+
         this.props.bulkRecipientTypeChange({
             types: [parentType],
             direction: selection.direction

--- a/src/js/models/search/SearchAwardsOperation.js
+++ b/src/js/models/search/SearchAwardsOperation.js
@@ -6,6 +6,7 @@
 import { rootKeys, timePeriodKeys, agencyKeys, awardAmountKeys }
     from 'dataMapping/search/awardsOperationKeys';
 import * as FiscalYearHelper from 'helpers/fiscalYearHelper';
+import { recipientTypeGroups } from 'dataMapping/search/recipientType';
 
 class SearchAwardsOperation {
     constructor() {
@@ -194,7 +195,15 @@ class SearchAwardsOperation {
         }
 
         if (this.recipientType.length > 0) {
-            filters[rootKeys.recipientType] = this.recipientType;
+            const expandedRecipientTypes = this.recipientType.reduce((adjusted, type) => {
+                if ({}.hasOwnProperty.call(recipientTypeGroups, type)) {
+                    // this is a parent recipient type, add in its children instead
+                    return adjusted.concat(recipientTypeGroups[type]);
+                }
+                adjusted.push(type);
+                return adjusted;
+            }, []);
+            filters[rootKeys.recipientType] = expandedRecipientTypes;
         }
 
         // Add Locations

--- a/tests/containers/search/filters/recipientFilter/RecipientTypeContainer-test.jsx
+++ b/tests/containers/search/filters/recipientFilter/RecipientTypeContainer-test.jsx
@@ -83,6 +83,28 @@ describe('RecipientTypeContainer', () => {
                 direction: 'add'
             });
         });
+        it('when a parent recipient type is provided, it should remove any previously selected child types', () => {
+            const mockRedux = Object.assign({}, mockTypeRedux, {
+                bulkRecipientTypeChange: jest.fn(),
+                recipientType: new Set(['small_business'])
+            });
+            const container = shallow(<RecipientTypeContainer {...mockRedux} />);
+
+            container.instance().bulkRecipientTypeChange({
+                types: recipientTypeGroups.business,
+                direction: 'add'
+            });
+
+            expect(mockRedux.bulkRecipientTypeChange).toHaveBeenCalledTimes(2);
+            expect(mockRedux.bulkRecipientTypeChange.mock.calls[0]).toEqual([{
+                types: ['small_business'],
+                direction: 'remove'
+            }]);
+            expect(mockRedux.bulkRecipientTypeChange).toHaveBeenLastCalledWith({
+                types: ['business'],
+                direction: 'add'
+            });
+        });
     });
     describe('dirtyFilters', () => {
         it('should return an ES6 Symbol when the staged filters do not match with the applied filters', () => {


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-624

* Sends all the child recipient type values to the API when a parent recipient type filter is selected on Advanced Search
* When a parent recipient type is selected, any previously selected child recipient type is overwritten with the parent recipient type to prevent duplicates in the API call and the top filter bar