### PR TITLE
Award Summary Recipient - fix for missing business categories

### DIFF
--- a/src/js/components/awardv2/contract/Accordion.jsx
+++ b/src/js/components/awardv2/contract/Accordion.jsx
@@ -53,7 +53,7 @@ export default class Accordion extends React.Component {
                 <div className="accordion-content">
                     {Object.keys(this.props.accordionData).map((key) => (
                         <div className="data-row">
-                            <span key={key}>{key.split("_").join(" ")}</span>
+                            <span key={key}>{key}</span>
                             <span key={this.props.accordionData[key]}>{this.props.accordionData[key] || 'not provided'}</span>
                         </div>
                     ))}

--- a/src/js/components/awardv2/contract/Recipient.jsx
+++ b/src/js/components/awardv2/contract/Recipient.jsx
@@ -51,7 +51,7 @@ export default class Recipient extends React.Component {
                     </div>
                     <div className="award__col data-values">
                         {
-                            awardData.recipient.businessCategories.map((item, index) => <span key={item}>{ (index ? ', ' : '') + item }</span>)
+                            awardData.recipient.businessCategories ? awardData.recipient.businessCategories.map((item, index) => <span key={item}>{ (index ? ', ' : '') + item }</span>) : null
                         }
                     </div>
                 </div>


### PR DESCRIPTION
High level description:
Non-matching api response causing `view more` buttons to break. 

Technical details:
API response(`api/v2/awards`) in dev for `recipient` is showing a value called `business_categories` which unfortunately, isn't matching the value specified in the API contract `business_categories_name`. 
This PR handles this issue by checking to see if the field exists before attempting to use it.

JIRA Ticket:
[DEV-1563](https://federal-spending-transparency.atlassian.net/browse/DEV-1563)
