### PR TITLE
[DEV-2226] A/C 1 and 2: Removing IDV_B from subsection search and Calls from BPA Description

### DIFF
--- a/src/js/components/search/filters/awardType/AwardType.jsx
+++ b/src/js/components/search/filters/awardType/AwardType.jsx
@@ -45,10 +45,9 @@ const awardTypesData = [
     }
 ];
 
-const awardTypeCodesData = {
-    ...awardTypeCodes,
+const awardTypeCodesData = Object.assign(awardTypeCodes, {
     IDV_E: "Blanket Purchase Agreements (BPA)"
-};
+});
 
 const propTypes = {
     awardTypes: PropTypes.arrayOf(PropTypes.object),

--- a/src/js/components/search/filters/awardType/AwardType.jsx
+++ b/src/js/components/search/filters/awardType/AwardType.jsx
@@ -10,41 +10,40 @@ import { awardTypeGroups, awardTypeCodes } from 'dataMapping/search/awardType';
 import PrimaryCheckboxType from 'components/sharedComponents/checkbox/PrimaryCheckboxType';
 import SubmitHint from 'components/sharedComponents/filterSidebar/SubmitHint';
 
-const defaultProps = {
-    awardTypes: [
-        {
-            id: 'award-contracts',
-            name: 'Contracts',
-            filters: awardTypeGroups.contracts
-        },
-        {
-            id: 'indefinite-delivery-vehicle',
-            name: 'Contract IDVs',
-            // Consider possibly removing this from awardTypeGroups as the model changed in DEV-2226
-            filters: awardTypeGroups.idvs.filter((filter) => filter !== "IDV_B")
-        },
-        {
-            id: 'award-grants',
-            name: 'Grants',
-            filters: awardTypeGroups.grants
-        },
-        {
-            id: 'award-direct-payments',
-            name: 'Direct Payments',
-            filters: awardTypeGroups.direct_payments
-        },
-        {
-            id: 'award-loans',
-            name: 'Loans',
-            filters: awardTypeGroups.loans
-        },
-        {
-            id: 'award-other',
-            name: 'Other',
-            filters: awardTypeGroups.other
-        }
-    ]
-};
+const awardTypesData = [
+    {
+        id: 'award-contracts',
+        name: 'Contracts',
+        filters: awardTypeGroups.contracts
+    },
+    {
+        id: 'indefinite-delivery-vehicle',
+        name: 'Contract IDVs',
+        // Consider possibly removing this from awardTypeGroups dataMap as the model changed in DEV-2226
+        filters: awardTypeGroups.idvs
+            .filter((filter) => filter !== "IDV_B")
+    },
+    {
+        id: 'award-grants',
+        name: 'Grants',
+        filters: awardTypeGroups.grants
+    },
+    {
+        id: 'award-direct-payments',
+        name: 'Direct Payments',
+        filters: awardTypeGroups.direct_payments
+    },
+    {
+        id: 'award-loans',
+        name: 'Loans',
+        filters: awardTypeGroups.loans
+    },
+    {
+        id: 'award-other',
+        name: 'Other',
+        filters: awardTypeGroups.other
+    }
+];
 
 const propTypes = {
     awardTypes: PropTypes.arrayOf(PropTypes.object),
@@ -63,7 +62,7 @@ export default class AwardType extends React.Component {
     }
     render() {
         const awardTypes = (
-            this.props.awardTypes.map((type, index) => (
+            awardTypesData.map((type, index) => (
                 <PrimaryCheckboxType
                     {...type}
                     {...this.props}
@@ -90,5 +89,4 @@ export default class AwardType extends React.Component {
         );
     }
 }
-AwardType.defaultProps = defaultProps;
 AwardType.propTypes = propTypes;

--- a/src/js/components/search/filters/awardType/AwardType.jsx
+++ b/src/js/components/search/filters/awardType/AwardType.jsx
@@ -20,7 +20,8 @@ const defaultProps = {
         {
             id: 'indefinite-delivery-vehicle',
             name: 'Contract IDVs',
-            filters: awardTypeGroups.idvs
+            // Consider possibly removing this from awardTypeGroups as the model changed in DEV-2226
+            filters: awardTypeGroups.idvs.filter((filter) => filter !== "IDV_B")
         },
         {
             id: 'award-grants',
@@ -62,15 +63,16 @@ export default class AwardType extends React.Component {
     }
     render() {
         const awardTypes = (
-            this.props.awardTypes.map((type, index) =>
-                (<PrimaryCheckboxType
+            this.props.awardTypes.map((type, index) => (
+                <PrimaryCheckboxType
                     {...type}
                     {...this.props}
                     key={index}
                     types={awardTypeCodes}
                     filterType="Award"
                     selectedCheckboxes={this.props.awardType}
-                    bulkTypeChange={this.props.bulkTypeChange} />)
+                    bulkTypeChange={this.props.bulkTypeChange} />
+            )
             ));
 
         return (

--- a/src/js/components/search/filters/awardType/AwardType.jsx
+++ b/src/js/components/search/filters/awardType/AwardType.jsx
@@ -45,6 +45,11 @@ const awardTypesData = [
     }
 ];
 
+const awardTypeCodesData = {
+    ...awardTypeCodes,
+    IDV_E: "Blanket Purchase Agreements (BPA)"
+};
+
 const propTypes = {
     awardTypes: PropTypes.arrayOf(PropTypes.object),
     awardType: PropTypes.object,
@@ -61,18 +66,16 @@ export default class AwardType extends React.Component {
         }
     }
     render() {
-        const awardTypes = (
-            awardTypesData.map((type, index) => (
-                <PrimaryCheckboxType
-                    {...type}
-                    {...this.props}
-                    key={index}
-                    types={awardTypeCodes}
-                    filterType="Award"
-                    selectedCheckboxes={this.props.awardType}
-                    bulkTypeChange={this.props.bulkTypeChange} />
-            )
-            ));
+        const awardTypes = awardTypesData.map((type, index) => (
+            <PrimaryCheckboxType
+                {...type}
+                {...this.props}
+                key={index}
+                types={awardTypeCodesData}
+                filterType="Award"
+                selectedCheckboxes={this.props.awardType}
+                bulkTypeChange={this.props.bulkTypeChange} />
+        ));
 
         return (
             <div className="award-type-filter search-filter checkbox-type-filter">


### PR DESCRIPTION
**High level description:**
* Removing `IDV_B` award type from Advanced Search award type sub-section filter area
* Omitting "Calls" from the `BPA` award type sub-section filter check-box label

**Technical details:**
Instead of changing the relevant data maps (which are very widely used), I'm changing the relevant values after they've been imported as stored as a variable in the relevant component, so that `IDV_B` is not included in the `awardTypeGroups` under the IDV key-space, and the "BPA" awardTypeCode value omits "Calls."

**JIRA Ticket:**
[DEV-2226](https://federal-spending-transparency.atlassian.net/browse/DEV-2226) (A/C 1 &2)

**Commits:**
4c5ed1c -- Removing IDV_B award type from Award Type Advanced Search Filter sub-section (e1c50e2 removes a propType that was not used)
b8508b8 -- Omitting "Calls" from BPA Award type description (8a565eb uses `Object.assign() instead of `...`)

The following are ALL required for the PR to be merged:
- [ ] Code review
- [ ] [API #1731](https://github.com/fedspendingtransparency/usaspending-api/pull/1731) merged (if applicable) (Front end doesn't depend on this, but (A/C 3 &4 do)
