### PR TITLE
Update Redux dev tools

### DIFF
--- a/src/js/containers/AppContainer.jsx
+++ b/src/js/containers/AppContainer.jsx
@@ -17,7 +17,7 @@ let devExtension;
 let store;
 if (kGlobalConstants.DEV) {
     // only enable Redux debugging in dev mode
-    devExtension = window.devToolsExtension ? window.devToolsExtension() : undefined;
+    devExtension = window.__REDUX_DEVTOOLS_EXTENSION__ ? window.__REDUX_DEVTOOLS_EXTENSION__() : undefined;
 }
 
 if (kGlobalConstants.PERF_LOG) {


### PR DESCRIPTION
**High level description:**

The [Redux Dev Tools Extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd) window variable has been renamed in the latest version.

**Technical details:**

See https://github.com/zalmoxisus/redux-devtools-extension#usage

Removes this console warning:
> `window.devToolsExtension` is deprecated in favor of `window.__REDUX_DEVTOOLS_EXTENSION__`, and will be removed in next version of Redux DevTools: https://git.io/fpEJZ

**JIRA Ticket:**
N/A (technical improvement)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:
- [x] Code review
