### PR TITLE
Cleanup API Contracts

### DIFF
--- a/api_contracts/contracts/award/AwardProfile.md
+++ b/api_contracts/contracts/award/AwardProfile.md
@@ -13,10 +13,10 @@ These endpoints support the individual Award pages that display data for a speci
 
 This endpoint returns a list of data that is associated with the award profile page.
 
-### Award [GET]
-
 + Parameters
-    + generated_unique_award_id
+    + generated_unique_award_id: 25764264
+
+### Award [GET]
 
 + Request A request with a contract id (application/json)
     + Attributes
@@ -25,7 +25,7 @@ This endpoint returns a list of data that is associated with the award profile p
 + Response 200 (application/json)
     + Attributes (ContractResponse)
 
-+ Request A request with an id that is other than contract (application/json)
++ Request A request with a non-contract id (application/json)
      + Attributes
         + generated_unique_award_id: 42954959
 
@@ -156,9 +156,9 @@ This endpoint returns a list of transactions, their amount, type, action date, a
 + parent_award_piid: `1301` (required, string, nullable)
 + description: `ewraijwrw` (required, string, nullable)
     Description of the first transaction for this award
-+ awarding_agency: (required, Agency, fixed-type)
-+ funding_agency: (required, Agency, fixed-type)
-+ recipient: (required, Recipient, fixed-type)
++ awarding_agency (required, Agency, fixed-type)
++ funding_agency (required, Agency, fixed-type)
++ recipient (required, Recipient, fixed-type)
 + total_obligation (required, number)
 + base_and_all_options_value: 24242432 (required, number)
     The ceiling and amount of the award
@@ -186,9 +186,9 @@ This endpoint returns a list of transactions, their amount, type, action date, a
 + recipient_name: `Booz Allen Hamilton` (required, string, nullable)
 + recipient_unique_id: 2424224 (required, number, nullable)
 + parent_recipient_unique_id: 2424232 (required, number, nullable)
-+ location: (required, Location, nullable)
++ location (required, Location, nullable)
 + recipient_parent_name: `HoneyWell` (string, nullable)
-+ business_categories: (required, array[string])
++ business_categories (required, array[string])
 
 ## PerformancePeriod
 + period_of_performance_start_date: `2004-02-19` (required, string)
@@ -252,7 +252,7 @@ This endpoint returns a list of transactions, their amount, type, action date, a
 + type_of_contract_pric_desc: `FIRM FIXED PRICE` (required, string, nullable)
 
 ## Executive
-+ officers: (required, array[Officer])
++ officers (required, array[Officer])
 
 ## Officer
 + name: `John Doe` (required, string)
@@ -267,11 +267,11 @@ This endpoint returns a list of transactions, their amount, type, action date, a
 + cfda_objectives: `Some HTML string` (required, string, nullable)
 + cfda_number: `0.434` (required, string, nullable)
 + cfda_title: `Flood Insurance` (required, string, nullable)
-+ awarding_agency: (required, Agency, fixed-type)
-+ funding_agency: (required, Agency, fixed-type)
-+ recipient: (required, Recipient, fixed-type)
++ awarding_agency (required, Agency, fixed-type)
++ funding_agency (required, Agency, fixed-type)
++ recipient (required, Recipient, fixed-type)
 + subaward_count: 430 (required, number)
 + total_subaward_amount: 35345353453 (required, number)
-+ period_of_performance: (required, PerformancePeriod, fixed-type)
-+ place_of_performance: (required, Location, fixed-type)
++ period_of_performance (required, PerformancePeriod, fixed-type)
++ place_of_performance (required, Location, fixed-type)
 + executive_details (required, Executive, fixed-type)

--- a/api_contracts/contracts/downloadCenter/DownloadCenter.md
+++ b/api_contracts/contracts/downloadCenter/DownloadCenter.md
@@ -1,13 +1,13 @@
 FORMAT: 1A
 HOST: https://api.usaspending.gov
 
-# Custom Account Download
+# Download Center
 
-These endpoints are used to power USAspending.gov's custom download pages. This data can be used to create account data files. 
+These endpoints are used to power USAspending.gov's download center. 
 
-# Custom Account Page
+# Group Custom Account Data
 
-These endpoints generate files using the filters on the custom account.
+These endpoints power the generation of custom account data files.
 
 ## Custom Account Data [/api/v2/download/accounts/]
 

--- a/api_contracts/contracts/recipient/RecipientProfile.md
+++ b/api_contracts/contracts/recipient/RecipientProfile.md
@@ -13,37 +13,38 @@ This endpoint supports the recipient landing page, which provides a list of all 
 
 This endpoint returns a list of recipients, their level, DUNS, and amount.
 
-+ Parameters
-    + order: desc (optional, string)
-        The direction results are sorted by. `asc` for ascending, `desc` for descending.
-        + Default: desc
-    + sort: amount (optional, string)
-        The field results are sorted by.
-        + Default: amount
-        + Members
-            + name
-            + duns
-            + amount
-    + limit: 50 (optional, number)
-        The number of results to include per page.
-        + Default: 50
-    + page: 1 (optional, number)
-        The page of results to return based on the limit.
-        + Default: 1
-    + keyword: (optional, string)
-        The keyword results are filtered by. Searches on name and DUNS.
-    + award_type: all (optional, string)
-        The award type results are filtered by.
-        + Default: all
-        + Members
-            + all
-            + contracts
-            + grants
-            + loans
-            + direct_payments
-            + other_financial_assistance
-
 ### List Recipients [POST]
+
++ Request (application/json)
+    + Attributes (object)
+        + order: desc (optional, string)
+            The direction results are sorted by. `asc` for ascending, `desc` for descending.
+            + Default: desc
+        + sort: amount (optional, enum[string])
+            The field results are sorted by.
+            + Default: amount
+            + Members
+                + name
+                + duns
+                + amount
+        + limit: 50 (optional, number)
+            The number of results to include per page.
+            + Default: 50
+        + page: 1 (optional, number)
+            The page of results to return based on the limit.
+            + Default: 1
+        + keyword (optional, string)
+            The keyword results are filtered by. Searches on name and DUNS.
+        + award_type: all (optional, enum[string])
+            The award type results are filtered by.
+            + Default: all
+            + Members
+                + all
+                + contracts
+                + grants
+                + loans
+                + direct_payments
+                + other_financial_assistance
 
 + Response 200 (application/json)
     + Attributes (RecipientsListResponse)
@@ -102,7 +103,7 @@ This endpoint returns a the count of new awards grouped by time period in ascend
             + `fiscal_year`
             + `quarter`
             + `month`
-        + results: (array[TimeResult], fixed-type)
+        + results (array[TimeResult], fixed-type)
 
 # Data Structures
 
@@ -119,7 +120,7 @@ This endpoint returns a the count of new awards grouped by time period in ascend
     A unique identifier for the recipient at this `recipient_level`.
 + amount: 30020000000 (required, number)
     The aggregate monetary value of all transactions associated with this recipient for the trailing 12 months.
-+ `recipient_level`: C (required, string)
++ `recipient_level`: C (required, enum[string])
     A letter representing the recipient level. `R` for neither parent nor child, `P` for Parent Recipient, or `C` for child recipient.
     + Members
         + R
@@ -147,14 +148,14 @@ This endpoint returns a the count of new awards grouped by time period in ascend
     Parent recipient's DUNS number. `null` if the recipient does not have a parent recipient, or the parent recipient's DUNS is not provided.
 + `parent_id`: `0036a0cb-0d88-2db3-59e0-0f9af8ffef57-P` (required, string, nullable)
     A unique identifier for the parent recipient. `null` if the recipient does not have a parent recipient.
-+ location: (required, RecipientLocation, fixed-type)
++ location (required, RecipientLocation, fixed-type)
 + `business_types`: `minority_owned_business`, `for_profit_organization` (required, array[string], fixed-type)
     An array of business type field names used to categorize recipients.
 + `total_transaction_amount`: 30020000000 (required, number)
     The aggregate monetary value of all transactions associated with this recipient for the given time period.
 + `total_transactions`: 327721 (required, number)
     The number of transactions associated with this recipient for the given time period.
-+ `recipient_level`: C (required, string)
++ `recipient_level`: C (required, enum[string])
     A letter representing the recipient level. `R` for neither parent nor child, `P` for Parent Recipient, or `C` for child recipient.
     + Members
         + R
@@ -164,25 +165,25 @@ This endpoint returns a the count of new awards grouped by time period in ascend
 ## RecipientLocation (object)
 + `address_line1`: 123 Sesame St (required, string, nullable)
     The first line of the recipient's street address.
-+ `address_line2`: (required, string, nullable)
++ `address_line2` (required, string, nullable)
     Second line of the recipient's street address.
-+ `address_line3`: (required, string, nullable)
++ `address_line3` (required, string, nullable)
     Third line of the recipient's street address.
-+ `foreign_province`: (required, string, nullable)
++ `foreign_province` (required, string, nullable)
     Name of the province in which the recipient is located, if it is outside the United States.
 + `city_name`: McLean (required, string, nullable)
     Name of the city in which the recipient is located.
-+ `county_name`: (required, string, nullable)
++ `county_name` (required, string, nullable)
     Name of the county in which the recipient is located.
 + `state_code`: VA (required, string, nullable)
     Code for the state in which the recipient is located.
 + zip: `22102` (required, string, nullable)
     Recipient's zip code (5 digits)
-+ zip4: (required, string, nullable)
++ zip4 (required, string, nullable)
     Recipient's zip code (4 digits)
-+ `foreign_postal_code`: (required, string, nullable)
++ `foreign_postal_code` (required, string, nullable)
     Recipient's postal code, if it is outside the United States.
-+ `country_name`: (required, string, nullable)
++ `country_name` (required, string, nullable)
      Name of the country in which the recipient is located.
 + `country_code`: USA (required, string, nullable)
      Code for the country in which the recipient is located.
@@ -202,13 +203,13 @@ This endpoint returns a the count of new awards grouped by time period in ascend
     The aggregate monetary value of transactions associated with this child recipient for the selected time period.
 
 ## TimeResult (object)
-+ time_period: (TimePeriodGroup)
++ time_period (required, TimePeriodGroup)
 + new_award_count_in_period: 25 (required, number)
     The count of new awards for this time period and the given filters.
     
 ## TimeFilterObject (object)
 + time_period (optional, array[TimePeriodObject], fixed-type)
-+ recipient_id: `123ABC-R` (optional, string)
++ recipient_id: `0036a0cb-0d88-2db3-59e0-0f9af8ffef57-P` (optional, string)
     A hash of recipient DUNS, name, and level. A unique identifier for recipients.
     
 ## TimePeriodGroup (object)

--- a/api_contracts/contracts/search/AdvancedSearch.md
+++ b/api_contracts/contracts/search/AdvancedSearch.md
@@ -69,7 +69,7 @@ This endpoint returns a list of aggregated award amounts grouped by time period 
             + `fiscal_year`
             + `quarter`
             + `month`
-        + results: (array[TimeResult], fixed-type)
+        + results (array[TimeResult], fixed-type)
 
 # Data Structures
 
@@ -82,7 +82,7 @@ This endpoint returns a list of aggregated award amounts grouped by time period 
 + amount: 591230394.12 (required, number)
 
 ## TimeResult (object)
-+ time_period: (TimePeriodGroup)
++ time_period (required, TimePeriodGroup)
 + aggregated_amount: 200000000 (required, number)
     The aggregate award amount for this time period and the given filters.
 
@@ -92,35 +92,35 @@ This endpoint returns a list of aggregated award amounts grouped by time period 
 + hasPrevious: false (required, boolean)
 
 ## FilterObject (object)
-+ keywords: zombie, pizza (optional, array[string])
++ keywords: pizza (optional, array[string])
 + time_period (optional, array[TimePeriodObject], fixed-type)
 + place_of_performance_scope: domestic (optional, enum[string])
     + domestic
     + foreign
 + place_of_performance_locations (optional, array[LocationObject], fixed-type)
 + agencies (optional, array[AgencyObject])
-+ recipient_search_text: kearney (optional, array[string])
-+ recipient_id: `123ABC-R` (optional, string)
++ recipient_search_text: Hampton (optional, array[string])
++ recipient_id (optional, string)
     A hash of recipient DUNS, name, and level. A unique identifier for recipients, used for profile page urls.
 + recipient_scope: domestic (optional, enum[string])
     + domestic
     + foreign
 + recipient_locations (optional, array[LocationObject])
-+ recipient_type_names: Small Business (optional, array[string])
++ recipient_type_names: `category_business` (optional, array[string])
     See options at https://github.com/fedspendingtransparency/usaspending-api/wiki/Recipient-Business-Types
-+ award_type_codes: A, B, 03 (optional, array[string])
-+ award_ids: 1605SS17F00018, P063P151708, `AID-OFDA-G-14-00121-01` (optional, array[string])
++ award_type_codes: A, B, C, D (optional, array[string])
++ award_ids: SPE30018FLGFZ, SPE30018FLJFN (optional, array[string])
 + award_amounts (optional, array[AwardAmounts])
-+ program_numbers: 10.553 (optional, array[string])
-+ naics_codes: 336411 (optional, array[string])
-+ psc_codes: 1510 (optional, array[string])
-+ contract_pricing_type_codes: SAMPLECODE123 (optional, array[string])
-+ set_aside_type_codes: SAMPLECODE123 (optional, array[string])
-+ extent_competed_type_codes: SAMPLECODE123 (optional, array[string])
++ program_numbers: 10.331 (optional, array[string])
++ naics_codes: 311812 (optional, array[string])
++ psc_codes: 8940, 8910 (optional, array[string])
++ contract_pricing_type_codes: J (optional, array[string])
++ set_aside_type_codes: NONE (optional, array[string])
++ extent_competed_type_codes: A (optional, array[string])
 
 ## TimePeriodObject (object)
-+ start_date: `2016-10-01` (required, string)
-+ end_date: `2017-09-30` (required, string)
++ start_date: `2017-10-01` (required, string)
++ end_date: `2018-09-30` (required, string)
 + `date_type`: `action_date` (optional, enum[string])
     + action_date
     + last_modified_date
@@ -144,8 +144,8 @@ This endpoint returns a list of aggregated award amounts grouped by time period 
 + tier: toptier (required, enum[string])
     + `toptier`
     + `subtier`
-+ name: `Office of Pizza` (required, string)
++ name: `Department of Defense` (required, string)
 
 ## AwardAmounts (object)
-+ lower_bound: 5000.50 (optional, number)
-+ upper_bound: 6000.50 (optional, number)
++ lower_bound (optional, number)
++ upper_bound: 1000000 (optional, number)

--- a/api_contracts/contracts/spendingExplorer/SpendingExplorer.md
+++ b/api_contracts/contracts/spendingExplorer/SpendingExplorer.md
@@ -42,8 +42,8 @@ Using the response from the general Spending Explorer, you can drill down to mor
 
 + Response 200 (application/json)
     + Attributes (object)
-        + total: 126073789264.49 (required, number)
-        + 
+        + total: 126073789264.49 (required, number, nullable)
+            Total should only be null when there are no results.
         + end_date: `2017-09-30` (required, string)
             This is the "as-of" date for the data being returned.
         + results (required, array[SpendingExplorerGeneralResponse, SpendingExplorerGeneralUnreportedResponse], fixed-type)
@@ -63,7 +63,8 @@ Using the response from the general Spending Explorer, you can drill down to mor
 
 + Response 200 (application/json)
     + Attributes (object)
-        + total: 1410774412.52 (required, number)
+        + total: 1410774412.52 (required, number, nullable)
+            Total should only be null when there are no results.
         + end_date: `2017-09-30` (required, string)
             This is the "as-of" date for the data being returned.
         + results (required, array[SpendingExplorerDetailedResponse], fixed-type)
@@ -71,16 +72,16 @@ Using the response from the general Spending Explorer, you can drill down to mor
 # Data Structures
 
 ## GeneralFilter (object)
-+ fy: 2017 (required, string)
-+ quarter: 4 (required, enum[string])
++ fy: `2017` (required, string)
++ quarter: `4` (required, enum[string])
     + `1`
     + `2`
     + `3`
     + `4`
 
 ## DetailedFilter (object)
-+ fy: 2017 (required, string)
-+ quarter: 4 (required, enum[string])
++ fy: `2017` (required, string)
++ quarter: `4` (required, enum[string])
     + `1`
     + `2`
     + `3`
@@ -97,7 +98,7 @@ Using the response from the general Spending Explorer, you can drill down to mor
 
 ## SpendingExplorerGeneralResponse (object)
 + code: `019` (required, string)
-+ id: 315 (required, number)
++ id: `315` (required, string)
 + type: agency (required, string)
     The `type` will always be equal to the `type` parameter you provided in the request.
 + name: Department of State (required, string)
@@ -105,7 +106,7 @@ Using the response from the general Spending Explorer, you can drill down to mor
 
 ### SpendingExplorerDetailedResponse (object)
 + code: `0006` (required, string)
-+ id: 11367 (required, number)
++ id: `11367` (required, string)
 + type: `program_activity` (required, string)
     The `type` will always be equal to the `type` parameter you provided in the request.
 + name: Law Enforcement Operations (required, string)

--- a/src/js/components/explorer/detail/visualization/table/cells/LinkCell.jsx
+++ b/src/js/components/explorer/detail/visualization/table/cells/LinkCell.jsx
@@ -5,7 +5,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-// import reactStringReplace from 'react-string-replace';
 
 const propTypes = {
     name: PropTypes.string,

--- a/tests/containers/explorer/detail/DetailContentContainer-test.jsx
+++ b/tests/containers/explorer/detail/DetailContentContainer-test.jsx
@@ -122,11 +122,11 @@ describe('DetailContentContainer', () => {
         it('should build the root object and update the trail', () => {
             const mockTrail =
                 [{
-                    "subdivision": "agency",
-                    "title": "",
-                    "total": 100,
-                    "within": "root",
-                    "id": ""
+                    subdivision: 'agency',
+                    title: '',
+                    total: 100,
+                    within: 'root',
+                    id: ''
                 }];
 
             const container = shallow(<DetailContentContainer
@@ -232,10 +232,10 @@ describe('DetailContentContainer', () => {
     describe('goDeeper', () => {
         it('should update the state, trail, and make an API call', () => {
             const mockRequest = {
-                "subdivision": "federal_account",
-                "title": "Third Agency",
-                "within": "agency",
-                "id": 3
+                subdivision: 'federal_account',
+                title: 'Third Agency',
+                within: 'agency',
+                id: '3'
             };
             const mockLoadData = jest.fn();
             const container = shallow(<DetailContentContainer
@@ -296,9 +296,9 @@ describe('DetailContentContainer', () => {
     describe('changeSubdivisionType', () => {
         it('should revisualize the data without changing the trail or filters', () => {
             const mockRequest = {
-                "subdivision": "object_class",
-                "total": 100,
-                "within": "root"
+                subdivision: 'object_class',
+                total: 100,
+                within: 'root'
             };
             const mockLoadData = jest.fn();
             const container = shallow(<DetailContentContainer
@@ -340,7 +340,7 @@ describe('DetailContentContainer', () => {
             container.instance().rewindToFilter(0);
 
             expect(mockPrepareRoot).toHaveBeenCalledTimes(1);
-            expect(mockPrepareRoot).toHaveBeenCalledWith("agency", "1984", "2");
+            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '2');
         });
         it ('should overwrite the explorer trail and update the transition steps', () => {
             const container = mount(<DetailContentContainer

--- a/tests/containers/explorer/detail/mockData.js
+++ b/tests/containers/explorer/detail/mockData.js
@@ -6,7 +6,7 @@ export const mockApiResponse = {
     end_date: '1984-06-30',
     results: [
         {
-            id: 1,
+            id: '1',
             type: 'agency',
             name: 'First Agency',
             code: 'agency-1',
@@ -14,7 +14,7 @@ export const mockApiResponse = {
             total: 75
         },
         {
-            id: 2,
+            id: '2',
             type: 'agency',
             name: 'Second Agency',
             code: 'agency-2',
@@ -22,7 +22,7 @@ export const mockApiResponse = {
             total: 15
         },
         {
-            id: 3,
+            id: '3',
             type: 'agency',
             name: 'Third Agency',
             code: 'agency-3',
@@ -36,7 +36,7 @@ export const mockAwardResponse = {
     total: 200,
     results: [
         {
-            id: 1,
+            id: '1',
             type: 'award',
             name: 'Award',
             code: '123',
@@ -90,20 +90,20 @@ export const mockReducerChild = {
 };
 
 export const mockLevelData = {
-    type: "agency",
+    type: 'agency',
     amount: 10,
-    id: 3,
-    name: "Third Agency",
-    code: "agency_3",
+    id: '3',
+    name: 'Third Agency',
+    code: 'agency_3',
     total: 100,
     percent: 0.0841,
-    percentString: "8.4%"
+    percentString: '8.4%'
 };
 
 export const mockDeeperRoot = {
     root: 'agency',
     fy: '1984',
-    quarter: "2",
+    quarter: '2',
     active: new ActiveScreen({
         within: 'federal_account',
         subdivision: 'award',
@@ -123,16 +123,16 @@ export const mockDeeperRoot = {
             title: 'Health'
         },
         {
-            within: "budget_subfunction",
-            subdivision: "federal_account",
-            title: "Health care services",
+            within: 'budget_subfunction',
+            subdivision: 'federal_account',
+            title: 'Health care services',
             total: 60
         }
     ])
 };
 
 export const mockActiveScreen = new ActiveScreen (
-    {"subdivision": "agency", "total": 100, "within": "root"}
+    {'subdivision': 'agency', 'total': 100, 'within': 'root'}
 );
 
 export const mockTable = {
@@ -145,35 +145,35 @@ export const mockTable = {
 
 export const mockParsedResults = [
     {
-        "display": {
-            "name": "First Agency",
-            "obligated_amount": "$75",
-            "percent_of_total": "75.00%"
+        'display': {
+            'name': 'First Agency',
+            'obligated_amount': '$75',
+            'percent_of_total': '75.00%'
         },
-        "id": 1,
-        "name": "First Agency",
-        "obligated_amount": 75,
-        "percent_of_total": 0.75
+        'id': '1',
+        'name': 'First Agency',
+        'obligated_amount': 75,
+        'percent_of_total': 0.75
     }, {
-        "display": {
-            "name": "Second Agency",
-            "obligated_amount": "$15",
-            "percent_of_total": "15.00%"
+        'display': {
+            'name': 'Second Agency',
+            'obligated_amount': '$15',
+            'percent_of_total': '15.00%'
         },
-        "id": 2,
-        "name": "Second Agency",
-        "obligated_amount": 15,
-        "percent_of_total": 0.15
+        'id': '2',
+        'name': 'Second Agency',
+        'obligated_amount': 15,
+        'percent_of_total': 0.15
     }, {
-        "display": {
-            "name": "Third Agency",
-            "obligated_amount": "$10",
-            "percent_of_total": "10.00%"
+        'display': {
+            'name': 'Third Agency',
+            'obligated_amount': '$10',
+            'percent_of_total': '10.00%'
         },
-        "id": 3,
-        "name": "Third Agency",
-        "obligated_amount": 10,
-        "percent_of_total": 0.1
+        'id': '3',
+        'name': 'Third Agency',
+        'obligated_amount': 10,
+        'percent_of_total': 0.1
     }
 ];
 


### PR DESCRIPTION
**High level description:**
Fixes some formatting issues in existing API contracts.

**Technical details:**
-  Ensures that [compliance tests](https://github.com/fedspendingtransparency/usaspending-website/tree/dev/api_contracts#automated-dev-api-compliance-testing) will not fail because of formatting issues in the contract. Compliance tests may still fail because:
a) the endpoint doesn't exist yet
b) the endpoint does not match the contract 
- Improves generated [API Documentation](https://github.com/fedspendingtransparency/usaspending-website/tree/dev/api_contracts#generating-api-documentation)
- Changes `v2/spending` results' `id` to a string in preparation for [DEV-1549](https://federal-spending-transparency.atlassian.net/browse/DEV-1549)

**Link to JIRA Ticket:**
N/A, preparation for tech debt item(s) to remove duplication and provide linkage between backend/frontend API docs

The following are ALL required for the PR to be merged:
- [ ] Code review