### PR TITLE
Feature idv tooltips

### DIFF
--- a/src/_scss/pages/awardV2/awardPage.scss
+++ b/src/_scss/pages/awardV2/awardPage.scss
@@ -37,6 +37,18 @@
                 font-weight: $font-light;
             }
 
+            .award__icon {
+                background-color: transparent;
+                margin: 0 0 0 rem(5);
+                padding: 0;
+        
+                svg {
+                    width: rem(15);
+                    height: rem(15);
+                    fill: $color-gray-border;
+                }
+            }
+
             .award__row {
                 @include display(flex);
                 @include flex-wrap(wrap);

--- a/src/_scss/pages/awardV2/idv/_infoTooltip.scss
+++ b/src/_scss/pages/awardV2/idv/_infoTooltip.scss
@@ -1,0 +1,60 @@
+.award__info-wrapper{
+    .info-tooltip-spacer {
+        display: none;
+        @include media($medium-screen) {
+            display: block;
+            position: absolute;
+            z-index: 9;
+        }
+    }
+    .info-tooltip {
+        width: rem(300);
+        .info-tooltip__interior {
+            position: relative;
+            // inherit from the standard tooltip arrow style
+            $color-tooltip-border: $color-primary-alt-light;
+            @import "components/visualizations/tooltip/_arrow";
+            .tooltip-pointer {
+                // override the coloring
+                &:after {
+                    background: $color-primary-alt-lightest;
+                }
+                z-index: 2;
+                top: rem(32);
+                right: rem(2);
+            }
+            .info-tooltip__content {
+                @include display(flex);
+                @include flex-direction(row);
+                @include justify-content(center);
+                @include align-items(center);
+                position: relative;
+                box-shadow: $box-shadow;
+                background-color: $color-primary-alt-lightest;
+                border: solid rem(1) $color-primary-alt-light;
+                padding: rem(15);
+    
+                .info-tooltip__icon {
+                    @include flex(0 0 auto);
+                    @include align-self(flex-start);
+                    margin-right: rem(10);
+                    width: rem(20);
+                    height: rem(20);
+                    svg {
+                        width: rem(20);
+                        height: rem(20);
+                        fill: $color-primary-alt;
+                    }
+                }
+                .info-tooltip__message {
+                    @include flex(1 1 auto);
+                    text-align: left;
+                    font-size: $small-font-size;
+                    .info-tooltip__list {
+                        margin-bottom: 0;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/_scss/pages/awardV2/idv/_infoTooltip.scss
+++ b/src/_scss/pages/awardV2/idv/_infoTooltip.scss
@@ -8,7 +8,7 @@
         }
     }
     .info-tooltip {
-        width: rem(300);
+        width: rem(375);
         .info-tooltip__interior {
             position: relative;
             // inherit from the standard tooltip arrow style
@@ -43,6 +43,7 @@
                     }
                     .info-tooltip__text {
                         padding: 0 rem(15) rem(15);
+                        font-weight: $font-normal;
                         ul {
                             margin: 0;
                             padding-left: 0;

--- a/src/_scss/pages/awardV2/idv/_infoTooltip.scss
+++ b/src/_scss/pages/awardV2/idv/_infoTooltip.scss
@@ -12,16 +12,15 @@
         .info-tooltip__interior {
             position: relative;
             // inherit from the standard tooltip arrow style
-            $color-tooltip-border: $color-primary-alt-light;
+            $color-tooltip-border: $color-gray-light;
             @import "components/visualizations/tooltip/_arrow";
             .tooltip-pointer {
                 // override the coloring
                 &:after {
-                    background: $color-primary-alt-lightest;
+                    background: $color-gray-lightest;
                 }
                 z-index: 2;
-                top: rem(32);
-                right: rem(2);
+                top: rem(15);
             }
             .info-tooltip__content {
                 @include display(flex);
@@ -30,28 +29,25 @@
                 @include align-items(center);
                 position: relative;
                 box-shadow: $box-shadow;
-                background-color: $color-primary-alt-lightest;
-                border: solid rem(1) $color-primary-alt-light;
-                padding: rem(15);
-    
-                .info-tooltip__icon {
-                    @include flex(0 0 auto);
-                    @include align-self(flex-start);
-                    margin-right: rem(10);
-                    width: rem(20);
-                    height: rem(20);
-                    svg {
-                        width: rem(20);
-                        height: rem(20);
-                        fill: $color-primary-alt;
-                    }
-                }
+                background-color: $color-white;
+                border: solid rem(1) $color-gray-light;
                 .info-tooltip__message {
                     @include flex(1 1 auto);
                     text-align: left;
                     font-size: $small-font-size;
-                    .info-tooltip__list {
-                        margin-bottom: 0;
+                    .info-tooltip__title {
+                        background-color: $color-gray-lightest;
+                        padding: rem(10) rem(15);
+                        font-weight: $font-bold;
+                        z-index: 10;
+                    }
+                    .info-tooltip__text {
+                        padding: 0 rem(15) rem(15);
+                        ul {
+                            margin: 0;
+                            padding-left: 0;
+                            list-style-type: none;
+                        }
                     }
                 }
             }

--- a/src/_scss/pages/awardV2/idv/awardIdv.scss
+++ b/src/_scss/pages/awardV2/idv/awardIdv.scss
@@ -21,6 +21,7 @@
     }
   }
 
+  @import './infoTooltip';
   @import './awardHistory';
   @import './referencedAwards';
   @import './awardAmounts';

--- a/src/_scss/pages/awardV2/visualizations/awardViz.scss
+++ b/src/_scss/pages/awardV2/visualizations/awardViz.scss
@@ -3,75 +3,101 @@
     @import "pages/search/results/table/_tableTypes";
     @import "pages/search/results/table/_resultsTablePicker";
     @import "pages/search/results/visualizations/_messages";
-   
+
     .visualization-message-container {
         margin-top: rem(30);
         height: rem(112);
         padding-top: rem(45);
     }
+
     .award-viz__heading {
         @include display(flex);
         @include justify-content(flex-start);
         @include align-items(center);
+
         .award-viz__icon {
             @include flex(0 0 auto);
+
             height: rem(20);
             width: rem(20);
             margin-right: rem(9);
+
             svg {
                 fill: $color-gray;
             }
         }
+
         h3.award-viz__title {
+            @include display(flex);
             @include flex(1 1 auto);
+
             margin: 0;
             line-height: $base-line-height;
             font-size: rem(18);
             font-weight: $font-semibold;
         }
+
+        .award__info-wrapper {
+            @include display(flex);
+            @include flex(0 0 auto);
+            @include align-self(flex-end);
+        }
     }
+
     .award-viz__button {
         @include button-unstyled;
+
         color: $color-link;
+
         &:hover, &:focus {
             color: $color-visited;
         }
     }
+
     .award-viz__link {
         @include display(flex);
         @include justify-content(flex-start);
         @include flex(0 0 auto);
         @include align-items(center);
+
         width: fit-content;
         padding: rem(4) 0;
+
         .award-viz__link-icon {
             @include display(flex);
             @include flex(0 0 auto);
+
             margin-right: rem(5);
+
             svg {
                 height: rem(15);
                 width: rem(15);
                 fill: $color-link;
             }
         }
+
         .award-viz__link-icon_hidden {
             display: none;
         }
+
         .award-viz__link-text {
             @include display(flex);
             @include flex(0 0 auto);
         }
+
         &:hover {
             cursor: pointer;
             text-decoration: none;
         }
+
         &:visited, &:hover {
-            .award-viz__link-icon{
+            .award-viz__link-icon {
                 svg {
                     fill: $color-visited;
                 }
             }
         }
+
         .award-viz__link-text_hidden {
             display: none;
         }

--- a/src/_scss/pages/awardV2/visualizations/overview/_relatedAwards.scss
+++ b/src/_scss/pages/awardV2/visualizations/overview/_relatedAwards.scss
@@ -1,4 +1,12 @@
 .related-awards {
+    .related-awards__title {
+        @include display(flex);
+        .award__info-wrapper {
+            width: fit-content;
+            @include display(flex);
+            @include flex(0 0 auto);
+        }
+    }
     .related-awards__label {
         font-weight: $font-light;
         padding-bottom: rem(5);

--- a/src/js/components/awardv2/idv/IdvDates.jsx
+++ b/src/js/components/awardv2/idv/IdvDates.jsx
@@ -5,9 +5,10 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import * as TimeRangeHelper from 'helpers/timeRangeHelper';
 import moment from 'moment';
-import * as Icons from 'components/sharedComponents/icons/Icons';
+import InfoTooltip from './InfoTooltip';
 
 const propTypes = {
     dates: PropTypes.object
@@ -80,14 +81,18 @@ export default class IdvDates extends React.Component {
                 <div className="idv-dates__heading">
                     <div className="award-overview__title idv-dates__title">
                         Dates
-                        <button
-                            onBlur={this.closeTooltip}
-                            className="award__icon"
-                            onFocus={this.showTooltip}
-                            onMouseEnter={this.showTooltip}
-                            onClick={this.showTooltip}>
-                            <Icons.InfoCircle alt="Information" />
-                        </button>
+                        <InfoTooltip>
+                            <strong>Dates</strong>
+                            <p>The dates below are described in more detail:</p>
+                            <ul>
+                                <li>
+                                    <strong>Start Date</strong> – This is the effective date, or when the IDV was made available for use by agencies.
+                                </li>
+                                <li>
+                                    <strong>End Date</strong> – This is the last date for agencies to make purchases under this IDV.
+                                </li>
+                            </ul>
+                        </InfoTooltip>
                     </div>
                     <div className="idv-dates__remaining">
                         {remainingText}

--- a/src/js/components/awardv2/idv/IdvDates.jsx
+++ b/src/js/components/awardv2/idv/IdvDates.jsx
@@ -82,16 +82,18 @@ export default class IdvDates extends React.Component {
                     <div className="award-overview__title idv-dates__title">
                         Dates
                         <InfoTooltip>
-                            <strong>Dates</strong>
-                            <p>The dates below are described in more detail:</p>
-                            <ul>
-                                <li>
-                                    <strong>Start Date</strong> – This is the effective date, or when the IDV was made available for use by agencies.
-                                </li>
-                                <li>
-                                    <strong>End Date</strong> – This is the last date for agencies to make purchases under this IDV.
-                                </li>
-                            </ul>
+                            <div className="info-tooltip__title">Dates</div>
+                            <div className="info-tooltip__text">
+                                <p>The dates below are described in more detail:</p>
+                                <ul>
+                                    <li>
+                                        <strong>Start Date</strong> – This is the effective date, or when the IDV was made available for use by agencies.
+                                    </li>
+                                    <li>
+                                        <strong>End Date</strong> – This is the last date for agencies to make purchases under this IDV.
+                                    </li>
+                                </ul>
+                            </div>
                         </InfoTooltip>
                     </div>
                     <div className="idv-dates__remaining">

--- a/src/js/components/awardv2/idv/IdvDates.jsx
+++ b/src/js/components/awardv2/idv/IdvDates.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import * as TimeRangeHelper from 'helpers/timeRangeHelper';
 import moment from 'moment';
+import * as Icons from 'components/sharedComponents/icons/Icons';
 
 const propTypes = {
     dates: PropTypes.object
@@ -79,6 +80,14 @@ export default class IdvDates extends React.Component {
                 <div className="idv-dates__heading">
                     <div className="award-overview__title idv-dates__title">
                         Dates
+                        <button
+                            onBlur={this.closeTooltip}
+                            className="award__icon"
+                            onFocus={this.showTooltip}
+                            onMouseEnter={this.showTooltip}
+                            onClick={this.showTooltip}>
+                            <Icons.InfoCircle alt="Information" />
+                        </button>
                     </div>
                     <div className="idv-dates__remaining">
                         {remainingText}

--- a/src/js/components/awardv2/idv/IdvDates.jsx
+++ b/src/js/components/awardv2/idv/IdvDates.jsx
@@ -81,7 +81,7 @@ export default class IdvDates extends React.Component {
                 <div className="idv-dates__heading">
                     <div className="award-overview__title idv-dates__title">
                         Dates
-                        <InfoTooltip>
+                        <InfoTooltip left>
                             <div className="info-tooltip__title">Dates</div>
                             <div className="info-tooltip__text">
                                 <p>The dates below are described in more detail:</p>

--- a/src/js/components/awardv2/idv/InfoTooltip.jsx
+++ b/src/js/components/awardv2/idv/InfoTooltip.jsx
@@ -51,7 +51,7 @@ export default class InfoTooltip extends React.Component {
 
     measureOffset() {
         const targetElement = this.referenceDiv;
-        const offsetTop = targetElement.offsetTop - 35;
+        const offsetTop = targetElement.offsetTop - 15;
         const offsetRight = window.innerWidth - targetElement.offsetLeft - targetElement.clientWidth - 315;
         this.setState({
             offsetTop,

--- a/src/js/components/awardv2/idv/InfoTooltip.jsx
+++ b/src/js/components/awardv2/idv/InfoTooltip.jsx
@@ -53,9 +53,10 @@ export default class InfoTooltip extends React.Component {
     measureOffset() {
         const targetElement = this.referenceDiv;
         const offsetTop = targetElement.offsetTop - 15;
-        let offsetRight = window.innerWidth - targetElement.offsetLeft - targetElement.clientWidth - 315;
+        const tooltipWidth = 375;
+        let offsetRight = window.innerWidth - targetElement.offsetLeft - targetElement.clientWidth - tooltipWidth - 30;
         if (this.props.left) {
-            offsetRight = (window.innerWidth - targetElement.offsetLeft - 10) + targetElement.clientWidth;
+            offsetRight = (window.innerWidth - targetElement.offsetLeft - 25) + targetElement.clientWidth;
         }
         this.setState({
             offsetTop,

--- a/src/js/components/awardv2/idv/InfoTooltip.jsx
+++ b/src/js/components/awardv2/idv/InfoTooltip.jsx
@@ -5,25 +5,103 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { throttle } from 'lodash';
+import { InfoCircle } from 'components/sharedComponents/icons/Icons';
 
 const propTypes = {
     children: PropTypes.node
 };
 
 export default class InfoTooltip extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showInfoTooltip: false,
+            offsetTop: 0,
+            offsetRight: 0
+        };
+        this.showTooltip = this.showTooltip.bind(this);
+        this.closeTooltip = this.closeTooltip.bind(this);
+        this.measureOffset = throttle(this.measureOffset.bind(this), 16);
+    }
+
+    componentDidMount() {
+        this.measureOffset();
+        window.addEventListener('scroll', this.measureOffset);
+        window.addEventListener('resize', this.measureOffset);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('scroll', this.measureOffset);
+        window.removeEventListener('resize', this.measureOffset);
+    }
+
+    showTooltip() {
+        this.setState({
+            showInfoTooltip: true
+        });
+    }
+
+    closeTooltip() {
+        this.setState({
+            showInfoTooltip: false
+        });
+    }
+
+    measureOffset() {
+        const targetElement = this.referenceDiv;
+        const offsetTop = targetElement.offsetTop - 35;
+        const offsetRight = window.innerWidth - targetElement.offsetLeft - targetElement.clientWidth - 315;
+        this.setState({
+            offsetTop,
+            offsetRight
+        });
+    }
+
     render() {
-        return (
-            <div
-                className="info-tooltip"
-                id="info-tooltip"
-                role="tooltip">
-                <div className="info-tooltip__interior">
-                    <div className="tooltip-pointer" />
-                    <div className="info-tooltip__content">
-                        <div className="info-tooltip__message">
-                            {this.props.children}
+        let tooltip = null;
+        if (this.state.showInfoTooltip) {
+            const style = {
+                top: this.state.offsetTop,
+                right: this.state.offsetRight
+            };
+
+            tooltip = (
+                <div
+                    className="info-tooltip-spacer"
+                    style={style}>
+                    <div
+                        className="info-tooltip"
+                        id="info-tooltip"
+                        role="tooltip">
+                        <div className="info-tooltip__interior">
+                            <div className="tooltip-pointer" />
+                            <div className="info-tooltip__content">
+                                <div className="info-tooltip__message">
+                                    {this.props.children}
+                                </div>
+                            </div>
                         </div>
                     </div>
+                </div>
+            );
+        }
+        return (
+            <div className="award__info-wrapper">
+                <div ref={(div) => {
+                    this.referenceDiv = div;
+                }}>
+                    <button
+                        onBlur={this.closeTooltip}
+                        className="award__icon"
+                        onFocus={this.showTooltip}
+                        onMouseEnter={this.showTooltip}
+                        onMouseLeave={this.closeTooltip}
+                        onClick={this.showTooltip}>
+                        <InfoCircle alt="Information" />
+                    </button>
+                    {tooltip}
                 </div>
             </div>
         );

--- a/src/js/components/awardv2/idv/InfoTooltip.jsx
+++ b/src/js/components/awardv2/idv/InfoTooltip.jsx
@@ -1,0 +1,33 @@
+/**
+ * InfoTooltip.jsx
+ * Created by Lizzie Salita 3/8/19
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+    children: PropTypes.node
+};
+
+export default class InfoTooltip extends React.Component {
+    render() {
+        return (
+            <div
+                className="info-tooltip"
+                id="info-tooltip"
+                role="tooltip">
+                <div className="info-tooltip__interior">
+                    <div className="tooltip-pointer" />
+                    <div className="info-tooltip__content">
+                        <div className="info-tooltip__message">
+                            {this.props.children}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+InfoTooltip.propTypes = propTypes;

--- a/src/js/components/awardv2/idv/InfoTooltip.jsx
+++ b/src/js/components/awardv2/idv/InfoTooltip.jsx
@@ -9,7 +9,8 @@ import { throttle } from 'lodash';
 import { InfoCircle } from 'components/sharedComponents/icons/Icons';
 
 const propTypes = {
-    children: PropTypes.node
+    children: PropTypes.node,
+    left: PropTypes.bool
 };
 
 export default class InfoTooltip extends React.Component {
@@ -52,7 +53,10 @@ export default class InfoTooltip extends React.Component {
     measureOffset() {
         const targetElement = this.referenceDiv;
         const offsetTop = targetElement.offsetTop - 15;
-        const offsetRight = window.innerWidth - targetElement.offsetLeft - targetElement.clientWidth - 315;
+        let offsetRight = window.innerWidth - targetElement.offsetLeft - targetElement.clientWidth - 315;
+        if (this.props.left) {
+            offsetRight = (window.innerWidth - targetElement.offsetLeft - 10) + targetElement.clientWidth;
+        }
         this.setState({
             offsetTop,
             offsetRight
@@ -61,12 +65,11 @@ export default class InfoTooltip extends React.Component {
 
     render() {
         let tooltip = null;
+        const style = {
+            top: this.state.offsetTop,
+            right: this.state.offsetRight
+        };
         if (this.state.showInfoTooltip) {
-            const style = {
-                top: this.state.offsetTop,
-                right: this.state.offsetRight
-            };
-
             tooltip = (
                 <div
                     className="info-tooltip-spacer"
@@ -76,7 +79,7 @@ export default class InfoTooltip extends React.Component {
                         id="info-tooltip"
                         role="tooltip">
                         <div className="info-tooltip__interior">
-                            <div className="tooltip-pointer" />
+                            <div className={`tooltip-pointer ${this.props.left ? 'right' : ''}`} />
                             <div className="info-tooltip__content">
                                 <div className="info-tooltip__message">
                                     {this.props.children}

--- a/src/js/components/awardv2/visualizations/amounts/AwardAmounts.jsx
+++ b/src/js/components/awardv2/visualizations/amounts/AwardAmounts.jsx
@@ -9,6 +9,7 @@ import AwardAmountsContainer from 'containers/awardV2/visualization/AwardAmounts
 import ResultsTableTabs from 'components/search/table/ResultsTableTabs';
 import ResultsTablePicker from 'components/search/table/ResultsTablePicker';
 import IDVAmounts from './IDVAmounts';
+import InfoTooltip from '../../idv/InfoTooltip';
 
 const propTypes = {
     overview: PropTypes.object,
@@ -52,6 +53,24 @@ export default class AwardAmounts extends React.Component {
                     <h3 className="award-viz__title">
                         $ Award Amounts
                     </h3>
+                    <InfoTooltip>
+                        <div className="info-tooltip__title">
+                            Award Amounts
+                        </div>
+                        <div className="info-tooltip__text">
+                            <p>
+                                This section provides information on the value of the award at two different levels, shown separately under the following tabs:
+                            </p>
+                            <ul>
+                                <li>
+                                    <strong>Awards Under this IDV</strong> – The information within this tab is derived from the data of every award made under this IDV, not the IDV award itself. This is done because award amount data is not typically found in IDV award records themselves. In order to provide a better idea of the actual value of the IDV as a whole, award amounts are taken from every award made under the IDV and then aggregated (or summed together) and presented here.
+                                </li>
+                                <li>
+                                    <strong>This IDV</strong> – This tab contains data that is directly attributed to the IDV record summarized on this page. This data does not include the data attributed to the awards made under it.  In many cases, the data directly attributed to an IDV record does not show actual award amounts, which is why the amounts in this tab are often $0.
+                                </li>
+                            </ul>
+                        </div>
+                    </InfoTooltip>
                 </div>
                 <hr />
                 <div className="award-viz__tabs">

--- a/src/js/components/awardv2/visualizations/description/AwardDescription.jsx
+++ b/src/js/components/awardv2/visualizations/description/AwardDescription.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { SpeechBubble, Glossary, AngleDown, AngleUp } from 'components/sharedComponents/icons/Icons';
+import InfoTooltip from '../../idv/InfoTooltip';
 
 const propTypes = {
     awardId: PropTypes.string,
@@ -73,6 +74,20 @@ export default class AwardDescription extends React.Component {
                     <h3 className="award-viz__title">
                         Description
                     </h3>
+                    <InfoTooltip left>
+                        <div className="info-tooltip__title">Description</div>
+                        <div className="info-tooltip__text">
+                            <p>
+                                The description of the award is provided by the contract officer who submitted this award data. The quality of these descriptions can vary as they are largely dependent on their author and agency standards.
+                            </p>
+                            <p>
+                                Also shown below are codes from two sets, North American Industry Classification System (NAICS) and Product Service Codes (PSC), used to categorize awards by what they are or are for.
+                            </p>
+                            <p>
+                                Click on the glossary icons for more information on those systems.
+                            </p>
+                        </div>
+                    </InfoTooltip>
                 </div>
                 <hr />
                 <div className="award-description__content">

--- a/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
+++ b/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
@@ -5,9 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { throttle } from 'lodash';
 
-import * as Icons from 'components/sharedComponents/icons/Icons';
 import InfoTooltip from '../../idv/InfoTooltip';
 
 const propTypes = {
@@ -15,53 +13,6 @@ const propTypes = {
 };
 
 export default class RelatedAwards extends React.Component {
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            showTooltip: false,
-            offsetTop: 0,
-            offsetRight: 0
-        };
-
-        this.showTooltip = this.showTooltip.bind(this);
-        this.closeTooltip = this.closeTooltip.bind(this);
-        this.measureOffset = throttle(this.measureOffset.bind(this), 16);
-    }
-
-    componentDidMount() {
-        this.measureOffset();
-        window.addEventListener('scroll', this.measureOffset);
-        window.addEventListener('resize', this.measureOffset);
-    }
-
-    componentWillUnmount() {
-        window.removeEventListener('scroll', this.measureOffset);
-        window.removeEventListener('resize', this.measureOffset);
-    }
-
-    showTooltip() {
-        this.setState({
-            showInfoTooltip: true
-        });
-    }
-
-    closeTooltip() {
-        this.setState({
-            showInfoTooltip: false
-        });
-    }
-
-    measureOffset() {
-        const targetElement = this.referenceDiv;
-        const offsetTop = targetElement.offsetTop - 35;
-        const offsetRight = window.innerWidth - targetElement.offsetLeft - targetElement.clientWidth - 300;
-        this.setState({
-            offsetTop,
-            offsetRight
-        });
-    }
-
     render() {
         let parentLink = 'N/A';
         if (this.props.overview.parentAward && this.props.overview.parentId) {
@@ -73,17 +24,11 @@ export default class RelatedAwards extends React.Component {
                 </a>
             );
         }
-        let tooltip = null;
-        if (this.state.showInfoTooltip) {
-            const style = {
-                top: this.state.offsetTop,
-                right: this.state.offsetRight
-            };
-
-            tooltip = (
-                <div
-                    className="info-tooltip-spacer"
-                    style={style}>
+        return (
+            <div
+                className="related-awards">
+                <div className="award-overview__title related-awards__title">
+                    Related Awards
                     <InfoTooltip>
                         <strong>Related Awards</strong>
                         <p>
@@ -98,30 +43,6 @@ export default class RelatedAwards extends React.Component {
                             </li>
                         </ul>
                     </InfoTooltip>
-                </div>
-            );
-        }
-        return (
-            <div
-                className="related-awards">
-                <div className="award-overview__title related-awards__title">
-                    Related Awards
-                    <div className="award__info-wrapper">
-                        <div ref={(div) => {
-                            this.referenceDiv = div;
-                        }}>
-                            <button
-                                onBlur={this.closeTooltip}
-                                className="award__icon"
-                                onFocus={this.showTooltip}
-                                onMouseEnter={this.showTooltip}
-                                onMouseLeave={this.closeTooltip}
-                                onClick={this.showTooltip}>
-                                <Icons.InfoCircle alt="Information" />
-                            </button>
-                            {tooltip}
-                        </div>
-                    </div>
                 </div>
                 <div className="related-awards__parent">
                     <div className="related-awards__label">

--- a/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
+++ b/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
@@ -5,9 +5,10 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { throttle } from 'lodash';
 
 import * as Icons from 'components/sharedComponents/icons/Icons';
-import Tooltip from 'components/sharedComponents/Tooltip';
+import InfoTooltip from '../../idv/InfoTooltip';
 
 const propTypes = {
     overview: PropTypes.object
@@ -18,15 +19,25 @@ export default class RelatedAwards extends React.Component {
         super(props);
 
         this.state = {
-            showInfoTooltip: false,
-            tooltip: {
-                x: 0,
-                y: 0
-            }
+            showTooltip: false,
+            offsetTop: 0,
+            offsetRight: 0
         };
 
         this.showTooltip = this.showTooltip.bind(this);
         this.closeTooltip = this.closeTooltip.bind(this);
+        this.measureOffset = throttle(this.measureOffset.bind(this), 16);
+    }
+
+    componentDidMount() {
+        this.measureOffset();
+        window.addEventListener('scroll', this.measureOffset);
+        window.addEventListener('resize', this.measureOffset);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('scroll', this.measureOffset);
+        window.removeEventListener('resize', this.measureOffset);
     }
 
     showTooltip() {
@@ -40,6 +51,17 @@ export default class RelatedAwards extends React.Component {
             showInfoTooltip: false
         });
     }
+
+    measureOffset() {
+        const targetElement = this.referenceDiv;
+        const offsetTop = targetElement.offsetTop - 35;
+        const offsetRight = window.innerWidth - targetElement.offsetLeft - targetElement.clientWidth - 300;
+        this.setState({
+            offsetTop,
+            offsetRight
+        });
+    }
+
     render() {
         let parentLink = 'N/A';
         if (this.props.overview.parentAward && this.props.overview.parentId) {
@@ -51,18 +73,55 @@ export default class RelatedAwards extends React.Component {
                 </a>
             );
         }
+        let tooltip = null;
+        if (this.state.showInfoTooltip) {
+            const style = {
+                top: this.state.offsetTop,
+                right: this.state.offsetRight
+            };
+
+            tooltip = (
+                <div
+                    className="info-tooltip-spacer"
+                    style={style}>
+                    <InfoTooltip>
+                        <strong>Related Awards</strong>
+                        <p>
+                            Related Awards refers to two possible types of awards related to this IDV:
+                        </p>
+                        <ul>
+                            <li>
+                                <strong>Parent Award</strong> – The parent award is an IDV award that this contract was made under.  Click on the link to view more information on this award&apos;s parent.
+                            </li>
+                            <li>
+                                <strong>Parent Award Orders Under this IDV</strong> – This is a count of how many awards were made under this IDV.  Click on the link to see more information about all of those orders.
+                            </li>
+                        </ul>
+                    </InfoTooltip>
+                </div>
+            );
+        }
         return (
-            <div className="related-awards">
+            <div
+                className="related-awards">
                 <div className="award-overview__title related-awards__title">
                     Related Awards
-                    <button
-                        onBlur={this.closeTooltip}
-                        className="award__icon"
-                        onFocus={this.showTooltip}
-                        onMouseEnter={this.showTooltip}
-                        onClick={this.showTooltip}>
-                        <Icons.InfoCircle alt="Information" />
-                    </button>
+                    <div className="award__info-wrapper">
+                        <div ref={(div) => {
+                            this.referenceDiv = div;
+                        }}>
+                            <button
+                                onBlur={this.closeTooltip}
+                                className="award__icon"
+                                onFocus={this.showTooltip}
+                                onMouseEnter={this.showTooltip}
+                                onMouseLeave={this.closeTooltip}
+                                onClick={this.showTooltip}>
+                                <Icons.InfoCircle alt="Information" />
+                            </button>
+                            {tooltip}
+                        </div>
+                    </div>
                 </div>
                 <div className="related-awards__parent">
                     <div className="related-awards__label">

--- a/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
+++ b/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
@@ -6,11 +6,40 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import * as Icons from 'components/sharedComponents/icons/Icons';
+import Tooltip from 'components/sharedComponents/Tooltip';
+
 const propTypes = {
     overview: PropTypes.object
 };
 
 export default class RelatedAwards extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showInfoTooltip: false,
+            tooltip: {
+                x: 0,
+                y: 0
+            }
+        };
+
+        this.showTooltip = this.showTooltip.bind(this);
+        this.closeTooltip = this.closeTooltip.bind(this);
+    }
+
+    showTooltip() {
+        this.setState({
+            showInfoTooltip: true
+        });
+    }
+
+    closeTooltip() {
+        this.setState({
+            showInfoTooltip: false
+        });
+    }
     render() {
         let parentLink = 'N/A';
         if (this.props.overview.parentAward && this.props.overview.parentId) {
@@ -26,6 +55,14 @@ export default class RelatedAwards extends React.Component {
             <div className="related-awards">
                 <div className="award-overview__title related-awards__title">
                     Related Awards
+                    <button
+                        onBlur={this.closeTooltip}
+                        className="award__icon"
+                        onFocus={this.showTooltip}
+                        onMouseEnter={this.showTooltip}
+                        onClick={this.showTooltip}>
+                        <Icons.InfoCircle alt="Information" />
+                    </button>
                 </div>
                 <div className="related-awards__parent">
                     <div className="related-awards__label">

--- a/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
+++ b/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
@@ -30,18 +30,22 @@ export default class RelatedAwards extends React.Component {
                 <div className="award-overview__title related-awards__title">
                     Related Awards
                     <InfoTooltip>
-                        <strong>Related Awards</strong>
-                        <p>
-                            Related Awards refers to two possible types of awards related to this IDV:
-                        </p>
-                        <ul>
-                            <li>
-                                <strong>Parent Award</strong> – The parent award is an IDV award that this contract was made under.  Click on the link to view more information on this award&apos;s parent.
-                            </li>
-                            <li>
-                                <strong>Parent Award Orders Under this IDV</strong> – This is a count of how many awards were made under this IDV.  Click on the link to see more information about all of those orders.
-                            </li>
-                        </ul>
+                        <div className="info-tooltip__title">
+                            Related Awards
+                        </div>
+                        <div className="info-tooltip__text">
+                            <p>
+                                Related Awards refers to two possible types of awards related to this IDV:
+                            </p>
+                            <ul>
+                                <li>
+                                    <strong>Parent Award</strong> – The parent award is an IDV award that this contract was made under.  Click on the link to view more information on this award&apos;s parent.
+                                </li>
+                                <li>
+                                    <strong>Parent Award Orders Under this IDV</strong> – This is a count of how many awards were made under this IDV.  Click on the link to see more information about all of those orders.
+                                </li>
+                            </ul>
+                        </div>
                     </InfoTooltip>
                 </div>
                 <div className="related-awards__parent">

--- a/src/js/components/sharedComponents/Tooltip.jsx
+++ b/src/js/components/sharedComponents/Tooltip.jsx
@@ -1,0 +1,113 @@
+/**
+ * Tooltip.jsx
+ * Created by David Trinh 2/28/19
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { throttle } from 'lodash';
+
+import * as Icons from 'components/sharedComponents/icons/Icons';
+
+const propTypes = {
+    content: PropTypes.object, // Pass in a JSX object here as a render prop
+    closeTooltip: PropTypes.func,
+    showInfoTooltip: PropTypes.bool
+};
+
+const tooltipWidth = 160;
+const margin = 15;
+const tooltipPadding = 6;
+
+export default class Tooltip extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            windowWidth: 0,
+            iconTop: 0,
+            iconLeft: 0
+        };
+
+        this.handleWindowResize = throttle(this.handleWindowResize.bind(this), 50);
+        this.setWrapperRef = this.setWrapperRef.bind(this);
+        this.handleClickOutside = this.handleClickOutside.bind(this);
+    }
+
+    componentDidMount() {
+        this.handleWindowResize();
+        window.addEventListener('resize', this.handleWindowResize);
+        document.addEventListener('mousedown', this.handleClickOutside);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.handleWindowResize);
+        document.removeEventListener('mousedown', this.handleClickOutside);
+    }
+
+    getPosition() {
+        const container = document.getElementById('');
+        const conatinerOffsetY = container.getBoundingClientRect().top;
+
+        const icon = document.getElementById('');
+        const iconTop = icon.getBoundingClientRect().top - conatinerOffsetY - tooltipPadding;
+        let iconLeft = icon.getBoundingClientRect().left - tooltipPadding;
+
+        const windowWidth = window.innerWidth;
+        if ((iconLeft + tooltipWidth) > windowWidth) {
+            iconLeft = windowWidth - tooltipWidth - margin;
+        }
+
+        return { iconTop, iconLeft };
+    }
+
+    setWrapperRef(node) {
+        this.wrapperRef = node;
+    }
+
+    handleClickOutside(event) {
+        if (this.props.showInfoTooltip && this.wrapperRef && !this.wrapperRef.contains(event.target)) {
+            this.props.closeTooltip();
+        }
+    }
+
+    handleWindowResize() {
+        // determine if the width changed
+        const windowWidth = window.innerWidth;
+        if (this.state.windowWidth !== windowWidth) {
+            // width changed, update the visualization width
+            const position = this.getPosition();
+
+            this.setState({
+                windowWidth,
+                iconTop: position.iconTop,
+                iconLeft: position.iconLeft
+            });
+        }
+    }
+
+    render() {
+        return (
+            <div
+                ref={this.setWrapperRef}
+                className="tooltip"
+                onMouseLeave={this.props.closeTooltip}
+                onBlur={this.props.closeTooltip}
+                style={{
+                    top: this.state.iconTop,
+                    left: this.state.iconLeft
+                }}>
+                <div className="tooltip__icon">
+                    <Icons.InfoCircle />
+                </div>
+                <div className="homepage-hero-tooltip__text_holder">
+                    <div className="tooltip__content">
+                        {this.props.content}
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+Tooltip.propTypes = propTypes;


### PR DESCRIPTION
**High level description:**

Adds info icons with tooltips to multiple IDV summary page sections.

**Technical details:**

- Created a shared `InfoTooltip` component that includes the `i` icon and handles show/hide logic. It also has the option to display the tooltip to the left or right of the icon
- Added the `InfoTooltip` component to the following sections: Related Awards, Dates, Award Amounts, Description

**JIRA Ticket:**
[DEV-1992](https://federal-spending-transparency.atlassian.net/browse/DEV-1992)

**Mockup:**
https://bahdigital.invisionapp.com/share/69IA8EPGPCM#/296002761_Award_Summary_2-0_-_IDV_-MVP- (hover over combined award amounts for tooltip styling)

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Design review
- [x] Verified cross-browser compatibility
