### PR TITLE
Close advanced search when complete

### DIFF
--- a/src/js/components/search/modals/fullDownload/FullDownloadModal.jsx
+++ b/src/js/components/search/modals/fullDownload/FullDownloadModal.jsx
@@ -39,8 +39,8 @@ export default class FullDownloadModal extends React.Component {
         this.hideModal = this.hideModal.bind(this);
     }
 
-    componentDidUpdate(nextProps) {
-        if (this.props.pendingDownload && !nextProps.pendingDownload) {
+    componentDidUpdate(prevProps) {
+        if (this.props.pendingDownload && !prevProps.pendingDownload) {
             // we went from there being a download to there not being a download
             // this likely means the download finished (or failed), so the user can start a new
             // download request after closing the modal.

--- a/src/js/components/search/modals/fullDownload/FullDownloadModal.jsx
+++ b/src/js/components/search/modals/fullDownload/FullDownloadModal.jsx
@@ -43,7 +43,8 @@ export default class FullDownloadModal extends React.Component {
         if (this.props.pendingDownload && !nextProps.pendingDownload) {
             // we went from there being a download to there not being a download
             // this likely means the download finished (or failed), so the user can start a new
-            // download request
+            // download request after closing the modal.
+            this.hideModal();
             this.resetModal();
         }
     }

--- a/src/js/components/search/modals/fullDownload/FullDownloadModal.jsx
+++ b/src/js/components/search/modals/fullDownload/FullDownloadModal.jsx
@@ -39,19 +39,19 @@ export default class FullDownloadModal extends React.Component {
         this.hideModal = this.hideModal.bind(this);
     }
 
-    componentWillReceiveProps(nextProps) {
+    componentDidUpdate(nextProps) {
         if (this.props.pendingDownload && !nextProps.pendingDownload) {
             // we went from there being a download to there not being a download
             // this likely means the download finished (or failed), so the user can start a new
             // download request after closing the modal.
-            this.hideModal();
             this.resetModal();
         }
     }
-
     resetModal() {
         this.setState({
             downloadStep: 1
+        }, () => {
+            this.props.hideModal();
         });
     }
 

--- a/src/js/components/search/modals/fullDownload/FullDownloadModal.jsx
+++ b/src/js/components/search/modals/fullDownload/FullDownloadModal.jsx
@@ -40,7 +40,7 @@ export default class FullDownloadModal extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (this.props.pendingDownload && !prevProps.pendingDownload) {
+        if (!this.props.pendingDownload && prevProps.pendingDownload) {
             // we went from there being a download to there not being a download
             // this likely means the download finished (or failed), so the user can start a new
             // download request after closing the modal.


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-1139
- Modal is now properly hidden after downloading results from advanced search
- Modal also resets when reopened to allow the user to request a new download