### PR TITLE
Update s3 links

### DIFF
--- a/src/js/components/about/DataQuality.jsx
+++ b/src/js/components/about/DataQuality.jsx
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import kGlobalConstants from 'GlobalConstants';
 
 export default class DataQuality extends React.Component {
     render() {
@@ -64,7 +65,7 @@ export default class DataQuality extends React.Component {
                         raw quarterly submission files, including Quarterly Assurance Statements from Senior Accountable Officials of each agency about known data quality issues, are&nbsp;
                         <a
                             target="_blank"
-                            href="http://usaspending-submissions.s3-website-us-gov-west-1.amazonaws.com/"
+                            href={`https://files${kGlobalConstants.DEV ? '-nonprod' : ''}.usaspending.gov/agency_submissions/`}
                             rel="noopener noreferrer"
                             aria-label="Raw quarterly submission files">
                             available here

--- a/src/js/components/bulkDownload/accounts/AccountDataContent.jsx
+++ b/src/js/components/bulkDownload/accounts/AccountDataContent.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import kGlobalConstants from 'GlobalConstants';
 
 import { accountDownloadOptions } from 'dataMapping/bulkDownload/bulkDownloadOptions';
 import { Glossary } from 'components/sharedComponents/icons/Icons';
@@ -132,7 +133,7 @@ export default class AccountDataContent extends React.Component {
                             . Federal account data is essentially a &ldquo;roll-up&rdquo; of multiple treasury account data.
                         </p>
                         <p>
-                            The files available are categorized by type, according to the scope of spending they cover. More information on the different file types can be found in our <a href="https://s3-us-gov-west-1.amazonaws.com/da-public-files/user_reference_docs/Custom+Account+Data+Dictionary.xlsx">Custom Account Data Dictionary</a>.
+                            The files available are categorized by type, according to the scope of spending they cover. More information on the different file types can be found in our <a href={`https://files${kGlobalConstants.DEV ? '-nonprod' : ''}.usaspending.gov/docs/Custom+Account+Data+Dictionary.xlsx`}>Custom Account Data Dictionary</a>.
                         </p>
                     </div>
                     <div className="download-info__section">

--- a/src/js/dataMapping/navigation/menuOptions.js
+++ b/src/js/dataMapping/navigation/menuOptions.js
@@ -89,7 +89,7 @@ export const downloadOptions = [
     {
         label: 'Database Download',
         type: '',
-        url: 'http://usaspending-db.s3-website-us-gov-west-1.amazonaws.com',
+        url: `https://files${kGlobalConstants.DEV ? '-nonprod' : ''}.usaspending.gov/database_download/`,
         code: 'database',
         description: 'Our entire database available as a download – the most complete download option available for advanced users.',
         callToAction: 'Explore Database Download',

--- a/src/js/dataMapping/navigation/menuOptions.js
+++ b/src/js/dataMapping/navigation/menuOptions.js
@@ -78,7 +78,7 @@ export const downloadOptions = [
     {
         label: 'Agency Submission Files',
         type: 'snapshots',
-        url: 'http://usaspending-submissions.s3-website-us-gov-west-1.amazonaws.com/',
+        url: `https://files${kGlobalConstants.DEV ? '-nonprod' : ''}.usaspending.gov/agency_submissions/`,
         code: 'submission',
         description: 'Raw, unadulterated data submitted by federal agencies in compliance with the DATA Act.',
         callToAction: 'Download Raw Files',

--- a/src/js/models/v2/state/BaseStateProfile.js
+++ b/src/js/models/v2/state/BaseStateProfile.js
@@ -4,6 +4,7 @@
  */
 
 import * as MoneyFormatter from 'helpers/moneyFormatter';
+import kGlobalConstants from 'GlobalConstants';
 
 const BaseStateProfile = {
     populate(data) {
@@ -49,7 +50,7 @@ const BaseStateProfile = {
     },
     get flag() {
         if (this.id) {
-            return `https://s3-us-gov-west-1.amazonaws.com/da-public-files/usaspending_state_flags/${this.id}.png`;
+            return `https://files${kGlobalConstants.DEV ? '-nonprod' : ''}.usaspending.gov/state-flags/${this.id}.png`;
         }
         return '';
     }

--- a/src/js/models/v2/state/BaseStateProfile.js
+++ b/src/js/models/v2/state/BaseStateProfile.js
@@ -50,7 +50,7 @@ const BaseStateProfile = {
     },
     get flag() {
         if (this.id) {
-            return `https://files${kGlobalConstants.DEV ? '-nonprod' : ''}.usaspending.gov/state-flags/${this.id}.png`;
+            return `https://files${kGlobalConstants.DEV ? '-nonprod' : ''}.usaspending.gov/state_flags/${this.id}.png`;
         }
         return '';
     }

--- a/tests/models/state/BaseStateProfile-test.js
+++ b/tests/models/state/BaseStateProfile-test.js
@@ -5,6 +5,7 @@
 
 import BaseStateProfile from 'models/v2/state/BaseStateProfile';
 import { mockStateApi } from './mockStateApi';
+import kGlobalConstants from 'GlobalConstants';
 
 const state = Object.create(BaseStateProfile);
 state.populate(mockStateApi);
@@ -62,7 +63,7 @@ describe('BaseStateProfile', () => {
     });
     describe('State flag image', () => {
         it('should determine the filename based on FIPS', () => {
-            expect(state.flag).toEqual('https://s3-us-gov-west-1.amazonaws.com/da-public-files/usaspending_state_flags/06.png');
+            expect(state.flag).toEqual(`https://files${kGlobalConstants.DEV ? '-nonprod' : ''}.usaspending.gov/state-flags/06.png`);
         });
     });
 });

--- a/tests/models/state/BaseStateProfile-test.js
+++ b/tests/models/state/BaseStateProfile-test.js
@@ -63,7 +63,7 @@ describe('BaseStateProfile', () => {
     });
     describe('State flag image', () => {
         it('should determine the filename based on FIPS', () => {
-            expect(state.flag).toEqual(`https://files${kGlobalConstants.DEV ? '-nonprod' : ''}.usaspending.gov/state-flags/06.png`);
+            expect(state.flag).toEqual(`https://files${kGlobalConstants.DEV ? '-nonprod' : ''}.usaspending.gov/state_flags/06.png`);
         });
     });
 });


### PR DESCRIPTION
**High level description:**

Changes s3 links to new .gov urls in the following places: 
- Custom Account Data Dictionary link (Custom Account page)
- Raw quarterly submission files link (About page, Data Quality section)
- State flag images (State Profile pages)
- Agency Submission Files & Database Download (Download menu)

**Technical details:**

- Determines whether the url should use `files.usaspending.gov` or `files-nonprod.usaspending.gov` based on the global constants variable
- There was no need to update download file urls because they come directly from the `v2/bulk_download/` API

**JIRA Ticket:**
[DEV-1546](https://federal-spending-transparency.atlassian.net/browse/DEV-1546)


The following are ALL required for the PR to be merged:
- [x] Frontend code review
- [x] Ops review