### PR TITLE
Update recipient no location data

### DIFF
--- a/src/js/components/recipient/RecipientOverview.jsx
+++ b/src/js/components/recipient/RecipientOverview.jsx
@@ -72,6 +72,21 @@ export default class RecipientOverview extends React.Component {
             );
         }
 
+        // Format business types
+        let businessTypes = (
+            <td>
+                Not provided in source system
+            </td>
+        );
+        if (recipient.businessTypes.length > 0) {
+            businessTypes = (
+                <td>
+                    {recipient.businessTypes.map((type, i) =>
+                        <div key={i}>{type}</div>)}
+                </td>
+            );
+        }
+
         return (
             <div
                 id="recipient-overview"
@@ -114,10 +129,7 @@ export default class RecipientOverview extends React.Component {
                                     </tr>
                                     <tr>
                                         <th>Business Types</th>
-                                        <td>
-                                            {recipient.businessTypes.map((type, i) =>
-                                                <div key={i}>{type}</div>)}
-                                        </td>
+                                        {businessTypes}
                                     </tr>
                                 </tbody>
                             </table>

--- a/src/js/components/recipient/RecipientOverview.jsx
+++ b/src/js/components/recipient/RecipientOverview.jsx
@@ -57,6 +57,21 @@ export default class RecipientOverview extends React.Component {
                 </button>
             );
         }
+
+        // Format the location data
+        let address = (
+            <td>Address not provided in source system</td>
+        );
+        if (recipient.location.streetAddress || recipient.location.regionalAddress || recipient.location.fullCongressionalDistrict) {
+            address = (
+                <td>
+                    <div>{recipient.location.streetAddress}</div>
+                    <div>{recipient.location.regionalAddress}</div>
+                    <div>{recipient.location.fullCongressionalDistrict}</div>
+                </td>
+            );
+        }
+
         return (
             <div
                 id="recipient-overview"
@@ -95,11 +110,7 @@ export default class RecipientOverview extends React.Component {
                                     </tr>
                                     <tr>
                                         <th>Address</th>
-                                        <td>
-                                            <div>{recipient.location.streetAddress}</div>
-                                            <div>{recipient.location.regionalAddress}</div>
-                                            <div>Congressional District: {recipient.location.congressionalDistrict}</div>
-                                        </td>
+                                        {address}
                                     </tr>
                                     <tr>
                                         <th>Business Types</th>

--- a/src/js/models/v2/CoreLocation.js
+++ b/src/js/models/v2/CoreLocation.js
@@ -49,6 +49,9 @@ const CoreLocation = {
         }
         return '';
     },
+    get fullCongressionalDistrict() {
+        return this.congressionalDistrict && `\nCongressional District: ${this.congressionalDistrict}`;
+    },
     get stateProvince() {
         if (this._city && this._stateCode) {
             return this._stateCode;
@@ -64,7 +67,7 @@ const CoreLocation = {
     get fullAddress() {
         const line1 = (this.streetAddress && `${this.streetAddress}`) || '';
         const line2 = (this.regionalAddress && `${this.regionalAddress}`) || '';
-        const line3 = (this.congressionalDistrict && `\nCongressional District: ${this.congressionalDistrict}`) || '';
+        const line3 = this.fullCongressionalDistrict;
         return `${line1}${line2}${line3}` || '--';
     }
 };

--- a/tests/models/CoreLocation-test.js
+++ b/tests/models/CoreLocation-test.js
@@ -52,7 +52,7 @@ describe('Core Location getter functions', () => {
         expect(location.congressionalDistrict).toEqual('IN-04');
     });
     it('should format the congressional district with a prefix', () => {
-       expect(location.fullCongressionalDistrict).toEqual('Congressional District: IN-04');
+       expect(location.fullCongressionalDistrict).toEqual('\nCongressional District: IN-04');
     });
     it('should use province as the state/province when state is not available', () => {
         expect(foreignLocation.stateProvince).toEqual('Quebec');

--- a/tests/models/CoreLocation-test.js
+++ b/tests/models/CoreLocation-test.js
@@ -51,6 +51,9 @@ describe('Core Location getter functions', () => {
     it('should format the congressional district', () => {
         expect(location.congressionalDistrict).toEqual('IN-04');
     });
+    it('should format the congressional district with a prefix', () => {
+       expect(location.fullCongressionalDistrict).toEqual('Congressional District: IN-04');
+    });
     it('should use province as the state/province when state is not available', () => {
         expect(foreignLocation.stateProvince).toEqual('Quebec');
     });
@@ -111,6 +114,7 @@ describe('Core Location getter functions', () => {
         partialLocation.populateCore(missingData);
 
         expect(partialLocation.congressionalDistrict).toEqual('');
+        expect(partialLocation.fullCongressionalDistrict).toEqual('');
         expect(partialLocation.fullAddress).toEqual('602 Trumball Street\nApt 2\nPawnee, IN 12345');
     });
 });


### PR DESCRIPTION
- Fixes a bug causing just `Congressional District:` to display when there was no location data
- Shows `Address not provided in source system` when no location data is available 
- Shows `Not provided in source system` when there are no business types