### PR TITLE
Fix: Business Recipient Type Filter

### DIFF
--- a/src/js/components/search/filters/recipient/RecipientType.jsx
+++ b/src/js/components/search/filters/recipient/RecipientType.jsx
@@ -15,7 +15,7 @@ const defaultProps = {
         {
             id: 'recipient-business',
             name: 'Business',
-            filters: recipientTypeGroups.business
+            filters: recipientTypeGroups.category_business
         },
         {
             id: 'recipient-minority-owned-business',

--- a/src/js/containers/search/filters/recipient/RecipientTypeContainer.jsx
+++ b/src/js/containers/search/filters/recipient/RecipientTypeContainer.jsx
@@ -101,6 +101,20 @@ export class RecipientTypeContainer extends React.Component {
             return;
         }
 
+        // identify any individual filters within this group that may have already been selected
+        const existingChildren = this.props.recipientType.filter((type) =>
+            recipientTypeGroups[parentType].indexOf(type) > -1
+        );
+        if (existingChildren.count() > 0 && selection.direction === 'add') {
+            // children are already selected
+            // remove these filters before adding anything to prevent duplicates in the Redux store
+            // and subsequent API calls/top filter bar
+            this.props.bulkRecipientTypeChange({
+                types: existingChildren.toArray(),
+                direction: 'remove'
+            });
+        }
+
         this.props.bulkRecipientTypeChange({
             types: [parentType],
             direction: selection.direction

--- a/src/js/dataMapping/search/recipientType.js
+++ b/src/js/dataMapping/search/recipientType.js
@@ -61,12 +61,11 @@ export const recipientTypes = {
     'local_government': 'Local Government',
     'indian_native_american_tribal_government': 'Indian/Native American Tribal Government',
     'authorities_and_commissions': 'Authorities and Commissions',
-
     'individuals': 'Individuals'
 };
 
 export const recipientTypeGroups = {
-    business: [
+    category_business: [
         'small_business',
         'other_than_small_business'
     ],
@@ -133,7 +132,7 @@ export const recipientTypeGroups = {
 };
 
 export const groupKeys = [
-    'business',
+    'category_business',
     'minority_owned_business',
     'woman_owned_business',
     'veteran_owned_business',
@@ -144,7 +143,7 @@ export const groupKeys = [
     'individuals'];
 
 export const groupLabels = {
-    business: 'Business',
+    category_business: 'Business',
     minority_owned_business: 'Minority Owned Business',
     woman_owned_business: 'Women Owned Business',
     veteran_owned_business: 'Veteran Owned Business',

--- a/tests/containers/search/filters/recipientFilter/RecipientTypeContainer-test.jsx
+++ b/tests/containers/search/filters/recipientFilter/RecipientTypeContainer-test.jsx
@@ -23,9 +23,9 @@ describe('RecipientTypeContainer', () => {
     describe('ungroupSelectedTypes', () => {
         it('should split filter values associated with parent recipient type items into their child values', () => {
             const container = shallow(<RecipientTypeContainer {...mockTypeRedux} />);
-            container.instance().ungroupSelectedTypes(new Set(['business']));
+            container.instance().ungroupSelectedTypes(new Set(['category_business']));
 
-            expect(container.state().selectedTypes).toEqual(new Set(recipientTypeGroups.business));
+            expect(container.state().selectedTypes).toEqual(new Set(recipientTypeGroups.category_business));
         });
 
         it('should pass the filter values into state as-is when the filter value is not a parent recipient type', () => {
@@ -39,9 +39,9 @@ describe('RecipientTypeContainer', () => {
     describe('determineParentType', () => {
         it('should return the parent value when the input matches any recipient type group value', () => {
             const container = shallow(<RecipientTypeContainer {...mockTypeRedux} />);
-            const parentType = container.instance().determineParentType(recipientTypeGroups.business);
+            const parentType = container.instance().determineParentType(recipientTypeGroups.category_business);
 
-            expect(parentType).toEqual('business');
+            expect(parentType).toEqual('category_business');
         });
         it('should return the null when the input is not a member of any recipient type group', () => {
             const container = shallow(<RecipientTypeContainer {...mockTypeRedux} />);
@@ -73,13 +73,35 @@ describe('RecipientTypeContainer', () => {
             const container = shallow(<RecipientTypeContainer {...mockRedux} />);
 
             container.instance().bulkRecipientTypeChange({
-                types: recipientTypeGroups.business,
+                types: recipientTypeGroups.category_business,
                 direction: 'add'
             });
 
             expect(mockRedux.bulkRecipientTypeChange).toHaveBeenCalledTimes(1);
             expect(mockRedux.bulkRecipientTypeChange).toHaveBeenCalledWith({
-                types: ['business'],
+                types: ['category_business'],
+                direction: 'add'
+            });
+        });
+        it('when a parent recipient type is provided, it should remove any previously selected child types', () => {
+            const mockRedux = Object.assign({}, mockTypeRedux, {
+                bulkRecipientTypeChange: jest.fn(),
+                recipientType: new Set(['small_business'])
+            });
+            const container = shallow(<RecipientTypeContainer {...mockRedux} />);
+
+            container.instance().bulkRecipientTypeChange({
+                types: recipientTypeGroups.category_business,
+                direction: 'add'
+            });
+
+            expect(mockRedux.bulkRecipientTypeChange).toHaveBeenCalledTimes(2);
+            expect(mockRedux.bulkRecipientTypeChange.mock.calls[0]).toEqual([{
+                types: ['small_business'],
+                direction: 'remove'
+            }]);
+            expect(mockRedux.bulkRecipientTypeChange).toHaveBeenLastCalledWith({
+                types: ['category_business'],
                 direction: 'add'
             });
         });


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-624
*  Use `category_business` instead of `business` for recipient type in Advanced Search
* When a parent recipient type is selected, any previously selected child recipient type is overwritten with the parent recipient type to prevent duplicates in the API call and the top filter bar
