### PR TITLE
Hotfix: Keyword download

### DIFF
--- a/src/js/containers/keyword/KeywordContainer.jsx
+++ b/src/js/containers/keyword/KeywordContainer.jsx
@@ -85,15 +85,15 @@ export class KeywordContainer extends React.Component {
             }
         };
 
-        this.requestDownload(params, 'awards');
+        this.requestDownload(params);
     }
 
-    requestDownload(params, type) {
+    requestDownload(params) {
         if (this.downloadRequest) {
             this.downloadRequest.cancel();
         }
 
-        this.downloadRequest = BulkDownloadHelper.requestBulkDownload(params, type);
+        this.downloadRequest = BulkDownloadHelper.requestAwardsDownload(params);
 
         this.downloadRequest.promise
             .then((res) => {

--- a/tests/containers/bulkDownload/mockBulkDownloadHelper.js
+++ b/tests/containers/bulkDownload/mockBulkDownloadHelper.js
@@ -15,7 +15,7 @@ export const requestAgenciesList = () => ({
     cancel: jest.fn()
 });
 
-export const requestBulkDownload = () => ({
+export const requestAwardsDownload = () => ({
     promise: new Promise((resolve) => {
         process.nextTick(() => {
             resolve({

--- a/tests/containers/keyword/KeywordContainer-test.jsx
+++ b/tests/containers/keyword/KeywordContainer-test.jsx
@@ -109,7 +109,7 @@ describe('KeywordContainer', () => {
 
             container.instance().startDownload();
 
-            expect(requestDownload).toHaveBeenCalledWith(expectedParams, "awards");
+            expect(requestDownload).toHaveBeenCalledWith(expectedParams);
         });
     });
 


### PR DESCRIPTION
* Updates KeywordContainer to use the correct bulkDownloadHelper function resulting from a helper function refactor

- [x] Requires an API hotfix to remediate `keyword` contract violation in `v2/bulk_download/awards/`