### PR TITLE
Update Fema Autocomplete v2

### DIFF
--- a/src/js/containers/search/filters/AgencyListContainer.jsx
+++ b/src/js/containers/search/filters/AgencyListContainer.jsx
@@ -83,25 +83,18 @@ export default class AgencyListContainer extends React.Component {
             }
         }
 
-        // Separate top and subtier agencies
-        let toptierAgencies = filter(agencies, ['data.agencyType', 'toptier']);
-        let subtierAgencies = filter(agencies, ['data.agencyType', 'subtier']);
+        // For searches for FEMA, leave the results in the same order as the API response
+        if ((this.state.agencySearchString.toLowerCase() !== 'fem') && (this.state.agencySearchString.toLowerCase() !== 'fema')) {
+            // Separate top and subtier agencies
+            let toptierAgencies = filter(agencies, ['data.agencyType', 'toptier']);
+            let subtierAgencies = filter(agencies, ['data.agencyType', 'subtier']);
 
-        // Sort individual groups alphabetically
-        toptierAgencies = sortBy(toptierAgencies, 'title');
-        subtierAgencies = sortBy(subtierAgencies, 'title');
+            // Sort individual groups alphabetically
+            toptierAgencies = sortBy(toptierAgencies, 'title');
+            subtierAgencies = sortBy(subtierAgencies, 'title');
 
-        // FEMA is no longer a toptier agency, so we want its subtier entries to come first
-        const fema = toptierAgencies.find((agency) => agency.title === 'Federal Emergency Management Agency (FEMA)');
-
-        if (fema) {
-            // remove FEMA from toptier agencies
-            toptierAgencies = toptierAgencies.filter((agency) => agency.title !== 'Federal Emergency Management Agency (FEMA)');
-            // Add it to the end of the subtier agencies list
-            subtierAgencies = subtierAgencies.concat([fema]);
+            agencies = slice(concat(toptierAgencies, subtierAgencies), 0, 10);
         }
-
-        agencies = slice(concat(toptierAgencies, subtierAgencies), 0, 10);
 
         this.setState({
             noResults,
@@ -169,6 +162,12 @@ export default class AgencyListContainer extends React.Component {
 
         // use the JS search library to search within the records
         const results = search.search(this.state.agencySearchString);
+
+        if ((this.state.agencySearchString.toLowerCase() === 'fem') || (this.state.agencySearchString.toLowerCase() === 'fema')) {
+            // don't change the order of results returned from the API
+            this.parseAutocompleteAgencies(slice(results, 0, 10));
+        }
+
         const toptier = [];
         const subtier = [];
 

--- a/tests/containers/search/filters/agencyFilter/AgencyListContainer-test.jsx
+++ b/tests/containers/search/filters/agencyFilter/AgencyListContainer-test.jsx
@@ -11,7 +11,7 @@ import { OrderedMap } from 'immutable';
 import AgencyListContainer from 'containers/search/filters/AgencyListContainer';
 
 import { mockAgencies } from './mockAgencies';
-import { mockSecondaryResults } from './mockLocalSearch';
+import { mockSecondaryResults, mockFemaResults, mockResults } from './mockLocalSearch';
 
 jest.mock('helpers/searchHelper', () => require('../searchHelper'));
 jest.mock('js-search', () => require('./mockLocalSearch'));
@@ -110,45 +110,6 @@ describe('AgencyListContainer', () => {
 
             expect(agencyListContainer.state().autocompleteAgencies.length).toEqual(0);
         });
-        it('should move FEMA\'s toptier entry to the end of the list', () => {
-            const agencyListContainer = setup(initialFilters);
-            agencyListContainer.instance().parseAutocompleteAgencies([
-                {
-                    id: 14,
-                    toptier_flag: true,
-                    toptier_agency: {
-                        cgac_code: "058",
-                        fpds_code: "",
-                        abbreviation: "FEMA",
-                        name: "Federal Emergency Management Agency"
-                    },
-                    subtier_agency: {
-                        subtier_code: "5800",
-                        abbreviation: "FEMA",
-                        name: "Federal Emergency Management Agency"
-                    },
-                    office_agency: null
-                }, {
-                    id: 15,
-                    toptier_flag: false,
-                    toptier_agency: {
-                        cgac_code: "058",
-                        fpds_code: "",
-                        abbreviation: "FEMA",
-                        name: "Federal Emergency Management Agency"
-                    },
-                    subtier_agency: {
-                        subtier_code: "585D",
-                        abbreviation: "",
-                        name: "FEMA Region IV"
-                    },
-                    office_agency: null
-                }
-            ]);
-
-            expect(agencyListContainer.state().autocompleteAgencies[0].data.toptier_flag).toBeFalsy();
-            expect(agencyListContainer.state().autocompleteAgencies[1].data.toptier_flag).toBeTruthy();
-        });
         it('should clear the autocomplete list when the Autocomplete tells it to', () => {
             const agencyListContainer = setup(initialFilters);
             agencyListContainer.setState({
@@ -172,6 +133,34 @@ describe('AgencyListContainer', () => {
 
             expect(container.instance().parseAutocompleteAgencies).toHaveBeenCalledTimes(1);
             expect(container.instance().parseAutocompleteAgencies).toHaveBeenCalledWith(mockSecondaryResults);
+        });
+    });
+
+    describe('parseAutocompleteAgencies', () => {
+        it('should separate toptier and subtier agencies and alphabetize each group', async () => {
+            const container = setupShallow(initialFilters);
+            container.setState({
+                agencySearchString: 'abc'
+            });
+
+            container.instance().parseAutocompleteAgencies(mockResults);
+
+            // Toptier agencies should have been moved to the top of the list
+            expect(container.state().autocompleteAgencies[0].title).toEqual('Department ABC (ABC)');
+            expect(container.state().autocompleteAgencies[1].title).toEqual('Department XYZ (XYZ)');
+            expect(container.state().autocompleteAgencies[2].title).toEqual('DEF Agency (DEF)');
+            expect(container.state().autocompleteAgencies[2].subtitle).toEqual('Sub-Agency of Department ABC (ABC)');
+        });
+        it('should not change the order of results when searching for FEMA', async () => {
+            const container = setupShallow(initialFilters);
+            container.setState({
+                agencySearchString: 'fema'
+            });
+
+            container.instance().parseAutocompleteAgencies(mockFemaResults);
+
+            // Results should stay in the same order with a subtier agency at the top of the list
+            expect(container.state().autocompleteAgencies[0].toptier_flag).toBeFalsy;
         });
     });
 });

--- a/tests/containers/search/filters/agencyFilter/mockLocalSearch.js
+++ b/tests/containers/search/filters/agencyFilter/mockLocalSearch.js
@@ -3,15 +3,15 @@ export const mockSecondaryResults = [
         id: 14,
         toptier_flag: true,
         toptier_agency: {
-            cgac_code: "004",
-            fpds_code: "0400",
-            abbreviation: "GPO",
-            name: "Government Publishing Office"
+            cgac_code: '004',
+            fpds_code: '0400',
+            abbreviation: 'GPO',
+            name: 'Government Publishing Office'
         },
         subtier_agency: {
-            subtier_code: "0400",
-            abbreviation: "",
-            name: "Government Publishing Office"
+            subtier_code: '0400',
+            abbreviation: '',
+            name: 'Government Publishing Office'
         },
         office_agency: null
     },
@@ -19,15 +19,15 @@ export const mockSecondaryResults = [
         id: 1125,
         toptier_flag: true,
         toptier_agency: {
-            cgac_code: "434",
-            fpds_code: "9549",
-            abbreviation: "OGE",
-            name: "Office of Government Ethics"
+            cgac_code: '434',
+            fpds_code: '9549',
+            abbreviation: 'OGE',
+            name: 'Office of Government Ethics'
         },
         subtier_agency: {
-            subtier_code: "9549",
-            abbreviation: "",
-            name: "Office of Government Ethics"
+            subtier_code: '9549',
+            abbreviation: '',
+            name: 'Office of Government Ethics'
         },
         office_agency: null
     }
@@ -47,3 +47,81 @@ export class Search {
         return mockSecondaryResults;
     }
 }
+
+export const mockFemaResults = [
+    {
+        id: 13,
+        toptier_flag: false,
+        toptier_agency: {
+            abbreviation: 'DHS',
+            name: 'Department of Homeland Security'
+        },
+        subtier_agency: {
+            abbreviation: 'FEMA',
+            name: 'Federal Emergency Management Agency'
+        }
+    },
+    {
+        id: 10,
+        toptier_flag: true,
+        toptier_agency: {
+            abbreviation: 'FEMA',
+            name: 'Federal Emergency Management Agency'
+        },
+        subtier_agency: {
+            abbreviation: 'FEMA',
+            name: 'Federal Emergency Management Agency'
+        }
+    },
+    {
+        id: 11,
+        toptier_flag: false,
+        toptier_agency: {
+            abbreviation: 'FEMA',
+            name: 'Federal Emergency Management Agency'
+        },
+        subtier_agency: {
+            abbreviation: '',
+            name: 'FEMA Region IV'
+        }
+    }
+];
+
+export const mockResults = [
+    {
+        id: 11,
+        toptier_flag: true,
+        toptier_agency: {
+            abbreviation: 'XYZ',
+            name: 'Department XYZ'
+        },
+        subtier_agency: {
+            abbreviation: 'XYZ',
+            name: 'Department XYZ'
+        }
+    },
+    {
+        id: 13,
+        toptier_flag: false,
+        toptier_agency: {
+            abbreviation: 'ABC',
+            name: 'Department ABC'
+        },
+        subtier_agency: {
+            abbreviation: 'DEF',
+            name: 'DEF Agency'
+        }
+    },
+    {
+        id: 13,
+        toptier_flag: true,
+        toptier_agency: {
+            abbreviation: 'ABC',
+            name: 'Department ABC'
+        },
+        subtier_agency: {
+            abbreviation: 'ABC',
+            name: 'Department ABC'
+        }
+    }
+];


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-1543

First PR (#895) only moved the toptier entry to the end of the list. This version retains the order of results in the API response when searching for FEMA, so that older subagencies of top-tier FEMA will also be at the end of the list. 

- [ ] Code review