### PR TITLE
Dev-2418 IDV Summary Grandchildren

### DIFF
--- a/src/_scss/pages/awardV2/idv/awardAmounts/_dataTable.scss
+++ b/src/_scss/pages/awardV2/idv/awardAmounts/_dataTable.scss
@@ -56,3 +56,19 @@
     }
 }
 
+.award-amounts-children__data-wrapper {
+  margin-top: rem(30);
+  margin-bottom: rem(15);
+  
+  .award-amounts-children__data-content {
+      @extend %column-less-table__row;
+      border-bottom: 0;
+      &:nth-of-type(1) {
+          border-radius: rem(5) rem(5) 0 0;
+      }
+      &:last-of-type {
+          border-radius: 0 0 rem(5) rem(5);
+          border-bottom: solid rem(1) $border-light-gray;
+      }
+  }
+}

--- a/src/_scss/pages/awardV2/visualizations/overview/_relatedAwards.scss
+++ b/src/_scss/pages/awardV2/visualizations/overview/_relatedAwards.scss
@@ -13,6 +13,23 @@
         &.related-awards__label_count {
             padding-top: rem(10);
         }
+        .related-awards__glossary-icon {
+            @include display(inline-flex);
+            // @include flex-wrap(nowrap);
+            // @include flex(0 0 auto);
+            padding-left: rem(5);
+            svg {
+                @include display(flex);
+                fill: $color-gray-light;
+                height: rem(20);
+                width: rem(20);
+            }
+            &:hover, &:focus {
+                svg {
+                    fill: $color-gray;
+                }
+            }
+        }
     }
     .award-viz__button {
         padding: rem(5) 0;

--- a/src/_scss/pages/awardV2/visualizations/overview/_relatedAwards.scss
+++ b/src/_scss/pages/awardV2/visualizations/overview/_relatedAwards.scss
@@ -11,27 +11,26 @@
         font-weight: $font-light;
         padding-bottom: rem(5);
         &.related-awards__label_count {
+            @include display(flex);
             padding-top: rem(10);
         }
-        .related-awards__glossary-icon {
-            @include display(inline-flex);
-            // @include flex-wrap(nowrap);
-            // @include flex(0 0 auto);
-            padding-left: rem(5);
-            svg {
-                @include display(flex);
-                fill: $color-gray-light;
-                height: rem(20);
-                width: rem(20);
-            }
-            &:hover, &:focus {
-                svg {
-                    fill: $color-gray;
-                }
-            }
+    }
+    .related-awards__counts {
+        @include display(flex);
+        @include flex-direction(column);
+        @include align-items(right);
+        @include justify-content(right);
+        margin-right: rem(8);
+        .award-viz__button {
+          font-size: rem(16);
+          display: block;
+          text-align: right;
         }
     }
-    .award-viz__button {
-        padding: rem(5) 0;
+    .related-awards__description {
+      @include display(flex);
+      @include flex-direction(column);
+      @include justify-content(center);
+      @include align-items(left);
     }
 }

--- a/src/js/components/awardv2/AwardV2.jsx
+++ b/src/js/components/awardv2/AwardV2.jsx
@@ -53,7 +53,7 @@ export default class Award extends React.Component {
             sectionPositions: [],
             window: {
                 height: 0
-            },
+            }
         };
 
         this.jumpToSection = this.jumpToSection.bind(this);

--- a/src/js/components/awardv2/AwardV2.jsx
+++ b/src/js/components/awardv2/AwardV2.jsx
@@ -54,22 +54,12 @@ export default class Award extends React.Component {
             window: {
                 height: 0
             },
-            tableType: 'child_awards'
         };
 
         this.jumpToSection = this.jumpToSection.bind(this);
-        this.switchTab = this.switchTab.bind(this);
     }
 
-    switchTab(tableType) {
-        if (tableType !== this.state.tableType) {
-            this.setState({
-                tableType
-            });
-        }
-    }
-
-    jumpToSection(section = '', updateState) {
+    jumpToSection(section = '') {
         // we've been provided a section to jump to
         // check if it's a valid section
         const matchedSection = find(awardSections, {
@@ -90,10 +80,6 @@ export default class Award extends React.Component {
 
         const sectionTop = sectionDom.offsetTop - 145;
         scrollToY(sectionTop, 700);
-        if (updateState) {
-            const newState = Object.assign({}, updateState);
-            this.setState(newState);
-        }
     }
 
     render() {
@@ -119,9 +105,7 @@ export default class Award extends React.Component {
                         awardId={this.props.awardId}
                         overview={overview}
                         counts={this.props.award.counts}
-                        jumpToSection={this.jumpToSection}
-                        tableType={this.state.tableType}
-                        switchTab={this.switchTab} />
+                        jumpToSection={this.jumpToSection} />
                 );
             }
             else {

--- a/src/js/components/awardv2/AwardV2.jsx
+++ b/src/js/components/awardv2/AwardV2.jsx
@@ -53,13 +53,23 @@ export default class Award extends React.Component {
             sectionPositions: [],
             window: {
                 height: 0
-            }
+            },
+            tableType: 'child_awards'
         };
 
         this.jumpToSection = this.jumpToSection.bind(this);
+        this.switchTab = this.switchTab.bind(this);
     }
 
-    jumpToSection(section = '') {
+    switchTab(tableType) {
+        if (tableType !== this.state.tableType) {
+            this.setState({
+                tableType
+            });
+        }
+    }
+
+    jumpToSection(section = '', updateState) {
         // we've been provided a section to jump to
         // check if it's a valid section
         const matchedSection = find(awardSections, {
@@ -80,6 +90,10 @@ export default class Award extends React.Component {
 
         const sectionTop = sectionDom.offsetTop - 145;
         scrollToY(sectionTop, 700);
+        if (updateState) {
+            const newState = Object.assign({}, updateState);
+            this.setState(newState);
+        }
     }
 
     render() {
@@ -105,7 +119,9 @@ export default class Award extends React.Component {
                         awardId={this.props.awardId}
                         overview={overview}
                         counts={this.props.award.counts}
-                        jumpToSection={this.jumpToSection} />
+                        jumpToSection={this.jumpToSection}
+                        tableType={this.state.tableType}
+                        switchTab={this.switchTab} />
                 );
             }
             else {

--- a/src/js/components/awardv2/idv/IdvContent.jsx
+++ b/src/js/components/awardv2/idv/IdvContent.jsx
@@ -97,7 +97,8 @@ export default class IdvContent extends React.Component {
                     <RelatedAwards
                         counts={this.props.counts}
                         jumpToSection={this.props.jumpToSection}
-                        overview={this.props.overview} />
+                        overview={this.props.overview}
+                        awardId={this.props.awardId} />
                     <IdvDates
                         dates={this.props.overview.dates} />
                 </div>

--- a/src/js/components/awardv2/idv/IdvContent.jsx
+++ b/src/js/components/awardv2/idv/IdvContent.jsx
@@ -24,26 +24,34 @@ const propTypes = {
     awardId: PropTypes.string,
     counts: AWARD_V2_COUNTS_PROPS,
     overview: AWARD_V2_OVERVIEW_PROPS,
-    jumpToSection: PropTypes.func,
-    tableType: PropTypes.string,
-    switchTab: PropTypes.func
+    jumpToSection: PropTypes.func
 };
 
 export default class IdvContent extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            awardHistoryActiveTab: 'transaction' // or fedaccount
+            awardHistoryActiveTab: 'transaction', // or fedaccount
+            relatedAwardsActiveTab: 'child_awards'
         };
 
-        this.setActiveTab = this.setActiveTab.bind(this);
+        this.setHistoryActiveTab = this.setHistoryActiveTab.bind(this);
+        this.setRelatedAwardsTab = this.setRelatedAwardsTab.bind(this);
         this.jumpToFederalAccountsHistory = this.jumpToFederalAccountsHistory.bind(this);
     }
 
-    setActiveTab(activeTab = 'transaction') {
+    setHistoryActiveTab(activeTab = 'transaction') {
         this.setState({
             awardHistoryActiveTab: activeTab
         });
+    }
+
+    setRelatedAwardsTab(relatedAwardsActiveTab) {
+        if (relatedAwardsActiveTab !== this.state.relatedAwardsActiveTab) {
+            this.setState({
+                relatedAwardsActiveTab
+            });
+        }
     }
 
     jumpToFederalAccountsHistory() {
@@ -99,6 +107,7 @@ export default class IdvContent extends React.Component {
                     <RelatedAwards
                         counts={this.props.counts}
                         jumpToSection={this.props.jumpToSection}
+                        setRelatedAwardsTab={this.setRelatedAwardsTab}
                         overview={this.props.overview} />
                     <IdvDates
                         dates={this.props.overview.dates} />
@@ -119,9 +128,9 @@ export default class IdvContent extends React.Component {
                     <AwardMetaDataContainer jumpToFederalAccountsHistory={this.jumpToFederalAccountsHistory} />
                 </div>
                 <ReferencedAwardsContainer
-                    tableType={this.props.tableType}
-                    switchTab={this.props.switchTab} />
-                <AwardHistory activeTab={this.state.awardHistoryActiveTab} setActiveTab={this.setActiveTab} overview={this.props.overview} />
+                    tableType={this.state.relatedAwardsActiveTab}
+                    switchTab={this.setRelatedAwardsTab} />
+                <AwardHistory activeTab={this.state.awardHistoryActiveTab} setActiveTab={this.setHistoryActiveTab} overview={this.props.overview} />
                 <AdditionalInfo overview={this.props.overview} />
             </div>
         );

--- a/src/js/components/awardv2/idv/IdvContent.jsx
+++ b/src/js/components/awardv2/idv/IdvContent.jsx
@@ -24,7 +24,9 @@ const propTypes = {
     awardId: PropTypes.string,
     counts: AWARD_V2_COUNTS_PROPS,
     overview: AWARD_V2_OVERVIEW_PROPS,
-    jumpToSection: PropTypes.func
+    jumpToSection: PropTypes.func,
+    tableType: PropTypes.string,
+    switchTab: PropTypes.func
 };
 
 export default class IdvContent extends React.Component {
@@ -97,8 +99,7 @@ export default class IdvContent extends React.Component {
                     <RelatedAwards
                         counts={this.props.counts}
                         jumpToSection={this.props.jumpToSection}
-                        overview={this.props.overview}
-                        awardId={this.props.awardId} />
+                        overview={this.props.overview} />
                     <IdvDates
                         dates={this.props.overview.dates} />
                 </div>
@@ -117,7 +118,9 @@ export default class IdvContent extends React.Component {
                     <ComingSoonSection includeHeader title="IDV Activity" icon="chart-area" />
                     <AwardMetaDataContainer jumpToFederalAccountsHistory={this.jumpToFederalAccountsHistory} />
                 </div>
-                <ReferencedAwardsContainer />
+                <ReferencedAwardsContainer
+                    tableType={this.props.tableType}
+                    switchTab={this.props.switchTab} />
                 <AwardHistory activeTab={this.state.awardHistoryActiveTab} setActiveTab={this.setActiveTab} overview={this.props.overview} />
                 <AdditionalInfo overview={this.props.overview} />
             </div>

--- a/src/js/components/awardv2/idv/referencedAwards/ReferencedAwardsSection.jsx
+++ b/src/js/components/awardv2/idv/referencedAwards/ReferencedAwardsSection.jsx
@@ -46,7 +46,7 @@ export default class ReferencedAwardsSection extends React.Component {
                         <div className="award-viz__icon">
                             <img src="img/icon-hierarchy.png" alt="pedigree chart" />
                         </div>
-                        <h3 className="award-viz__title">Award Orders Made Under this IDV</h3>
+                        <h3 className="award-viz__title">Orders Made Under this IDV</h3>
                         <InfoToolTip left>
                             {relatedAwardsInfo}
                         </InfoToolTip>

--- a/src/js/components/awardv2/visualizations/amounts/AggregatedAwardAmounts.jsx
+++ b/src/js/components/awardv2/visualizations/amounts/AggregatedAwardAmounts.jsx
@@ -74,8 +74,13 @@ export default class AggregatedAwardAmounts extends React.Component {
                 <AwardsBanner
                     jumpToReferencedAwardsTable={this.jumpToReferencedAwardsTable} />
                 {visualization}
-                <div className="award-amounts__data">
-                    <span>Awards Under this IDV</span><span>{awardAmounts.idvCount + awardAmounts.contractCount}</span>
+                <div className="award-amounts-children__data-wrapper">
+                    <div className="award-amounts-children__data-content">
+                        <div>Child Award Orders</div><span>{awardAmounts.childIDVCount}</span>
+                    </div>
+                    <div className="award-amounts-children__data-content">
+                        <div>Grandchild Award Orders</div><span>{awardAmounts.grandchildAwardCount}</span>
+                    </div>
                 </div>
                 <button
                     onClick={this.jumpToReferencedAwardsTable}

--- a/src/js/components/awardv2/visualizations/amounts/AggregatedAwardAmounts.jsx
+++ b/src/js/components/awardv2/visualizations/amounts/AggregatedAwardAmounts.jsx
@@ -76,13 +76,18 @@ export default class AggregatedAwardAmounts extends React.Component {
                 {visualization}
                 <div className="award-amounts-children__data-wrapper">
                     <div className="award-amounts-children__data-content">
-                        <div>Count of Total Orders</div><span>{awardAmounts.childIDVCount + awardAmounts.grandchildAwardCount}</span>
+                        <div>Count of Total Orders</div>
+                        <span>
+                            {awardAmounts.childAwardCount + awardAmounts.grandchildAwardCount}
+                        </span>
                     </div>
                     <div className="award-amounts-children__data-content">
-                        <div>Count of Child Award Orders</div><span>{awardAmounts.childIDVCount}</span>
+                        <div>Count of Child Award Orders</div>
+                        <span>{awardAmounts.childAwardCount}</span>
                     </div>
                     <div className="award-amounts-children__data-content">
-                        <div>Count of Grandchild Award Orders</div><span>{awardAmounts.grandchildAwardCount}</span>
+                        <div>Count of Grandchild Award Orders</div>
+                        <span>{awardAmounts.grandchildAwardCount}</span>
                     </div>
                 </div>
                 <button

--- a/src/js/components/awardv2/visualizations/amounts/AggregatedAwardAmounts.jsx
+++ b/src/js/components/awardv2/visualizations/amounts/AggregatedAwardAmounts.jsx
@@ -76,10 +76,13 @@ export default class AggregatedAwardAmounts extends React.Component {
                 {visualization}
                 <div className="award-amounts-children__data-wrapper">
                     <div className="award-amounts-children__data-content">
-                        <div>Child Award Orders</div><span>{awardAmounts.childIDVCount}</span>
+                        <div>Count of Total Orders</div><span>{awardAmounts.childIDVCount + awardAmounts.grandchildAwardCount}</span>
                     </div>
                     <div className="award-amounts-children__data-content">
-                        <div>Grandchild Award Orders</div><span>{awardAmounts.grandchildAwardCount}</span>
+                        <div>Count of Child Award Orders</div><span>{awardAmounts.childIDVCount}</span>
+                    </div>
+                    <div className="award-amounts-children__data-content">
+                        <div>Count of Grandchild Award Orders</div><span>{awardAmounts.grandchildAwardCount}</span>
                     </div>
                 </div>
                 <button
@@ -89,7 +92,7 @@ export default class AggregatedAwardAmounts extends React.Component {
                         <Table />
                     </div>
                     <div className="award-viz__link-text">
-                        View referencing awards table
+                        View award orders table
                     </div>
                 </button>
                 <div className="award-amounts__data-wrapper">

--- a/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
+++ b/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
@@ -36,13 +36,13 @@ export default class RelatedAwards extends React.Component {
         return (
             <div>
                 <div className="related-awards__label related-awards__label_count">
-                    {this.pluralizeTitle(counts.child_award_counts, 'Child Award')}
+                    {this.pluralizeTitle(counts.child_award_count, 'Child Award')}
                 </div>
                 <div className="related-awards__label related-awards__label_count">
-                    {this.pluralizeTitle(counts.child_idv_counts, 'Child IDV')}
+                    {this.pluralizeTitle(counts.child_idv_count, 'Child IDV')}
                 </div>
                 <div className="related-awards__label related-awards__label_count">
-                    {this.pluralizeTitle(counts.grandchild_award_counts, 'Grandchild Award')}
+                    {this.pluralizeTitle(counts.grandchild_award_count, 'Grandchild Award')}
                 </div>
             </div>
         );

--- a/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
+++ b/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
@@ -6,24 +6,43 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { map } from 'lodash';
-import { Glossary } from 'components/sharedComponents/icons/Icons';
 import InfoTooltip from '../../idv/InfoTooltip';
 
 const propTypes = {
     overview: PropTypes.object,
     jumpToSection: PropTypes.func,
-    counts: PropTypes.object,
-    awardId: PropTypes.string
+    counts: PropTypes.object
 };
 
 export default class RelatedAwards extends React.Component {
     constructor(props) {
         super(props);
 
-        this.jumpToReferencedAwardsTable = this.jumpToReferencedAwardsTable.bind(this);
+        this.jumpToReferencedAwardsTableChildAwardsTab =
+        this.jumpToReferencedAwardsTableChildAwardsTab.bind(this);
+        this.jumpToReferencedAwardsTableChildIDVsTab =
+        this.jumpToReferencedAwardsTableChildIDVsTab.bind(this);
+        this.jumpToReferencedAwardsTableGrandchildAwardsTab =
+        this.jumpToReferencedAwardsTableGrandchildAwardsTab.bind(this);
     }
-    jumpToReferencedAwardsTable() {
-        this.props.jumpToSection('referenced-awards');
+
+    jumpToReferencedAwardsTableChildAwardsTab() {
+        this.props.jumpToSection(
+            'referenced-awards',
+            { tableType: 'child_awards' }
+        );
+    }
+    jumpToReferencedAwardsTableChildIDVsTab() {
+        this.props.jumpToSection(
+            'referenced-awards',
+            { tableType: 'child_idvs' }
+        );
+    }
+    jumpToReferencedAwardsTableGrandchildAwardsTab() {
+        this.props.jumpToSection(
+            'referenced-awards',
+            { tableType: 'grandchild_awards' }
+        );
     }
 
     referencedAwardCounts() {
@@ -31,37 +50,46 @@ export default class RelatedAwards extends React.Component {
         if (!counts) return null;
         const childData = [
             {
-                count: counts.child_award_count,
+                count: counts.child_award_count || 'N/A',
                 name: 'Child Award',
+                funcName: 'ChildAwards',
                 glossary: 'contract'
             },
             {
-                count: counts.child_idv_count,
+                count: counts.child_idv_count || 'N/A',
                 name: 'Child IDV',
+                funcName: 'ChildIDVs',
                 glossary: 'IDV'
             },
             {
-                count: counts.grandchild_award_count,
+                count: counts.grandchild_award_count || 'N/A',
                 name: 'Grandchild Award',
+                funcName: 'GrandchildAwards',
                 glossary: 'award'
             }
         ];
 
-        return map(childData, (data) => (
-            <div key={data.glossary} className="related-awards__label related-awards__label_count">
-                <button
-                    onClick={this.jumpToReferencedAwardsTable}
-                    className="award-viz__button">
-                    {data.count}
-                </button>
-                {data.name} {data.count === 1 ? 'Order' : 'Orders'}
-                <div className="related-awards__glossary-icon">
-                    <a href={`/#/award/${this.props.awardId}?glossary=${data.glossary}`}>
-                        <Glossary />
-                    </a>
+        return (
+            <div className="related-awards__label related-awards__label_count">
+                <div className="related-awards__counts">
+                    {map(childData, (data) => (
+                        <button
+                            key={`${data.glossary}count`}
+                            className="award-viz__button"
+                            onClick={this[`jumpToReferencedAwardsTable${data.funcName}Tab`]}>
+                            {data.count}
+                        </button>
+                    ))}
+                </div>
+                <div className="related-awards__description">
+                    {map(childData, (data) => (
+                        <div key={`${data.glossary}text`} className="related-awards__text">
+                            {data.name} {data.count === 1 ? 'Order' : 'Orders'}
+                        </div>
+                    ))}
                 </div>
             </div>
-        ));
+        );
     }
 
     render() {
@@ -105,7 +133,9 @@ export default class RelatedAwards extends React.Component {
                     </div>
                     {parentLink}
                 </div>
-                {this.referencedAwardCounts()}
+                <div className="related-awards__children">
+                    {this.referencedAwardCounts()}
+                </div>
             </div>
         );
     }

--- a/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
+++ b/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
@@ -5,14 +5,15 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Table } from 'components/sharedComponents/icons/Icons';
-
+import { map } from 'lodash';
+import { Glossary } from 'components/sharedComponents/icons/Icons';
 import InfoTooltip from '../../idv/InfoTooltip';
 
 const propTypes = {
     overview: PropTypes.object,
     jumpToSection: PropTypes.func,
-    counts: PropTypes.object
+    counts: PropTypes.object,
+    awardId: PropTypes.string
 };
 
 export default class RelatedAwards extends React.Component {
@@ -25,27 +26,42 @@ export default class RelatedAwards extends React.Component {
         this.props.jumpToSection('referenced-awards');
     }
 
-    pluralizeTitle(count, title) {
-        return `${count} ${title} ${count === 1 ? 'Order' : 'Orders'}`;
-    }
-
-    referencedCount() {
+    referencedAwardCounts() {
         const { counts } = this.props;
         if (!counts) return null;
+        const childData = [
+            {
+                count: counts.child_award_count,
+                name: 'Child Award',
+                glossary: 'contract'
+            },
+            {
+                count: counts.child_idv_count,
+                name: 'Child IDV',
+                glossary: 'IDV'
+            },
+            {
+                count: counts.grandchild_award_count,
+                name: 'Grandchild Award',
+                glossary: 'award'
+            }
+        ];
 
-        return (
-            <div>
-                <div className="related-awards__label related-awards__label_count">
-                    {this.pluralizeTitle(counts.child_award_count, 'Child Award')}
-                </div>
-                <div className="related-awards__label related-awards__label_count">
-                    {this.pluralizeTitle(counts.child_idv_count, 'Child IDV')}
-                </div>
-                <div className="related-awards__label related-awards__label_count">
-                    {this.pluralizeTitle(counts.grandchild_award_count, 'Grandchild Award')}
+        return map(childData, (data) => (
+            <div key={data.glossary} className="related-awards__label related-awards__label_count">
+                <button
+                    onClick={this.jumpToReferencedAwardsTable}
+                    className="award-viz__button">
+                    {data.count}
+                </button>
+                {data.name} {data.count === 1 ? 'Order' : 'Orders'}
+                <div className="related-awards__glossary-icon">
+                    <a href={`/#/award/${this.props.awardId}?glossary=${data.glossary}`}>
+                        <Glossary />
+                    </a>
                 </div>
             </div>
-        );
+        ));
     }
 
     render() {
@@ -89,17 +105,7 @@ export default class RelatedAwards extends React.Component {
                     </div>
                     {parentLink}
                 </div>
-                {this.referencedCount()}
-                <button
-                    onClick={this.jumpToReferencedAwardsTable}
-                    className="award-viz__button">
-                    <div className="award-viz__link-icon">
-                        <Table />
-                    </div>
-                    <div className="award-viz__link-text">
-                        View referencing awards table
-                    </div>
-                </button>
+                {this.referencedAwardCounts()}
             </div>
         );
     }

--- a/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
+++ b/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
@@ -11,6 +11,7 @@ import InfoTooltip from '../../idv/InfoTooltip';
 const propTypes = {
     overview: PropTypes.object,
     jumpToSection: PropTypes.func,
+    setRelatedAwardsTab: PropTypes.func,
     counts: PropTypes.object
 };
 
@@ -27,22 +28,16 @@ export default class RelatedAwards extends React.Component {
     }
 
     jumpToReferencedAwardsTableChildAwardsTab() {
-        this.props.jumpToSection(
-            'referenced-awards',
-            { tableType: 'child_awards' }
-        );
+        this.props.setRelatedAwardsTab('child_awards');
+        this.props.jumpToSection('referenced-awards');
     }
     jumpToReferencedAwardsTableChildIDVsTab() {
-        this.props.jumpToSection(
-            'referenced-awards',
-            { tableType: 'child_idvs' }
-        );
+        this.props.setRelatedAwardsTab('child_idvs');
+        this.props.jumpToSection('referenced-awards');
     }
     jumpToReferencedAwardsTableGrandchildAwardsTab() {
-        this.props.jumpToSection(
-            'referenced-awards',
-            { tableType: 'grandchild_awards' }
-        );
+        this.props.setRelatedAwardsTab('grandchild_awards');
+        this.props.jumpToSection('referenced-awards');
     }
 
     referencedAwardCounts() {

--- a/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
+++ b/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
@@ -24,6 +24,30 @@ export default class RelatedAwards extends React.Component {
     jumpToReferencedAwardsTable() {
         this.props.jumpToSection('referenced-awards');
     }
+
+    pluralizeTitle(count, title) {
+        return `${count} ${title} ${count === 1 ? 'Order' : 'Orders'}`;
+    }
+
+    referencedCount() {
+        const { counts } = this.props;
+        if (!counts) return null;
+
+        return (
+            <div>
+                <div className="related-awards__label related-awards__label_count">
+                    {this.pluralizeTitle(counts.child_award_counts, 'Child Award')}
+                </div>
+                <div className="related-awards__label related-awards__label_count">
+                    {this.pluralizeTitle(counts.child_idv_counts, 'Child IDV')}
+                </div>
+                <div className="related-awards__label related-awards__label_count">
+                    {this.pluralizeTitle(counts.grandchild_award_counts, 'Grandchild Award')}
+                </div>
+            </div>
+        );
+    }
+
     render() {
         let parentLink = 'N/A';
         if (this.props.overview.parentAward && this.props.overview.parentId) {
@@ -35,14 +59,7 @@ export default class RelatedAwards extends React.Component {
                 </a>
             );
         }
-        let referencedCount = null;
-        if (this.props.counts) {
-            referencedCount = (
-                <div className="related-awards__label related-awards__label_count">
-                    {this.props.counts.total} Awards Reference this IDV
-                </div>
-            );
-        }
+
         return (
             <div className="award-viz related-awards">
                 <div className="award-overview__title related-awards__title">
@@ -72,7 +89,7 @@ export default class RelatedAwards extends React.Component {
                     </div>
                     {parentLink}
                 </div>
-                {referencedCount}
+                {this.referencedCount()}
                 <button
                     onClick={this.jumpToReferencedAwardsTable}
                     className="award-viz__button">

--- a/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
+++ b/src/js/components/awardv2/visualizations/overview/RelatedAwards.jsx
@@ -50,19 +50,19 @@ export default class RelatedAwards extends React.Component {
         if (!counts) return null;
         const childData = [
             {
-                count: counts.child_award_count || 'N/A',
+                count: counts.child_awards,
                 name: 'Child Award',
                 funcName: 'ChildAwards',
                 glossary: 'contract'
             },
             {
-                count: counts.child_idv_count || 'N/A',
+                count: counts.child_idvs,
                 name: 'Child IDV',
                 funcName: 'ChildIDVs',
                 glossary: 'IDV'
             },
             {
-                count: counts.grandchild_award_count || 'N/A',
+                count: counts.grandchild_awards,
                 name: 'Grandchild Award',
                 funcName: 'GrandchildAwards',
                 glossary: 'award'

--- a/src/js/containers/awardV2/idv/ReferencedAwardsContainer.jsx
+++ b/src/js/containers/awardV2/idv/ReferencedAwardsContainer.jsx
@@ -14,22 +14,24 @@ import BaseReferencedAwardResult from 'models/v2/awardsV2/BaseReferencedAwardRes
 import ReferencedAwardsSection from 'components/awardv2/idv/referencedAwards/ReferencedAwardsSection';
 
 const propTypes = {
-    award: PropTypes.object
+    award: PropTypes.object,
+    tableType: PropTypes.string,
+    switchTab: PropTypes.func
 };
 
 const tableTypes = [
     {
-        label: 'Child Awards',
+        label: 'Child Award Orders',
         internal: 'child_awards',
         enabled: true
     },
     {
-        label: 'Child IDVs',
+        label: 'Child IDV Orders',
         internal: 'child_idvs',
         enabled: true
     },
     {
-        label: 'Grandchild Awards',
+        label: 'Grandchild Award Orders',
         internal: 'grandchild_awards',
         enabled: true
     }
@@ -38,10 +40,8 @@ const tableTypes = [
 export class ReferencedAwardsContainer extends React.Component {
     constructor(props) {
         super(props);
-
         this.state = {
             limit: 10,
-            tableType: 'child_idvs',
             sort: {
                 child_idvs: 'period_of_performance_start_date',
                 child_awards: 'period_of_performance_start_date',
@@ -80,6 +80,8 @@ export class ReferencedAwardsContainer extends React.Component {
         if (this.props.award.id !== prevProps.award.id || !isEqual(this.props.award.counts, prevProps.award.counts)) {
             this.pickDefaultTab();
         }
+
+        if (this.props.tableType !== prevProps.tableType) this.loadResults();
     }
 
     loadResults() {
@@ -88,12 +90,14 @@ export class ReferencedAwardsContainer extends React.Component {
         }
 
         const {
-            tableType, page, sort, order
+            page, sort, order
         } = this.state;
+
+        const { tableType } = this.props;
 
         const params = {
             award_id: this.props.award.id,
-            type: this.state.tableType,
+            type: tableType,
             limit: this.state.limit,
             page: page[tableType],
             sort: sort[tableType],
@@ -123,8 +127,8 @@ export class ReferencedAwardsContainer extends React.Component {
 
     pickDefaultTab() {
         const { counts } = this.props.award;
-        if (counts.child_idvs === 0 && counts.child_awards !== 0) {
-            this.switchTab('child_awards');
+        if (counts.child_awards === 0 && counts.child_idvs !== 0) {
+            this.switchTab('child_idvs');
         }
         else {
             this.loadResults();
@@ -146,7 +150,8 @@ export class ReferencedAwardsContainer extends React.Component {
     }
 
     updateSort(newSort, newOrder) {
-        const { tableType, sort, order } = this.state;
+        const { sort, order } = this.state;
+        const { tableType } = this.props;
         const updatedSort = Object.assign({}, sort, {
             [tableType]: newSort
         });
@@ -162,9 +167,9 @@ export class ReferencedAwardsContainer extends React.Component {
     }
 
     changePage(newPage) {
-        const { tableType, page } = this.state;
+        const { page } = this.state;
         const updatedPage = Object.assign({}, page, {
-            [tableType]: newPage
+            [this.props.tableType]: newPage
         });
         this.setState({
             page: updatedPage
@@ -174,13 +179,7 @@ export class ReferencedAwardsContainer extends React.Component {
     }
 
     switchTab(tableType) {
-        if (tableType !== this.state.tableType) {
-            this.setState({
-                tableType
-            }, () => {
-                this.loadResults();
-            });
-        }
+        this.props.switchTab(tableType);
     }
 
     render() {
@@ -191,6 +190,7 @@ export class ReferencedAwardsContainer extends React.Component {
                 switchTab={this.switchTab}
                 changePage={this.changePage}
                 updateSort={this.updateSort}
+                tableType={this.props.tableType}
                 tableTypes={tableTypes} />
         );
     }

--- a/src/js/containers/awardV2/idv/ReferencedAwardsContainer.jsx
+++ b/src/js/containers/awardV2/idv/ReferencedAwardsContainer.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { isCancel } from 'axios';
-import { isEqual } from 'lodash';
+import { isEqual, pick, findKey } from 'lodash';
 
 import * as IdvHelper from 'helpers/idvHelper';
 import BaseReferencedAwardResult from 'models/v2/awardsV2/BaseReferencedAwardResult';
@@ -17,6 +17,10 @@ const propTypes = {
     award: PropTypes.object,
     tableType: PropTypes.string,
     switchTab: PropTypes.func
+};
+
+const defaultProps = {
+    tableType: 'child_awards'
 };
 
 const tableTypes = [
@@ -127,8 +131,11 @@ export class ReferencedAwardsContainer extends React.Component {
 
     pickDefaultTab() {
         const { counts } = this.props.award;
-        if (counts.child_awards === 0 && counts.child_idvs !== 0) {
-            this.switchTab('child_idvs');
+        const tableKeys = tableTypes.map((type) => type.internal);
+        const tableCounts = pick(counts, tableKeys);
+        const defaultTab = findKey(tableCounts, (count) => count !== 0);
+        if (counts.child_awards === 0 && defaultTab) {
+            this.switchTab(defaultTab);
         }
         else {
             this.loadResults();
@@ -197,6 +204,7 @@ export class ReferencedAwardsContainer extends React.Component {
 }
 
 ReferencedAwardsContainer.propTypes = propTypes;
+ReferencedAwardsContainer.defaultProps = defaultProps;
 
 export default connect(
     (state) => ({

--- a/src/js/containers/awardV2/idv/ReferencedAwardsContainer.jsx
+++ b/src/js/containers/awardV2/idv/ReferencedAwardsContainer.jsx
@@ -19,13 +19,18 @@ const propTypes = {
 
 const tableTypes = [
     {
-        label: 'Contract IDVs',
-        internal: 'idvs',
+        label: 'Child Awards',
+        internal: 'child_awards',
         enabled: true
     },
     {
-        label: 'Contracts',
-        internal: 'contracts',
+        label: 'Child IDVs',
+        internal: 'child_idvs',
+        enabled: true
+    },
+    {
+        label: 'Grandchild Awards',
+        internal: 'grandchild_awards',
         enabled: true
     }
 ];
@@ -36,18 +41,21 @@ export class ReferencedAwardsContainer extends React.Component {
 
         this.state = {
             limit: 10,
-            tableType: 'idvs',
+            tableType: 'child_idvs',
             sort: {
-                idvs: 'period_of_performance_start_date',
-                contracts: 'period_of_performance_start_date'
+                child_idvs: 'period_of_performance_start_date',
+                child_awards: 'period_of_performance_start_date',
+                grandchild_awards: 'period_of_performance_start_date'
             },
             page: {
-                idvs: 1,
-                contracts: 1
+                child_idvs: 1,
+                child_awards: 1,
+                grandchild_awards: 1
             },
             order: {
-                idvs: 'desc',
-                contracts: 'desc'
+                child_idvs: 'desc',
+                child_awards: 'desc',
+                grandchild_awards: 'desc'
             },
             tableTypes,
             inFlight: true,
@@ -85,7 +93,7 @@ export class ReferencedAwardsContainer extends React.Component {
 
         const params = {
             award_id: this.props.award.id,
-            idv: this.state.tableType === 'idvs',
+            type: this.state.tableType,
             limit: this.state.limit,
             page: page[tableType],
             sort: sort[tableType],
@@ -114,9 +122,9 @@ export class ReferencedAwardsContainer extends React.Component {
     }
 
     pickDefaultTab() {
-        const counts = this.props.award.counts;
-        if (counts.idvs === 0 && counts.contracts !== 0) {
-            this.switchTab('contracts');
+        const { counts } = this.props.award;
+        if (counts.child_idvs === 0 && counts.child_awards !== 0) {
+            this.switchTab('child_awards');
         }
         else {
             this.loadResults();

--- a/src/js/containers/awardV2/visualization/AwardAmountsContainer.jsx
+++ b/src/js/containers/awardV2/visualization/AwardAmountsContainer.jsx
@@ -96,9 +96,10 @@ export class AwardAmountsContainer extends React.Component {
         // Store the counts in Redux for use in the referenced awards table
         // and related awards section
         this.props.setCounts({
-            idvs: data.idv_count,
-            contracts: data.contract_count,
-            total: data.idv_count + data.contract_count
+            child_idvs: data.child_idv_count,
+            child_awards: data.child_award_count,
+            grandchild_awards: data.grandchild_award_count,
+            total: data.child_idv_count + data.child_award_count + data.grandchild_award_count
         });
     }
 

--- a/src/js/containers/awardV2/visualization/AwardAmountsContainer.jsx
+++ b/src/js/containers/awardV2/visualization/AwardAmountsContainer.jsx
@@ -96,8 +96,8 @@ export class AwardAmountsContainer extends React.Component {
         // Store the counts in Redux for use in the referenced awards table
         // and related awards section
         this.props.setCounts({
-            child_idvs: data.child_idv_count,
             child_awards: data.child_award_count,
+            child_idvs: data.child_idv_count,
             grandchild_awards: data.grandchild_award_count,
             total: data.child_idv_count + data.child_award_count + data.grandchild_award_count
         });

--- a/src/js/dataMapping/awardsv2/referencedAwards.js
+++ b/src/js/dataMapping/awardsv2/referencedAwards.js
@@ -7,7 +7,7 @@
 // We only have one export but want to maintain consistency with other files
 
 export const referencedAwardsColumns = {
-    idvs: [
+    child_idvs: [
         {
             name: 'piid',
             label: 'Award ID',
@@ -44,7 +44,44 @@ export const referencedAwardsColumns = {
             field: 'description'
         }
     ],
-    contracts: [
+    child_awards: [
+        {
+            name: 'piid',
+            label: 'Award ID',
+            field: 'piid'
+        },
+        {
+            name: 'agency',
+            label: 'Contracting Agency',
+            field: 'funding_agency'
+        },
+        {
+            name: 'awardType',
+            label: 'Award Type',
+            field: 'award_type'
+        },
+        {
+            name: 'obligatedAmount',
+            label: 'Obligated Amount',
+            field: 'obligated_amount'
+        },
+        {
+            name: 'startDate',
+            label: 'Start Date',
+            field: 'period_of_performance_start_date'
+        },
+        {
+            name: 'endDate',
+            label: 'End Date',
+            field: 'period_of_performance_current_end_date'
+        },
+        {
+            name: 'description',
+            label: 'Description',
+            field: 'description'
+        }
+    ],
+    grandchild_awards: [
         {
             name: 'piid',
             label: 'Award ID',

--- a/src/js/models/v2/awardsV2/BaseAwardAmounts.js
+++ b/src/js/models/v2/awardsV2/BaseAwardAmounts.js
@@ -12,9 +12,15 @@ const BaseAwardAmounts = {
         this.childIDVCount = data.child_idv_count || 0;
         this.childAwardCount = data.child_award_count || 0;
         this.grandchildAwardCount = data.grandchild_award_count || 0;
-        this._combinedPotentialAwardAmounts = parseFloat(data.rollup_base_and_all_options_value) || 0;
-        this._obligation = parseFloat(data.rollup_total_obligation) || 0;
-        this._combinedCurrentAwardAmounts = parseFloat(data.rollup_base_exercised_options_val) || 0;
+        this._combinedPotentialAwardAmounts = parseFloat(
+            data.child_award_base_and_all_options_value + data.grandchild_award_base_and_all_options_value
+        ) || 0;
+        this._obligation = parseFloat(
+            data.child_award_total_obligation + data.grandchild_award_total_obligation
+        ) || 0;
+        this._combinedCurrentAwardAmounts = parseFloat(
+            data.child_award_base_exercised_options_val + data.grandchild_award_base_exercised_options_val
+        ) || 0;
     },
     get combinedPotentialAwardAmounts() {
         return MoneyFormatter.formatMoneyWithPrecision(this._combinedPotentialAwardAmounts, 2);

--- a/src/js/models/v2/awardsV2/BaseAwardAmounts.js
+++ b/src/js/models/v2/awardsV2/BaseAwardAmounts.js
@@ -9,8 +9,9 @@ const BaseAwardAmounts = {
     populate(data) {
         this.id = (data.award_id && `${data.award_id}`) || '';
         this.generatedId = data.generated_unique_award_id || '';
-        this.idvCount = data.idv_count || 0;
-        this.contractCount = data.contract_count || 0;
+        this.childIDVCount = data.child_idv_count || 0;
+        this.childAwardCount = data.child_award_count || 0;
+        this.grandchildAwardCount = data.grandchild_award_count || 0;
         this._combinedPotentialAwardAmounts = parseFloat(data.rollup_base_and_all_options_value) || 0;
         this._obligation = parseFloat(data.rollup_total_obligation) || 0;
         this._combinedCurrentAwardAmounts = parseFloat(data.rollup_base_exercised_options_val) || 0;

--- a/src/js/propTypes/index.js
+++ b/src/js/propTypes/index.js
@@ -22,7 +22,7 @@ export const AWARD_V2_OVERVIEW_PROPS = PropTypes.shape({
 export const AWARD_V2_COUNTS_PROPS = PropTypes.shape({
     child_awards: PropTypes.number,
     child_idvs: PropTypes.number,
-    granchild_awards: PropTypes.number,
+    grandchild_awards: PropTypes.number,
     total: PropTypes.number
 });
 

--- a/src/js/propTypes/index.js
+++ b/src/js/propTypes/index.js
@@ -20,8 +20,9 @@ export const AWARD_V2_OVERVIEW_PROPS = PropTypes.shape({
 });
 
 export const AWARD_V2_COUNTS_PROPS = PropTypes.shape({
-    contracts: PropTypes.number,
-    idvs: PropTypes.number,
+    child_awards: PropTypes.number,
+    child_idvs: PropTypes.number,
+    granchild_awards: PropTypes.number,
     total: PropTypes.number
 });
 

--- a/tests/containers/awardV2/idv/ReferencedAwardsContainer-test.jsx
+++ b/tests/containers/awardV2/idv/ReferencedAwardsContainer-test.jsx
@@ -79,8 +79,8 @@ describe('ReferencedAwardsContainer', () => {
             container.instance().updateSort('obligated_amount', 'asc');
             await container.instance().request.promise;
 
-            expect(container.state().sort.idvs).toEqual('obligated_amount');
-            expect(container.state().order.idvs).toEqual('asc');
+            expect(container.state().sort.child_idvs).toEqual('obligated_amount');
+            expect(container.state().order.child_idvs).toEqual('asc');
             expect(parseAwards).toHaveBeenCalled();
         });
     });
@@ -95,7 +95,7 @@ describe('ReferencedAwardsContainer', () => {
             container.instance().changePage(2);
             await container.instance().request.promise;
 
-            expect(container.state().page.idvs).toEqual(2);
+            expect(container.state().page.child_idvs).toEqual(2);
             expect(parseAwards).toHaveBeenCalled();
         });
     });
@@ -107,10 +107,10 @@ describe('ReferencedAwardsContainer', () => {
             const parseAwards = jest.fn();
             container.instance().parseAwards = parseAwards;
 
-            container.instance().switchTab('contracts');
+            container.instance().switchTab('child_awards');
             await container.instance().request.promise;
 
-            expect(container.state().tableType).toEqual('contracts');
+            expect(container.state().tableType).toEqual('child_awards');
             expect(parseAwards).toHaveBeenCalled();
         });
     });

--- a/tests/containers/awardV2/idv/ReferencedAwardsContainer-test.jsx
+++ b/tests/containers/awardV2/idv/ReferencedAwardsContainer-test.jsx
@@ -78,9 +78,8 @@ describe('ReferencedAwardsContainer', () => {
 
             container.instance().updateSort('obligated_amount', 'asc');
             await container.instance().request.promise;
-
-            expect(container.state().sort.child_idvs).toEqual('obligated_amount');
-            expect(container.state().order.child_idvs).toEqual('asc');
+            expect(container.state().sort.child_awards).toEqual('obligated_amount');
+            expect(container.state().order.child_awards).toEqual('asc');
             expect(parseAwards).toHaveBeenCalled();
         });
     });
@@ -91,26 +90,10 @@ describe('ReferencedAwardsContainer', () => {
 
             const parseAwards = jest.fn();
             container.instance().parseAwards = parseAwards;
-
             container.instance().changePage(2);
             await container.instance().request.promise;
 
-            expect(container.state().page.child_idvs).toEqual(2);
-            expect(parseAwards).toHaveBeenCalled();
-        });
-    });
-    describe('switchTab', () => {
-        it('should update the state, reset the page to 1, and make an API call', async () => {
-            const container = shallow(<ReferencedAwardsContainer
-                {...mockRedux} />);
-
-            const parseAwards = jest.fn();
-            container.instance().parseAwards = parseAwards;
-
-            container.instance().switchTab('child_awards');
-            await container.instance().request.promise;
-
-            expect(container.state().tableType).toEqual('child_awards');
+            expect(container.state().page.child_awards).toEqual(2);
             expect(parseAwards).toHaveBeenCalled();
         });
     });

--- a/tests/models/awardsV2/BaseAwardAmounts-test.js
+++ b/tests/models/awardsV2/BaseAwardAmounts-test.js
@@ -11,21 +11,28 @@ awardAmounts.populate(mockAwardAmounts);
 
 const awardAmountsNeg = Object.create(BaseAwardAmounts);
 const negativeObligation = {
-    rollup_total_obligation: -1623321.02
+    child_award_total_obligation: -811660.51,
+    grandchild_award_total_obligation: -811660.51
 };
 
 const awardAmountsOverspent = Object.create(BaseAwardAmounts);
 const overspending = {
-    rollup_base_exercised_options_val: 5000000.00,
-    rollup_base_and_all_options_value: 10000000.00,
-    rollup_total_obligation: 7500000.00
+    child_award_base_exercised_options_val: 2500000,
+    grandchild_award_base_exercised_options_val: 2500000,
+    child_award_base_and_all_options_value: 5000000,
+    grandchild_award_base_and_all_options_value: 5000000,
+    child_award_total_obligation: 3750000,
+    grandchild_award_total_obligation: 3750000
 };
 
 const awardAmountsExtremeOverspent = Object.create(BaseAwardAmounts);
 const extremeOverspending = {
-    rollup_base_exercised_options_val: 2500000.00,
-    rollup_base_and_all_options_value: 5000000.00,
-    rollup_total_obligation: 10000000.00
+    child_award_base_exercised_options_val: 1250000,
+    grandchild_award_base_exercised_options_val: 1250000,
+    child_award_base_and_all_options_value: 2500000,
+    grandchild_award_base_and_all_options_value: 2500000,
+    child_award_total_obligation: 5000000,
+    grandchild_award_total_obligation: 5000000
 };
 
 awardAmountsNeg.populate(negativeObligation);

--- a/tests/models/awardsV2/mockAwardApi.js
+++ b/tests/models/awardsV2/mockAwardApi.js
@@ -326,10 +326,14 @@ export const mockAwardAmounts = {
     award_id: 12178065,
     generated_unique_award_id: null,
     child_idv_count: 100,
-    contract_count: 10,
-    rollup_base_exercised_options_val: 10000000,
-    rollup_base_and_all_options_value: 106987321.10,
-    rollup_total_obligation: 1623321.02
+    child_award_count: 10,
+    child_award_base_exercised_options_val: 5000000,
+    grandchild_award_base_exercised_options_val: 5000000,
+    child_award_base_and_all_options_value: 53493660.55,
+    grandchild_award_base_and_all_options_value: 53493660.55,
+    child_award_total_obligation: 811660.51,
+    grandchild_award_total_obligation: 811660.51
+
 };
 
 export const mockReferencedAwards = {

--- a/tests/models/awardsV2/mockAwardApi.js
+++ b/tests/models/awardsV2/mockAwardApi.js
@@ -325,7 +325,7 @@ export const mockIdv = {
 export const mockAwardAmounts = {
     award_id: 12178065,
     generated_unique_award_id: null,
-    idv_count: 100,
+    child_idv_count: 100,
     contract_count: 10,
     rollup_base_exercised_options_val: 10000000,
     rollup_base_and_all_options_value: 106987321.10,


### PR DESCRIPTION
**High level description:**

This covers adding grandchildren to the Referenced Awards tables, Related Awards and Award Amounts sections of the IDV Summary page.

**Technical details:**

The `ReferencedAwardContainer` now has three tables `child_idvs` ( previously `idvs` ), `child_awards` ( previously `contracts` ), `grandchild_awards`.

The `BaseAwardAmounts` has been updated to use the new values from the API.

- `rollup_total_obligation` is now `child_award_total_obligation + grandchild_award_total_obligation`

- `rollup_base_exercised_options_val` is now `child_award_base_exercised_options_val + grandchild_award_base_exercised_options_val`

- `rollup_base_and_all_options_value` is now `child_award_base_and_all_options_value + grandchild_award_base_and_all_options_value`

**JIRA Ticket:**
[DEV-2418](https://federal-spending-transparency.atlassian.net/browse/DEV-2418)

**Mockup:**
https://bahdigital.invisionapp.com/share/XVIAA8SMWKY#/screens

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Design review
- [x] API contract approved by @kbard 
- [x] [API #1745](https://github.com/fedspendingtransparency/usaspending-api/pull/1745) merged 
- [x] Verified cross-browser compatibility
