### PR TITLE
Hotfix Budget Sub-function dropdown

### DIFF
--- a/src/_scss/pages/bulkDownload/downloadData.scss
+++ b/src/_scss/pages/bulkDownload/downloadData.scss
@@ -12,19 +12,6 @@
             @include span-columns(9);
         }
         margin-bottom: rem(30);
-        .download-center__heading {
-            @include display(flex);
-            @include align-items(flex-start);
-            .download-center__beta {
-                @include display(flex);
-                @include flex(0 0 auto);
-                margin: rem(5) 0 0 rem(30);
-                background-color: $color-gray-lightest;
-                height: fit-content;
-                padding: rem(2) rem(10);
-                font-size: $small-font-size;
-            }
-        }
         .download-center__title {
             @include display(flex);
             @include flex(1 1 auto);

--- a/src/js/components/bulkDownload/accounts/AccountDataContent.jsx
+++ b/src/js/components/bulkDownload/accounts/AccountDataContent.jsx
@@ -83,10 +83,7 @@ export default class AccountDataContent extends React.Component {
         return (
             <div className="download-center">
                 <div className="download-center__filters">
-                    <div className="download-center__heading">
-                        <h2 className="download-center__title">Custom Account Data</h2>
-                        <div className="download-center__beta">BETA</div>
-                    </div>
+                    <h2 className="download-center__title">Custom Account Data</h2>
                     <FilterSelection valid={accounts.budgetFunction.code !== '' || accounts.agency.id !== ''} />
                     <form
                         className="download-center-form"

--- a/src/js/components/bulkDownload/accounts/filters/BudgetFunctionFilter.jsx
+++ b/src/js/components/bulkDownload/accounts/filters/BudgetFunctionFilter.jsx
@@ -130,7 +130,7 @@ export default class BudgetFunctionFilter extends React.Component {
                     value={budgetSubfunction.budget_subfunction_code}
                     onClick={this.handleBudgetSubfunctionSelect}
                     name={budgetSubfunction.budget_subfunction_title} >
-                    {budgetSubfunction.budget_subfunction_code} - {budgetSubfunction.budget_subfunction_title}
+                    {budgetSubfunction.budget_subfunction_title} - {budgetSubfunction.budget_subfunction_code}
                 </button>
             </li>
         ));


### PR DESCRIPTION
- Switches order of title and code
- Removes `BETA` flag from custom account download page

[DEV-1446](https://federal-spending-transparency.atlassian.net/browse/DEV-1446) failed testing because the results were not listed in alphabetical order. Now that the results are alphabetized, it makes more sense to display the budget sub-function title before the code.