### PR TITLE
Fix Custom Award Data Date Range

### DIFF
--- a/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
+++ b/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
@@ -95,6 +95,11 @@ export const awardDownloadOptions = {
                 label: 'last 30 days',
                 startDate: moment().subtract(30, 'day').format('YYYY-MM-DD'),
                 endDate: moment().format('YYYY-MM-DD')
+            },
+            {
+                label: 'last 60 days',
+                startDate: moment().subtract(60, 'day').format('YYYY-MM-DD'),
+                endDate: moment().format('YYYY-MM-DD')
             }
         ],
         column4: [

--- a/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
+++ b/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
@@ -77,11 +77,6 @@ export const awardDownloadOptions = {
     dateRangeButtons: {
         column3: [
             {
-                label: 'today',
-                startDate: moment().format('YYYY-MM-DD'),
-                endDate: moment().format('YYYY-MM-DD')
-            },
-            {
                 label: 'yesterday',
                 startDate: moment().subtract(1, 'day').format('YYYY-MM-DD'),
                 endDate: moment().subtract(1, 'day').format('YYYY-MM-DD')


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-802

- Removed _today_ from the list of predefined data ranges on the Custom Award Data page.