### PR TITLE
[dev-2458] Quick fix for wide tooltips that were not showing properly on full width components

### DIFF
--- a/src/js/components/awardv2/idv/InfoTooltip.jsx
+++ b/src/js/components/awardv2/idv/InfoTooltip.jsx
@@ -51,7 +51,7 @@ export default class InfoTooltip extends React.Component {
 
     closeTooltip() {
         this.setState({
-            showInfoTooltip: false
+            showInfoTooltip: true
         });
     }
 
@@ -59,7 +59,14 @@ export default class InfoTooltip extends React.Component {
         const targetElement = this.referenceDiv;
         const offsetTop = targetElement.offsetTop - 15;
         let tooltipWidth = 375;
-        if (this.props.wide) {
+        // is the t.t. in a section that takes up the full width of the screen?
+        const isTooltipJustifiedRight = (window.innerWidth - targetElement.offsetLeft) < window.innerWidth / 6;
+
+        if (this.props.wide && isTooltipJustifiedRight) {
+            tooltipWidth = 700;
+        }
+        else if (this.props.wide) {
+            // is there at least 700px of space to the right for the t.t.?
             tooltipWidth = (window.innerWidth - targetElement.offsetLeft > 700)
                 ? 700
                 : window.innerWidth - targetElement.offsetLeft - 100;

--- a/src/js/components/awardv2/idv/InfoTooltip.jsx
+++ b/src/js/components/awardv2/idv/InfoTooltip.jsx
@@ -51,7 +51,7 @@ export default class InfoTooltip extends React.Component {
 
     closeTooltip() {
         this.setState({
-            showInfoTooltip: true
+            showInfoTooltip: false
         });
     }
 


### PR DESCRIPTION
**High level description:**
Adds new condition to handle edge case for tooltips -- when prop `wide` is true and parent component is full width

**Technical details:**
Adds a condition to see if the `window.innerWidth - tooltip.offsetLeft` is lower than anticipated (lower than 1/6 of the screen) to handle edge case of when tool tip is on a full width component and has the wide property set to true

**JIRA Ticket:**
[DEV-2458](https://federal-spending-transparency.atlassian.net/browse/DEV-2458)

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Design review (if applicable)
