### PR TITLE
Temporarily disabling glossary link on parent recipient label

### DIFF
--- a/src/js/components/recipient/RecipientOverview.jsx
+++ b/src/js/components/recipient/RecipientOverview.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { CaretRight, Glossary } from 'components/sharedComponents/icons/Icons';
+import { CaretRight } from 'components/sharedComponents/icons/Icons';
 
 const propTypes = {
     recipient: PropTypes.object,
@@ -45,7 +45,7 @@ export default class RecipientOverview extends React.Component {
             label = (
                 <span
                     className="recipient-overview__label recipient-overview__label_parent">
-                    Parent Recipient <Glossary />
+                    Parent Recipient
                 </span>
             );
             viewChildren = (

--- a/src/js/components/recipient/RecipientOverview.jsx
+++ b/src/js/components/recipient/RecipientOverview.jsx
@@ -44,7 +44,6 @@ export default class RecipientOverview extends React.Component {
             // This is a parent recipient
             label = (
                 <a
-                    href={`#/recipient/${this.props.recipient.id}/?glossary=parent-duns`}
                     className="recipient-overview__label recipient-overview__label_parent">
                     Parent Recipient <Glossary />
                 </a>

--- a/src/js/components/recipient/RecipientOverview.jsx
+++ b/src/js/components/recipient/RecipientOverview.jsx
@@ -43,10 +43,10 @@ export default class RecipientOverview extends React.Component {
         else if (recipient.level === 'P') {
             // This is a parent recipient
             label = (
-                <a
+                <span
                     className="recipient-overview__label recipient-overview__label_parent">
                     Parent Recipient <Glossary />
-                </a>
+                </span>
             );
             viewChildren = (
                 <button


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-1479
Temporarily disabling parent recipient glossary link as per service desk request