### PR TITLE
Hotfix sub-award recipient name

### DIFF
--- a/src/js/models/v2/awards/subawards/BaseSubawardRow.js
+++ b/src/js/models/v2/awards/subawards/BaseSubawardRow.js
@@ -18,7 +18,7 @@ const BaseSubawardRow = {
             (data.action_date && parseDate(data.action_date)) || null
         );
         this._amount = parseFloat(data.amount) || 0;
-        this.recipient = (data.recipient && data.recipient.recipient_name) || '';
+        this.recipient = (data.recipient_name) || '';
     },
     get actionDate() {
         if (this._actionDate) {

--- a/tests/models/awards/BaseSubawardRow-test.js
+++ b/tests/models/awards/BaseSubawardRow-test.js
@@ -11,9 +11,7 @@ const mockSubaward = {
     description: null,
     action_date: '1987-01-02',
     amount: '2023.67',
-    recipient: {
-        recipient_name: 'Mock Recipient Name'
-    }
+    recipient_name: 'Mock Recipient Name'
 };
 
 const subawardRow = Object.create(BaseSubawardRow);


### PR DESCRIPTION
Changes the Award Summary Sub-award table Recipient column to display the top-level API field `recipient_name` instead of nested `recipient__recipient_name`

• [ ] Frontend code review
• [ ] Merge concurrently with backend updates (@tony-sappe)