### PR TITLE
Release IDV summary pages

### DIFF
--- a/src/js/components/awardv2/AwardV2.jsx
+++ b/src/js/components/awardv2/AwardV2.jsx
@@ -22,8 +22,7 @@ import Error from '../sharedComponents/Error';
 
 const propTypes = {
     award: PropTypes.object,
-    noAward: PropTypes.bool,
-    inFlight: PropTypes.bool
+    noAward: PropTypes.bool
 };
 
 const awardSections = [

--- a/src/js/components/awardv2/AwardV2.jsx
+++ b/src/js/components/awardv2/AwardV2.jsx
@@ -22,7 +22,6 @@ import Error from '../sharedComponents/Error';
 
 const propTypes = {
     award: PropTypes.object,
-    awardId: PropTypes.string,
     noAward: PropTypes.bool,
     inFlight: PropTypes.bool
 };
@@ -87,7 +86,7 @@ export default class Award extends React.Component {
             if (overview.category === 'contract') {
                 content = (
                     <ContractContent
-                        awardId={this.props.awardId}
+                        awardId={this.props.award.id}
                         overview={overview}
                         jumpToSection={this.jumpToSection} />
                 );
@@ -95,7 +94,7 @@ export default class Award extends React.Component {
             else if (overview.category === 'idv') {
                 content = (
                     <IdvContent
-                        awardId={this.props.awardId}
+                        awardId={this.props.award.id}
                         overview={overview}
                         jumpToSection={this.jumpToSection} />
                 );
@@ -103,7 +102,7 @@ export default class Award extends React.Component {
             else {
                 content = (
                     <FinancialAssistanceContent
-                        awardId={this.props.awardId}
+                        awardId={this.props.award.id}
                         overview={overview}
                         jumpToSection={this.jumpToSection} />
                 );

--- a/src/js/containers/award/AwardContainer.jsx
+++ b/src/js/containers/award/AwardContainer.jsx
@@ -21,7 +21,7 @@ require('pages/award/awardPage.scss');
 
 const propTypes = {
     setSelectedAward: PropTypes.func,
-    params: PropTypes.object
+    awardId: PropTypes.string
 };
 
 export class AwardContainer extends React.Component {
@@ -37,12 +37,12 @@ export class AwardContainer extends React.Component {
     }
 
     componentDidMount() {
-        this.getSelectedAward(this.props.params.awardId);
+        this.getSelectedAward(this.props.awardId);
     }
 
     componentDidUpdate(prevProps) {
-        if (this.props.params.awardId !== prevProps.params.awardId) {
-            this.getSelectedAward(this.props.params.awardId);
+        if (this.props.awardId !== prevProps.awardId) {
+            this.getSelectedAward(this.props.awardId);
         }
     }
 

--- a/src/js/containers/awardV2/AwardV2Container.jsx
+++ b/src/js/containers/awardV2/AwardV2Container.jsx
@@ -130,7 +130,6 @@ export class AwardContainer extends React.Component {
             if (this.props.award.category === 'idv' || isV2url) {
                 content = (<Award
                     award={this.props.award}
-                    inFlight={this.state.inFlight}
                     noAward={this.state.noAward} />);
             }
             else {

--- a/src/js/containers/awardV2/AwardV2Container.jsx
+++ b/src/js/containers/awardV2/AwardV2Container.jsx
@@ -130,7 +130,6 @@ export class AwardContainer extends React.Component {
             if (this.props.award.category === 'idv' || isV2url) {
                 content = (<Award
                     award={this.props.award}
-                    awardId={this.props.params.awardId}
                     inFlight={this.state.inFlight}
                     noAward={this.state.noAward} />);
             }

--- a/src/js/containers/awardV2/AwardV2Container.jsx
+++ b/src/js/containers/awardV2/AwardV2Container.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import { isCancel } from 'axios';
 
 import Award from 'components/awardv2/AwardV2';
+import AwardV1Container from 'containers/award/AwardContainer';
 
 import * as SearchHelper from 'helpers/searchHelper';
 import * as awardActions from 'redux/actions/awardV2/awardActions';
@@ -122,13 +123,18 @@ export class AwardContainer extends React.Component {
     }
 
     render() {
-        return (
-            <Award
+        let content = null;
+        if (this.props.award.category === 'idv' && !this.state.inFlight) {
+            content = (<Award
                 award={this.props.award}
                 awardId={this.props.params.awardId}
                 inFlight={this.state.inFlight}
-                noAward={this.state.noAward} />
-        );
+                noAward={this.state.noAward} />);
+        }
+        else if (this.props.award.category !== 'idv' && !this.state.inFlight) {
+            content = (<AwardV1Container awardId={this.props.params.awardId} />);
+        }
+        return content;
     }
 }
 

--- a/src/js/containers/awardV2/AwardV2Container.jsx
+++ b/src/js/containers/awardV2/AwardV2Container.jsx
@@ -9,6 +9,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { isCancel } from 'axios';
 
+import Router from 'containers/router/Router';
 import Award from 'components/awardv2/AwardV2';
 import AwardV1Container from 'containers/award/AwardContainer';
 
@@ -123,16 +124,19 @@ export class AwardContainer extends React.Component {
     }
 
     render() {
+        const isV2url = Router.history.location.pathname.includes('award_v2');
         let content = null;
-        if (this.props.award.category === 'idv' && !this.state.inFlight) {
-            content = (<Award
-                award={this.props.award}
-                awardId={this.props.params.awardId}
-                inFlight={this.state.inFlight}
-                noAward={this.state.noAward} />);
-        }
-        else if (this.props.award.category !== 'idv' && !this.state.inFlight) {
-            content = (<AwardV1Container awardId={this.props.params.awardId} />);
+        if (!this.state.inFlight) {
+            if (this.props.award.category === 'idv' || isV2url) {
+                content = (<Award
+                    award={this.props.award}
+                    awardId={this.props.params.awardId}
+                    inFlight={this.state.inFlight}
+                    noAward={this.state.noAward} />);
+            }
+            else {
+                content = (<AwardV1Container awardId={this.props.params.awardId} />);
+            }
         }
         return content;
     }

--- a/src/js/containers/router/RouterRoutes.jsx
+++ b/src/js/containers/router/RouterRoutes.jsx
@@ -61,7 +61,7 @@ const routes = {
             parent: '/award',
             component: (cb) => {
                 require.ensure([], (require) => {
-                    cb(require('containers/award/AwardContainer').default);
+                    cb(require('containers/awardV2/AwardV2Container').default);
                 });
             }
         },

--- a/tests/containers/award/AwardContainer-test.jsx
+++ b/tests/containers/award/AwardContainer-test.jsx
@@ -21,10 +21,9 @@ jest.mock('components/award/Award', () => jest.fn(() => null));
 describe('AwardContainer', () => {
     it('should make an API call for the selected award on mount', async () => {
 
-        const container = mount(
-            <AwardContainer
-                {...mockParams}
-                {...mockActions} />);
+        const container = mount(<AwardContainer
+            {...mockParams}
+            {...mockActions} />);
 
         const parseAward = jest.fn();
         container.instance().parseAward = parseAward;
@@ -34,10 +33,9 @@ describe('AwardContainer', () => {
     });
 
     it('should make an API call when the award ID parameter changes', () => {
-        const container = shallow (
-            <AwardContainer
-                {...mockParams}
-                {...mockActions} />);
+        const container = shallow(<AwardContainer
+            {...mockParams}
+            {...mockActions} />);
 
         const getSelectedAward = jest.fn();
         container.instance().getSelectedAward = getSelectedAward;
@@ -47,9 +45,7 @@ describe('AwardContainer', () => {
         expect(getSelectedAward).toHaveBeenCalledWith(1234);
 
         const prevProps = Object.assign({}, mockParams, {
-            params: {
-                awardId: 222
-            }
+            awardId: '222'
         });
 
         container.instance().componentDidUpdate(prevProps);
@@ -60,10 +56,9 @@ describe('AwardContainer', () => {
 
     describe('parseAward', () => {
         it('should parse returned contract data and send to the Redux store', () => {
-            const awardContainer = shallow(
-                <AwardContainer
-                    {...mockParams}
-                    {...mockActions} />);
+            const awardContainer = shallow(<AwardContainer
+                {...mockParams}
+                {...mockActions} />);
 
             const expectedAward = Object.create(BaseContract);
             expectedAward.populate(mockApi);
@@ -73,10 +68,9 @@ describe('AwardContainer', () => {
             expect(mockActions.setSelectedAward).toHaveBeenCalledWith(expectedAward);
         });
         it('should parse returned financial assistance data and send to the Redux store', () => {
-            const awardContainer = shallow(
-                <AwardContainer
-                    {...mockParams}
-                    {...mockActions} />);
+            const awardContainer = shallow(<AwardContainer
+                {...mockParams}
+                {...mockActions} />);
 
             const expectedAward = Object.create(BaseFinancialAssistance);
             expectedAward.populate(mockFinancialAssistanceApi);
@@ -86,10 +80,9 @@ describe('AwardContainer', () => {
             expect(mockActions.setSelectedAward).toHaveBeenCalledWith(expectedAward);
         });
         it('should parse returned IDV data and send to the Redux store', () => {
-            const awardContainer = shallow(
-                <AwardContainer
-                    {...mockParams}
-                    {...mockActions} />);
+            const awardContainer = shallow(<AwardContainer
+                {...mockParams}
+                {...mockActions} />);
 
             const mockIDV = Object.assign({}, mockApi, {
                 category: 'idv'

--- a/tests/containers/award/mockResults.js
+++ b/tests/containers/award/mockResults.js
@@ -1444,9 +1444,7 @@ export const mockFinancialAssistanceApi = {
 };
 
 export const mockParams = {
-    params: {
-        awardId: 1234
-    },
+    awardId: 1234,
     award: {
         selectedAward: {
             category: "contract",

--- a/tests/containers/awardV2/AwardV2Container-test.jsx
+++ b/tests/containers/awardV2/AwardV2Container-test.jsx
@@ -17,7 +17,7 @@ import BaseFinancialAssistance from "models/v2/awardsV2/BaseFinancialAssistance"
 
 jest.mock('helpers/searchHelper', () => require('./awardV2Helper'));
 
-// mock the child components by replacing them with functions that return a null elements
+// mock the child components by replacing them with functions that return null elements
 jest.mock('components/awardv2/AwardV2', () => jest.fn(() => null));
 jest.mock('containers/award/AwardContainer', () => jest.fn(() => null));
 

--- a/tests/containers/awardV2/AwardV2Container-test.jsx
+++ b/tests/containers/awardV2/AwardV2Container-test.jsx
@@ -4,7 +4,7 @@
  **/
 
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import { AwardContainer } from 'containers/awardV2/AwardV2Container';
 
@@ -17,29 +17,28 @@ import BaseFinancialAssistance from "models/v2/awardsV2/BaseFinancialAssistance"
 
 jest.mock('helpers/searchHelper', () => require('./awardV2Helper'));
 
-// mock the child component by replacing it with a function that returns a null element
+// mock the child components by replacing them with functions that return a null elements
 jest.mock('components/awardv2/AwardV2', () => jest.fn(() => null));
+jest.mock('containers/award/AwardContainer', () => jest.fn(() => null));
 
 describe('AwardV2Container', () => {
     it('should make an API call for the selected award on mount', async () => {
-
-        const container = mount(
-            <AwardContainer
-                {...mockParams}
-                {...mockActions} />);
+        const container = shallow(<AwardContainer
+            {...mockParams}
+            {...mockActions} />);
 
         const parseAward = jest.fn();
         container.instance().parseAward = parseAward;
+        container.instance().componentDidMount();
         await container.instance().awardRequest.promise;
 
         expect(parseAward).toHaveBeenCalled();
     });
 
     it('should make an API call when the award ID parameter changes', () => {
-        const container = shallow (
-            <AwardContainer
-                {...mockParams}
-                {...mockActions} />);
+        const container = shallow(<AwardContainer
+            {...mockParams}
+            {...mockActions} />);
 
         const getSelectedAward = jest.fn();
         container.instance().getSelectedAward = getSelectedAward;
@@ -62,10 +61,9 @@ describe('AwardV2Container', () => {
 
     describe('parseAward', () => {
         it('should parse returned contract data and send to the Redux store', () => {
-            const awardContainer = shallow(
-                <AwardContainer
-                    {...mockParams}
-                    {...mockActions} />);
+            const awardContainer = shallow(<AwardContainer
+                {...mockParams}
+                {...mockActions} />);
 
             const expectedAward = Object.create(BaseContract);
             expectedAward.populate(mockContract);
@@ -75,10 +73,9 @@ describe('AwardV2Container', () => {
             expect(mockActions.setAward).toHaveBeenCalledWith(expectedAward);
         });
         it('should parse returned IDV data and send to the Redux store', () => {
-            const awardContainer = shallow(
-                <AwardContainer
-                    {...mockParams}
-                    {...mockActions} />);
+            const awardContainer = shallow(<AwardContainer
+                {...mockParams}
+                {...mockActions} />);
 
             const expectedAward = Object.create(BaseIdv);
             expectedAward.populate(mockIdv);
@@ -88,10 +85,9 @@ describe('AwardV2Container', () => {
             expect(mockActions.setAward).toHaveBeenCalledWith(expectedAward);
         });
         it('should parse returned financial assistance data and send to the Redux store', () => {
-            const awardContainer = shallow(
-                <AwardContainer
-                    {...mockParams}
-                    {...mockActions} />);
+            const awardContainer = shallow(<AwardContainer
+                {...mockParams}
+                {...mockActions} />);
 
             const expectedAward = Object.create(BaseFinancialAssistance);
             expectedAward.populate(mockLoan);


### PR DESCRIPTION
**High level description:**

* `/#/award/{id}` urls will now display the v2 summary pages for IDVs
* `/#/award/{id}` urls still display the v1 summary pages for non-IDVs
* `/#/award_v2/{id}` can still be used to preview v2 summary pages for non-IDVs

**Technical details:**

The `/award` route now points to `AwardV2Container`.

* The `AwardV2Container` makes an API call to the `v2/awards` endpoint, and uses the response to determine if `category === 'idv'`
* `AwardV2Container` checks the current url to see if it contains `'award_v2'`
* If the current award is either an IDV or we are at an `/award_v2/` url, show the v2 Award Component
* If it is not an IDV and we are at a normal `/award/` url, render the v1 `AwardContainer`, which makes an API call to the `v1/awards` endpoint and renders subsequent v1 components as before

Note: `awardId` is passed as a param to the v1 `AwardContainer` because it requires the internal id format (e.g. `68935929`), which is not yet available via Redux since v2 uses the generated unique id format (e.g. `CONT_AW_8000_-NONE-_NNK14MA74C_-NONE-`)

**JIRA Ticket:**
[DEV-2233](https://federal-spending-transparency.atlassian.net/browse/DEV-2233)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Verified cross-browser compatibility
