### PR TITLE
Hotfix award links

### DIFF
--- a/src/js/components/awardv2/AwardV2.jsx
+++ b/src/js/components/awardv2/AwardV2.jsx
@@ -21,6 +21,7 @@ import Footer from '../sharedComponents/Footer';
 import Error from '../sharedComponents/Error';
 
 const propTypes = {
+    awardId: PropTypes.string,
     award: PropTypes.object,
     noAward: PropTypes.bool
 };
@@ -89,7 +90,7 @@ export default class Award extends React.Component {
             if (overview.category === 'contract') {
                 content = (
                     <ContractContent
-                        awardId={this.props.award.id}
+                        awardId={this.props.awardId}
                         overview={overview}
                         jumpToSection={this.jumpToSection} />
                 );
@@ -97,7 +98,7 @@ export default class Award extends React.Component {
             else if (overview.category === 'idv') {
                 content = (
                     <IdvContent
-                        awardId={this.props.award.id}
+                        awardId={this.props.awardId}
                         overview={overview}
                         counts={this.props.award.counts}
                         jumpToSection={this.jumpToSection} />
@@ -106,7 +107,7 @@ export default class Award extends React.Component {
             else {
                 content = (
                     <FinancialAssistanceContent
-                        awardId={this.props.award.id}
+                        awardId={this.props.awardId}
                         overview={overview}
                         jumpToSection={this.jumpToSection} />
                 );

--- a/src/js/components/awardv2/idv/IdvContent.jsx
+++ b/src/js/components/awardv2/idv/IdvContent.jsx
@@ -32,7 +32,7 @@ export default class IdvContent extends React.Component {
         let glossaryLink = null;
         if (glossarySlug) {
             glossaryLink = (
-                <a href={`/#/award_v2/${this.props.awardId}?glossary=${glossarySlug}`}>
+                <a href={`/#/award/${this.props.awardId}?glossary=${glossarySlug}`}>
                     <Glossary />
                 </a>
             );

--- a/src/js/components/awardv2/idv/referencedAwards/ReferencedAwardsTable.jsx
+++ b/src/js/components/awardv2/idv/referencedAwards/ReferencedAwardsTable.jsx
@@ -60,7 +60,7 @@ export default class ReferencedAwardsTable extends React.Component {
                     {columns.map((col) => {
                         let data = row[col.name];
                         if (col.name === 'piid') {
-                            data = (<a href={`/#/award_v2/${row.internalId}`}>{row[col.name]}</a>);
+                            data = (<a href={`/#/award/${row.internalId}`}>{row[col.name]}</a>);
                         }
                         if (col.name === 'agency' && row.agencyId) {
                             data = (<a href={`/#/agency/${row.agencyId}`}>{row[col.name]}</a>);

--- a/src/js/components/awardv2/visualizations/description/AwardDescription.jsx
+++ b/src/js/components/awardv2/visualizations/description/AwardDescription.jsx
@@ -99,7 +99,7 @@ export default class AwardDescription extends React.Component {
                             <div className="naics-psc__heading">
                                 NAICS
                                 <div className="naics-psc__icon">
-                                    <a href={`#/award_v2/${this.props.awardId}/?glossary=naics`}>
+                                    <a href={`#/award/${this.props.awardId}/?glossary=naics`}>
                                         <Glossary />
                                     </a>
                                 </div>
@@ -110,7 +110,7 @@ export default class AwardDescription extends React.Component {
                             <div className="naics-psc__heading">
                                 PSC
                                 <div className="naics-psc__icon">
-                                    <a href={`#/award_v2/${this.props.awardId}/?glossary=productservice-code-psc`}>
+                                    <a href={`#/award/${this.props.awardId}/?glossary=productservice-code-psc`}>
                                         <Glossary />
                                     </a>
                                 </div>

--- a/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
+++ b/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
@@ -30,7 +30,7 @@ export default class RelatedAwards extends React.Component {
             parentLink = (
                 <a
                     className="related-awards__link"
-                    href={`#/award_v2/${this.props.overview.parentId}`}>
+                    href={`#/award/${this.props.overview.parentId}`}>
                     {this.props.overview.parentAward}
                 </a>
             );

--- a/src/js/containers/awardV2/AwardV2Container.jsx
+++ b/src/js/containers/awardV2/AwardV2Container.jsx
@@ -129,6 +129,7 @@ export class AwardContainer extends React.Component {
         if (!this.state.inFlight) {
             if (this.props.award.category === 'idv' || isV2url) {
                 content = (<Award
+                    awardId={this.props.params.awardId}
                     award={this.props.award}
                     noAward={this.state.noAward} />);
             }


### PR DESCRIPTION
**High level description:**

Fixes links on the IDV page that opened the glossary and pointed to other award pages to use the `award/` url instead of `award_v2/`.
* Glossary link to IDV type description
* NAICS & PSC glossary links
* `Related Awards` section `Parent Award` link
* Links in the `Award ID` column of the `Awards that Reference this IDV` table

**Technical details:**

* Passing down `awardId` directly from the url params to ensure that the same value is used to create glossary links, because award pages accept either an internal id (e.g. `68891350`) or the generated unique id (e.g. `CONT_AW_3600_-NONE-_V246P00002_-NONE-`). 
* Kept `award_v2/` for the v2 Contract and Financial Assistance pages

**JIRA Ticket:**
[DEV-2233](https://federal-spending-transparency.atlassian.net/browse/DEV-2233) (failed test)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Verified cross-browser compatibility
