### PR TITLE
Contract Summary Updates

### DIFF
--- a/src/js/components/award/AwardAmounts.jsx
+++ b/src/js/components/award/AwardAmounts.jsx
@@ -32,7 +32,7 @@ export default class AwardAmounts extends React.Component {
         let awardNarrative = (
             <p>
                 This {award.category} was awarded to&nbsp;
-                <b className="recipient-name">{recipient}</b> with a ceiling of
+                <b className="recipient-name">{recipient}</b> with a potential award amount of
                 &nbsp;<b>{ceiling}</b>.&nbsp;
                 Of this amount, <b>{percentage}%</b> (<b>{current}</b>)
                 has been obligated.

--- a/src/js/dataMapping/contracts/additionalDetails.js
+++ b/src/js/dataMapping/contracts/additionalDetails.js
@@ -108,6 +108,10 @@ export const competitionFields = [
     {
         label: 'Small Business Competitiveness Demonstration Program',
         field: 'smallBusinessCompetitivenessDemo'
+    },
+    {
+        label: 'Fair Opportunity Limited Sources',
+        field: 'fairOpportunityLimitedSources'
     }
 ];
 
@@ -188,10 +192,6 @@ export const additionalFields = [
     {
         label: 'Domestic or Foreign Entity',
         field: 'domesticForeign'
-    },
-    {
-        label: 'Fair Opportunity Limited Sources',
-        field: 'fairOpportunityLimitedSources'
     },
     {
         label: 'Foreign Funding',

--- a/src/js/models/v2/awards/additionalDetails/BaseContractAdditionalDetails.js
+++ b/src/js/models/v2/awards/additionalDetails/BaseContractAdditionalDetails.js
@@ -20,13 +20,14 @@ const BaseContractAdditionalDetails = {
         this.solicitationProcedures = data.solicitation_procedur_desc || data.solicitation_procedures || '--';
         this.numberOffers = data.number_of_offers_received || '--';
         this.extentCompeted = data.extent_compete_description || data.extent_competed || '--';
-        this.notCompeted = data.other_than_full_and_open_c || '--';
+        this.notCompeted = data.other_than_full_and_o_desc || '--';
         this.setAsideType = data.type_set_aside_description || '--';
         this.commercialAcquisitionProcedures = data.commercial_item_acqui_desc || data.commercial_item_acquisitio || '--';
         this.commercialTestProgram = data.commercial_item_test_desc || '--';
         this.evaluatedPreference = data.evaluated_preference_desc || '--';
         this.fedBizOpps = data.fed_biz_opps_description || '--';
         this.smallBusinessCompetitivenessDemo = data.small_business_competitive || '--';
+        this.fairOpportunityLimitedSources = data.fair_opportunity_limi_desc || '--';
 
         // Product or Service Details
         this._pscCode = data.product_or_service_code || '';
@@ -47,7 +48,6 @@ const BaseContractAdditionalDetails = {
         // Additional Details
         this.costOrPricingData = data.cost_or_pricing_data_desc || '--';
         this.domesticForeign = data.domestic_or_foreign_e_desc || '--';
-        this.fairOpportunityLimitedSources = data.fair_opportunity_limi_desc || '--';
         this.foreignFunding = data.foreign_funding_desc || '--';
         this.interagencyContactingAuthority = data.interagency_contract_desc || '--';
         this.majorProgram = data.major_program || '--';


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-628
- Shows the field `other_than_full_and_o_desc` for "Not Competed Reason"
- Groups "Fair Opportunity Limited Sources" under "Competition Details" instead of "Additional Details"
- Replaces "ceiling" with "potential award amount" in the Award Amount visualization 
