### PR TITLE
[DEV-2225] follow up to ensure model includes "/" character in longDescription

### DIFF
--- a/src/js/components/awardv2/idv/IdvContent.jsx
+++ b/src/js/components/awardv2/idv/IdvContent.jsx
@@ -5,7 +5,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { startCase } from 'lodash';
 
 import ReferencedAwardsContainer from 'containers/awardV2/idv/ReferencedAwardsContainer';
 import { Glossary } from 'components/sharedComponents/icons/Icons';
@@ -40,7 +39,7 @@ export default class IdvContent extends React.Component {
             <div className="award award-idv">
                 <div className="idv__heading">
                     <div className="idv__info">
-                        <div className="award__heading-text">{startCase(this.props.overview.longTypeDescription)}</div>
+                        <div className="award__heading-text">{this.props.overview.longTypeDescription}</div>
                         <div className="award__heading-icon">
                             {glossaryLink}
                         </div>

--- a/src/js/models/v2/awardsV2/CoreAward.js
+++ b/src/js/models/v2/awardsV2/CoreAward.js
@@ -2,7 +2,7 @@
  * CoreAward.js
  * Created by David Trinh 10/9/18
  */
-
+import { startCase } from 'lodash';
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 import { parseDate, formatDate } from './CorePeriodOfPerformance';
 import { longTypeDescriptionsByAwardTypes } from "../../../dataMapping/awardsv2/longAwardTypeDescriptions";
@@ -16,7 +16,7 @@ const CoreAward = {
         this.typeDescription = data.typeDescription || "--";
         this.longTypeDescription =
           longTypeDescriptionsByAwardTypes[data.type] ||
-          data.typeDescription ||
+          startCase(data.typeDescription) ||
           "--";
         this.description = data.description || '--';
         this._subawardTotal = parseFloat(data.subawardTotal) || 0;


### PR DESCRIPTION
**High level description:**
"/" was omitted from longDescription of award types 

**Technical details:**
The lodash method `startCase` was removing this character in the component

**JIRA Ticket:**
[DEV-2225](https://federal-spending-transparency.atlassian.net/browse/DEV-2225)

**Mockup:**
https://bahdigital.invisionapp.com/share/HEIA8W7U43G#/screens

**Commits:**
6000cae -- removing `startCase` from component
db80d49 -- applying `startCase` to model when value in map is undefined

The following are ALL required for the PR to be merged:
- [x] Code review
[ ] Design review (if applicable) `N/A`
[ ] API contract approved by @backendDev (if applicable) `N/A`
[ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged (if applicable) `N/A`
- [x] Verified cross-browser compatibility
