### PR TITLE
Added support for IDVs in Advance Search

### DIFF
--- a/src/js/components/bulkDownload/awards/filters/AwardTypeFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/AwardTypeFilter.jsx
@@ -33,6 +33,7 @@ export default class AwardTypeFilter extends React.Component {
     render() {
         const isValid = (
             this.props.currentAwardTypes.contracts ||
+            this.props.currentAwardTypes.idv ||
             this.props.currentAwardTypes.grants ||
             this.props.currentAwardTypes.directPayments ||
             this.props.currentAwardTypes.loans ||

--- a/src/js/components/search/filters/awardType/AwardType.jsx
+++ b/src/js/components/search/filters/awardType/AwardType.jsx
@@ -18,6 +18,13 @@ const defaultProps = {
             filters: awardTypeGroups.contracts
         },
         {
+            id: 'indefinite-delivery-vehicle',
+            name: 'Indefinite Delivery Vehicle',
+            filters: awardTypeGroups.idv,
+            // Temporarily hide IDV children until later implementation
+            restrictChildren: true
+        },
+        {
             id: 'award-grants',
             name: 'Grants',
             filters: awardTypeGroups.grants
@@ -44,7 +51,8 @@ const propTypes = {
     awardTypes: PropTypes.arrayOf(PropTypes.object),
     awardType: PropTypes.object,
     bulkTypeChange: PropTypes.func,
-    dirtyFilters: PropTypes.symbol
+    dirtyFilters: PropTypes.symbol,
+    restrictChildren: PropTypes.bool
 };
 
 export default class AwardType extends React.Component {

--- a/src/js/components/sharedComponents/checkbox/PrimaryCheckboxType.jsx
+++ b/src/js/components/sharedComponents/checkbox/PrimaryCheckboxType.jsx
@@ -23,7 +23,8 @@ const propTypes = {
     filterType: PropTypes.string,
     types: PropTypes.object,
     selectedCheckboxes: PropTypes.object,
-    enableAnalytics: PropTypes.bool
+    enableAnalytics: PropTypes.bool,
+    restrictChildren: PropTypes.bool
 };
 
 const defaultProps = {
@@ -33,7 +34,8 @@ const defaultProps = {
     filterType: '',
     types: {},
     selectedCheckboxes: new Set(),
-    enableAnalytics: false
+    enableAnalytics: false,
+    restrictChildren: false
 };
 
 export default class PrimaryCheckboxType extends React.Component {
@@ -155,7 +157,7 @@ export default class PrimaryCheckboxType extends React.Component {
             arrowState={this.state.arrowState}
             toggleExpand={this.toggleSubItems}
             toggleChildren={this.toggleChildren}
-            hideArrow={this.state.selectedChildren} />);
+            hideArrow={this.state.selectedChildren || this.props.restrictChildren} />);
 
         let secondaryTypes = null;
 

--- a/src/js/components/sharedComponents/checkbox/SecondaryCheckboxType.jsx
+++ b/src/js/components/sharedComponents/checkbox/SecondaryCheckboxType.jsx
@@ -16,14 +16,16 @@ const propTypes = {
     toggleCheckboxType: PropTypes.func,
     filterType: PropTypes.string,
     selectedCheckboxes: PropTypes.object,
-    enableAnalytics: PropTypes.bool
+    enableAnalytics: PropTypes.bool,
+    restrictChildren: PropTypes.bool
 };
 
 const defaultProps = {
     id: `checkbox-${uniqueId()}`,
     filterType: '',
     selectedCheckboxes: new Set(),
-    enableAnalytics: false
+    enableAnalytics: false,
+    restrictChildren: false
 };
 
 export default class SecondaryCheckboxType extends React.Component {
@@ -80,7 +82,8 @@ export default class SecondaryCheckboxType extends React.Component {
                         id={elementId}
                         value={this.props.code}
                         checked={checked}
-                        onChange={this.toggleFilter} />
+                        onChange={this.toggleFilter}
+                        disabled={this.props.restrictChildren} />
                     <span className="checkbox-item-label">
                         {this.props.name}
                     </span>

--- a/src/js/dataMapping/search/awardType.js
+++ b/src/js/dataMapping/search/awardType.js
@@ -10,6 +10,14 @@ export const awardTypeCodes = {
     'B': 'Purchase Orders (PO)',
     'C': 'Delivery Orders (DO)',
     'D': 'Definitive Contracts',
+    'IDV_A': 'GWAC',
+    // IDV_B: <to be determined>
+    'IDV_B_A': 'Requirements',
+    'IDV_B_B': 'Indefinite Quantity',
+    'IDV_B_C': 'Definite Quantity',
+    'IDV_C': 'FSS',
+    'IDV_D': 'BOA',
+    'IDV_E': 'BPA',
     '02': 'Block Grant',
     '03': 'Formula Grant',
     '04': 'Project Grant',
@@ -25,6 +33,7 @@ export const awardTypeCodes = {
 
 export const awardTypeGroups = {
     contracts: ['A', 'B', 'C', 'D'],
+    idv: ['IDV_A', 'IDV_B_A', 'IDV_B_B', 'IDV_B_C', 'IDV_C', 'IDV_D', 'IDV_E'],
     grants: ['02', '03', '04', '05'],
     direct_payments: ['10', '06'],
     loans: ['07', '08'],
@@ -34,6 +43,7 @@ export const awardTypeGroups = {
 
 export const awardTypeGroupLabels = {
     contracts: 'Contracts',
+    idv: "Indefinite Vehicle Delivery",
     grants: 'Grants',
     direct_payments: 'Direct Payments',
     loans: 'Loans',

--- a/tests/containers/account/awards/AccountAwardsContainer-test.jsx
+++ b/tests/containers/account/awards/AccountAwardsContainer-test.jsx
@@ -70,6 +70,7 @@ describe('AccountAwardsContainer', () => {
                 contracts: 2,
                 direct_payments: 0,
                 grants: 0,
+                idv: 0,
                 loans: 0,
                 other: 0
             });


### PR DESCRIPTION
High level description:
Added support for searching of IDVs in Advanced Search. IDV filter is now a child of Award Type. It sends a POST request containing all IDV names. Modified testing to accommodate for new IDV as a field to receive from API.

JIRA Ticket:
[DEV-1793](https://federal-spending-transparency.atlassian.net/browse/DEV-1793)

The following are ALL required for the PR to be merged:

- [ ] Code Review
- [ ] API Changes has been made