### PR TITLE
Fix Explorer Table Account Links

### DIFF
--- a/src/js/containers/explorer/detail/table/ExplorerTableContainer.jsx
+++ b/src/js/containers/explorer/detail/table/ExplorerTableContainer.jsx
@@ -102,6 +102,7 @@ export class ExplorerTableContainer extends React.Component {
             const result = {
                 name: item.name,
                 id: item.id,
+                account_number: item.account_number,
                 obligated_amount: item.amount,
                 percent_of_total: percentageValue,
                 display: {


### PR DESCRIPTION
**High level description:**
Fixed links to Federal Account profile pages from the list view of the spending explorer. 

<img width="1354" alt="screen shot 2018-10-23 at 12 30 15 pm" src="https://user-images.githubusercontent.com/7108785/47376063-b515c300-d6bf-11e8-8a2c-a35473ab3f96.png">

**Technical details:**
- Added account number property to table result items

**JIRA Ticket:**
[DEV-1678](https://federal-spending-transparency.atlassian.net/browse/DEV-1678)

The following are ALL required for the PR to be merged:
- [ ] Code review