### PR TITLE
Move FEMA's toptier entry to the end of the autocomplete list

### DIFF
--- a/src/js/containers/search/filters/AgencyListContainer.jsx
+++ b/src/js/containers/search/filters/AgencyListContainer.jsx
@@ -91,6 +91,16 @@ export default class AgencyListContainer extends React.Component {
         toptierAgencies = sortBy(toptierAgencies, 'title');
         subtierAgencies = sortBy(subtierAgencies, 'title');
 
+        // FEMA is no longer a toptier agency, so we want its subtier entries to come first
+        const fema = toptierAgencies.find((agency) => agency.title === 'Federal Emergency Management Agency (FEMA)');
+
+        if (fema) {
+            // remove FEMA from toptier agencies
+            toptierAgencies = toptierAgencies.filter((agency) => agency.title !== 'Federal Emergency Management Agency (FEMA)');
+            // Add it to the end of the subtier agencies list
+            subtierAgencies = subtierAgencies.concat([fema]);
+        }
+
         agencies = slice(concat(toptierAgencies, subtierAgencies), 0, 10);
 
         this.setState({

--- a/tests/containers/search/filters/agencyFilter/AgencyListContainer-test.jsx
+++ b/tests/containers/search/filters/agencyFilter/AgencyListContainer-test.jsx
@@ -77,13 +77,13 @@ describe('AgencyListContainer', () => {
             // setup the agency list container
             const agencyListContainer = setup(initialFilters);
 
-            agencyListContainer.instance().queryAutocompleteAgencies('office of government')
+            agencyListContainer.instance().queryAutocompleteAgencies('office of government');
             await agencyListContainer.instance().agencySearchRequest.promise;
 
             expect(agencyListContainer.state().autocompleteAgencies.length).toEqual(mockSecondaryResults.length);
         });
 
-        it('should no display autocomplete agencies that have already previously selected', () => {
+        it('should not display autocomplete agencies that have already previously selected', () => {
             const agencyListContainer = setup(Object.assign({}, initialFilters, {
                 selectedAgencies: new OrderedMap({
                     '14_toptier': {}
@@ -109,6 +109,45 @@ describe('AgencyListContainer', () => {
             ]);
 
             expect(agencyListContainer.state().autocompleteAgencies.length).toEqual(0);
+        });
+        it('should move FEMA\'s toptier entry to the end of the list', () => {
+            const agencyListContainer = setup(initialFilters);
+            agencyListContainer.instance().parseAutocompleteAgencies([
+                {
+                    id: 14,
+                    toptier_flag: true,
+                    toptier_agency: {
+                        cgac_code: "058",
+                        fpds_code: "",
+                        abbreviation: "FEMA",
+                        name: "Federal Emergency Management Agency"
+                    },
+                    subtier_agency: {
+                        subtier_code: "5800",
+                        abbreviation: "FEMA",
+                        name: "Federal Emergency Management Agency"
+                    },
+                    office_agency: null
+                }, {
+                    id: 15,
+                    toptier_flag: false,
+                    toptier_agency: {
+                        cgac_code: "058",
+                        fpds_code: "",
+                        abbreviation: "FEMA",
+                        name: "Federal Emergency Management Agency"
+                    },
+                    subtier_agency: {
+                        subtier_code: "585D",
+                        abbreviation: "",
+                        name: "FEMA Region IV"
+                    },
+                    office_agency: null
+                }
+            ]);
+
+            expect(agencyListContainer.state().autocompleteAgencies[0].data.toptier_flag).toBeFalsy();
+            expect(agencyListContainer.state().autocompleteAgencies[1].data.toptier_flag).toBeTruthy();
         });
         it('should clear the autocomplete list when the Autocomplete tells it to', () => {
             const agencyListContainer = setup(initialFilters);


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-1543
- On Advanced Search Awarding Agency & Funding Agency filters, move FEMA's toptier entry to the end of the autocomplete list