### PR TITLE
Hotfix state profile copy

### DIFF
--- a/src/_scss/pages/state/spendingovertime/_stateTimeVisualization.scss
+++ b/src/_scss/pages/state/spendingovertime/_stateTimeVisualization.scss
@@ -1,4 +1,4 @@
-.awards-over-time {
+.transactions-over-time {
     @import "pages/search/results/visualizations/time/chart/barChart";
     @import "./_period";
 

--- a/src/js/components/state/StateContent.jsx
+++ b/src/js/components/state/StateContent.jsx
@@ -23,8 +23,8 @@ const stateSections = [
         label: 'Overview'
     },
     {
-        section: 'awards-over-time',
-        label: 'Awards Over Time'
+        section: 'transactions-over-time',
+        label: 'Transactions Over Time'
     },
     {
         section: 'top-five',

--- a/src/js/components/state/spendingovertime/StateTimeVisualization.jsx
+++ b/src/js/components/state/spendingovertime/StateTimeVisualization.jsx
@@ -10,7 +10,6 @@ import ChartMessage from 'components/search/visualizations/time/TimeVisualizatio
 import BarChart from 'components/search/visualizations/time/chart/BarChart';
 import TimeTooltip from './StateTimeVisualizationTooltip';
 
-
 const defaultProps = {
     groups: [],
     xSeries: [],

--- a/src/js/components/state/spendingovertime/StateTimeVisualizationSection.jsx
+++ b/src/js/components/state/spendingovertime/StateTimeVisualizationSection.jsx
@@ -55,8 +55,8 @@ export default class StateTimeVisualizationSection extends React.Component {
     render() {
         return (
             <section
-                id="state-awards-over-time"
-                className="state-section awards-over-time">
+                id="state-transactions-over-time"
+                className="state-section transactions-over-time">
                 <h3 className="state-section__title">Transactions Over Time</h3>
                 <hr
                     className="results-divider"

--- a/src/js/components/state/spendingovertime/StateTimeVisualizationTooltip.jsx
+++ b/src/js/components/state/spendingovertime/StateTimeVisualizationTooltip.jsx
@@ -63,7 +63,7 @@ export default class StateTimeVisualizationTooltip extends React.Component {
                                 {dollarValue}
                             </div>
                             <div className="tooltip-label">
-                                Awarded Amount
+                                Amount Obligated
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-1523
- Changes State Profile sidebar label from "Awards Over Time" to "Transactions Over Time"
- Changes State & Recipient Profile tooltips from "Awarded Amount" to "Amount Obligated"