### PR TITLE
Hotfix: Add link to raw files on About page

### DIFF
--- a/src/js/components/about/DataQuality.jsx
+++ b/src/js/components/about/DataQuality.jsx
@@ -62,7 +62,14 @@ export default class DataQuality extends React.Component {
                         Data System (FPDS). If there are any discrepancies in procurement data, FPDS
                         is the authoritative source. In addition, the federal agencies&apos;
                         raw quarterly submission files, including Quarterly Assurance Statements
-                        about the data, are available here.
+                        about the data, are&nbsp;
+                        <a
+                            target="_blank"
+                            href="http://usaspending-submissions.s3-website-us-gov-west-1.amazonaws.com/"
+                            rel="noopener noreferrer"
+                            aria-label="Raw quarterly submission files">
+                            available here
+                        </a>.
                     </p>
                     <p>
                         Additionally, the Inspector General of each agency must issue reports to


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-933

* Adds a link to the raw agency submissions on the About page