### PR TITLE
Hotfix disable data dictionary

### DIFF
--- a/src/js/dataMapping/navigation/menuOptions.js
+++ b/src/js/dataMapping/navigation/menuOptions.js
@@ -116,7 +116,7 @@ export const downloadOptions = [
         description: 'TODO',
         callToAction: 'Explore the Data Dictionary',
         newTab: false,
-        enabled: true,
+        enabled: false,
         externalLink: false
     }
 ];


### PR DESCRIPTION
- Disables the Data Dictionary link and adds a "Coming Soon" label

[DEV-1253](https://federal-spending-transparency.atlassian.net/browse/DEV-1253) failed testing, so we are temporarily disabling this feature.