### PR TITLE
DEV-2402 Google Analytics

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -8,7 +9,8 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.usaspending.gov/" />
     <meta property="og:title" content="USAspending.gov" />
-    <meta property="og:description" content="USAspending.gov is the new official source of accessible, searchable and reliable spending data for the U.S. Government." />
+    <meta property="og:description"
+        content="USAspending.gov is the new official source of accessible, searchable and reliable spending data for the U.S. Government." />
     <meta property="og:site_name" content="USAspending.gov" />
     <meta property="og:image" content="https://www.usaspending.gov/img/FacebookOG.png" />
 
@@ -16,7 +18,8 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:domain" value="usaspending.gov" />
     <meta name="twitter:title" value="USAspending.gov" />
-    <meta name="twitter:description" value="USAspending.gov is the new official source of accessible, searchable and reliable spending data for the U.S. Government." />
+    <meta name="twitter:description"
+        value="USAspending.gov is the new official source of accessible, searchable and reliable spending data for the U.S. Government." />
     <meta name="twitter:image" content="https://www.usaspending.gov/img/TwitterCard.png" />
     <meta name="twitter:url" value="https://www.usaspending.gov/" />
     <meta name="twitter:label1" value="" />
@@ -29,21 +32,22 @@
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.2/mapbox-gl.css" rel="stylesheet" />
     <link rel="shortcut icon" href="img/favicon.ico">
 
-    <script async type="text/javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=TREAS&subagency=FS"></script>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-92617810-1"></script>
+    <script async type="text/javascript" id="_fed_an_ua_tag"
+        src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=TREAS&subagency=FS"></script>
+    <!-- Google Analytics -->
     <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-
-        gtag('config', 'UA-92617810-1');
+        window.ga = window.ga || function () { (ga.q = ga.q || []).push(arguments) }; ga.l = +new Date;
+        ga('create', 'UA-60737492-1', 'auto');
+        ga('create', 'UA-92617810-1', 'auto', 'testTracker');
     </script>
-
+    <script async src='https://www.google-analytics.com/analytics.js'></script>
+    <!-- End Google Analytics -->
 </head>
+
 <body>
     <div id="app"></div>
     <script type="text/javascript" src="<%= htmlWebpackPlugin.files.chunks.vendor.entry %>"></script>
     <script type="text/javascript" src="<%= htmlWebpackPlugin.files.chunks.app.entry %>"></script>
 </body>
+
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -30,6 +30,15 @@
     <link rel="shortcut icon" href="img/favicon.ico">
 
     <script async type="text/javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=TREAS&subagency=FS"></script>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-92617810-1"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'UA-92617810-1');
+    </script>
 
 </head>
 <body>

--- a/src/js/helpers/analytics/Analytics.js
+++ b/src/js/helpers/analytics/Analytics.js
@@ -3,31 +3,33 @@
  * Created by Kevin Li 2/2/18
  */
 
+import kGlobalConstants from 'GlobalConstants';
 
 const Analytics = {
     _prefix: 'USAspending - ',
     _execute(...args) {
-        if (this.isDAP) {
-            return window.gas(...args);
+        if (this.isDAP && !kGlobalConstants.DEV) {
+            window.gas(...args);
         }
-        else if (this.isGA) {
-            return window.ga(...args);
+        if (this.isGA) {
+            window.ga(...args);
         }
-        // fall back if no library is loaded (most likely due to adblocking)
         return null;
     },
     get isDAP() {
         return Boolean(window.gas && typeof window.gas === 'function');
     },
     get isGA() {
-        return Boolean(!this.isDAP && window.ga && typeof window.ga === 'function');
+        return Boolean(window.ga && typeof window.ga === 'function');
     },
     event(args) {
         if (!args.category || !args.action) {
             return;
         }
+        // Use the test tracker for non-prod environments
+        const tracker = kGlobalConstants.DEV ? 'testTracker.send' : 'send';
         this._execute(
-            'send',
+            tracker,
             'event',
             `${this._prefix}${args.category}`,
             args.action,
@@ -39,11 +41,13 @@ const Analytics = {
     pageview(args) {
         let path = args;
         let title;
+        // Use the test tracker for non-prod environments
+        const tracker = kGlobalConstants.DEV ? 'testTracker.send' : 'send';
         if (typeof args === 'object') {
             ({ path, title } = args);
         }
         this._execute(
-            'send',
+            tracker,
             'pageview',
             path,
             title


### PR DESCRIPTION
**High level description:**

Adds a new Google Analytics tracking id to the site as requested by the analytics team.

**Technical details:**

- Also adds the tracker for testing environment that devs can use to test new GA events without skewing production data
- Changes the Analytics wrapper to allow logging to both DAP and the new (default) GA in prod
- See https://developers.google.com/analytics/devguides/collection/analyticsjs/creating-trackers#working_with_multiple_trackers

**JIRA Ticket:**
[DEV-2402](https://federal-spending-transparency.atlassian.net/browse/DEV-2402)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Verified pageviews & events work in the Treasury GA dashboard by mocking prod environment locally @mgarlipp-treas 
- [x] Verified cross-browser compatibility
