### PR TITLE
Hotfix Referenced Award links

### DIFF
--- a/src/js/components/awardv2/idv/referencedAwards/ReferencedAwardsTable.jsx
+++ b/src/js/components/awardv2/idv/referencedAwards/ReferencedAwardsTable.jsx
@@ -60,7 +60,7 @@ export default class ReferencedAwardsTable extends React.Component {
                     {columns.map((col) => {
                         let data = row[col.name];
                         if (col.name === 'piid') {
-                            data = (<a href={`/#/award/${row.internalId}`}>{row[col.name]}</a>);
+                            data = (<a href={`/#/award/${row.id}`}>{row[col.name]}</a>);
                         }
                         if (col.name === 'agency' && row.agencyId) {
                             data = (<a href={`/#/agency/${row.agencyId}`}>{row[col.name]}</a>);


### PR DESCRIPTION
**High level description:**

Fixes links to award summary pages in the IDV referenced awards table. 

**Technical details:**

Uses the award id that is compatible with the `awards/v1` endpoint to build the link. It was already available in the API response and model. 

**JIRA Ticket:**
[DEV-2233](https://federal-spending-transparency.atlassian.net/browse/DEV-2233) (Failed test) see comments.

**Mockup:**
N/A

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Verified cross-browser compatibility
