### PR TITLE
Update hide trendline

### DIFF
--- a/src/js/components/recipient/spendingOverTime/RecipientTimeVisualizationSection.jsx
+++ b/src/js/components/recipient/spendingOverTime/RecipientTimeVisualizationSection.jsx
@@ -9,7 +9,7 @@ import { throttle } from 'lodash';
 
 import TimeVisualizationPeriodButton from 'components/search/visualizations/time/TimeVisualizationPeriodButton';
 
-import RecipientTimeVisualization from './RecipientTimeVisualization';
+import StateTimeVisualization from "components/state/spendingovertime/StateTimeVisualization";
 
 const propTypes = {
     data: PropTypes.object,
@@ -97,7 +97,7 @@ export default class RecipientTimeVisualizationSection extends React.Component {
                     </div>
                 </div>
 
-                <RecipientTimeVisualization
+                <StateTimeVisualization
                     visualizationPeriod={this.props.visualizationPeriod}
                     loading={this.props.loading}
                     error={this.props.error}

--- a/src/js/components/recipient/spendingOverTime/RecipientTimeVisualizationSection.jsx
+++ b/src/js/components/recipient/spendingOverTime/RecipientTimeVisualizationSection.jsx
@@ -102,7 +102,8 @@ export default class RecipientTimeVisualizationSection extends React.Component {
                     loading={this.props.loading}
                     error={this.props.error}
                     data={this.props.data}
-                    width={this.state.visualizationWidth} />
+                    width={this.state.visualizationWidth}
+                    color="#141D3B" />
             </section>
         );
     }

--- a/src/js/components/recipient/spendingOverTime/RecipientTimeVisualizationSection.jsx
+++ b/src/js/components/recipient/spendingOverTime/RecipientTimeVisualizationSection.jsx
@@ -8,8 +8,7 @@ import PropTypes from 'prop-types';
 import { throttle } from 'lodash';
 
 import TimeVisualizationPeriodButton from 'components/search/visualizations/time/TimeVisualizationPeriodButton';
-
-import StateTimeVisualization from "components/state/spendingovertime/StateTimeVisualization";
+import StateTimeVisualization from 'components/state/spendingovertime/StateTimeVisualization';
 
 const propTypes = {
     data: PropTypes.object,

--- a/src/js/components/search/visualizations/time/chart/BarXAxis.jsx
+++ b/src/js/components/search/visualizations/time/chart/BarXAxis.jsx
@@ -96,7 +96,7 @@ export default class BarXAxis extends React.Component {
     }
 
     // Finds the position of the label, under bar for years or
-    // average start and end for monthly/quartlery
+    // average start and end for monthly/quarterly
     calculateXPos(item, index, labelOffset, props) {
         if (props.visualizationPeriod === 'fiscal_year') {
             return props.scale(item.year) + (props.scale.bandwidth() / 2);

--- a/src/js/components/state/spendingovertime/StateTimeVisualization.jsx
+++ b/src/js/components/state/spendingovertime/StateTimeVisualization.jsx
@@ -87,8 +87,7 @@ export default class StateTimeVisualization extends React.Component {
                 rawLabels={this.props.data.rawLabels}
                 legend={legend}
                 showTooltip={this.showTooltip}
-                visualizationPeriod={this.props.visualizationPeriod}
-                activeLabel={this.state.tooltipData} />);
+                visualizationPeriod={this.props.visualizationPeriod} />);
         }
 
         let tooltip = null;

--- a/src/js/components/state/spendingovertime/StateTimeVisualization.jsx
+++ b/src/js/components/state/spendingovertime/StateTimeVisualization.jsx
@@ -34,7 +34,8 @@ const propTypes = {
     height: PropTypes.number,
     data: PropTypes.object,
     loading: PropTypes.bool,
-    visualizationPeriod: PropTypes.string
+    visualizationPeriod: PropTypes.string,
+    color: PropTypes.string
 };
 /* eslint-enable react/no-unused-prop-types */
 
@@ -67,7 +68,7 @@ export default class StateTimeVisualization extends React.Component {
 
         const legend = [
             {
-                color: '#708893',
+                color: this.props.color,
                 label: 'Awarded Amount',
                 offset: 0
             }];

--- a/src/js/components/state/spendingovertime/StateTimeVisualizationSection.jsx
+++ b/src/js/components/state/spendingovertime/StateTimeVisualizationSection.jsx
@@ -100,7 +100,8 @@ export default class StateTimeVisualizationSection extends React.Component {
                     visualizationPeriod={this.props.visualizationPeriod}
                     loading={this.props.loading}
                     data={this.props.data}
-                    width={this.state.visualizationWidth} />
+                    width={this.state.visualizationWidth}
+                    color="#708893" />
             </section>
         );
     }


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-1399

- Hides the trendline + its axis & label by re-using state profile's time visualization component
    - Keeps the x-axis labels static on hover per Recipient Profile design review
    - Adds a prop for the color of the bars (can be removed later)