### PR TITLE
Feature Custom Accounts Grouping

### DIFF
--- a/api_contracts/contracts/downloads/CustomAccountDownload.md
+++ b/api_contracts/contracts/downloads/CustomAccountDownload.md
@@ -1,0 +1,64 @@
+FORMAT: 1A
+HOST: https://api.usaspending.gov
+
+# Custom Account Download
+
+These endpoints are used to power USAspending.gov's custom download pages. This data can be used to create account data files. 
+
+# Custom Account Page
+
+These endpoints generate files using the filters on the custom account.
+
+## Custom Account Data [/api/v2/download/accounts/]
+
+This endpoint returns the generated file's metadata.
+
+### Custom Account Data [POST]
+
++ Request (application/json)
+    + Attributes (object)
+        + account_level: `treasury_account` (required, enum[string])
+            The account level is used to filter for a specific type of file.
+            + Members
+                + treasury_account
+                + federal_account
+        + file_format: `csv` (optional, string)
+            The file format that should be returned. 
+            + Default: `csv`
+        + filters: (required, FilterObject)
+            The filters used to filter the data
+
++ Response 200 (application/json)
+    + Attributes
+        + results (array[CustomDataResult], fixed-type)
+
+# Data Structures
+
+## CustomDataResult (object)
++ total_size: 35.055 (required, number)
+    The total size of the file being returned
++ file_name: `012_account_balances_20180613140845.zip` (required, string)
++ total_rows: 652 (required, number)
++ total_columns: 27 (required, number)
++ url: `S3/path_to/bucket/012_account_balances_20180613140845.zip` (required, string)
+    Where the file lives in S3
++ message (optional, nullable)
++ status: `finished` (required, string)
++ seconds_elapsed `10.061132` (required, string)
+    
+## FilterObject (object)
++ agency: `all` (optional, string)
+    The agency to filter by
+    + Default: `all`
+    submission_type: `award_financial` (required, enum[string])
+    + Members
+        + account_balances
+        + object_class_program_activity
+        + award_financial
++ fy: `2017` (required, string)
+    The fiscal year to filter by in the format `YYYY`
++ quarter: 1 (required, enum[string])
+    + `1`
+    + `2`
+    + `3`
+    + `4`

--- a/api_contracts/contracts/downloads/CustomAccountDownload.md
+++ b/api_contracts/contracts/downloads/CustomAccountDownload.md
@@ -23,7 +23,7 @@ This endpoint returns the generated file's metadata.
                 + treasury_account
                 + federal_account
         + file_format: `csv` (optional, string)
-            The file format that should be returned. 
+        /    The file format that should be returned. 
             + Default: `csv`
         + filters: (required, FilterObject)
             The filters used to filter the data
@@ -50,7 +50,7 @@ This endpoint returns the generated file's metadata.
 + agency: `all` (optional, string)
     The agency to filter by
     + Default: `all`
-    submission_type: `award_financial` (required, enum[string])
+    + submission_type: `award_financial` (required, enum[string])
     + Members
         + account_balances
         + object_class_program_activity

--- a/api_contracts/contracts/downloads/CustomAccountDownload.md
+++ b/api_contracts/contracts/downloads/CustomAccountDownload.md
@@ -23,7 +23,7 @@ This endpoint returns the generated file's metadata.
                 + treasury_account
                 + federal_account
         + file_format: `csv` (optional, string)
-        /    The file format that should be returned. 
+            The file format that should be returned. 
             + Default: `csv`
         + filters: (required, FilterObject)
             The filters used to filter the data
@@ -43,21 +43,26 @@ This endpoint returns the generated file's metadata.
 + url: `S3/path_to/bucket/012_account_balances_20180613140845.zip` (required, string)
     Where the file lives in S3
 + message (optional, nullable)
-+ status: `finished` (required, string)
++ status: `finished` (required, enum[string])
+    + Members
+        + ready
+        + running
+        + finished
+        + failed
 + seconds_elapsed `10.061132` (required, string)
     
 ## FilterObject (object)
 + agency: `all` (optional, string)
     The agency to filter by
     + Default: `all`
-    + submission_type: `award_financial` (required, enum[string])
++ submission_type: `award_financial` (required, enum[string])
     + Members
         + account_balances
         + object_class_program_activity
         + award_financial
 + fy: `2017` (required, string)
     The fiscal year to filter by in the format `YYYY`
-+ quarter: 1 (required, enum[string])
++ quarter: `1` (required, enum[string])
     + `1`
     + `2`
     + `3`

--- a/src/js/components/bulkDownload/accounts/AccountDataContent.jsx
+++ b/src/js/components/bulkDownload/accounts/AccountDataContent.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import { accountDownloadOptions } from 'dataMapping/bulkDownload/bulkDownloadOptions';
 import { Glossary } from 'components/sharedComponents/icons/Icons';
 
+import AccountLevelFilter from './filters/AccountLevelFilter';
 import AgencyFilter from './filters/AgencyFilter';
 import SubmissionTypeFilter from './filters/SubmissionTypeFilter';
 import FiscalYearFilter from './filters/FiscalYearFilter';
@@ -75,6 +76,11 @@ export default class AccountDataContent extends React.Component {
                     <form
                         className="download-center-form"
                         onSubmit={this.handleSubmit}>
+                        <AccountLevelFilter
+                            accountLevels={accountDownloadOptions.accountLevels}
+                            currentAccountLevel={accounts.accountLevel}
+                            updateFilter={this.props.updateFilter}
+                            valid={accounts.accountLevel !== ''} />
                         <AgencyFilter
                             agencies={this.props.agencies}
                             currentAgency={accounts.agency}

--- a/src/js/components/bulkDownload/accounts/UserSelections.jsx
+++ b/src/js/components/bulkDownload/accounts/UserSelections.jsx
@@ -84,7 +84,7 @@ export default class UserSelections extends React.Component {
                     <div className="selection">
                         <div className="selection__heading">Account Level</div>
                         <div className="selection__content">
-                            Treasury Account
+                            {this.generateAccountLevelString()}
                         </div>
                     </div>
                     <div className="selection">

--- a/src/js/components/bulkDownload/accounts/filters/AccountLevelFilter.jsx
+++ b/src/js/components/bulkDownload/accounts/filters/AccountLevelFilter.jsx
@@ -62,7 +62,7 @@ export default class AccountLevelFilter extends React.Component {
         return (
             <div className="download-filter">
                 <h3 className="download-filter__title">
-                    {icon} Select the <span className="download-center-filter__title_em">account level</span> to include.
+                    {icon} Select the <span className="download-filter__title_em">account level</span> to include.
                 </h3>
                 <div className="download-filter__content">
                     {accountLevels}

--- a/src/js/components/bulkDownload/accounts/filters/AccountLevelFilter.jsx
+++ b/src/js/components/bulkDownload/accounts/filters/AccountLevelFilter.jsx
@@ -54,7 +54,7 @@ export default class AccountLevelFilter extends React.Component {
                 <label
                     className="radio-label"
                     htmlFor="account-level">
-                    {level.label} <span className="radio-label__subtext"> {level.account}</span>
+                    {level.label} <span className="radio-label__subtext"> {level.description}</span>
                 </label>
             </div>
         ));

--- a/src/js/components/bulkDownload/accounts/filters/AccountLevelFilter.jsx
+++ b/src/js/components/bulkDownload/accounts/filters/AccountLevelFilter.jsx
@@ -50,12 +50,11 @@ export default class AccountLevelFilter extends React.Component {
                     value={level.name}
                     name="account-level"
                     checked={this.props.currentAccountLevel === level.name}
-                    onChange={this.onChange}
-                    disabled={level.disabled} />
+                    onChange={this.onChange} />
                 <label
-                    className={`radio-label ${level.disabled ? 'disabled' : ''}`}
+                    className="radio-label"
                     htmlFor="account-level">
-                    {level.label}
+                    {level.label} <span className="radio-label__subtext"> {level.account}</span>
                 </label>
             </div>
         ));

--- a/src/js/components/bulkDownload/accounts/filters/SubmissionTypeFilter.jsx
+++ b/src/js/components/bulkDownload/accounts/filters/SubmissionTypeFilter.jsx
@@ -54,7 +54,7 @@ export default class SubmissionTypeFilter extends React.Component {
                 <label
                     className="radio-label"
                     htmlFor="submission-type">
-                    {type.label}<span className="radio-label__subtext"> {type.file}</span>
+                    {type.label}
                 </label>
             </div>
         ));

--- a/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
+++ b/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
@@ -136,6 +136,11 @@ export class BulkDownloadPageContainer extends React.Component {
     startAccountDownload() {
         const formState = this.props.bulkDownload.accounts;
 
+        const accountLevels = accountDownloadOptions.accountLevels;
+        const accountLevel = accountLevels.find((account) =>
+            account.name === formState.accountLevel
+        );
+
         // Get the submission type object
         const submissionTypes = accountDownloadOptions.submissionTypes;
         const submissionType = submissionTypes.find((type) =>
@@ -143,7 +148,7 @@ export class BulkDownloadPageContainer extends React.Component {
         );
 
         const params = {
-            account_level: 'treasury_account',
+            account_level: accountLevel.apiName,
             filters: {
                 agency: formState.agency.id,
                 submission_type: submissionType.apiName,

--- a/src/js/containers/bulkDownload/accounts/AccountDataContainer.jsx
+++ b/src/js/containers/bulkDownload/accounts/AccountDataContainer.jsx
@@ -59,6 +59,7 @@ export class AccountDataContainer extends React.Component {
 
         this.agencyListRequest.promise
             .then((res) => {
+                console.log(res.data.agencies);
                 const cfoAgencies = res.data.agencies.cfo_agencies;
                 const otherAgencies = res.data.agencies.other_agencies;
                 this.setState({

--- a/src/js/containers/bulkDownload/accounts/AccountDataContainer.jsx
+++ b/src/js/containers/bulkDownload/accounts/AccountDataContainer.jsx
@@ -59,7 +59,6 @@ export class AccountDataContainer extends React.Component {
 
         this.agencyListRequest.promise
             .then((res) => {
-                console.log(res.data.agencies);
                 const cfoAgencies = res.data.agencies.cfo_agencies;
                 const otherAgencies = res.data.agencies.other_agencies;
                 this.setState({

--- a/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
+++ b/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
@@ -138,13 +138,13 @@ export const accountDownloadOptions = {
             name: 'federalAccount',
             label: 'Federal Account',
             apiName: 'federal_account',
-            disabled: true
+            account: 'Aggregate of Treasury Accounts'
         },
         {
             name: 'treasuryAccount',
             label: 'Treasury Account',
             apiName: 'treasury_account',
-            disabled: false
+            account: 'Includes Period of Availability'
         }
     ],
     submissionTypes: [

--- a/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
+++ b/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
@@ -159,6 +159,12 @@ export const accountDownloadOptions = {
             label: 'Account Breakdown by Program Activity & Object Class',
             apiName: 'object_class_program_activity',
             file: 'File B'
+        },
+        {
+            name: 'accountBreakdownByAward',
+            label: 'Account Breakdown by Award',
+            apiName: 'object_class_program_activity',
+            file: 'File C'
         }
     ],
     fileFormats: [

--- a/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
+++ b/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
@@ -163,7 +163,7 @@ export const accountDownloadOptions = {
         {
             name: 'accountBreakdownByAward',
             label: 'Account Breakdown by Award',
-            apiName: 'object_class_program_activity',
+            apiName: 'award_financial',
             file: 'File C'
         }
     ],

--- a/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
+++ b/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
@@ -138,13 +138,13 @@ export const accountDownloadOptions = {
             name: 'federalAccount',
             label: 'Federal Account',
             apiName: 'federal_account',
-            account: 'Aggregate of Treasury Accounts'
+            description: 'Aggregate of Treasury Accounts'
         },
         {
             name: 'treasuryAccount',
             label: 'Treasury Account',
             apiName: 'treasury_account',
-            account: 'Includes Period of Availability'
+            description: 'Includes Period of Availability'
         }
     ],
     submissionTypes: [

--- a/src/js/dataMapping/navigation/menuOptions.js
+++ b/src/js/dataMapping/navigation/menuOptions.js
@@ -72,7 +72,7 @@ export const downloadOptions = [
         description: 'The best way to grab detailed subsets of account data, which offer a broad view of how the government allocates funding from top to bottom.',
         callToAction: 'Download Account Data',
         newTab: false,
-        enabled: false,
+        enabled: true,
         externalLink: false
     },
     {

--- a/src/js/redux/reducers/bulkDownload/bulkDownloadReducer.js
+++ b/src/js/redux/reducers/bulkDownload/bulkDownloadReducer.js
@@ -49,7 +49,7 @@ export const initialState = {
         fileFormat: 'csv'
     },
     accounts: {
-        accountLevel: 'treasuryAccount',
+        accountLevel: 'federalAccount',
         agency: {
             id: '',
             name: 'Select an Agency'


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-1059, https://federal-spending-transparency.atlassian.net/browse/DEV-1156

- Implemented the option to group by File C
- Implemented the option to group by Federal accounts
- Created API contract for Custom Accounts

- [x] Code Review

- [x] Design Review

- [x] fedspendingtransparency/usaspending-api#1291 merged