### PR TITLE
Updated Fiscal Year/Document URL/Spending total for 2018

### DIFF
--- a/src/js/components/homepage/hero/Hero.jsx
+++ b/src/js/components/homepage/hero/Hero.jsx
@@ -9,20 +9,14 @@ import { InfoCircle } from 'components/sharedComponents/icons/Icons';
 import HeroButton from './HeroButton';
 import HeroTooltip from './HeroTooltip';
 
-// Fiscal year, document URL, and spending amount constants, updated yearly
+// Fiscal year, spending amount constants, to be updated yearly
 // last updated: 11/5/2018
-const FISCAL_YEAR = 2018;
-const FISCAL_DOCUMENT_URL = `https://www.fiscal.treasury.gov/fsreports/rpt/mthTreasStmt/mts0918.pdf`;
-const FISCAL_SPENDING_AMOUNT = `$4.11 trillion`;
+const fiscalYear = 2018;
+const fiscalSpendingAmount = `$4.11 trillion`;
 
 export default class Hero extends React.Component {
     constructor(props) {
         super(props);
-
-        this.fiscalData = {
-            fiscalYear: FISCAL_YEAR,
-            fiscalDocumentURL: FISCAL_DOCUMENT_URL
-        };
 
         this.state = {
             showInfoTooltip: false
@@ -49,7 +43,7 @@ export default class Hero extends React.Component {
         if (this.state.showInfoTooltip) {
             tooltip = (
                 <HeroTooltip
-                    fiscalData={this.fiscalData}
+                    fiscalYear={fiscalYear}
                     showInfoTooltip={this.state.showInfoTooltip}
                     closeTooltip={this.closeTooltip} />
             );
@@ -61,7 +55,7 @@ export default class Hero extends React.Component {
                     className="homepage-hero__wrapper">
                     <div className="homepage-hero__content">
                         <h1 className="homepage-hero__headline" tabIndex={-1}>
-                            In {FISCAL_YEAR}, the government spent <strong className="homepage-hero__headline homepage-hero__headline_weight_bold">{FISCAL_SPENDING_AMOUNT}.</strong>
+                            In {fiscalYear}, the government spent <strong className="homepage-hero__headline homepage-hero__headline_weight_bold">{fiscalSpendingAmount}.</strong>
                             <span className="homepage-hero__info_icon_holder">
                                 <button
                                     id="homepage-hero__info_icon"

--- a/src/js/components/homepage/hero/Hero.jsx
+++ b/src/js/components/homepage/hero/Hero.jsx
@@ -9,9 +9,20 @@ import { InfoCircle } from 'components/sharedComponents/icons/Icons';
 import HeroButton from './HeroButton';
 import HeroTooltip from './HeroTooltip';
 
+// Fiscal year, document URL, and spending amount constants, updated yearly
+// last updated: 11/5/2018
+const FISCAL_YEAR = 2018;
+const FISCAL_DOCUMENT_URL = `https://www.fiscal.treasury.gov/fsreports/rpt/mthTreasStmt/mts0918.pdf`;
+const FISCAL_SPENDING_AMOUNT = `$4.11 trillion`;
+
 export default class Hero extends React.Component {
     constructor(props) {
         super(props);
+
+        this.fiscalData = {
+            fiscalYear: FISCAL_YEAR,
+            fiscalDocumentURL: FISCAL_DOCUMENT_URL
+        };
 
         this.state = {
             showInfoTooltip: false
@@ -38,11 +49,11 @@ export default class Hero extends React.Component {
         if (this.state.showInfoTooltip) {
             tooltip = (
                 <HeroTooltip
+                    fiscalData={this.fiscalData}
                     showInfoTooltip={this.state.showInfoTooltip}
                     closeTooltip={this.closeTooltip} />
             );
         }
-
         return (
             <section className="homepage-hero" aria-label="Introduction">
                 <div
@@ -50,7 +61,7 @@ export default class Hero extends React.Component {
                     className="homepage-hero__wrapper">
                     <div className="homepage-hero__content">
                         <h1 className="homepage-hero__headline" tabIndex={-1}>
-                            In 2017, the government spent <strong className="homepage-hero__headline homepage-hero__headline_weight_bold">$3.98 trillion.</strong>
+                            In {FISCAL_YEAR}, the government spent <strong className="homepage-hero__headline homepage-hero__headline_weight_bold">{FISCAL_SPENDING_AMOUNT}.</strong>
                             <span className="homepage-hero__info_icon_holder">
                                 <button
                                     id="homepage-hero__info_icon"

--- a/src/js/components/homepage/hero/HeroTooltip.jsx
+++ b/src/js/components/homepage/hero/HeroTooltip.jsx
@@ -10,6 +10,13 @@ import { throttle } from 'lodash';
 import * as Icons from 'components/sharedComponents/icons/Icons';
 
 const propTypes = {
+    fiscalData: PropTypes.shape({
+        fiscalYear: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.number
+        ]),
+        fiscalDocumentURL: PropTypes.string
+    }),
     closeTooltip: PropTypes.func,
     showInfoTooltip: PropTypes.bool
 };
@@ -104,9 +111,9 @@ export default class HeroTooltip extends React.Component {
                         Data Source:
                     </div>
                     <div className="homepage-hero-tooltip__tooltip_text">
-                        Fiscal Year 2017 net outlays as reported on the&nbsp;
+                        Fiscal Year {this.props.fiscalData.fiscalYear} net outlays as reported on the&nbsp;
                         <a
-                            href="https://www.fiscal.treasury.gov/fsreports/rpt/mthTreasStmt/current.htm"
+                            href={this.props.fiscalData.fiscalDocumentURL}
                             target="_blank"
                             rel="noopener noreferrer">
                             Monthly Treasury Statement

--- a/src/js/components/homepage/hero/HeroTooltip.jsx
+++ b/src/js/components/homepage/hero/HeroTooltip.jsx
@@ -10,13 +10,10 @@ import { throttle } from 'lodash';
 import * as Icons from 'components/sharedComponents/icons/Icons';
 
 const propTypes = {
-    fiscalData: PropTypes.shape({
-        fiscalYear: PropTypes.oneOfType([
-            PropTypes.string,
-            PropTypes.number
-        ]),
-        fiscalDocumentURL: PropTypes.string
-    }),
+    fiscalYear: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+    ]),
     closeTooltip: PropTypes.func,
     showInfoTooltip: PropTypes.bool
 };
@@ -111,9 +108,9 @@ export default class HeroTooltip extends React.Component {
                         Data Source:
                     </div>
                     <div className="homepage-hero-tooltip__tooltip_text">
-                        Fiscal Year {this.props.fiscalData.fiscalYear} net outlays as reported on the&nbsp;
+                        Fiscal Year {this.props.fiscalYear} net outlays as reported on the&nbsp;
                         <a
-                            href={this.props.fiscalData.fiscalDocumentURL}
+                            href="https://www.fiscal.treasury.gov/fsreports/rpt/mthTreasStmt/current.htm"
                             target="_blank"
                             rel="noopener noreferrer">
                             Monthly Treasury Statement


### PR DESCRIPTION
**High level description:**

Changed the following values on front-page:
- FY: 2017 -> 2018
- Spending Total: `$3.98` trillion to `$4.11 trillion`
- Modify _Monthly Treasury Link_ in info popup to newly requested URL
- Minor refactoring for easier future maintainability

**Technical details:**

A few minor edits were made to change hard-coded values into constant variables to simplify maintainability for future changes.

**JIRA Ticket:**
[DEV-1633](https://federal-spending-transparency.atlassian.net/browse/DEV-1633)


The following are ALL required for the PR to be merged:
- [x] Code review
- [X] Verified cross-browser compatibility