### PR TITLE
Update congressional districts

### DIFF
--- a/src/js/components/search/visualizations/geo/MapWrapper.jsx
+++ b/src/js/components/search/visualizations/geo/MapWrapper.jsx
@@ -98,7 +98,6 @@ export default class MapWrapper extends React.Component {
     }
 
     componentDidMount() {
-        console.log(this.props.data);
         this.displayData();
         if (!this.props.stateProfile) {
             this.prepareBroadcastReceivers();

--- a/src/js/components/search/visualizations/geo/MapWrapper.jsx
+++ b/src/js/components/search/visualizations/geo/MapWrapper.jsx
@@ -59,8 +59,8 @@ const mapboxSources = {
     congressionalDistrict: {
         label: 'congressional district',
         minZoom: 4,
-        url: 'mapbox://usaspending.51fn3vaz',
-        layer: 'tl_2017_us_cd115-4w4nmz',
+        url: 'mapbox://usaspending.a4bkzui0',
+        layer: 'tl_2018_us_cd116-34qpds',
         filterKey: 'GEOID' // the GEOID is state FIPS + district
     },
     zip: {
@@ -98,6 +98,7 @@ export default class MapWrapper extends React.Component {
     }
 
     componentDidMount() {
+        console.log(this.props.data);
         this.displayData();
         if (!this.props.stateProfile) {
             this.prepareBroadcastReceivers();


### PR DESCRIPTION
**High level description:**
Points the Congressional District layer of maps to a new MapBox tileset. 

**Technical details:**
- Updated once in the MapWrapper component, which applies to both Advanced Search and State Profile page maps. 
- The old congressional district tileset can be removed once this change has been deployed to production.
- There is a related ticket to investigate how the data is impacted by districts changing over time: [DEV-2572](https://federal-spending-transparency.atlassian.net/browse/DEV-2572)

**JIRA Ticket:**
[DEV-2400](https://federal-spending-transparency.atlassian.net/browse/DEV-2400)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Verified cross-browser compatibility
