### PR TITLE
Hotfix delay 2019 Q1

### DIFF
--- a/src/js/containers/explorer/detail/helpers/explorerQuarters.js
+++ b/src/js/containers/explorer/detail/helpers/explorerQuarters.js
@@ -14,6 +14,16 @@ export const handlePotentialStrings = (input) => {
 };
 
 export const mostRecentQuarter = () => {
+    // Delay Q1 of 2019 because of the gov't shutdown
+    const startDelayRange = moment('02/01/2019', 'MM/DD/YYYY');
+    const endDelayRange = moment('03/20/2019', 'MM/DD/YYYY');
+    if (moment().isSameOrAfter(startDelayRange) && moment().isSameOrBefore(endDelayRange)) {
+        return {
+            quarter: 4,
+            year: 2018
+        };
+    }
+
     // go back 45 days prior to today
     const todayAdjusted = moment().subtract(FiscalYearHelper.quarterCloseWindow, 'days');
     // determine the quarter that date was in

--- a/src/js/helpers/fiscalYearHelper.js
+++ b/src/js/helpers/fiscalYearHelper.js
@@ -37,6 +37,14 @@ export const defaultFiscalYear = () => {
     // Calculate the configurable delay for Q1 close so that we aren't requesting data
     // for a new FY when no data exists in it yet
     const today = moment();
+
+    // Delay FY 2019 Q1
+    const startDelayRange = moment('02/01/2019', 'MM/DD/YYYY');
+    const endDelayRange = moment('03/20/2019', 'MM/DD/YYYY');
+    if (today.isSameOrAfter(startDelayRange) && today.isSameOrBefore(endDelayRange)) {
+        return 2018;
+    }
+
     const newFiscalYearStartDate = moment()
         .startOf('year')
         .add(quarterCloseWindow, 'days');

--- a/tests/containers/explorer/detail/helpers/explorerQuarters-test.js
+++ b/tests/containers/explorer/detail/helpers/explorerQuarters-test.js
@@ -68,6 +68,22 @@ describe('explorerQuarters', () => {
                 year: 2018
             });
         });
+        it('should delay the release of FY 2019 Q1 data until March 21, 2019', () => {
+            mockDate('2019-03-20');
+            const output = explorerQuarters.mostRecentQuarter();
+            expect(output).toEqual({
+                quarter: 4,
+                year: 2018
+            });
+        });
+        it('should return 2019 Q1 on March 21, 2019', () => {
+            mockDate('2019-03-21');
+            const output = explorerQuarters.mostRecentQuarter();
+            expect(output).toEqual({
+                quarter: 1,
+                year: 2019
+            });
+        });
     });
 
     describe('lastCompletedQuarterInFY', () => {
@@ -98,11 +114,8 @@ describe('explorerQuarters', () => {
         it('should accept both string and number FY values', () => {
             mockDate('1912-06-01');
 
-            expect(
-                explorerQuarters.lastCompletedQuarterInFY('1899')
-            ).toEqual(
-                explorerQuarters.lastCompletedQuarterInFY(1899)
-            );
+            expect(explorerQuarters.lastCompletedQuarterInFY('1899'))
+                .toEqual(explorerQuarters.lastCompletedQuarterInFY(1899));
         });
     });
 
@@ -157,11 +170,8 @@ describe('explorerQuarters', () => {
         });
         it('should accept a string or number argument', () => {
             mockDate('2020-06-01');
-            expect(
-                explorerQuarters.availableQuartersInFY('2018')
-            ).toEqual(
-                explorerQuarters.availableQuartersInFY(2018)
-            );
+            expect(explorerQuarters.availableQuartersInFY('2018'))
+                .toEqual(explorerQuarters.availableQuartersInFY(2018));
         });
     });
 

--- a/tests/helpers/fiscalYearHelper-test.js
+++ b/tests/helpers/fiscalYearHelper-test.js
@@ -78,6 +78,28 @@ describe('Fiscal Year helper functions', () => {
             // reset moment's date to the current time
             moment.now = () => (new Date());
         });
+
+        it('should delay the switchover to 2019 until March 21, 2019', () => {
+            const mockedDate = moment('2019-03-20', 'YYYY-MM-DD').toDate();
+            moment.now = () => (mockedDate);
+
+            const currentFY = FiscalYearHelper.defaultFiscalYear();
+            expect(currentFY).toEqual(2018);
+
+            // reset moment's date to the current time
+            moment.now = () => (new Date());
+        });
+
+        it('should return 2019 on March 21, 2019', () => {
+            const mockedDate = moment('2019-03-21', 'YYYY-MM-DD').toDate();
+            moment.now = () => (mockedDate);
+
+            const currentFY = FiscalYearHelper.defaultFiscalYear();
+            expect(currentFY).toEqual(2019);
+
+            // reset moment's date to the current time
+            moment.now = () => (new Date());
+        });
     });
 
     describe('convertFYtoDateRange', () => {


### PR DESCRIPTION
**High level description:**

Delays the release of 2019 Q1 Account data until March 21, 2019.

**Technical details:**

Affects the following components:
- Spending explorer FY and quarter picker
- Custom Account download FY and quarter picker
- Federal Account Landing page `Budgetary Resources` column (API request and heading)
- Federal Account Profile page Sankey (API request and heading), and available time period filters

**JIRA Ticket:**
[DEV-2091](https://federal-spending-transparency.atlassian.net/browse/DEV-2091)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:
- [x] Code review