### PR TITLE
Hotfix spending explorer

### DIFF
--- a/src/js/components/explorer/detail/DetailContent.jsx
+++ b/src/js/components/explorer/detail/DetailContent.jsx
@@ -6,9 +6,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import LoadingSpinner from 'components/sharedComponents/LoadingSpinner';
 import RootHeader from './header/RootHeader';
 import DetailHeader from './header/DetailHeader';
-
 import ExplorerVisualization from './visualization/ExplorerVisualization';
 import FakeScreens from './FakeScreens';
 import NoAwardsScreen from './NoAwardsScreen';
@@ -64,9 +64,9 @@ export default class DetailContent extends React.Component {
             else if (nextProps.transition === 'end') {
                 this.finishTransition();
             }
-        }
-        else if (nextProps.data !== this.props.data) {
-            this.updateChart(nextProps.data);
+            else if (nextProps.data !== this.props.data) {
+                this.updateChart(nextProps.data);
+            }
         }
     }
 
@@ -149,10 +149,20 @@ export default class DetailContent extends React.Component {
                     className="explorer-detail-content"
                     ref={(div) => {
                         this.wrapperDiv = div;
-                    }} />
+                    }}>
+                    <div className="explorer-detail-content__loading">
+                        <div className="explorer-detail-content__loading-message">
+                            <LoadingSpinner />
+                            <div className="explorer-detail-content__loading-title">Gathering your data...</div>
+                            <div className="explorer-detail-content__loading-subtitle">Updating Spending Explorer.</div>
+                            <div>This should only take a few moments...</div>
+                        </div>
+                    </div>
+                </div>
             );
         }
         let header = (<RootHeader
+            isLoading={this.props.isLoading}
             root={this.props.root}
             fy={this.props.fy}
             lastUpdate={this.props.lastUpdate}
@@ -179,6 +189,7 @@ export default class DetailContent extends React.Component {
             }
 
             header = (<DetailHeader
+                isLoading={this.props.isLoading}
                 within={lastFilter.within}
                 title={lastFilter.title}
                 id={id}

--- a/src/js/components/explorer/detail/DetailContent.jsx
+++ b/src/js/components/explorer/detail/DetailContent.jsx
@@ -6,7 +6,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import LoadingSpinner from 'components/sharedComponents/LoadingSpinner';
 import RootHeader from './header/RootHeader';
 import DetailHeader from './header/DetailHeader';
 import ExplorerVisualization from './visualization/ExplorerVisualization';
@@ -149,20 +148,10 @@ export default class DetailContent extends React.Component {
                     className="explorer-detail-content"
                     ref={(div) => {
                         this.wrapperDiv = div;
-                    }}>
-                    <div className="explorer-detail-content__loading">
-                        <div className="explorer-detail-content__loading-message">
-                            <LoadingSpinner />
-                            <div className="explorer-detail-content__loading-title">Gathering your data...</div>
-                            <div className="explorer-detail-content__loading-subtitle">Updating Spending Explorer.</div>
-                            <div>This should only take a few moments...</div>
-                        </div>
-                    </div>
-                </div>
+                    }} />
             );
         }
         let header = (<RootHeader
-            isLoading={this.props.isLoading}
             root={this.props.root}
             fy={this.props.fy}
             lastUpdate={this.props.lastUpdate}
@@ -189,7 +178,6 @@ export default class DetailContent extends React.Component {
             }
 
             header = (<DetailHeader
-                isLoading={this.props.isLoading}
                 within={lastFilter.within}
                 title={lastFilter.title}
                 id={id}

--- a/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
+++ b/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
@@ -12,11 +12,9 @@ import { remove } from 'lodash';
 
 import { measureTreemapHeader, measureTreemapValue } from 'helpers/textMeasurement';
 
-import LoadingSpinner from 'components/sharedComponents/LoadingSpinner';
 import TreemapCell from './TreemapCell';
 
 const propTypes = {
-    isLoading: PropTypes.bool,
     width: PropTypes.number,
     height: PropTypes.number,
     data: PropTypes.object,
@@ -217,23 +215,8 @@ export default class ExplorerTreemap extends React.Component {
                 goToUnreported={this.props.goToUnreported} />
         ));
 
-        let loadingMessage = null;
-        if (this.props.isLoading) {
-            loadingMessage = (
-                <div className="explorer-detail-content__loading">
-                    <div className="explorer-detail-content__loading-message">
-                        <LoadingSpinner />
-                        <div className="explorer-detail-content__loading-title">Gathering your data...</div>
-                        <div className="explorer-detail-content__loading-subtitle">Updating Spending Explorer.</div>
-                        <div>This should only take a few moments...</div>
-                    </div>
-                </div>
-            );
-        }
-
         return (
             <div className="explorer-treemap">
-                {loadingMessage}
                 <svg
                     className="treemap"
                     width="100%"

--- a/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
+++ b/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
@@ -12,9 +12,11 @@ import { remove } from 'lodash';
 
 import { measureTreemapHeader, measureTreemapValue } from 'helpers/textMeasurement';
 
+import LoadingSpinner from 'components/sharedComponents/LoadingSpinner';
 import TreemapCell from './TreemapCell';
 
 const propTypes = {
+    isLoading: PropTypes.bool,
     width: PropTypes.number,
     height: PropTypes.number,
     data: PropTypes.object,
@@ -39,7 +41,7 @@ export default class ExplorerTreemap extends React.Component {
         this.selectedCell = this.selectedCell.bind(this);
     }
 
-    componentWillMount() {
+    componentDidMount() {
         this.buildVirtualChart(this.props);
     }
 
@@ -215,8 +217,23 @@ export default class ExplorerTreemap extends React.Component {
                 goToUnreported={this.props.goToUnreported} />
         ));
 
+        let loadingMessage = null;
+        if (this.props.isLoading) {
+            loadingMessage = (
+                <div className="explorer-detail-content__loading">
+                    <div className="explorer-detail-content__loading-message">
+                        <LoadingSpinner />
+                        <div className="explorer-detail-content__loading-title">Gathering your data...</div>
+                        <div className="explorer-detail-content__loading-subtitle">Updating Spending Explorer.</div>
+                        <div>This should only take a few moments...</div>
+                    </div>
+                </div>
+            );
+        }
+
         return (
             <div className="explorer-treemap">
+                {loadingMessage}
                 <svg
                     className="treemap"
                     width="100%"

--- a/src/js/containers/explorer/detail/ExplorerDetailPageContainer.jsx
+++ b/src/js/containers/explorer/detail/ExplorerDetailPageContainer.jsx
@@ -20,13 +20,13 @@ const propTypes = {
 };
 
 export class ExplorerDetailPageContainer extends React.Component {
-    componentDidMount() {
+    componentWillMount() {
         this.validateRoot(this.props.params.root);
     }
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.params.root !== this.props.params.root) {
-            this.validateRoot(this.props.params.root);
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.params.root !== this.props.params.root) {
+            this.validateRoot(nextProps.params.root);
         }
     }
 


### PR DESCRIPTION
**High level description:**
Hotfix for Spending Explorer display wrong view.

**Technical details:**
Reverts life cycle updates for Spending Explorer containers and components. 

**JIRA Ticket:**
[DEV-1906](https://federal-spending-transparency.atlassian.net/browse/DEV-1906)

The following are ALL required for the PR to be merged:
- [x] Code review