### PR TITLE
Fix Account Spending Over Time order

### DIFF
--- a/src/js/containers/account/visualizations/AccountTimeVisualizationContainer.jsx
+++ b/src/js/containers/account/visualizations/AccountTimeVisualizationContainer.jsx
@@ -233,22 +233,19 @@ export class AccountTimeVisualizationSectionContainer extends React.PureComponen
         const ySeries = [];
         const allY = [];
         const yData = {};
-        const quartersYears = [];
+        const groupLabels = [];
 
         data.forEach((balance, balanceIndex) => {
             const type = this.balanceRequests[balanceIndex].type;
             balance.data.results.forEach((group) => {
-                let quarterYear;
+                let groupLabel = `${group.item}`;
                 if (this.state.visualizationPeriod === 'quarter') {
-                    quarterYear = `${group.item} Q${group.submission__reporting_fiscal_quarter}`;
+                    groupLabel = `${group.item} Q${group.submission__reporting_fiscal_quarter}`;
                 }
-                else if (this.state.visualizationPeriod === 'year') {
-                    quarterYear = `${group.item}`;
-                }
-                if (!yData[quarterYear]) {
-                    quartersYears.push(quarterYear);
+                if (!yData[groupLabel]) {
+                    groupLabels.push(groupLabel);
                     if (this.state.hasFilteredObligated) {
-                        yData[quarterYear] = {
+                        yData[groupLabel] = {
                             obligatedFiltered: 0,
                             outlay: 0,
                             budgetAuthority: 0,
@@ -256,7 +253,7 @@ export class AccountTimeVisualizationSectionContainer extends React.PureComponen
                         };
                     }
                     else {
-                        yData[quarterYear] = {
+                        yData[groupLabel] = {
                             obligated: 0,
                             outlay: 0,
                             budgetAuthority: 0,
@@ -264,17 +261,20 @@ export class AccountTimeVisualizationSectionContainer extends React.PureComponen
                         };
                     }
                 }
-                yData[quarterYear][type] = parseFloat(group.aggregate);
+                yData[groupLabel][type] = parseFloat(group.aggregate);
             });
         });
 
-        quartersYears.forEach((quarterYear) => {
-            xSeries.push(`${quarterYear}`);
+        // Ensure the group labels are in chronological order
+        groupLabels.sort();
+
+        groupLabels.forEach((group) => {
+            xSeries.push(`${group}`);
             if (this.state.hasFilteredObligated) {
-                const budgetAuthority = yData[quarterYear].budgetAuthority;
-                const unobligated = yData[quarterYear].unobligated;
-                const obligatedFiltered = yData[quarterYear].obligatedFiltered;
-                const outlay = yData[quarterYear].outlay;
+                const budgetAuthority = yData[group].budgetAuthority;
+                const unobligated = yData[group].unobligated;
+                const obligatedFiltered = yData[group].obligatedFiltered;
+                const outlay = yData[group].outlay;
                 // Calculate Obligated (Other)
                 const obligatedOther = budgetAuthority - unobligated - obligatedFiltered;
 
@@ -311,30 +311,30 @@ export class AccountTimeVisualizationSectionContainer extends React.PureComponen
                 const period = {
                     obligated: {
                         bottom: 0,
-                        top: yData[quarterYear].obligated,
-                        value: yData[quarterYear].obligated,
+                        top: yData[group].obligated,
+                        value: yData[group].obligated,
                         description: 'Obligations Incurred'
                     },
                     unobligated: {
-                        bottom: yData[quarterYear].obligated,
-                        top: yData[quarterYear].unobligated + yData[quarterYear].obligated,
-                        value: yData[quarterYear].unobligated,
+                        bottom: yData[group].obligated,
+                        top: yData[group].unobligated + yData[group].obligated,
+                        value: yData[group].unobligated,
                         description: 'Unobligated Balance'
                     },
                     outlay: {
-                        bottom: yData[quarterYear].outlay,
-                        top: yData[quarterYear].outlay,
-                        value: yData[quarterYear].outlay,
+                        bottom: yData[group].outlay,
+                        top: yData[group].outlay,
+                        value: yData[group].outlay,
                         description: 'Outlay'
                     }
                 };
 
                 ySeries.push(period);
-                allY.push(yData[quarterYear].obligated);
+                allY.push(yData[group].obligated);
             }
-            allY.push(yData[quarterYear].outlay);
-            allY.push(yData[quarterYear].budgetAuthority);
-            allY.push(yData[quarterYear].unobligated);
+            allY.push(yData[group].outlay);
+            allY.push(yData[group].budgetAuthority);
+            allY.push(yData[group].unobligated);
         });
 
         // determine the bar stacks to display and their order

--- a/tests/containers/account/mockAccount.js
+++ b/tests/containers/account/mockAccount.js
@@ -108,10 +108,12 @@ export const mockBalances = {
             count: 1,
             page_number: 1
         },
-        results: [{
-            item: "2016",
-            aggregate: "198707976.61"
-        }],
+        results: [
+            {
+                item: "2016",
+                aggregate: "198707976.61"
+            }
+        ],
         total_metadata: {
             count: 1
         }
@@ -121,10 +123,12 @@ export const mockBalances = {
             count: 1,
             page_number: 1
         },
-        results: [{
-            item: "2016",
-            aggregate: "2696684.86"
-        }],
+        results: [
+            {
+                item: "2016",
+                aggregate: "2696684.86"
+            }
+        ],
         total_metadata: {
             count: 1
         }
@@ -134,10 +138,12 @@ export const mockBalances = {
             count: 1,
             page_number: 1
         },
-        results: [{
-            item: "2016",
-            aggregate: "201404661.47"
-        }],
+        results: [
+            {
+                item: "2016",
+                aggregate: "201404661.47"
+            }
+        ],
         total_metadata: {
             count: 1
         }
@@ -147,10 +153,12 @@ export const mockBalances = {
             count: 1,
             page_number: 1
         },
-        results: [{
-            item: "2016",
-            aggregate: "-5505246.42"
-        }],
+        results: [
+            {
+                item: "2016",
+                aggregate: "-5505246.42"
+            }
+        ],
         total_metadata: {
             count: 1
         }
@@ -163,18 +171,20 @@ export const mockQuarters = {
             count: 1,
             page_number: 1
         },
-        results: [{
-            item: "2016",
-            aggregate: "198707976.61",
-            submission__reporting_fiscal_year: "2016",
-            submission__reporting_fiscal_quarter: "1"
-        },
-        {
-            item: "2016",
-            aggregate: "5851779752.00",
-            submission__reporting_fiscal_year: "2016",
-            submission__reporting_fiscal_quarter: "2"
-        }],
+        results: [
+            {
+                item: "2016",
+                aggregate: "198707976.61",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "1"
+            },
+            {
+                item: "2016",
+                aggregate: "5851779752.00",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "2"
+            }
+        ],
         total_metadata: {
             count: 1
         }
@@ -184,18 +194,20 @@ export const mockQuarters = {
             count: 1,
             page_number: 1
         },
-        results: [{
-            item: "2016",
-            aggregate: "2696684.86",
-            submission__reporting_fiscal_year: "2016",
-            submission__reporting_fiscal_quarter: "1"
-        },
-        {
-            item: "2016",
-            aggregate: "3851752.00",
-            submission__reporting_fiscal_year: "2016",
-            submission__reporting_fiscal_quarter: "2"
-        }],
+        results: [
+            {
+                item: "2016",
+                aggregate: "2696684.86",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "1"
+            },
+            {
+                item: "2016",
+                aggregate: "3851752.00",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "2"
+            }
+        ],
         total_metadata: {
             count: 1
         }
@@ -205,18 +217,20 @@ export const mockQuarters = {
             count: 1,
             page_number: 1
         },
-        results: [{
-            item: "2016",
-            aggregate: "201404661.47",
-            submission__reporting_fiscal_year: "2016",
-            submission__reporting_fiscal_quarter: "1"
-        },
-        {
-            item: "2016",
-            aggregate: "101905442.35",
-            submission__reporting_fiscal_year: "2016",
-            submission__reporting_fiscal_quarter: "2"
-        }],
+        results: [
+            {
+                item: "2016",
+                aggregate: "201404661.47",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "1"
+            },
+            {
+                item: "2016",
+                aggregate: "101905442.35",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "2"
+            }
+        ],
         total_metadata: {
             count: 1
         }
@@ -226,18 +240,20 @@ export const mockQuarters = {
             count: 1,
             page_number: 1
         },
-        results: [{
-            item: "2016",
-            aggregate: "-5505246.42",
-            submission__reporting_fiscal_year: "2016",
-            submission__reporting_fiscal_quarter: "1"
-        },
-        {
-            item: "2016",
-            aggregate: "-4413237.11",
-            submission__reporting_fiscal_year: "2016",
-            submission__reporting_fiscal_quarter: "2"
-        }],
+        results: [
+            {
+                item: "2016",
+                aggregate: "-5505246.42",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "1"
+            },
+            {
+                item: "2016",
+                aggregate: "-4413237.11",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "2"
+            }
+        ],
         total_metadata: {
             count: 1
         }
@@ -250,10 +266,12 @@ export const mockFilteredObligated = {
             count: 1,
             page_number: 1
         },
-        results: [{
-            item: "2016",
-            aggregate: "198707976.61"
-        }],
+        results: [
+            {
+                item: "2016",
+                aggregate: "198707976.61"
+            }
+        ],
         total_metadata: {
             count: 1
         }
@@ -263,10 +281,12 @@ export const mockFilteredObligated = {
             count: 1,
             page_number: 1
         },
-        results: [{
-            item: "2016",
-            aggregate: "2696684.86"
-        }],
+        results: [
+            {
+                item: "2016",
+                aggregate: "2696684.86"
+            }
+        ],
         total_metadata: {
             count: 1
         }
@@ -276,10 +296,12 @@ export const mockFilteredObligated = {
             count: 1,
             page_number: 1
         },
-        results: [{
-            item: "2016",
-            aggregate: "201404661.47"
-        }],
+        results: [
+            {
+                item: "2016",
+                aggregate: "201404661.47"
+            }
+        ],
         total_metadata: {
             count: 1
         }
@@ -289,10 +311,12 @@ export const mockFilteredObligated = {
             count: 1,
             page_number: 1
         },
-        results: [{
-            item: "2016",
-            aggregate: "-5505246.42"
-        }],
+        results: [
+            {
+                item: "2016",
+                aggregate: "-5505246.42"
+            }
+        ],
         total_metadata: {
             count: 1
         }
@@ -305,18 +329,20 @@ export const mockFilteredObligatedQuarters = {
             count: 1,
             page_number: 1
         },
-        results: [{
-            item: "2016",
-            aggregate: "198707976.61",
-            submission__reporting_fiscal_year: "2016",
-            submission__reporting_fiscal_quarter: "1"
-        },
-        {
-            item: "2016",
-            aggregate: "5851779752.00",
-            submission__reporting_fiscal_year: "2016",
-            submission__reporting_fiscal_quarter: "2"
-        }],
+        results: [
+            {
+                item: "2016",
+                aggregate: "198707976.61",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "1"
+            },
+            {
+                item: "2016",
+                aggregate: "5851779752.00",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "2"
+            }
+        ],
         total_metadata: {
             count: 1
         }
@@ -326,18 +352,20 @@ export const mockFilteredObligatedQuarters = {
             count: 1,
             page_number: 1
         },
-        results: [{
-            item: "2016",
-            aggregate: "2696684.86",
-            submission__reporting_fiscal_year: "2016",
-            submission__reporting_fiscal_quarter: "1"
-        },
-        {
-            item: "2016",
-            aggregate: "3851752.00",
-            submission__reporting_fiscal_year: "2016",
-            submission__reporting_fiscal_quarter: "2"
-        }],
+        results: [
+            {
+                item: "2016",
+                aggregate: "2696684.86",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "1"
+            },
+            {
+                item: "2016",
+                aggregate: "3851752.00",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "2"
+            }
+        ],
         total_metadata: {
             count: 1
         }
@@ -347,18 +375,20 @@ export const mockFilteredObligatedQuarters = {
             count: 1,
             page_number: 1
         },
-        results: [{
-            item: "2016",
-            aggregate: "201404661.47",
-            submission__reporting_fiscal_year: "2016",
-            submission__reporting_fiscal_quarter: "1"
-        },
-        {
-            item: "2016",
-            aggregate: "101905442.35",
-            submission__reporting_fiscal_year: "2016",
-            submission__reporting_fiscal_quarter: "2"
-        }],
+        results: [
+            {
+                item: "2016",
+                aggregate: "201404661.47",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "1"
+            },
+            {
+                item: "2016",
+                aggregate: "101905442.35",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "2"
+            }
+        ],
         total_metadata: {
             count: 1
         }
@@ -368,18 +398,115 @@ export const mockFilteredObligatedQuarters = {
             count: 1,
             page_number: 1
         },
-        results: [{
-            item: "2016",
-            aggregate: "-5505246.42",
-            submission__reporting_fiscal_year: "2016",
-            submission__reporting_fiscal_quarter: "1"
+        results: [
+            {
+                item: "2016",
+                aggregate: "-5505246.42",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "1"
+            },
+            {
+                item: "2016",
+                aggregate: "-4413237.11",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "2"
+            }
+        ],
+        total_metadata: {
+            count: 1
+        }
+    }
+};
+
+export const mockIncomplete = {
+    unobligated: {
+        page_metadata: {
+            count: 1,
+            page_number: 1
         },
-        {
-            item: "2016",
-            aggregate: "-4413237.11",
-            submission__reporting_fiscal_year: "2016",
-            submission__reporting_fiscal_quarter: "2"
-        }],
+        results: [
+            {
+                item: "2016",
+                aggregate: "500.00",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "2"
+            },
+            {
+                item: "2016",
+                aggregate: "200.00",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "3"
+            }
+        ],
+        total_metadata: {
+            count: 1
+        }
+    },
+    obligatedFiltered: {
+        page_metadata: {
+            count: 1,
+            page_number: 1
+        },
+        results: [
+            {
+                item: "2016",
+                aggregate: "250.00",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "1"
+            },
+            {
+                item: "2016",
+                aggregate: "400.00",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "2"
+            }
+        ],
+        total_metadata: {
+            count: 1
+        }
+    },
+    budgetAuthority: {
+        page_metadata: {
+            count: 1,
+            page_number: 1
+        },
+        results: [
+            {
+                item: "2016",
+                aggregate: "200.00",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "1"
+            },
+            {
+                item: "2016",
+                aggregate: "100.00",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "2"
+            }
+        ],
+        total_metadata: {
+            count: 1
+        }
+    },
+    outlay: {
+        page_metadata: {
+            count: 1,
+            page_number: 1
+        },
+        results: [
+            {
+                item: "2016",
+                aggregate: "400.00",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "2"
+            },
+            {
+                item: "2016",
+                aggregate: "-500.00",
+                submission__reporting_fiscal_year: "2016",
+                submission__reporting_fiscal_quarter: "3"
+            }
+        ],
         total_metadata: {
             count: 1
         }
@@ -396,10 +523,12 @@ export const mockCategories = {
         has_next_page: true,
         has_previous_page: false
     },
-    results: [{
-        program_activity__program_activity_name: "Program Name",
-        aggregate: "2696684.86"
-    }]
+    results: [
+        {
+            program_activity__program_activity_name: "Program Name",
+            aggregate: "2696684.86"
+        }
+    ]
 };
 
 export const mockAwards = {
@@ -412,108 +541,112 @@ export const mockAwards = {
         previous: null
     },
     req: "19822973ca5",
-    results: [{
-        id: 57557,
-        type_description: "Definitive Contract",
-        piid: "DEAC0494AL85000",
-        fain: null,
-        uri: null,
-        total_obligation: "88074905.67",
-        description: "MANAGEMENT AND OPERATION OF SANDIA NATIONAL LABORATORIES BY SANDIA CORPORATION, CONTRACT NO. DE-AC04-94AL85000",
-        period_of_performance_start_date: "2016-11-30",
-        period_of_performance_current_end_date: "2017-04-30",
-        awarding_agency: {
-            id: 1611,
-            toptier_agency: {
-                cgac_code: "089",
-                fpds_code: "8900",
-                abbreviation: "DOE",
-                name: "Department of Energy"
+    results: [
+        {
+            id: 57557,
+            type_description: "Definitive Contract",
+            piid: "DEAC0494AL85000",
+            fain: null,
+            uri: null,
+            total_obligation: "88074905.67",
+            description: "MANAGEMENT AND OPERATION OF SANDIA NATIONAL LABORATORIES BY SANDIA CORPORATION, CONTRACT NO. DE-AC04-94AL85000",
+            period_of_performance_start_date: "2016-11-30",
+            period_of_performance_current_end_date: "2017-04-30",
+            awarding_agency: {
+                id: 1611,
+                toptier_agency: {
+                    cgac_code: "089",
+                    fpds_code: "8900",
+                    abbreviation: "DOE",
+                    name: "Department of Energy"
+                },
+                subtier_agency: {
+                    subtier_code: "8900",
+                    abbreviation: "",
+                    name: "Department of Energy"
+                },
+                office_agency: null
             },
-            subtier_agency: {
-                subtier_code: "8900",
-                abbreviation: "",
-                name: "Department of Energy"
+            funding_agency: {
+                id: 1805,
+                toptier_agency: {
+                    cgac_code: "097",
+                    fpds_code: "9700",
+                    abbreviation: "DOD",
+                    name: "Department of Defense"
+                },
+                subtier_agency: {
+                    subtier_code: "5700",
+                    abbreviation: "",
+                    name: "Department of the Air Force"
+                },
+                office_agency: null
             },
-            office_agency: null
-        },
-        funding_agency: {
-            id: 1805,
-            toptier_agency: {
-                cgac_code: "097",
-                fpds_code: "9700",
-                abbreviation: "DOD",
-                name: "Department of Defense"
-            },
-            subtier_agency: {
-                subtier_code: "5700",
-                abbreviation: "",
-                name: "Department of the Air Force"
-            },
-            office_agency: null
-        },
-        recipient: {
-            legal_entity_id: 7113228,
-            parent_recipient_unique_id: null,
-            recipient_name: "SANDIA CORP",
-            business_types: null,
-            business_types_description: "Unknown Types",
-            location: {
-                country_name: "UNITED STATES",
-                state_code: "IL",
-                state_name: null,
-                city_name: "ALBUQUERQUE",
-                address_line1: "1515 EUBANK BLVD. SE",
-                address_line2: "P.O. BOX 5800, MS-0180, 87185-0180",
-                address_line3: null,
-                zip5: null,
-                foreign_postal_code: null,
-                foreign_province: "NM",
-                foreign_city_name: null,
-                location_country_code: "USA"
+            recipient: {
+                legal_entity_id: 7113228,
+                parent_recipient_unique_id: null,
+                recipient_name: "SANDIA CORP",
+                business_types: null,
+                business_types_description: "Unknown Types",
+                location: {
+                    country_name: "UNITED STATES",
+                    state_code: "IL",
+                    state_name: null,
+                    city_name: "ALBUQUERQUE",
+                    address_line1: "1515 EUBANK BLVD. SE",
+                    address_line2: "P.O. BOX 5800, MS-0180, 87185-0180",
+                    address_line3: null,
+                    zip5: null,
+                    foreign_postal_code: null,
+                    foreign_province: "NM",
+                    foreign_city_name: null,
+                    location_country_code: "USA"
+                }
             }
         }
-    }]
+    ]
 };
 
 export const mockReduxAwards = {
-    awards: [{
-        id: 57557,
-        award_id: 'DEAC0494AL85000',
-        recipient_name: 'SANDIA CORP',
-        description: 'MANAGEMENT AND OPERATION OF SANDIA NATIONAL LABORATORIES BY SANDIA CORPORATION, CONTRACT NO. DE-AC04-94AL85000',
-        date_signed: '',
-        period_of_performance_start_date: '11/30/2016',
-        period_of_performance_current_end_date: '4/30/2017',
-        award_type: '',
-        type: 'Definitive Contract',
-        type_description: 'Definitive Contract',
-        awarding_agency_name: 'Department of Energy',
-        awarding_subtier_name: 'Department of Energy',
-        awarding_office_name: '',
-        funding_agency_name: 'Department of Defense',
-        funding_subtier_name: 'Department of the Air Force',
-        funding_office_name: '',
-        recipient_street: '1515 EUBANK BLVD. SEundefinednull',
-        recipient_city: 'ALBUQUERQUE',
-        recipient_state_province: 'IL',
-        recipient_zip_postal: '',
-        recipient_country: 'UNITED STATES',
-        pop_city: '',
-        parent_id: 0,
-        pop_state_province: '',
-        pop_zip: '',
-        pop_country: '',
-        total_obligation: '$88,074,906',
-        base_and_all_options_value: '$0',
-        recipient_duns: '',
-        recipient_parent_duns: '',
-        recipient_business_type: 'Unknown Types',
-        type_of_contract_pricing: '',
-        type_of_contract_pricing_description: '',
-        latest_transaction: '',
-        _jsid: 'award-35'
-    }],
+    awards: [
+        {
+            id: 57557,
+            award_id: 'DEAC0494AL85000',
+            recipient_name: 'SANDIA CORP',
+            description: 'MANAGEMENT AND OPERATION OF SANDIA NATIONAL LABORATORIES BY SANDIA CORPORATION, CONTRACT NO. DE-AC04-94AL85000',
+            date_signed: '',
+            period_of_performance_start_date: '11/30/2016',
+            period_of_performance_current_end_date: '4/30/2017',
+            award_type: '',
+            type: 'Definitive Contract',
+            type_description: 'Definitive Contract',
+            awarding_agency_name: 'Department of Energy',
+            awarding_subtier_name: 'Department of Energy',
+            awarding_office_name: '',
+            funding_agency_name: 'Department of Defense',
+            funding_subtier_name: 'Department of the Air Force',
+            funding_office_name: '',
+            recipient_street: '1515 EUBANK BLVD. SEundefinednull',
+            recipient_city: 'ALBUQUERQUE',
+            recipient_state_province: 'IL',
+            recipient_zip_postal: '',
+            recipient_country: 'UNITED STATES',
+            pop_city: '',
+            parent_id: 0,
+            pop_state_province: '',
+            pop_zip: '',
+            pop_country: '',
+            total_obligation: '$88,074,906',
+            base_and_all_options_value: '$0',
+            recipient_duns: '',
+            recipient_parent_duns: '',
+            recipient_business_type: 'Unknown Types',
+            type_of_contract_pricing: '',
+            type_of_contract_pricing_description: '',
+            latest_transaction: '',
+            _jsid: 'award-35'
+        }
+    ],
     awardsMeta: {
         batch: {
             queryId: '31',
@@ -539,67 +672,69 @@ export const mockTabCount = {
         previous: null
     },
     req: "ab71bbda468",
-    results: [{
-        item: null,
-        aggregate: "0.00",
-        type: null
-    }, {
-        item: "04",
-        aggregate: "0.00",
-        type: "04"
-    }, {
-        item: "05",
-        aggregate: "0.00",
-        type: "05"
-    }, {
-        item: "02",
-        aggregate: "0.00",
-        type: "02"
-    }, {
-        item: "09",
-        aggregate: "0.00",
-        type: "09"
-    }, {
-        item: "C",
-        aggregate: "7751.00",
-        type: "C"
-    }, {
-        item: "D",
-        aggregate: "1682.00",
-        type: "D"
-    }, {
-        item: "03",
-        aggregate: "0.00",
-        type: "03"
-    }, {
-        item: "08",
-        aggregate: "0.00",
-        type: "08"
-    }, {
-        item: "B",
-        aggregate: "6404.00",
-        type: "B"
-    }, {
-        item: "07",
-        aggregate: "0.00",
-        type: "07"
-    }, {
-        item: "06",
-        aggregate: "0.00",
-        type: "06"
-    }, {
-        item: "A",
-        aggregate: "3225.00",
-        type: "A"
-    }, {
-        item: "E",
-        aggregate: "585.00",
-        type: "E"
-    }, {
-        item: "11",
-        aggregate: "0.00",
-        type: "11"
-    }]
+    results: [
+        {
+            item: null,
+            aggregate: "0.00",
+            type: null
+        }, {
+            item: "04",
+            aggregate: "0.00",
+            type: "04"
+        }, {
+            item: "05",
+            aggregate: "0.00",
+            type: "05"
+        }, {
+            item: "02",
+            aggregate: "0.00",
+            type: "02"
+        }, {
+            item: "09",
+            aggregate: "0.00",
+            type: "09"
+        }, {
+            item: "C",
+            aggregate: "7751.00",
+            type: "C"
+        }, {
+            item: "D",
+            aggregate: "1682.00",
+            type: "D"
+        }, {
+            item: "03",
+            aggregate: "0.00",
+            type: "03"
+        }, {
+            item: "08",
+            aggregate: "0.00",
+            type: "08"
+        }, {
+            item: "B",
+            aggregate: "6404.00",
+            type: "B"
+        }, {
+            item: "07",
+            aggregate: "0.00",
+            type: "07"
+        }, {
+            item: "06",
+            aggregate: "0.00",
+            type: "06"
+        }, {
+            item: "A",
+            aggregate: "3225.00",
+            type: "A"
+        }, {
+            item: "E",
+            aggregate: "585.00",
+            type: "E"
+        }, {
+            item: "11",
+            aggregate: "0.00",
+            type: "11"
+        }
+    ]
 };
 
 export const parsedYearYSeries = {


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-541
- Sorts the list of quarters/years before iterating to create bar graphs
- Updates variable names for clarity

Test with staging API: 
- `/#/federal_account/404` by quarter, Other/Unknown Program Activity filters
- `/#/federal_account/388` by quarter, Above 185 of Poverty Program Activity filters
