### PR TITLE
Handle obligated exceeds current award amounts

### DIFF
--- a/src/_scss/pages/awardV2/idv/_awardAmounts.scss
+++ b/src/_scss/pages/awardV2/idv/_awardAmounts.scss
@@ -150,6 +150,20 @@
         left: -1px;
     }
 
+    .award-amounts-viz__desc-top-wrapper {
+        @include display(flex);
+        @include justify-content(space-between);
+        @include align-items(flex-end);
+        padding-bottom: rem(15);
+        .award-amounts-viz__desc-top {
+            margin-bottom: 0;
+            @include flex(1 1 auto);
+        }
+        .award-amounts-viz__desc {
+            text-align: right;
+            @include flex(1 1 auto);
+        }
+    }
 
     .award-amounts-viz__desc-top {
         font-size: $base-font-size;
@@ -183,6 +197,16 @@
             &.award-amounts-viz__legend-line_potential {
                 border: solid rem(1) $border-gray;
                 background-color: #ececec;
+            }
+            &.award-amounts-viz__legend-line_overspending {
+                border: solid rem(1) $color-gold;
+                background: repeating-linear-gradient(
+                    45deg,
+                    $color-white,
+                    $color-white rem(5),
+                    $color-gold rem(2),
+                    $color-gold rem(7)
+                );
             }
         }
     }

--- a/src/_scss/pages/awardV2/idv/_awardAmounts.scss
+++ b/src/_scss/pages/awardV2/idv/_awardAmounts.scss
@@ -189,6 +189,14 @@
             strong {
                 font-size: $lead-font-size;
             }
+            .award-amounts-viz__desc-text-wrapper {
+                @include display(flex);
+                @include justify-content(flex-end);
+                @include align-items(center);
+                .award__info-wrapper {
+                    margin-right: rem(5);
+                }
+            }
         }
         .award-amounts-viz__legend-line {
             @include flex(0 0 rem(5));

--- a/src/_scss/pages/awardV2/idv/_awardAmounts.scss
+++ b/src/_scss/pages/awardV2/idv/_awardAmounts.scss
@@ -82,9 +82,9 @@
                 background: repeating-linear-gradient(
                     45deg,
                     $color-cool-blue-light,
-                    $color-cool-blue-light 8px,
-                    $color-gold 2px,
-                    $color-gold 10px
+                    $color-cool-blue-light rem(8),
+                    $color-gold rem(2),
+                    $color-gold rem(10)
                 );
             }
         }
@@ -220,7 +220,18 @@
 
     .award-amounts__data-icon_transparent {
         background-color: white;
-        border: 2px solid #BBBBBB;
+        border: rem(2) solid #BBBBBB;
+    }
+
+    .award-amounts__data-icon_overspending {
+        background: repeating-linear-gradient(
+            45deg,
+            $color-white,
+            $color-white rem(5),
+            $color-gold rem(2),
+            $color-gold rem(7)
+        );
+        border: rem(1) solid $color-gold;
     }
 
     .award-amounts__data {

--- a/src/_scss/pages/awardV2/idv/_awardAmounts.scss
+++ b/src/_scss/pages/awardV2/idv/_awardAmounts.scss
@@ -73,8 +73,19 @@
             height: rem(40);
             background-color: #ececec;
             @include display(flex);
-            .award-amountdates__viz-obligated {
+            .award-amounts-viz__obligated {
                 border: solid rem(4) $border-light-gray;
+            }
+            .award-amounts-viz__exceeded {
+                border-top: solid rem(4) $color-gray-lightest;
+                border-bottom: solid rem(4) $color-gray-lightest;
+                background: repeating-linear-gradient(
+                    45deg,
+                    $color-cool-blue-light,
+                    $color-cool-blue-light 8px,
+                    $color-gold 2px,
+                    $color-gold 10px
+                );
             }
         }
     }

--- a/src/js/components/awardv2/idv/InfoTooltipContent.jsx
+++ b/src/js/components/awardv2/idv/InfoTooltipContent.jsx
@@ -165,11 +165,20 @@ export const relatedAwardsInfo = (
 export const awardAmountsOverspendingInfo = (
     <div>
         <div className="info-tooltip__title">
-             Exceeds Combined Current Award Amounts
+            Exceeds Combined Current Award Amount
         </div>
         <div className="info-tooltip__text">
             <p>
-               More information coming soon
+            The award orders underneath this IDV have a combined
+            obligated amount that exceeds their combined current award
+            amount. In other words, collectively speaking, the award
+            orders under this IDV have obligated more money than what
+            was made available to spend at this time (their combined
+            current awards amounts).
+            </p>
+            <p>
+            This can occur because of missing data, errors in the
+            data, or violations of procurement policy.
             </p>
         </div>
     </div>

--- a/src/js/components/awardv2/idv/InfoTooltipContent.jsx
+++ b/src/js/components/awardv2/idv/InfoTooltipContent.jsx
@@ -161,3 +161,16 @@ export const relatedAwardsInfo = (
         </div>
     </div>
 );
+
+export const awardAmountsOverspendingInfo = (
+    <div>
+        <div className="info-tooltip__title">
+             Exceeds Combined Current Award Amounts
+        </div>
+        <div className="info-tooltip__text">
+            <p>
+               More information coming soon
+            </p>
+        </div>
+    </div>
+);

--- a/src/js/components/awardv2/visualizations/amounts/AggregatedAwardAmounts.jsx
+++ b/src/js/components/awardv2/visualizations/amounts/AggregatedAwardAmounts.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { determineScenario } from 'helpers/aggregatedAmountsHelper';
+import { determineSpendingScenario } from 'helpers/aggregatedAmountsHelper';
 import ChartError from 'components/search/visualizations/ChartError';
 import { Table } from 'components/sharedComponents/icons/Icons';
 import AwardsBanner from './AwardsBanner';
@@ -34,7 +34,7 @@ export default class AggregatedAwardAmounts extends React.Component {
 
     generateVisualization() {
         const awardAmounts = this.props.awardAmounts;
-        const visualizationType = determineScenario(awardAmounts);
+        const visualizationType = determineSpendingScenario(awardAmounts);
         let visualization;
         let overspendingRow = null;
         switch (visualizationType) {

--- a/src/js/components/awardv2/visualizations/amounts/AggregatedAwardAmounts.jsx
+++ b/src/js/components/awardv2/visualizations/amounts/AggregatedAwardAmounts.jsx
@@ -50,12 +50,19 @@ export default class AggregatedAwardAmounts extends React.Component {
             const awardAmounts = this.props.awardAmounts;
             const visualizationType = determineScenario(awardAmounts);
             let visualization;
+            let extraRow = null;
             switch (visualizationType) {
                 case ('normal'):
                     visualization = (<NormalChart awardAmounts={awardAmounts} />);
                     break;
                 case ('exceedsCurrent'):
                     visualization = (<ExceedsCurrentChart awardAmounts={awardAmounts} />);
+                    extraRow = (
+                        <div className="award-amounts__data-content">
+                            <div><span className="award-amounts__data-icon award-amounts__data-icon_overspending" />Exceeds Combined Current Award Amounts</div>
+                            <span>{awardAmounts.overspending}</span>
+                        </div>
+                    );
                     break;
                 default:
                     visualization = (
@@ -97,6 +104,7 @@ export default class AggregatedAwardAmounts extends React.Component {
                             <div><span className="award-amounts__data-icon award-amounts__data-icon_transparent" />Combined Potential Award Amounts</div>
                             <span>{awardAmounts.combinedPotentialAwardAmounts}</span>
                         </div>
+                        {extraRow}
                     </div>
                 </div>
             );

--- a/src/js/components/awardv2/visualizations/amounts/AggregatedAwardAmounts.jsx
+++ b/src/js/components/awardv2/visualizations/amounts/AggregatedAwardAmounts.jsx
@@ -27,14 +27,79 @@ export default class AggregatedAwardAmounts extends React.Component {
 
         this.jumpToReferencedAwardsTable = this.jumpToReferencedAwardsTable.bind(this);
     }
+
     jumpToReferencedAwardsTable() {
         this.props.jumpToSection('referenced-awards');
     }
+
+    generateVisualization() {
+        const awardAmounts = this.props.awardAmounts;
+        const visualizationType = determineScenario(awardAmounts);
+        let visualization;
+        let overspendingRow = null;
+        switch (visualizationType) {
+            case ('normal'):
+                visualization = (<NormalChart awardAmounts={awardAmounts} />);
+                break;
+            case ('exceedsCurrent'):
+                visualization = (<ExceedsCurrentChart awardAmounts={awardAmounts} />);
+                overspendingRow = (
+                    <div className="award-amounts__data-content">
+                        <div><span className="award-amounts__data-icon award-amounts__data-icon_overspending" />Exceeds Combined Current Award Amounts</div>
+                        <span>{awardAmounts.overspending}</span>
+                    </div>
+                );
+                break;
+            default:
+                visualization = (
+                    <div className="award-amounts-viz award-amounts-viz_insufficient">
+                        <h4>Chart Not Available</h4>
+                        <p>Data in this instance is not suitable for charting.</p>
+                    </div>
+                );
+        }
+
+        return (
+            <div className="award-amounts__content">
+                <AwardsBanner
+                    jumpToReferencedAwardsTable={this.jumpToReferencedAwardsTable} />
+                {visualization}
+                <div className="award-amounts__data">
+                    <span>Awards Under this IDV</span><span>{awardAmounts.idvCount + awardAmounts.contractCount}</span>
+                </div>
+                <button
+                    onClick={this.jumpToReferencedAwardsTable}
+                    className="award-viz__button">
+                    <div className="award-viz__link-icon">
+                        <Table />
+                    </div>
+                    <div className="award-viz__link-text">
+                        View referencing awards table
+                    </div>
+                </button>
+                <div className="award-amounts__data-wrapper">
+                    <div className="award-amounts__data-content">
+                        <div><span className="award-amounts__data-icon award-amounts__data-icon_blue" />Combined Obligated Amounts</div>
+                        <span>{awardAmounts.obligation}</span>
+                    </div>
+                    <div className="award-amounts__data-content">
+                        <div><span className="award-amounts__data-icon award-amounts__data-icon_gray" />Combined Current Award Amounts</div>
+                        <span>{awardAmounts.combinedCurrentAwardAmounts}</span>
+                    </div>
+                    <div className="award-amounts__data-content">
+                        <div><span className="award-amounts__data-icon award-amounts__data-icon_transparent" />Combined Potential Award Amounts</div>
+                        <span>{awardAmounts.combinedPotentialAwardAmounts}</span>
+                    </div>
+                    {overspendingRow}
+                </div>
+            </div>
+        );
+    }
+
     render() {
-        let content = null;
         if (this.props.inFlight) {
             // API request is still pending
-            content = (
+            return (
                 <div className="visualization-message-container">
                     <div className="visualization-loading">
                         <div className="message">
@@ -44,73 +109,9 @@ export default class AggregatedAwardAmounts extends React.Component {
                 </div>);
         }
         else if (this.props.error) {
-            content = (<ChartError />);
+            return (<ChartError />);
         }
-        else {
-            const awardAmounts = this.props.awardAmounts;
-            const visualizationType = determineScenario(awardAmounts);
-            let visualization;
-            let extraRow = null;
-            switch (visualizationType) {
-                case ('normal'):
-                    visualization = (<NormalChart awardAmounts={awardAmounts} />);
-                    break;
-                case ('exceedsCurrent'):
-                    visualization = (<ExceedsCurrentChart awardAmounts={awardAmounts} />);
-                    extraRow = (
-                        <div className="award-amounts__data-content">
-                            <div><span className="award-amounts__data-icon award-amounts__data-icon_overspending" />Exceeds Combined Current Award Amounts</div>
-                            <span>{awardAmounts.overspending}</span>
-                        </div>
-                    );
-                    break;
-                default:
-                    visualization = (
-                        <div className="award-amounts-viz award-amounts-viz_insufficient">
-                            <h4>Chart Not Available</h4>
-                            <p>Data in this instance is not suitable for charting.</p>
-                        </div>
-                    );
-            }
-
-            content = (
-                <div className="award-amounts__content">
-                    <AwardsBanner
-                        jumpToReferencedAwardsTable={this.jumpToReferencedAwardsTable} />
-                    {visualization}
-                    <div className="award-amounts__data">
-                        <span>Awards Under this IDV</span><span>{awardAmounts.idvCount + awardAmounts.contractCount}</span>
-                    </div>
-                    <button
-                        onClick={this.jumpToReferencedAwardsTable}
-                        className="award-viz__button">
-                        <div className="award-viz__link-icon">
-                            <Table />
-                        </div>
-                        <div className="award-viz__link-text">
-                            View referencing awards table
-                        </div>
-                    </button>
-                    <div className="award-amounts__data-wrapper">
-                        <div className="award-amounts__data-content">
-                            <div><span className="award-amounts__data-icon award-amounts__data-icon_blue" />Combined Obligated Amounts</div>
-                            <span>{awardAmounts.obligation}</span>
-                        </div>
-                        <div className="award-amounts__data-content">
-                            <div><span className="award-amounts__data-icon award-amounts__data-icon_gray" />Combined Current Award Amounts</div>
-                            <span>{awardAmounts.combinedCurrentAwardAmounts}</span>
-                        </div>
-                        <div className="award-amounts__data-content">
-                            <div><span className="award-amounts__data-icon award-amounts__data-icon_transparent" />Combined Potential Award Amounts</div>
-                            <span>{awardAmounts.combinedPotentialAwardAmounts}</span>
-                        </div>
-                        {extraRow}
-                    </div>
-                </div>
-            );
-        }
-
-        return content;
+        return this.generateVisualization();
     }
 }
 AggregatedAwardAmounts.propTypes = propTypes;

--- a/src/js/components/awardv2/visualizations/amounts/AggregatedAwardAmounts.jsx
+++ b/src/js/components/awardv2/visualizations/amounts/AggregatedAwardAmounts.jsx
@@ -11,6 +11,7 @@ import ChartError from 'components/search/visualizations/ChartError';
 import { Table } from 'components/sharedComponents/icons/Icons';
 import AwardsBanner from './AwardsBanner';
 import NormalChart from './charts/NormalChart';
+import ExceedsCurrentChart from './charts/ExceedsCurrentChart';
 
 
 const propTypes = {
@@ -52,6 +53,9 @@ export default class AggregatedAwardAmounts extends React.Component {
             switch (visualizationType) {
                 case ('normal'):
                     visualization = (<NormalChart awardAmounts={awardAmounts} />);
+                    break;
+                case ('exceedsCurrent'):
+                    visualization = (<ExceedsCurrentChart awardAmounts={awardAmounts} />);
                     break;
                 default:
                     visualization = (

--- a/src/js/components/awardv2/visualizations/amounts/charts/ExceedsCurrentChart.jsx
+++ b/src/js/components/awardv2/visualizations/amounts/charts/ExceedsCurrentChart.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { generatePercentage } from 'helpers/aggregatedAmountsHelper';
 
 const propTypes = {
     awardAmounts: PropTypes.object
@@ -12,36 +13,36 @@ const propTypes = {
 
 export default class ExceedsCurrentChart extends React.Component {
     render() {
-        const awardAmounts = this.props.awardAmounts;
-        const currentPercentage = Math.round((awardAmounts._combinedCurrentAwardAmounts / awardAmounts._combinedPotentialAwardAmounts) * 100);
-        const exceededPercentage = Math.round(((awardAmounts._obligation - awardAmounts._combinedCurrentAwardAmounts) / awardAmounts._combinedPotentialAwardAmounts) * 100);
+        const obligation = this.props.awardAmounts._obligation;
+        const current = this.props.awardAmounts._combinedCurrentAwardAmounts;
+        const potential = this.props.awardAmounts._combinedPotentialAwardAmounts;
 
-        const currentStyle = {
-            width: `${currentPercentage}%`,
+        const currentBarStyle = {
+            width: generatePercentage(current / potential),
             backgroundColor: '#4773aa'
         };
 
-        const exceededStyle = {
-            width: `${exceededPercentage}%`
+        const overspendingBarStyle = {
+            width: generatePercentage((obligation - current) / potential)
         };
 
         const obligatedLabelStyle = {
-            width: `${currentPercentage + exceededPercentage}%`
+            width: generatePercentage(obligation / potential)
         };
 
         const currentLabelStyle = {
-            width: `${currentPercentage}%`
+            width: generatePercentage(current / potential)
         };
 
         return (
             <div className="award-amounts-viz">
                 <div className="award-amounts-viz__desc-top-wrapper">
                     <div className="award-amounts-viz__desc-top">
-                        <strong>{awardAmounts.obligationFormatted}</strong><br />Combined Obligated Amounts
+                        <strong>{this.props.awardAmounts.obligationFormatted}</strong><br />Combined Obligated Amounts
                     </div>
                     <div className="award-amounts-viz__desc">
                         <div className="award-amounts-viz__desc-text">
-                            <strong>{awardAmounts.overspendingFormatted}</strong><br />Exceeds Combined Current Award Amounts
+                            <strong>{this.props.awardAmounts.overspendingFormatted}</strong><br />Exceeds Combined Current Award Amounts
                         </div>
                         <div className="award-amounts-viz__legend-line award-amounts-viz__legend-line_overspending" />
                     </div>
@@ -51,15 +52,15 @@ export default class ExceedsCurrentChart extends React.Component {
                 </div>
                 <div className="award-amounts-viz__bar-wrapper">
                     <div className="award-amounts-viz__bar">
-                        <div className="award-amounts-viz__obligated" style={currentStyle} />
-                        <div className="award-amounts-viz__exceeded" style={exceededStyle} />
+                        <div className="award-amounts-viz__obligated" style={currentBarStyle} />
+                        <div className="award-amounts-viz__exceeded" style={overspendingBarStyle} />
                     </div>
                 </div>
                 <div className="award-amounts-viz__label" style={currentLabelStyle}>
                     <div className="award-amounts-viz__line" />
                     <div className="award-amounts-viz__desc">
                         <div className="award-amounts-viz__desc-text">
-                            <strong>{awardAmounts.combinedCurrentAwardAmountsFormatted}</strong><br />Combined Current Award Amounts
+                            <strong>{this.props.awardAmounts.combinedCurrentAwardAmountsFormatted}</strong><br />Combined Current Award Amounts
                         </div>
                         <div className="award-amounts-viz__legend-line" />
                     </div>
@@ -68,7 +69,7 @@ export default class ExceedsCurrentChart extends React.Component {
                     <div className="award-amounts-viz__line" />
                     <div className="award-amounts-viz__desc">
                         <div className="award-amounts-viz__desc-text">
-                            <strong>{awardAmounts.combinedPotentialAwardAmountsFormatted}</strong><br />Combined Potential Award Amounts
+                            <strong>{this.props.awardAmounts.combinedPotentialAwardAmountsFormatted}</strong><br />Combined Potential Award Amounts
                         </div>
                         <div className="award-amounts-viz__legend-line award-amounts-viz__legend-line_potential" />
                     </div>

--- a/src/js/components/awardv2/visualizations/amounts/charts/ExceedsCurrentChart.jsx
+++ b/src/js/components/awardv2/visualizations/amounts/charts/ExceedsCurrentChart.jsx
@@ -7,6 +7,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { generatePercentage } from 'helpers/aggregatedAmountsHelper';
 
+import InfoTooltip from 'components/awardv2/idv/InfoTooltip';
+import { awardAmountsOverspendingInfo } from 'components/awardv2/idv/InfoTooltipContent';
+
 const propTypes = {
     awardAmounts: PropTypes.object
 };
@@ -42,7 +45,10 @@ export default class ExceedsCurrentChart extends React.Component {
                     </div>
                     <div className="award-amounts-viz__desc">
                         <div className="award-amounts-viz__desc-text">
-                            <strong>{this.props.awardAmounts.overspendingFormatted}</strong><br />Exceeds Combined Current Award Amounts
+                            <strong>{this.props.awardAmounts.overspendingFormatted}</strong><br />
+                            <div className="award-amounts-viz__desc-text-wrapper">
+                                <InfoTooltip>{awardAmountsOverspendingInfo}</InfoTooltip> Exceeds Combined Current Award Amounts
+                            </div>
                         </div>
                         <div className="award-amounts-viz__legend-line award-amounts-viz__legend-line_overspending" />
                     </div>

--- a/src/js/components/awardv2/visualizations/amounts/charts/ExceedsCurrentChart.jsx
+++ b/src/js/components/awardv2/visualizations/amounts/charts/ExceedsCurrentChart.jsx
@@ -16,8 +16,6 @@ export default class ExceedsCurrentChart extends React.Component {
         const currentPercentage = Math.round((awardAmounts._combinedCurrentAwardAmounts / awardAmounts._combinedPotentialAwardAmounts) * 100);
         const exceededPercentage = Math.round(((awardAmounts._obligation - awardAmounts._combinedCurrentAwardAmounts) / awardAmounts._combinedPotentialAwardAmounts) * 100);
 
-        console.log('difference', awardAmounts._obligation - awardAmounts._combinedCurrentAwardAmounts);
-        console.log(exceededPercentage);
         const currentStyle = {
             width: `${currentPercentage}%`,
             backgroundColor: '#4773aa'

--- a/src/js/components/awardv2/visualizations/amounts/charts/ExceedsCurrentChart.jsx
+++ b/src/js/components/awardv2/visualizations/amounts/charts/ExceedsCurrentChart.jsx
@@ -1,6 +1,6 @@
 /**
- * NormalChart.jsx
- * Created by David Trinh 2/15/19
+ * ExceedsCurrentChart.jsx
+ * Created by Lizzie Salita 4/2/19
  **/
 
 import React from 'react';
@@ -10,26 +10,29 @@ const propTypes = {
     awardAmounts: PropTypes.object
 };
 
-export default class NormalChart extends React.Component {
+export default class ExceedsCurrentChart extends React.Component {
     render() {
         const awardAmounts = this.props.awardAmounts;
+        const currentPercentage = Math.round((awardAmounts._combinedCurrentAwardAmounts / awardAmounts._combinedPotentialAwardAmounts) * 100);
+        const exceededPercentage = Math.round(((awardAmounts._obligation - awardAmounts._combinedCurrentAwardAmounts) / awardAmounts._combinedPotentialAwardAmounts) * 100);
 
-        const obligatedStyle = {
-            width: `${awardAmounts.obligatedPercentage}%`,
+        console.log('difference', awardAmounts._obligation - awardAmounts._combinedCurrentAwardAmounts);
+        console.log(exceededPercentage);
+        const currentStyle = {
+            width: `${currentPercentage}%`,
             backgroundColor: '#4773aa'
         };
 
-        const currentStyle = {
-            width: `${awardAmounts.currentPercentage}%`,
-            backgroundColor: '#d8d8d8'
+        const exceededStyle = {
+            width: `${exceededPercentage}%`
         };
 
         const obligatedLabelStyle = {
-            width: `${awardAmounts.obligatedPercentage}%`
+            width: `${currentPercentage + exceededPercentage}%`
         };
 
         const currentLabelStyle = {
-            width: `${awardAmounts.currentLabelPercentage}%`
+            width: `${currentPercentage}%`
         };
 
         return (
@@ -42,8 +45,8 @@ export default class NormalChart extends React.Component {
                 </div>
                 <div className="award-amounts-viz__bar-wrapper">
                     <div className="award-amounts-viz__bar">
-                        <div className="award-amounts-viz__obligated" style={obligatedStyle} />
-                        <div className="award-amounts-viz__excerised" style={currentStyle} />
+                        <div className="award-amounts-viz__obligated" style={currentStyle} />
+                        <div className="award-amounts-viz__exceeded" style={exceededStyle} />
                     </div>
                 </div>
                 <div className="award-amounts-viz__label" style={currentLabelStyle}>
@@ -68,4 +71,4 @@ export default class NormalChart extends React.Component {
         );
     }
 }
-NormalChart.propTypes = propTypes;
+ExceedsCurrentChart.propTypes = propTypes;

--- a/src/js/components/awardv2/visualizations/amounts/charts/ExceedsCurrentChart.jsx
+++ b/src/js/components/awardv2/visualizations/amounts/charts/ExceedsCurrentChart.jsx
@@ -35,8 +35,16 @@ export default class ExceedsCurrentChart extends React.Component {
 
         return (
             <div className="award-amounts-viz">
-                <div className="award-amounts-viz__desc-top">
-                    <strong>{awardAmounts.obligationFormatted}</strong><br />Combined Obligated Amounts
+                <div className="award-amounts-viz__desc-top-wrapper">
+                    <div className="award-amounts-viz__desc-top">
+                        <strong>{awardAmounts.obligationFormatted}</strong><br />Combined Obligated Amounts
+                    </div>
+                    <div className="award-amounts-viz__desc">
+                        <div className="award-amounts-viz__desc-text">
+                            <strong>{awardAmounts.overspendingFormatted}</strong><br />Exceeds Combined Current Award Amounts
+                        </div>
+                        <div className="award-amounts-viz__legend-line award-amounts-viz__legend-line_overspending" />
+                    </div>
                 </div>
                 <div className="award-amounts-viz__label" style={obligatedLabelStyle}>
                     <div className="award-amounts-viz__line-up" />

--- a/src/js/components/awardv2/visualizations/amounts/charts/NormalChart.jsx
+++ b/src/js/components/awardv2/visualizations/amounts/charts/NormalChart.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { generatePercentage } from 'helpers/aggregatedAmountsHelper';
 
 const propTypes = {
     awardAmounts: PropTypes.object
@@ -12,45 +13,48 @@ const propTypes = {
 
 export default class NormalChart extends React.Component {
     render() {
-        const awardAmounts = this.props.awardAmounts;
+        // Rename properties to improve readability of the calculations
+        const obligation = this.props.awardAmounts._obligation;
+        const current = this.props.awardAmounts._combinedCurrentAwardAmounts;
+        const potential = this.props.awardAmounts._combinedPotentialAwardAmounts;
 
-        const obligatedStyle = {
-            width: `${awardAmounts.obligatedPercentage}%`,
+        const obligatedBarStyle = {
+            width: generatePercentage(obligation / potential),
             backgroundColor: '#4773aa'
         };
 
-        const currentStyle = {
-            width: `${awardAmounts.currentPercentage}%`,
+        const currentBarStyle = {
+            width: generatePercentage((current - obligation) / potential),
             backgroundColor: '#d8d8d8'
         };
 
         const obligatedLabelStyle = {
-            width: `${awardAmounts.obligatedPercentage}%`
+            width: generatePercentage(obligation / potential)
         };
 
         const currentLabelStyle = {
-            width: `${awardAmounts.currentLabelPercentage}%`
+            width: generatePercentage(current / potential)
         };
 
         return (
             <div className="award-amounts-viz">
                 <div className="award-amounts-viz__desc-top">
-                    <strong>{awardAmounts.obligationFormatted}</strong><br />Combined Obligated Amounts
+                    <strong>{this.props.awardAmounts.obligationFormatted}</strong><br />Combined Obligated Amounts
                 </div>
                 <div className="award-amounts-viz__label" style={obligatedLabelStyle}>
                     <div className="award-amounts-viz__line-up" />
                 </div>
                 <div className="award-amounts-viz__bar-wrapper">
                     <div className="award-amounts-viz__bar">
-                        <div className="award-amounts-viz__obligated" style={obligatedStyle} />
-                        <div className="award-amounts-viz__excerised" style={currentStyle} />
+                        <div className="award-amounts-viz__obligated" style={obligatedBarStyle} />
+                        <div className="award-amounts-viz__excerised" style={currentBarStyle} />
                     </div>
                 </div>
                 <div className="award-amounts-viz__label" style={currentLabelStyle}>
                     <div className="award-amounts-viz__line" />
                     <div className="award-amounts-viz__desc">
                         <div className="award-amounts-viz__desc-text">
-                            <strong>{awardAmounts.combinedCurrentAwardAmountsFormatted}</strong><br />Combined Current Award Amounts
+                            <strong>{this.props.awardAmounts.combinedCurrentAwardAmountsFormatted}</strong><br />Combined Current Award Amounts
                         </div>
                         <div className="award-amounts-viz__legend-line" />
                     </div>
@@ -59,7 +63,7 @@ export default class NormalChart extends React.Component {
                     <div className="award-amounts-viz__line" />
                     <div className="award-amounts-viz__desc">
                         <div className="award-amounts-viz__desc-text">
-                            <strong>{awardAmounts.combinedPotentialAwardAmountsFormatted}</strong><br />Combined Potential Award Amounts
+                            <strong>{this.props.awardAmounts.combinedPotentialAwardAmountsFormatted}</strong><br />Combined Potential Award Amounts
                         </div>
                         <div className="award-amounts-viz__legend-line award-amounts-viz__legend-line_potential" />
                     </div>

--- a/src/js/helpers/aggregatedAmountsHelper.js
+++ b/src/js/helpers/aggregatedAmountsHelper.js
@@ -7,7 +7,7 @@
 
 /* eslint-disable import/prefer-default-export */
 
-export const determineScenario = (amounts) => {
+export const determineSpendingScenario = (amounts) => {
     const obligated = amounts._obligation;
     const current = amounts._combinedCurrentAwardAmounts;
     const potential = amounts._combinedPotentialAwardAmounts;

--- a/src/js/helpers/aggregatedAmountsHelper.js
+++ b/src/js/helpers/aggregatedAmountsHelper.js
@@ -5,8 +5,6 @@
 
 // Handle edge cases in the IDV Combined Award Amounts visualization
 
-/* eslint-disable import/prefer-default-export */
-
 export const determineSpendingScenario = (amounts) => {
     const obligated = amounts._obligation;
     const current = amounts._combinedCurrentAwardAmounts;
@@ -27,4 +25,4 @@ export const determineSpendingScenario = (amounts) => {
     return 'insufficientData';
 };
 
-/* eslint-enable import/prefer-default-export */
+export const generatePercentage = (value) => `${(value * 100).toFixed(2)}%`;

--- a/src/js/models/v2/awardsV2/BaseAwardAmounts.js
+++ b/src/js/models/v2/awardsV2/BaseAwardAmounts.js
@@ -54,10 +54,10 @@ const BaseAwardAmounts = {
     get obligatedPercentage() {
         return Math.round(Math.abs((this._obligation / this._combinedPotentialAwardAmounts) * 100));
     },
-    get exercisedPercentage() {
+    get currentPercentage() {
         return Math.round(Math.abs((this._combinedCurrentAwardAmounts / this._combinedPotentialAwardAmounts) * 100)) - Math.round(Math.abs((this._obligation / this._combinedPotentialAwardAmounts) * 100));
     },
-    get exercisedLabelPercentage() {
+    get currentLabelPercentage() {
         return Math.round(Math.abs((this._combinedCurrentAwardAmounts) / this._combinedPotentialAwardAmounts) * 100);
     }
 };

--- a/src/js/models/v2/awardsV2/BaseAwardAmounts.js
+++ b/src/js/models/v2/awardsV2/BaseAwardAmounts.js
@@ -60,17 +60,6 @@ const BaseAwardAmounts = {
             return `${MoneyFormatter.formatMoneyWithPrecision((this._obligation - this._combinedCurrentAwardAmounts) / units.unit, 1)} ${units.unitLabel}`;
         }
         return MoneyFormatter.formatMoney(this._obligation - this._combinedCurrentAwardAmounts);
-    },
-    get obligatedPercentage() {
-        return Math.round(Math.abs((this._obligation / this._combinedPotentialAwardAmounts) * 100));
-    },
-    get currentPercentage() {
-        // Calculates the percentage to use as the width of the combined current award amounts bar
-        return Math.round(Math.abs((this._combinedCurrentAwardAmounts / this._combinedPotentialAwardAmounts) * 100)) - Math.round(Math.abs((this._obligation / this._combinedPotentialAwardAmounts) * 100));
-    },
-    get currentLabelPercentage() {
-        // Calculates the percentage to use as the width of the combined current award amounts label
-        return Math.round(Math.abs((this._combinedCurrentAwardAmounts) / this._combinedPotentialAwardAmounts) * 100);
     }
 };
 

--- a/src/js/models/v2/awardsV2/BaseAwardAmounts.js
+++ b/src/js/models/v2/awardsV2/BaseAwardAmounts.js
@@ -55,9 +55,11 @@ const BaseAwardAmounts = {
         return Math.round(Math.abs((this._obligation / this._combinedPotentialAwardAmounts) * 100));
     },
     get currentPercentage() {
+        // Calculates the percentage to use as the width of the combined current award amounts bar
         return Math.round(Math.abs((this._combinedCurrentAwardAmounts / this._combinedPotentialAwardAmounts) * 100)) - Math.round(Math.abs((this._obligation / this._combinedPotentialAwardAmounts) * 100));
     },
     get currentLabelPercentage() {
+        // Calculates the percentage to use as the width of the combined current award amounts label
         return Math.round(Math.abs((this._combinedCurrentAwardAmounts) / this._combinedPotentialAwardAmounts) * 100);
     }
 };

--- a/src/js/models/v2/awardsV2/BaseAwardAmounts.js
+++ b/src/js/models/v2/awardsV2/BaseAwardAmounts.js
@@ -51,6 +51,16 @@ const BaseAwardAmounts = {
         }
         return MoneyFormatter.formatMoney(this._combinedCurrentAwardAmounts);
     },
+    get overspending() {
+        return MoneyFormatter.formatMoneyWithPrecision(this._obligation - this._combinedCurrentAwardAmounts, 2);
+    },
+    get overspendingFormatted() {
+        if (this._obligation - this._combinedCurrentAwardAmounts >= MoneyFormatter.unitValues.MILLION) {
+            const units = MoneyFormatter.calculateUnitForSingleValue(this._obligation - this._combinedCurrentAwardAmounts);
+            return `${MoneyFormatter.formatMoneyWithPrecision((this._obligation - this._combinedCurrentAwardAmounts) / units.unit, 1)} ${units.unitLabel}`;
+        }
+        return MoneyFormatter.formatMoney(this._obligation - this._combinedCurrentAwardAmounts);
+    },
     get obligatedPercentage() {
         return Math.round(Math.abs((this._obligation / this._combinedPotentialAwardAmounts) * 100));
     },

--- a/tests/helpers/aggregatedAmountsHelper-text.js
+++ b/tests/helpers/aggregatedAmountsHelper-text.js
@@ -6,7 +6,7 @@
 import * as AggregatedAmountsHelper from 'helpers/aggregatedAmountsHelper';
 
 describe('Aggregated Amounts helper functions', () => {
-    describe('determineScenario', () => {
+    describe('determineSpendingScenario', () => {
         it('should return "normal" when obligated amount is less than current and potential', () => {
             const mockAmounts = {
                 _obligation: 50,
@@ -55,6 +55,11 @@ describe('Aggregated Amounts helper functions', () => {
             };
             const mockedScenario = AggregatedAmountsHelper.determineScenario(mockAmounts);
             expect(mockedScenario).toEqual("insufficientData");
+        });
+    });
+    describe('generatePercentage', () => {
+        it('should format the given value as a percentage, rounded to 2 decimal places', () => {
+            expect(AggregatedAmountsHelper.generatePercentage(0.23456)).toEqual('23.46%');
         });
     });
 });

--- a/tests/models/awardsV2/BaseAwardAmounts-test.js
+++ b/tests/models/awardsV2/BaseAwardAmounts-test.js
@@ -13,7 +13,16 @@ const awardAmountsNeg = Object.create(BaseAwardAmounts);
 const negativeObligation = {
     rollup_total_obligation: -1623321.02
 };
+
+const awardAmountsOverspent = Object.create(BaseAwardAmounts);
+const overspending = {
+    rollup_base_exercised_options_val: 5000000.00,
+    rollup_base_and_all_options_value: 10000000.00,
+    rollup_total_obligation: 7500000.00
+};
+
 awardAmountsNeg.populate(negativeObligation);
+awardAmountsOverspent.populate(overspending);
 
 describe('BaseAwardAmounts', () => {
     it('should have an empty string as a unique generated id if the field is null or undefined', () => {
@@ -48,5 +57,11 @@ describe('BaseAwardAmounts', () => {
     });
     it('should calculate the right percentage for width of the current combined award amounts label', () => {
         expect(awardAmounts.currentLabelPercentage).toEqual(9);
+    });
+    it('should format the amount overspent', () => {
+        expect(awardAmountsOverspent.overspending).toEqual('$2,500,000.00');
+    });
+    it('should format the amount overspent with units', () => {
+        expect(awardAmountsOverspent.overspendingFormatted).toEqual('$2.5 M');
     });
 });

--- a/tests/models/awardsV2/BaseAwardAmounts-test.js
+++ b/tests/models/awardsV2/BaseAwardAmounts-test.js
@@ -43,7 +43,10 @@ describe('BaseAwardAmounts', () => {
     it('should calculate the right obligated percentage', () => {
         expect(awardAmounts.obligatedPercentage).toEqual(2);
     });
-    it('should calculate the right exercised percentage', () => {
-        expect(awardAmounts.exercisedPercentage).toEqual(7);
+    it('should calculate the right percentage for width of the current combined award amounts bar', () => {
+        expect(awardAmounts.currentPercentage).toEqual(7);
+    });
+    it('should calculate the right percentage for width of the current combined award amounts label', () => {
+        expect(awardAmounts.currentLabelPercentage).toEqual(9);
     });
 });

--- a/tests/models/awardsV2/BaseAwardAmounts-test.js
+++ b/tests/models/awardsV2/BaseAwardAmounts-test.js
@@ -49,15 +49,6 @@ describe('BaseAwardAmounts', () => {
     it('should format the combined potential award amounts amounts with units', () => {
         expect(awardAmounts.combinedPotentialAwardAmountsFormatted).toEqual('$107.0 M');
     });
-    it('should calculate the right obligated percentage', () => {
-        expect(awardAmounts.obligatedPercentage).toEqual(2);
-    });
-    it('should calculate the right percentage for width of the current combined award amounts bar', () => {
-        expect(awardAmounts.currentPercentage).toEqual(7);
-    });
-    it('should calculate the right percentage for width of the current combined award amounts label', () => {
-        expect(awardAmounts.currentLabelPercentage).toEqual(9);
-    });
     it('should format the amount overspent', () => {
         expect(awardAmountsOverspent.overspending).toEqual('$2,500,000.00');
     });


### PR DESCRIPTION
### \*Merge after #1041\*

**High level description:**

Implements the bar graph for the "Overspending" case in the IDV aggregate Award Amounts visualization. 

**Technical details:**

- Refactored variable names used for percentage calculations to reflect updated terminology in the visualization
- Added `overspending` and `overspendingFormatted` getters to the model. These will be negative and/or unused in other scenarios
- Perform a check for the situation where obligated amounts exceed current amounts and implements the corresponding bar graph. Subsequent PR will check for "Extreme overspend".
- Award id for an example of the overspend in dev: `69146930` 

**JIRA Ticket:**
[DEV-2357](https://federal-spending-transparency.atlassian.net/browse/DEV-2357), subtask for step 3 of [DEV-2224](https://federal-spending-transparency.atlassian.net/browse/DEV-2224)

**Mockup:**
https://bahdigital.invisionapp.com/share/69IA8EPGPCM#/296009665_combinedAwardsSection--overCurrentUnderPotential

The following are ALL required for the PR to be merged:
- [x] #1041 merged, change base to dev
- [x] Add tooltip
- [x] Code review
- [x] Design review
- [x] Verified cross-browser compatibility
