### PR TITLE
Hotfix IDV additional details

### DIFF
--- a/src/js/containers/award/AwardContainer.jsx
+++ b/src/js/containers/award/AwardContainer.jsx
@@ -102,7 +102,7 @@ export class AwardContainer extends React.Component {
             noAward: false
         });
 
-        if (data.category === 'contract' || !data.category) {
+        if (data.category === 'contract' || data.category === 'idv') {
             const contract = Object.create(BaseContract);
             contract.populate(data);
             this.props.setSelectedAward(contract);

--- a/src/js/models/v2/awards/CoreAward.js
+++ b/src/js/models/v2/awards/CoreAward.js
@@ -11,7 +11,7 @@ export const formatDate = (date) => date.format('MM/DD/YYYY');
 
 const CoreAward = {
     populateCore(data) {
-        this._category = data.category || 'idv'; // IDVs have null values
+        this._category = data.category;
         this.id = data.id || '';
         this.internalId = data.internalId || '';
         this._startDate = (

--- a/src/js/models/v2/awards/CoreAward.js
+++ b/src/js/models/v2/awards/CoreAward.js
@@ -11,7 +11,7 @@ export const formatDate = (date) => date.format('MM/DD/YYYY');
 
 const CoreAward = {
     populateCore(data) {
-        this._category = data.category;
+        this._category = data.category || '';
         this.id = data.id || '';
         this.internalId = data.internalId || '';
         this._startDate = (

--- a/tests/containers/award/AwardContainer-test.jsx
+++ b/tests/containers/award/AwardContainer-test.jsx
@@ -85,5 +85,22 @@ describe('AwardContainer', () => {
 
             expect(mockActions.setSelectedAward).toHaveBeenCalledWith(expectedAward);
         });
+        it('should parse returned IDV data and send to the Redux store', () => {
+            const awardContainer = shallow(
+                <AwardContainer
+                    {...mockParams}
+                    {...mockActions} />);
+
+            const mockIDV = Object.assign({}, mockApi, {
+                category: 'idv'
+            });
+
+            const expectedAward = Object.create(BaseContract);
+            expectedAward.populate(mockIDV);
+
+            awardContainer.instance().parseAward(mockIDV);
+
+            expect(mockActions.setSelectedAward).toHaveBeenCalledWith(expectedAward);
+        });
     });
 });

--- a/tests/models/awards/BaseContract-test.js
+++ b/tests/models/awards/BaseContract-test.js
@@ -26,7 +26,7 @@ describe('BaseContract', () => {
     describe('awardType', () => {
         it('should return the idv type for the idv category', () => {
             const mockIdv = Object.assign({}, mockContractApi, {
-                category: null
+                category: 'idv'
             });
             const idv = Object.create(BaseContract);
             idv.populate(mockIdv);

--- a/tests/models/awards/CoreAward-test.js
+++ b/tests/models/awards/CoreAward-test.js
@@ -6,7 +6,7 @@
 import CoreAward from 'models/v2/awards/CoreAward';
 
 const awardData = {
-    category: null,
+    category: 'loans',
     startDate: '1989-01-02',
     endDate: '1999-12-31',
     subawardTotal: '12004.75'
@@ -16,8 +16,8 @@ const award = Object.create(CoreAward);
 award.populateCore(awardData);
 
 describe('Core Award getter functions', () => {
-    it('should use IDV when the category is null', () => {
-        expect(award.category).toEqual('idv');
+    it('should change the loans category to be singular', () => {
+        expect(award.category).toEqual('loan');
     });
     it('should properly format the start and end dates', () => {
         expect(award.startDate).toEqual('01/02/1989');


### PR DESCRIPTION
**High level description:**

Fixes the "Additional Details" tab on IDV Summary pages. 

**Technical details:**

Addresses an API change to `v1/awards`. Previously, IDVs had a null `category`. Category is now set to `'idv'`. 

**JIRA Ticket:**
Resuted from changes related to [DEV-1924](https://federal-spending-transparency.atlassian.net/browse/DEV-1924)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Backend approval @tony-sappe or @dpb-bah 