### PR TITLE
Update time period in contracts

### DIFF
--- a/api_contracts/contracts/recipient/RecipientProfile.md
+++ b/api_contracts/contracts/recipient/RecipientProfile.md
@@ -214,9 +214,9 @@ This endpoint returns a the count of new awards grouped by time period in ascend
 
 ## TimePeriodGroup (object)
 + fiscal_year: `2018` (required, string)
-+ quarter: 1 (optional, string)
++ quarter: `1` (optional, string)
     Excluded when grouping by `fiscal_year` or `month`.
-+ month: 1 (optional, string)
++ month: `1` (optional, string)
     Excluded when grouping by `fiscal_year` or `quarter`.
 
 ## TimePeriodObject (object)

--- a/api_contracts/contracts/recipient/RecipientProfile.md
+++ b/api_contracts/contracts/recipient/RecipientProfile.md
@@ -82,7 +82,7 @@ This endpoint returns a list of child recipients belonging to the given parent r
 
 + Response 200 (application/json)
     + Attributes (array[ChildRecipient], fixed-type)
-    
+
 ## New Awards Over Time [/api/v2/search/new_awards_over_time/]
 
 This endpoint returns a the count of new awards grouped by time period in ascending order (earliest to most recent).
@@ -206,17 +206,17 @@ This endpoint returns a the count of new awards grouped by time period in ascend
 + time_period (required, TimePeriodGroup)
 + new_award_count_in_period: 25 (required, number)
     The count of new awards for this time period and the given filters.
-    
+
 ## TimeFilterObject (object)
 + time_period (optional, array[TimePeriodObject], fixed-type)
 + recipient_id: `0036a0cb-0d88-2db3-59e0-0f9af8ffef57-P` (optional, string)
     A hash of recipient DUNS, name, and level. A unique identifier for recipients.
-    
+
 ## TimePeriodGroup (object)
 + fiscal_year: `2018` (required, string)
-+ quarter: 1 (optional, number)
++ quarter: 1 (optional, string)
     Excluded when grouping by `fiscal_year` or `month`.
-+ month: 1 (optional, number)
++ month: 1 (optional, string)
     Excluded when grouping by `fiscal_year` or `quarter`.
 
 ## TimePeriodObject (object)

--- a/api_contracts/contracts/search/AdvancedSearch.md
+++ b/api_contracts/contracts/search/AdvancedSearch.md
@@ -45,7 +45,7 @@ This endpoint returns a list of the top results of specific categories sorted by
         + results (array[CategoryResult], fixed-type)
         + limit: 10 (required, number)
         + page_metadata (PageMetadataObject)
-        
+
 ## Spending Over Time [/api/v2/search/spending_over_time/]
 
 This endpoint returns a list of aggregated award amounts grouped by time period in ascending order (earliest to most recent).
@@ -124,12 +124,12 @@ This endpoint returns a list of aggregated award amounts grouped by time period 
 + `date_type`: `action_date` (optional, enum[string])
     + action_date
     + last_modified_date
-    
+
 ## TimePeriodGroup (object)
 + fiscal_year: `2018` (required, string)
-+ quarter: 1 (optional, number)
++ quarter: 1 (optional, string)
     Excluded when grouping by `fiscal_year` or `month`.
-+ month: 1 (optional, number)
++ month: 1 (optional, string)
     Excluded when grouping by `fiscal_year` or `quarter`.
 
 ## LocationObject (object)

--- a/api_contracts/contracts/search/AdvancedSearch.md
+++ b/api_contracts/contracts/search/AdvancedSearch.md
@@ -127,9 +127,9 @@ This endpoint returns a list of aggregated award amounts grouped by time period 
 
 ## TimePeriodGroup (object)
 + fiscal_year: `2018` (required, string)
-+ quarter: 1 (optional, string)
++ quarter: `1` (optional, string)
     Excluded when grouping by `fiscal_year` or `month`.
-+ month: 1 (optional, string)
++ month: `1` (optional, string)
     Excluded when grouping by `fiscal_year` or `quarter`.
 
 ## LocationObject (object)


### PR DESCRIPTION
(@dtrinh50 Help with PR description)

Minor edits to SpendingOverTime API endpoint (`/api/v2/search/spending_over_time')

Making the `TimePeriodGroup` response object types consistent.

Link to https://github.com/fedspendingtransparency/usaspending-api/pull/1576