### PR TITLE
[DEV-2369] Adding Federal Account Funding Link on IDV Page

### DIFF
--- a/src/_scss/pages/awardV2/idv/_awardFundingSummary.scss
+++ b/src/_scss/pages/awardV2/idv/_awardFundingSummary.scss
@@ -1,5 +1,6 @@
 .federal-accounts {
     .award-funding-summary__table {
+        margin-bottom: rem(10);
         .award-funding-summary__data {
             @extend %column-less-table__row;
             margin: 0;

--- a/src/js/components/awardv2/AwardV2.jsx
+++ b/src/js/components/awardv2/AwardV2.jsx
@@ -38,6 +38,10 @@ const awardSections = [
     {
         section: 'referenced-awards',
         label: 'Referenced Awards'
+    },
+    {
+        section: 'award-history',
+        label: 'Award History'
     }
 ];
 

--- a/src/js/components/awardv2/idv/AwardHistory.jsx
+++ b/src/js/components/awardv2/idv/AwardHistory.jsx
@@ -33,7 +33,7 @@ export default class AwardHistory extends React.Component {
 
     render() {
         return (
-            <div className="award-viz award-history">
+            <div id="award-award-history" className="award-viz award-history">
                 <div className="award-viz__heading">
                     <div className="award-viz__icon">
                         <AwardLoop alt="Award History" />

--- a/src/js/components/awardv2/idv/AwardHistory.jsx
+++ b/src/js/components/awardv2/idv/AwardHistory.jsx
@@ -15,22 +15,6 @@ const propTypes = {
 };
 
 export default class AwardHistory extends React.Component {
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            activeTab: "transaction"
-        };
-
-        this.clickTab = this.clickTab.bind(this);
-    }
-
-    clickTab(tab) {
-        this.setState({
-            activeTab: tab
-        });
-    }
-
     render() {
         return (
             <div id="award-award-history" className="award-viz award-history">
@@ -58,8 +42,8 @@ export default class AwardHistory extends React.Component {
                 <hr />
                 <TablesSection
                     overview={this.props.overview}
-                    clickTab={this.clickTab}
-                    activeTab={this.state.activeTab} />
+                    clickTab={this.props.setActiveTab}
+                    activeTab={this.props.activeTab} />
             </div>
         );
     }

--- a/src/js/components/awardv2/idv/AwardHistory.jsx
+++ b/src/js/components/awardv2/idv/AwardHistory.jsx
@@ -11,7 +11,9 @@ import TablesSection from './TablesSection';
 import InfoTooltip from './InfoTooltip';
 
 const propTypes = {
-    overview: PropTypes.object
+    overview: PropTypes.object,
+    setActiveTab: PropTypes.func,
+    activeTab: PropTypes.string
 };
 
 export default class AwardHistory extends React.Component {

--- a/src/js/components/awardv2/idv/FundingSummary.jsx
+++ b/src/js/components/awardv2/idv/FundingSummary.jsx
@@ -10,58 +10,53 @@ const propTypes = {
     totalTransactionObligatedAmount: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     awardingAgencyCount: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     federalAccountCount: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    jumpToSection: PropTypes.func
+    jumpToFederalAccountsHistory: PropTypes.func
 };
 
 const FundingSummary = ({
     totalTransactionObligatedAmount,
     awardingAgencyCount,
     federalAccountCount,
-    jumpToSection
-}) => {
-    const jumpToAwardHistorySection = () => {
-        jumpToSection('award-history');
-    };
-    return (
-        <div className="award__col award-viz federal-accounts">
-            <div className="award__col__content">
-                <div className="award-viz__heading">
-                    <div className="award-viz__icon">
-                        <FontAwesomeIcon size="lg" icon="chart-pie" />
-                    </div>
-                    <h3 className="award-viz__title">Federal Accounts</h3>
+    jumpToFederalAccountsHistory
+}) => (
+    <div className="award__col award-viz federal-accounts">
+        <div className="award__col__content">
+            <div className="award-viz__heading">
+                <div className="award-viz__icon">
+                    <FontAwesomeIcon size="lg" icon="chart-pie" />
                 </div>
-                <hr />
-                <ComingSoonSection className="federal-accounts__section" />
-                <h4>Summary of Federal Accounts used by this IDV</h4>
-                <div className="award-funding-summary__table">
-                    <div className="award-funding-summary__data">
-                        <span>Total Funding Obligated</span>
-                        <span>
-                            {typeof totalTransactionObligatedAmount === "number"
-                                ? formatMoneyWithPrecision(totalTransactionObligatedAmount, 2)
-                                : totalTransactionObligatedAmount}
-                        </span>
-                    </div>
-                    <div className="award-funding-summary__data">
-                        <span>Total Count Of Awarding Agencies</span>
-                        <span>{awardingAgencyCount}</span>
-                    </div>
-                    <div className="award-funding-summary__data">
-                        <span>Total Count of Federal Accounts</span>
-                        <span>{federalAccountCount}</span>
-                    </div>
-                </div>
-                <button onClick={jumpToAwardHistorySection} className="award-viz__button">
-                    <div className="award-viz__link-icon">
-                        <Table />
-                    </div>
-                    <div className="award-viz__link-text">View Federal Account Funding</div>
-                </button>
+                <h3 className="award-viz__title">Federal Accounts</h3>
             </div>
+            <hr />
+            <ComingSoonSection className="federal-accounts__section" />
+            <h4>Summary of Federal Accounts used by this IDV</h4>
+            <div className="award-funding-summary__table">
+                <div className="award-funding-summary__data">
+                    <span>Total Funding Obligated</span>
+                    <span>
+                        {typeof totalTransactionObligatedAmount === "number"
+                            ? formatMoneyWithPrecision(totalTransactionObligatedAmount, 2)
+                            : totalTransactionObligatedAmount}
+                    </span>
+                </div>
+                <div className="award-funding-summary__data">
+                    <span>Total Count Of Awarding Agencies</span>
+                    <span>{awardingAgencyCount}</span>
+                </div>
+                <div className="award-funding-summary__data">
+                    <span>Total Count of Federal Accounts</span>
+                    <span>{federalAccountCount}</span>
+                </div>
+            </div>
+            <button onClick={jumpToFederalAccountsHistory} className="award-viz__button">
+                <div className="award-viz__link-icon">
+                    <Table />
+                </div>
+                <div className="award-viz__link-text">View Federal Account Funding</div>
+            </button>
         </div>
-    );
-};
+    </div>
+);
 
 FundingSummary.propTypes = propTypes;
 

--- a/src/js/components/awardv2/idv/FundingSummary.jsx
+++ b/src/js/components/awardv2/idv/FundingSummary.jsx
@@ -3,51 +3,65 @@ import PropTypes from 'prop-types';
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { formatMoneyWithPrecision } from '../../../helpers/moneyFormatter';
+import { Table } from "../../sharedComponents/icons/Icons";
 import ComingSoonSection from "./ComingSoonSection";
 
 const propTypes = {
     totalTransactionObligatedAmount: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     awardingAgencyCount: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    federalAccountCount: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+    federalAccountCount: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    jumpToSection: PropTypes.func
 };
 
 const FundingSummary = ({
     totalTransactionObligatedAmount,
     awardingAgencyCount,
-    federalAccountCount
-}) => (
-    <div className="award__col award-viz federal-accounts">
-        <div className="award__col__content">
-            <div className="award-viz__heading">
-                <div className="award-viz__icon">
-                    <FontAwesomeIcon size="lg" icon="chart-pie" />
+    federalAccountCount,
+    jumpToSection
+}) => {
+    const jumpToAwardHistorySection = () => {
+        jumpToSection('award-history');
+    };
+    return (
+        <div className="award__col award-viz federal-accounts">
+            <div className="award__col__content">
+                <div className="award-viz__heading">
+                    <div className="award-viz__icon">
+                        <FontAwesomeIcon size="lg" icon="chart-pie" />
+                    </div>
+                    <h3 className="award-viz__title">Federal Accounts</h3>
                 </div>
-                <h3 className="award-viz__title">Federal Accounts</h3>
-            </div>
-            <hr />
-            <ComingSoonSection className="federal-accounts__section" />
-            <h4>Summary of Federal Accounts used by this IDV</h4>
-            <div className="award-funding-summary__table">
-                <div className="award-funding-summary__data">
-                    <span>Total Funding Obligated</span>
-                    <span>
-                        {typeof totalTransactionObligatedAmount === "number"
-                            ? formatMoneyWithPrecision(totalTransactionObligatedAmount, 2)
-                            : totalTransactionObligatedAmount}
-                    </span>
+                <hr />
+                <ComingSoonSection className="federal-accounts__section" />
+                <h4>Summary of Federal Accounts used by this IDV</h4>
+                <div className="award-funding-summary__table">
+                    <div className="award-funding-summary__data">
+                        <span>Total Funding Obligated</span>
+                        <span>
+                            {typeof totalTransactionObligatedAmount === "number"
+                                ? formatMoneyWithPrecision(totalTransactionObligatedAmount, 2)
+                                : totalTransactionObligatedAmount}
+                        </span>
+                    </div>
+                    <div className="award-funding-summary__data">
+                        <span>Total Count Of Awarding Agencies</span>
+                        <span>{awardingAgencyCount}</span>
+                    </div>
+                    <div className="award-funding-summary__data">
+                        <span>Total Count of Federal Accounts</span>
+                        <span>{federalAccountCount}</span>
+                    </div>
                 </div>
-                <div className="award-funding-summary__data">
-                    <span>Total Count Of Awarding Agencies</span>
-                    <span>{awardingAgencyCount}</span>
-                </div>
-                <div className="award-funding-summary__data">
-                    <span>Total Count of Federal Accounts</span>
-                    <span>{federalAccountCount}</span>
-                </div>
+                <button onClick={jumpToAwardHistorySection} className="award-viz__button">
+                    <div className="award-viz__link-icon">
+                        <Table />
+                    </div>
+                    <div className="award-viz__link-text">View Federal Account Funding</div>
+                </button>
             </div>
         </div>
-    </div>
-);
+    );
+};
 
 FundingSummary.propTypes = propTypes;
 

--- a/src/js/components/awardv2/idv/IdvContent.jsx
+++ b/src/js/components/awardv2/idv/IdvContent.jsx
@@ -28,6 +28,29 @@ const propTypes = {
 };
 
 export default class IdvContent extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            awardHistoryActiveTab: 'transaction' // or fedaccount
+        };
+
+        this.setActiveTab = this.setActiveTab.bind(this);
+        this.jumpToFederalAccountsHistory = this.jumpToFederalAccountsHistory.bind(this);
+    }
+
+    setActiveTab(activeTab = 'transaction') {
+        this.setState({
+            awardHistoryActiveTab: activeTab
+        });
+    }
+
+    jumpToFederalAccountsHistory() {
+        this.setState({
+            awardHistoryActiveTab: 'fedaccount'
+        });
+        this.props.jumpToSection('award-history');
+    }
+
     render() {
         const glossarySlug = glossaryLinks[this.props.overview.type];
         let glossaryLink = null;
@@ -91,10 +114,10 @@ export default class IdvContent extends React.Component {
                 </div>
                 <div className="award__row">
                     <ComingSoonSection includeHeader title="IDV Activity" icon="chart-area" />
-                    <AwardMetaDataContainer jumpToSection={this.props.jumpToSection} />
+                    <AwardMetaDataContainer jumpToFederalAccountsHistory={this.jumpToFederalAccountsHistory} />
                 </div>
                 <ReferencedAwardsContainer />
-                <AwardHistory overview={this.props.overview} />
+                <AwardHistory activeTab={this.state.awardHistoryActiveTab} setActiveTab={this.setActiveTab} overview={this.props.overview} />
                 <AdditionalInfo overview={this.props.overview} />
             </div>
         );

--- a/src/js/components/awardv2/idv/IdvContent.jsx
+++ b/src/js/components/awardv2/idv/IdvContent.jsx
@@ -91,7 +91,7 @@ export default class IdvContent extends React.Component {
                 </div>
                 <div className="award__row">
                     <ComingSoonSection includeHeader title="IDV Activity" icon="chart-area" />
-                    <AwardMetaDataContainer />
+                    <AwardMetaDataContainer jumpToSection={this.props.jumpToSection} />
                 </div>
                 <ReferencedAwardsContainer />
                 <AwardHistory overview={this.props.overview} />

--- a/src/js/containers/awardV2/idv/AwardMetaDataContainer.jsx
+++ b/src/js/containers/awardV2/idv/AwardMetaDataContainer.jsx
@@ -7,7 +7,7 @@ import FundingSummary from '../../../components/awardv2/idv/FundingSummary';
 
 const propTypes = {
     awardId: PropTypes.string,
-    jumpToSection: PropTypes.func
+    jumpToFederalAccountsHistory: PropTypes.func
 };
 
 const defaultProps = {
@@ -63,7 +63,7 @@ export class AwardMetaDataContainer extends React.Component {
     }
 
     render() {
-        return <FundingSummary {...this.state} jumpToSection={this.props.jumpToSection} />;
+        return <FundingSummary {...this.state} jumpToFederalAccountsHistory={this.props.jumpToFederalAccountsHistory} />;
     }
 }
 

--- a/src/js/containers/awardV2/idv/AwardMetaDataContainer.jsx
+++ b/src/js/containers/awardV2/idv/AwardMetaDataContainer.jsx
@@ -6,7 +6,8 @@ import { fetchAwardFundingSummary } from '../../../helpers/idvHelper';
 import FundingSummary from '../../../components/awardv2/idv/FundingSummary';
 
 const propTypes = {
-    awardId: PropTypes.string
+    awardId: PropTypes.string,
+    jumpToSection: PropTypes.func
 };
 
 const defaultProps = {
@@ -62,7 +63,7 @@ export class AwardMetaDataContainer extends React.Component {
     }
 
     render() {
-        return <FundingSummary {...this.state} />;
+        return <FundingSummary {...this.state} jumpToSection={this.props.jumpToSection} />;
     }
 }
 


### PR DESCRIPTION
**High level description:**
Adding link to scroll to Award History Table and select accounts tab

**Technical details:**
Moved Award History active tab state to shared parent component `IdvContent` page from the `AwardHistory` component's local state

**JIRA Ticket:**
[DEV-2369](https://federal-spending-transparency.atlassian.net/browse/DEV-2369)

**Mockup:**
https://bahdigital.invisionapp.com/share/69IA8EPGPCM#/screens/296001079

**Commits:**
* a616c40 & d825e28 -- Adding `AwardHistoryTable` as a section to be jumped to
* 506eabd -- Passing the `jumpToSection` function to the Federal Spending Summary Page
* fec11f0 -- Moving activeTab state from one component to shared Parent component
* 4a45dea -- Adding styles

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Verified cross-browser compatibility
