### PR TITLE
Updated link for "Federal Government Procurement Data Quality Summary" as per hotfix request

### DIFF
--- a/src/js/components/about/DataQuality.jsx
+++ b/src/js/components/about/DataQuality.jsx
@@ -55,7 +55,7 @@ export default class DataQuality extends React.Component {
                         <a
                             target="_blank"
                             rel="noopener noreferrer"
-                            href="/data/Federal%20Government%20Data%20Quality%20Summary%20FY2011-2016.pdf">
+                            href="https://sam.gov/sam/transcript/FY2012-2017_govt-wide_procurement_data_quality_summary.pdf">
                             Federal Government Procurement Data Quality Summary
                         </a>
                         &nbsp;about data submitted by the agencies to the Federal Procurement


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-1290

- Updates link for "Federal Government Procurement Data Quality Summary" to latest link.