### PR TITLE
Handle null awarding/funding agencies

### DIFF
--- a/src/js/models/v2/awards/BaseContract.js
+++ b/src/js/models/v2/awards/BaseContract.js
@@ -51,6 +51,8 @@ BaseContract.populate = function populate(data) {
         this.placeOfPerformance = placeOfPerformance;
     }
 
+    const awardingAgency = Object.create(CoreAwardAgency);
+    this.awardingAgency = awardingAgency;
     if (data.awarding_agency) {
         const awardingAgencyData = {
             name: data.awarding_agency.toptier_agency && data.awarding_agency.toptier_agency.name,
@@ -58,11 +60,11 @@ BaseContract.populate = function populate(data) {
             officeName: data.latest_transaction && data.latest_transaction.contract_data
                 && data.latest_transaction.contract_data.awarding_office_name
         };
-        const awardingAgency = Object.create(CoreAwardAgency);
         awardingAgency.populateCore(awardingAgencyData);
-        this.awardingAgency = awardingAgency;
     }
 
+    const fundingAgency = Object.create(CoreAwardAgency);
+    this.fundingAgency = fundingAgency;
     if (data.funding_agency) {
         const fundingAgencyData = {
             name: data.funding_agency.toptier_agency && data.funding_agency.toptier_agency.name,
@@ -70,9 +72,7 @@ BaseContract.populate = function populate(data) {
             officeName: data.latest_transaction && data.latest_transaction.contract_data
                 && data.latest_transaction.contract_data.funding_office_name
         };
-        const fundingAgency = Object.create(CoreAwardAgency);
         fundingAgency.populateCore(fundingAgencyData);
-        this.fundingAgency = fundingAgency;
     }
 
     if (data.latest_transaction && data.latest_transaction.contract_data) {

--- a/src/js/models/v2/awards/BaseFinancialAssistance.js
+++ b/src/js/models/v2/awards/BaseFinancialAssistance.js
@@ -44,6 +44,8 @@ BaseFinancialAssistance.populate = function populate(data) {
     placeOfPerformance.populateCore(placeOfPerformanceData);
     this.placeOfPerformance = placeOfPerformance;
 
+    const awardingAgency = Object.create(CoreAwardAgency);
+    this.awardingAgency = awardingAgency;
     if (data.awarding_agency) {
         const awardingAgencyData = {
             name: data.awarding_agency.toptier_agency && data.awarding_agency.toptier_agency.name,
@@ -51,11 +53,11 @@ BaseFinancialAssistance.populate = function populate(data) {
             officeName: data.latest_transaction && data.latest_transaction.assistance_data
                 && data.latest_transaction.assistance_data.awarding_office_name
         };
-        const awardingAgency = Object.create(CoreAwardAgency);
         awardingAgency.populateCore(awardingAgencyData);
-        this.awardingAgency = awardingAgency;
     }
 
+    const fundingAgency = Object.create(CoreAwardAgency);
+    this.fundingAgency = fundingAgency;
     if (data.funding_agency) {
         const fundingAgencyData = {
             name: data.funding_agency.toptier_agency && data.funding_agency.toptier_agency.name,
@@ -63,9 +65,7 @@ BaseFinancialAssistance.populate = function populate(data) {
             officeName: data.latest_transaction && data.latest_transaction.assistance_data
                 && data.latest_transaction.assistance_data.funding_office_name
         };
-        const fundingAgency = Object.create(CoreAwardAgency);
         fundingAgency.populateCore(fundingAgencyData);
-        this.fundingAgency = fundingAgency;
     }
 
     this.description = data.description || '--';

--- a/src/js/models/v2/awards/CoreAwardAgency.js
+++ b/src/js/models/v2/awards/CoreAwardAgency.js
@@ -4,8 +4,9 @@
  */
 
 const CoreAwardAgency = {
+    name: '--',
     populateCore(data) {
-        this.name = data.name || '';
+        this.name = data.name || '--';
         this.subtierName = data.subtierName || '';
         this.officeName = data.officeName || '';
     }

--- a/tests/models/awards/BaseContract-test.js
+++ b/tests/models/awards/BaseContract-test.js
@@ -38,9 +38,10 @@ describe('BaseContract', () => {
         });
     });
     describe('agencies', () => {
-        it('should only create an awarding/funding agency if it is available in the API response', () => {
-            expect(contract.awardingAgency).toBeTruthy();
-            expect(contract.fundingAgency).toBeFalsy();
+        it('should only populate an awarding/funding agency if it is available in the API response', () => {
+            const emptyAgency = Object.create(CoreAwardAgency);
+            expect(contract.awardingAgency).not.toEqual(emptyAgency);
+            expect(contract.fundingAgency).toEqual(emptyAgency);
         });
         it('should format toptier and subtier names', () => {
             expect(Object.getPrototypeOf(contract.awardingAgency)).toEqual(CoreAwardAgency);

--- a/tests/models/awards/BaseFinancialAssistance-test.js
+++ b/tests/models/awards/BaseFinancialAssistance-test.js
@@ -29,8 +29,9 @@ describe('Base Financial Assistance', () => {
     });
     describe('agencies', () => {
         it('should only create an awarding/funding agency if it is available in the API response', () => {
-            expect(loan.awardingAgency).toBeTruthy();
-            expect(loan.fundingAgency).toBeFalsy();
+            const emptyAgency = Object.create(CoreAwardAgency);
+            expect(loan.awardingAgency).not.toEqual(emptyAgency);
+            expect(loan.fundingAgency).toEqual(emptyAgency);
         });
         it('should be an object with CoreAwardAgency in its prototype chain', () => {
             expect(Object.getPrototypeOf(loan.awardingAgency)).toEqual(CoreAwardAgency);

--- a/tests/models/awards/CoreAwardAgency-test.js
+++ b/tests/models/awards/CoreAwardAgency-test.js
@@ -28,8 +28,12 @@ describe('CoreAwardAgency', () => {
         };
         incompleteAgency.populateCore(missingData);
 
-        expect(incompleteAgency.name).toEqual('');
+        expect(incompleteAgency.name).toEqual('--');
         expect(incompleteAgency.subtierName).toEqual('');
         expect(incompleteAgency.officeName).toEqual('');
+    });
+    it('should use a -- for agency name when it is unpopulated', () => {
+        const emptyAgency = Object.create(CoreAwardAgency);
+        expect(emptyAgency.name).toEqual('--');
     });
 });


### PR DESCRIPTION
* Handle null awarding/funding agencies in the new award models so they don't break the agency toggle on the profile pages