### PR TITLE
Display Subawards with IDV as Prime in Advanced Search

### DIFF
--- a/src/js/dataMapping/search/awardType.js
+++ b/src/js/dataMapping/search/awardType.js
@@ -87,6 +87,6 @@ export const awardTypeGroupLabels = {
 };
 
 export const subawardTypeGroups = {
-    subcontracts: awardTypeGroups.contracts,
+    subcontracts: awardTypeGroups.contracts.concat(awardTypeGroups.idvs),
     subgrants: awardTypeGroups.grants
 };


### PR DESCRIPTION
**High level description:**

Display Subawards with IDV as Prime in the Advanced Search Spending by Sub-Award table.

**Technical details:**

The request to `api/v2/search/spending_by_award/` was sending `no intersection` for the award type codes filter because the award type codes mapped to the Sub-Contracts tab did not include IDV award types. This PR updates the mapping. 

**JIRA Ticket:**
[DEV-2362](https://federal-spending-transparency.atlassian.net/browse/DEV-2362)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:
- [x] Frontend code review
- [x] Backend approved (@tony-sappe, @emily-brents)
- [x] [Backend PR](https://github.com/fedspendingtransparency/usaspending-api/pull/1757) merged
- [x] Verified cross-browser compatibility
