### PR TITLE
Update Description for Archive and Delta Files with newer language

### DIFF
--- a/src/js/components/bulkDownload/archive/AwardDataArchiveContent.jsx
+++ b/src/js/components/bulkDownload/archive/AwardDataArchiveContent.jsx
@@ -29,7 +29,7 @@ export default class AwardDataArchiveContent extends React.Component {
                     are already prepared &mdash; you can access them instantaneously.
                 </p>
                 <p>
-                    New files are uploaded by the 15th of each month. Check the Date As Of column for the end date of data in the file. If an agency&apos;s data hasn&apos;t changed since the previous month, no new file will be added. <b>Full files</b> feature aggregate data (data for the fiscal year up until the date listed), and <b>delta files</b> feature only new, modified and deleted data from the past 1 month.
+                    New files are uploaded by the 15th of each month. Check the Data As Of column to see the last time files were generated. <b>Full files</b> feature data for the fiscal year up until the date the file was prepared, and <b>delta files</b> feature only new, modified, and deleted data since the date the last month&apos;s files were generated. The `correction_delete_ind` column in the delta files indicates whether a record has been modified (C), deleted (D), or added (blank).
                 </p>
                 <p>
                     Ready to grab your data? Complete the form below.

--- a/src/js/containers/bulkDownload/archive/AwardDataArchiveContainer.jsx
+++ b/src/js/containers/bulkDownload/archive/AwardDataArchiveContainer.jsx
@@ -26,7 +26,7 @@ const columns = [
     },
     {
         columnName: 'date',
-        displayName: 'Date As Of'
+        displayName: 'Data As Of'
     }
 ];
 
@@ -153,7 +153,8 @@ export default class AwardDataArchiveContainer extends React.Component {
             let formattedFY;
             if (item.fiscal_year === null) {
                 formattedFY = 'N/A';
-            } else {
+            }
+            else {
                 formattedFY = `FY ${item.fiscal_year}`;
             }
 
@@ -184,4 +185,3 @@ export default class AwardDataArchiveContainer extends React.Component {
         );
     }
 }
-


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-1238
- Updated "Award Data Archive" second paragraph of the description with newer langauge
- As per newer language, updated the title of the last column in the table to "Data as of" instead of "Date as of"