### PR TITLE
Fix Spending Explorer Rewind Feature

### DIFF
--- a/src/js/containers/explorer/detail/DetailContentContainer.jsx
+++ b/src/js/containers/explorer/detail/DetailContentContainer.jsx
@@ -405,14 +405,15 @@ export class DetailContentContainer extends React.Component {
             this.setState({
                 transitionSteps: steps
             }, () => {
-                this.prepareRootRequest(this.props.explorer.root, this.props.explorer.fy);
+                this.prepareRootRequest(this.props.explorer.root, this.props.explorer.fy, this.props.explorer.quarter);
             });
             return;
         }
 
         // iterate through the trail to rebuild the filter set
         const newFilters = {
-            fy: this.props.explorer.fy
+            fy: this.props.explorer.fy,
+            quarter: this.props.explorer.quarter
         };
         const newTrail = [];
         // iterate through the trail and include only those filters up to the point we are rewinding

--- a/tests/containers/explorer/detail/DetailContentContainer-test.jsx
+++ b/tests/containers/explorer/detail/DetailContentContainer-test.jsx
@@ -340,6 +340,7 @@ describe('DetailContentContainer', () => {
             container.instance().rewindToFilter(0);
 
             expect(mockPrepareRoot).toHaveBeenCalledTimes(1);
+            expect(mockPrepareRoot).toHaveBeenCalledWith("agency", "1984", "2");
         });
         it ('should overwrite the explorer trail and update the transition steps', () => {
             const container = mount(<DetailContentContainer

--- a/tests/containers/explorer/detail/mockData.js
+++ b/tests/containers/explorer/detail/mockData.js
@@ -103,6 +103,7 @@ export const mockLevelData = {
 export const mockDeeperRoot = {
     root: 'agency',
     fy: '1984',
+    quarter: "2",
     active: new ActiveScreen({
         within: 'federal_account',
         subdivision: 'award',


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-1172

- Fixed the rewind feature to use the currently selected quarter and added in a test to reflect that.

- [x] Code Review