### PR TITLE
[dev-2679/obstructed tooltip] Adds z-index to info-tooltip to avoid obstruction from visualization tool tip

### DIFF
--- a/src/_scss/components/tooltips/_customTooltipContent.scss
+++ b/src/_scss/components/tooltips/_customTooltipContent.scss
@@ -9,11 +9,14 @@
         margin-bottom: 0;
     }
 }
+// award visualization tooltips
 .combined-obligated-tt,
 .combined-current-tt,
 .combined-potential-tt,
 .combined-exceeds-potential-tt,
-.combined-exceeds-current-tt {
+.combined-exceeds-current-tt,
+// general info tooltips for each section on the awards v2 page
+.info-tt__container {
     @include display(flex);
     @include flex-direction(column);
     @include align-items(center);

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -15,7 +15,8 @@ import {
     faChartBar,
     faEllipsisH,
     faAngleDown,
-    faAngleRight
+    faAngleRight,
+    faInfoCircle
 } from "@fortawesome/free-solid-svg-icons";
 import AppContainer from 'containers/AppContainer';
 
@@ -40,7 +41,8 @@ library.add(
     faChartBar,
     faEllipsisH,
     faAngleDown,
-    faAngleRight
+    faAngleRight,
+    faInfoCircle
 );
 
 const appDiv = document.getElementById('app');

--- a/src/js/components/awardv2/idv/InfoTooltipContent.jsx
+++ b/src/js/components/awardv2/idv/InfoTooltipContent.jsx
@@ -222,11 +222,11 @@ export const awardAmountsOverspendingInfo = (
 );
 
 export const awardAmountsExtremeOverspendingInfo = (
-    <div>
-        <div className="info-tooltip__title">
+    <div className="info-tt__container exceeds-potential-info-tt">
+        <div className="tooltip__title">
              Exceeds Combined Potential Award Amounts
         </div>
-        <div className="info-tooltip__text">
+        <div className="tooltip__text">
             <p>
                 The award orders made underneath this IDV have a combined obligated
                 amount that exceeds their combined potential award amounts. In other

--- a/src/js/components/awardv2/idv/amounts/charts/ExceedsPotentialChart.jsx
+++ b/src/js/components/awardv2/idv/amounts/charts/ExceedsPotentialChart.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 
 import { generatePercentage } from 'helpers/aggregatedAmountsHelper';
 
-import InfoTooltip from 'components/awardv2/idv/InfoTooltip';
 import { awardAmountsExtremeOverspendingInfo } from 'components/awardv2/idv/InfoTooltipContent';
 import TooltipWrapper from "../../../../sharedComponents/TooltipWrapper";
 
@@ -99,9 +98,7 @@ export default class ExceedsPotentialChart extends React.Component {
                             <strong>{this.props.awardAmounts.extremeOverspendingFormatted}</strong>
                             <br />
                             <div className="award-amounts-viz__desc-text-wrapper">
-                                <InfoTooltip>
-                                    {awardAmountsExtremeOverspendingInfo}
-                                </InfoTooltip>
+                                <TooltipWrapper styles={{ zIndex: 10 }} icon="info" tooltipComponent={awardAmountsExtremeOverspendingInfo} />
                                 Exceeds Combined Potential Award Amounts
                             </div>
                         </div>

--- a/src/js/components/sharedComponents/TooltipWrapper.jsx
+++ b/src/js/components/sharedComponents/TooltipWrapper.jsx
@@ -24,7 +24,7 @@ const propTypes = {
         top: PropTypes.number,
         right: PropTypes.number
     }),
-    styles: PropTypes.shape({}) // currently only using width
+    styles: PropTypes.shape({})
 };
 
 const defaultProps = {


### PR DESCRIPTION
**High level description:**
Overlap of hover area 1 and hover area 2 results in two tooltips being shown, tooltip 1 being obstructed by tooltip 2.

![image](https://user-images.githubusercontent.com/12897813/57544587-c190fe80-7325-11e9-9d81-66a0a231ca52.png)


**Technical details:**
_If_ the user hover overs the overlapping-tooltip-hover area, both are shown but a higher z-index is given to tooltip1 so it is not obstructed. If the user hovers away from the hover-area-1, tooltip1 disappears and tooltip2 continues to show, unobstructed.

**JIRA Ticket:**
[DEV-2679](https://federal-spending-transparency.atlassian.net/browse/DEV-2679)

The following are ALL required for the PR to be merged:
- [x] Code review
- [ ] Design review (if applicable)
- [ ] Verified cross-browser compatibility
