### PR TITLE
Update IDC / Definite Quantity glossary mapping

### DIFF
--- a/src/js/dataMapping/search/awardType.js
+++ b/src/js/dataMapping/search/awardType.js
@@ -49,7 +49,7 @@ export const glossaryLinks = {
     'IDV_B': 'indefinite-delivery-contract-idc',
     'IDV_B_A': 'indefinite-delivery-requirements',
     'IDV_B_B': 'indefinite-delivery-indefinite-quantity-idiq-contract',
-    'IDV_B_C': 'indefinite-delivery-contract-idc',
+    'IDV_B_C': 'indefinite-delivery-contract-definite-quantity',
     'IDV_C': 'federal-supply-schedule-fss',
     'IDV_D': 'basic-ordering-agreement-boa',
     'IDV_E': 'blanket-purchase-agreement-bpa',


### PR DESCRIPTION
**High level description:**

On IDV Summary pages of type "Indefinite Delivery Contract / Definite Quantity", link to the new glossary definition. 

**Technical details:**

Updates the glossary slug used for award type code `IDV_B_C`. Award ID for an example of this type: `68876388` 

**JIRA Ticket:**
[DEV-2322](https://federal-spending-transparency.atlassian.net/browse/DEV-2322)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] [API #1760](https://github.com/fedspendingtransparency/usaspending-api/pull/1760) merged 
- [x] Verified cross-browser compatibility
