### PR TITLE
Hotfix: Support subawards in Keyword Search download

### DIFF
--- a/src/js/containers/keyword/KeywordContainer.jsx
+++ b/src/js/containers/keyword/KeywordContainer.jsx
@@ -79,7 +79,7 @@ export class KeywordContainer extends React.Component {
 
     startDownload() {
         const params = {
-            award_levels: ['prime_awards'],
+            award_levels: ['prime_awards', 'sub_awards'],
             filters: {
                 keyword: this.state.keyword
             }

--- a/tests/containers/keyword/KeywordContainer-test.jsx
+++ b/tests/containers/keyword/KeywordContainer-test.jsx
@@ -101,7 +101,7 @@ describe('KeywordContainer', () => {
             container.instance().requestDownload = requestDownload;
 
             const expectedParams = {
-                award_levels: ['prime_awards'],
+                award_levels: ['prime_awards', 'sub_awards'],
                 filters: {
                     keyword: 'test'
                 }


### PR DESCRIPTION
* Adds `sub_awards` parameter to the Keyword Search page download API request