### PR TITLE
add-idv-to-bulkdownload

### DIFF
--- a/src/js/components/bulkDownload/awards/AwardDataContent.jsx
+++ b/src/js/components/bulkDownload/awards/AwardDataContent.jsx
@@ -79,7 +79,7 @@ export default class AwardDataContent extends React.Component {
         const validForm = (
             (awards.awardLevels.primeAwards || awards.awardLevels.subAwards)
             && (awards.awardTypes.contracts || awards.awardTypes.grants || awards.awardTypes.directPayments
-                || awards.awardTypes.loans || awards.awardTypes.otherFinancialAssistance)
+                || awards.awardTypes.loans || awards.awardTypes.otherFinancialAssistance || awards.awardTypes.idvs)
             && this.state.validDates && (awards.dateType !== '')
             && (awards.agency.id !== '')
             && (awards.location !== '')
@@ -93,7 +93,6 @@ export default class AwardDataContent extends React.Component {
 
     render() {
         const awards = this.props.awards;
-
         const currentAgencies = {
             agency: awards.agency,
             subAgency: awards.subAgency

--- a/src/js/components/bulkDownload/awards/DownloadTooltip.jsx
+++ b/src/js/components/bulkDownload/awards/DownloadTooltip.jsx
@@ -29,7 +29,7 @@ export default class DownloadTooltip extends React.Component {
             requiredFields.push('Award Level');
         }
         if (!filters.awardTypes.contracts && !filters.awardTypes.grants && !filters.awardTypes.directPayments
-            && !filters.awardTypes.loans && !filters.awardTypes.otherFinancialAssistance) {
+            && !filters.awardTypes.loans && !filters.awardTypes.otherFinancialAssistance && !filters.awardTypes.idvs) {
             requiredFields.push('Award Type');
         }
         if (!this.props.validDates || !filters.dateType) {

--- a/src/js/components/bulkDownload/awards/filters/AwardTypeFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/AwardTypeFilter.jsx
@@ -36,7 +36,8 @@ export default class AwardTypeFilter extends React.Component {
             this.props.currentAwardTypes.grants ||
             this.props.currentAwardTypes.directPayments ||
             this.props.currentAwardTypes.loans ||
-            this.props.currentAwardTypes.otherFinancialAssistance
+            this.props.currentAwardTypes.otherFinancialAssistance ||
+            this.props.currentAwardTypes.idvs
         );
 
         let icon = (

--- a/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
+++ b/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
@@ -25,14 +25,19 @@ export const awardDownloadOptions = {
             apiName: 'contracts'
         },
         {
+            name: 'directPayments',
+            label: 'Direct Payments',
+            apiName: 'direct_payments'
+        },
+        {
             name: 'grants',
             label: 'Grants',
             apiName: 'grants'
         },
         {
-            name: 'directPayments',
-            label: 'Direct Payments',
-            apiName: 'direct_payments'
+            name: 'idvs',
+            label: 'IDVs',
+            apiName: 'idvs'
         },
         {
             name: 'loans',
@@ -43,11 +48,6 @@ export const awardDownloadOptions = {
             name: 'otherFinancialAssistance',
             label: 'Other Financial Assistance',
             apiName: 'other_financial_assistance'
-        },
-        {
-            name: 'idvs',
-            label: 'IDVs',
-            apiName: 'idvs'
         }
     ],
     dateTypes: [

--- a/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
+++ b/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
@@ -43,6 +43,11 @@ export const awardDownloadOptions = {
             name: 'otherFinancialAssistance',
             label: 'Other Financial Assistance',
             apiName: 'other_financial_assistance'
+        },
+        {
+            name: 'idvs',
+            label: 'IDVs',
+            apiName: 'idvs'
         }
     ],
     dateTypes: [

--- a/src/js/dataMapping/state/awardTypes.js
+++ b/src/js/dataMapping/state/awardTypes.js
@@ -8,5 +8,6 @@ export const awardTypeLabels = {
     grants: 'Grants',
     direct_payments: 'Direct Payments',
     loans: 'Loans',
-    other_financial_assistance: 'Other Financial Assistance'
+    other_financial_assistance: 'Other Financial Assistance',
+    idvs: 'IDVs'
 };

--- a/src/js/redux/reducers/bulkDownload/bulkDownloadReducer.js
+++ b/src/js/redux/reducers/bulkDownload/bulkDownloadReducer.js
@@ -20,7 +20,8 @@ export const initialState = {
             grants: false,
             directPayments: false,
             loans: false,
-            otherFinancialAssistance: false
+            otherFinancialAssistance: false,
+            idvs: false
         },
         agency: {
             id: '',

--- a/tests/containers/bulkDownload/mockData.js
+++ b/tests/containers/bulkDownload/mockData.js
@@ -96,7 +96,8 @@ export const mockRedux = {
                 grants: true,
                 directPayments: false,
                 loans: true,
-                otherFinancialAssistance: false
+                otherFinancialAssistance: false,
+                idvs: false
             },
             agency: {
                 id: '123',

--- a/tests/redux/reducers/bulkDownload/bulkDownloadReducer-test.js
+++ b/tests/redux/reducers/bulkDownload/bulkDownloadReducer-test.js
@@ -78,7 +78,8 @@ describe('bulkDownloadReducer', () => {
                         grants: true,
                         directPayments: true,
                         loans: false,
-                        otherFinancialAssistance: false
+                        otherFinancialAssistance: false,
+                        idvs: false
                     },
                     agency: {
                         id: '123',


### PR DESCRIPTION
**High level description:**

Allow users to bulk download IDVs

**Technical details:**

updated frontend data store to include `idvs` in awardTypes
updated validation

**JIRA Ticket:**
[DEV-2302](https://federal-spending-transparency.atlassian.net/browse/DEV-2302)

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] [API #1884](https://github.com/fedspendingtransparency/usaspending-api/pull/1713) merged
- [x] Verified cross-browser compatibility
