### PR TITLE
Hotfix Spending Explorer Agency View

### DIFF
--- a/src/js/components/explorer/detail/DetailContent.jsx
+++ b/src/js/components/explorer/detail/DetailContent.jsx
@@ -56,17 +56,17 @@ export default class DetailContent extends React.Component {
         this.updateChart(this.props.data);
     }
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.transitionSteps !== 0 && prevProps.transition !== this.props.transition) {
-            if (this.props.transition === 'start') {
-                this.startTransition(this.props.transitionSteps);
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.transitionSteps !== 0 && nextProps.transition !== this.props.transition) {
+            if (nextProps.transition === 'start') {
+                this.startTransition(nextProps.transitionSteps);
             }
-            else if (this.props.transition === 'end') {
+            else if (nextProps.transition === 'end') {
                 this.finishTransition();
             }
-        }
-        else if (prevProps.data !== this.props.data) {
-            this.updateChart(this.props.data);
+            else if (nextProps.data !== this.props.data) {
+                this.updateChart(nextProps.data);
+            }
         }
     }
 

--- a/src/js/components/explorer/detail/visualization/toolbar/BreakdownDropdown.jsx
+++ b/src/js/components/explorer/detail/visualization/toolbar/BreakdownDropdown.jsx
@@ -46,15 +46,15 @@ export default class BreakdownDropdown extends React.Component {
         this.prepareOptions(this.props);
     }
 
-    componentWillReceiveProps(prevProps) {
-        if (prevProps.active !== this.props.active) {
-            this.prepareOptions(this.props);
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.active !== this.props.active) {
+            this.prepareOptions(nextProps);
         }
-        else if (prevProps.root !== this.props.root) {
-            this.prepareOptions(this.props);
+        else if (nextProps.root !== this.props.root) {
+            this.prepareOptions(nextProps);
         }
-        else if (prevProps.isRoot !== this.props.isRoot) {
-            this.prepareOptions(this.props);
+        else if (nextProps.isRoot !== this.props.isRoot) {
+            this.prepareOptions(nextProps);
         }
     }
 

--- a/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
+++ b/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
@@ -45,12 +45,12 @@ export default class ExplorerTreemap extends React.Component {
         this.buildVirtualChart(this.props);
     }
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.data !== this.props.data) {
-            this.buildVirtualChart(this.props);
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.data !== this.props.data) {
+            this.buildVirtualChart(nextProps);
         }
-        else if (prevProps.width !== this.props.width || prevProps.height !== this.props.height) {
-            this.buildVirtualChart(this.props);
+        else if (nextProps.width !== this.props.width || nextProps.height !== this.props.height) {
+            this.buildVirtualChart(nextProps);
         }
     }
 

--- a/src/js/containers/explorer/detail/ExplorerDetailPageContainer.jsx
+++ b/src/js/containers/explorer/detail/ExplorerDetailPageContainer.jsx
@@ -24,9 +24,9 @@ export class ExplorerDetailPageContainer extends React.Component {
         this.validateRoot(this.props.params.root);
     }
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.params.root !== this.props.params.root) {
-            this.validateRoot(this.props.params.root);
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.params.root !== this.props.params.root) {
+            this.validateRoot(nextProps.params.root);
         }
     }
 

--- a/src/js/containers/explorer/detail/ExplorerDetailPageContainer.jsx
+++ b/src/js/containers/explorer/detail/ExplorerDetailPageContainer.jsx
@@ -20,7 +20,7 @@ const propTypes = {
 };
 
 export class ExplorerDetailPageContainer extends React.Component {
-    componentDidMount() {
+    componentWillMount() {
         this.validateRoot(this.props.params.root);
     }
 


### PR DESCRIPTION
**High level description:**
This hotfix resolves this issue of agency view displaying incorrect data in Spending Explorer.

**Technical details:**
Reverts React Lifecycle updates for the spending explorer.

**JIRA Ticket:**
[DEV-1906](https://federal-spending-transparency.atlassian.net/browse/DEV-1906)

The following are ALL required for the PR to be merged:
- [x] Code review

