### PR TITLE
Hotfix Exceeds Combined Potential label

### DIFF
--- a/src/js/components/awardv2/visualizations/amounts/charts/ExceedsPotentialChart.jsx
+++ b/src/js/components/awardv2/visualizations/amounts/charts/ExceedsPotentialChart.jsx
@@ -62,7 +62,7 @@ export default class ExceedsPotentialChart extends React.Component {
                         <div className="award-amounts-viz__desc-text">
                             <strong>{this.props.awardAmounts.extremeOverspendingFormatted}</strong><br />
                             <div className="award-amounts-viz__desc-text-wrapper">
-                                <InfoTooltip>{awardAmountsExtremeOverspendingInfo}</InfoTooltip>Exceeds Potential Award Amounts
+                                <InfoTooltip>{awardAmountsExtremeOverspendingInfo}</InfoTooltip>Exceeds Combined Potential Award Amounts
                             </div>
                         </div>
                         <div className="award-amounts-viz__legend-line award-amounts-viz__legend-line_extreme-overspending" />


### PR DESCRIPTION
**High level description:**
Changes the IDV Award Amounts visualization extreme overspending label from "Exceeds Potential Award Amounts" to "Exceeds **Combined** Potential Award Amounts" per the mockup.

**Technical details:**
N/A

**JIRA Ticket:**
[DEV-2224](https://federal-spending-transparency.atlassian.net/browse/DEV-2224)

**Mockup:**
https://bahdigital.invisionapp.com/share/69IA8EPGPCM#/296009663_combinedAwardsSection--overspend

The following are ALL required for the PR to be merged:
- [x] Code review
