### PR TITLE
Update pull_request_template.md

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -15,6 +15,6 @@ https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E
 The following are ALL required for the PR to be merged:
 - [ ] Code review
 - [ ] Design review (if applicable)
-- [ ] API contract approved by @backendDev (if applicable)
+- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated (if applicable)
 - [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged (if applicable)
 - [ ] Verified cross-browser compatibility


### PR DESCRIPTION
**High level description:**

Updates the PR template to reflect that API contracts have been moved to the [usaspending-api](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) repository. 

**JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [x] Code review

