### PR TITLE
[DEV-2430] Migrating to glossary API v2

### DIFF
--- a/src/js/containers/glossary/GlossaryContainer.jsx
+++ b/src/js/containers/glossary/GlossaryContainer.jsx
@@ -113,9 +113,7 @@ export class GlossaryContainer extends React.Component {
         });
 
         this.request = GlossaryHelper.fetchSearchResults({
-            fields: ['term'],
-            value: input,
-            matched_objects: true,
+            search_text: input,
             limit: 500
         });
 
@@ -129,7 +127,7 @@ export class GlossaryContainer extends React.Component {
 
                 this.request = null;
 
-                this.parseTerms(res.data.matched_objects.term);
+                this.parseTerms(res.data.matched_terms);
             })
             .catch((err) => {
                 if (!isCancel(err)) {

--- a/src/js/containers/glossary/GlossaryContainer.jsx
+++ b/src/js/containers/glossary/GlossaryContainer.jsx
@@ -42,6 +42,7 @@ export class GlossaryContainer extends React.Component {
         this.request = null;
 
         this.performSearch = this.performSearch.bind(this);
+        this.populateGlossaryWithAllTerms = this.populateGlossaryWithAllTerms.bind(this);
     }
     componentDidMount() {
         GlossaryListenerSingleton.subscribe(this);

--- a/src/js/helpers/glossaryHelper.js
+++ b/src/js/helpers/glossaryHelper.js
@@ -12,7 +12,7 @@ export const fetchAllTerms = () => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'v1/references/glossary/?limit=500',
+            url: 'v2/references/glossary/?limit=500',
             baseURL: kGlobalConstants.API,
             method: 'get',
             cancelToken: source.token

--- a/src/js/helpers/glossaryHelper.js
+++ b/src/js/helpers/glossaryHelper.js
@@ -27,7 +27,7 @@ export const fetchSearchResults = (params) => {
     const source = CancelToken.source();
     return {
         promise: Axios.request({
-            url: 'v1/references/glossary/autocomplete/',
+            url: 'v2/autocomplete/glossary/',
             baseURL: kGlobalConstants.API,
             method: 'post',
             data: params,

--- a/tests/containers/glossary/GlossaryContainer-test.jsx
+++ b/tests/containers/glossary/GlossaryContainer-test.jsx
@@ -20,6 +20,7 @@ global.Promise = require.requireActual('promise');
 // spy on specific functions inside the component
 const populateCacheSpy = sinon.spy(GlossaryContainer.prototype, 'populateCache');
 const performSearchSpy = sinon.spy(GlossaryContainer.prototype, 'performSearch');
+const populateGlossaryWithAllTermsSpy = sinon.spy(GlossaryContainer.prototype, 'populateGlossaryWithAllTerms');
 
 // mock the child component by replacing it with a function that returns a null element
 jest.mock('components/glossary/AnimatedGlossaryWrapper', () =>
@@ -58,17 +59,21 @@ const unmockGlossaryHelper = () => {
 };
 
 describe('GlossaryContainer', () => {
+    mockGlossaryHelper('populateCache', 'resolve', mockCache);
+    mockGlossaryHelper('performSearch', 'resolve', mockSearch);
+
+    mount(<GlossaryContainer
+        {...mockActions}
+        glossary={initialState} />);
+    jest.runAllTicks();
+
     it('should populate the cache via an API call on mount', () => {
-        mockGlossaryHelper('populateCache', 'resolve', mockCache);
-        mockGlossaryHelper('performSearch', 'resolve', mockSearch);
-
-        mount(<GlossaryContainer
-            {...mockActions}
-            glossary={initialState} />);
-        jest.runAllTicks();
-
         expect(populateCacheSpy.callCount).toEqual(1);
+        expect(performSearchSpy.callCount).toEqual(0);
+        expect(populateGlossaryWithAllTermsSpy.callCount).toEqual(0);
         populateCacheSpy.reset();
+        performSearchSpy.reset();
+        populateGlossaryWithAllTermsSpy.reset();
     });
 
     it('should only populate the cache when it is empty', () => {
@@ -77,6 +82,7 @@ describe('GlossaryContainer', () => {
 
         populateCacheSpy.reset();
         performSearchSpy.reset();
+        populateGlossaryWithAllTermsSpy.reset();
 
         mount(<GlossaryContainer
             {...mockActions}
@@ -85,8 +91,36 @@ describe('GlossaryContainer', () => {
 
         expect(populateCacheSpy.callCount).toEqual(0);
         expect(performSearchSpy.callCount).toEqual(1);
+        expect(populateGlossaryWithAllTermsSpy.callCount).toEqual(1);
+
         populateCacheSpy.reset();
         performSearchSpy.reset();
+        populateGlossaryWithAllTermsSpy.reset();
+    });
+
+    it('should only call populateGlossaryWithAllTerms when search term is empty', () => {
+        populateCacheSpy.reset();
+        performSearchSpy.reset();
+        populateGlossaryWithAllTermsSpy.reset();
+
+        const mockDataWithDefinedSearchTerm = Object.assign(mockData, {
+            search: {
+                input: 'test',
+                results: mockData.search.results
+            }
+        });
+
+        mount(<GlossaryContainer
+            {...mockActions}
+            glossary={mockDataWithDefinedSearchTerm} />);
+        jest.runAllTicks();
+
+        expect(populateGlossaryWithAllTermsSpy.callCount).toEqual(0);
+        expect(performSearchSpy.callCount).toEqual(1);
+        
+        populateCacheSpy.reset();
+        performSearchSpy.reset();
+        populateGlossaryWithAllTermsSpy.reset();
     });
 
     describe('writeCache', () => {


### PR DESCRIPTION
**High level description:**
Migrating the following two endpoints to v2:

1. POST: `v1/references/glossary/autocomplete/` --> `v2/autocomplete/glossary/`
2. GET: `v1/references/glossary/?limit=500` --> `v2/references/glossary/?limit=500`

**Technical details:**
Significant refactoring was needed as behavior around `1` has changed. In `v1` of this endpoint we could pass an empty string and the response would contain all the references, in `v2` an empty string returns an empty response.

Now, in order to maintain the previous UX, we add a condition to check for an empty string in `performSearch` and `populateCache`.

If the search string is empty in `performSearch` we exit the method and call a new method, `populateGlossaryWithAllTerms`; if the search string is empty in `populateCache`, we already have the data needed to populate the glossary, so we dispatch an action with that data and set loading to false.

**JIRA Ticket:**
[DEV-2430](https://federal-spending-transparency.atlassian.net/browse/DEV-2430)

**Commits:**
8d4a6b6 & 5d24062 -- update url and request payload for 1. above
6649f68 -- update url 2. above
40cd7f6 -- adds new conditional checks and class methods
79cfb2e -- adds tests to confirm new method is only called when search string is empty

The following are ALL required for the PR to be merged:
- [x] Code review
