### PR TITLE
Dev-1937 Hotfix Change Negative Percentage

### DIFF
--- a/src/js/containers/awardV2/idv/AwardMetaDataContainer.jsx
+++ b/src/js/containers/awardV2/idv/AwardMetaDataContainer.jsx
@@ -118,7 +118,7 @@ export class AwardMetaDataContainer extends React.Component {
             this.parseAllFederalAccounts(allFederalAccounts);
         }
         catch (e) {
-            if (!isCancel(e)) this.setState({ inflight: false, error: true });
+            if (!isCancel(e)) this.setState({ inFlightTreemap: false, errorTreemap: true });
             console.log(' Error : ', e);
         }
     }

--- a/src/js/models/v2/awardsV2/FederalAccountSummary.js
+++ b/src/js/models/v2/awardsV2/FederalAccountSummary.js
@@ -38,6 +38,8 @@ export default class FederalAccountSummary {
             percent: {
                 enumerable: true,
                 get: () => {
+                    if (this._obligatedAmount < 0) return 'N/A';
+                    if (this._obligatedAmount === 0) return '0%';
                     const decimal = this._percent.toFixed(2);
                     if (decimal === '0.00') return 'Less than 0.01%';
                     if (decimal[0] !== '0') {

--- a/tests/models/awardsV2/FederalAccountSummary-test.js
+++ b/tests/models/awardsV2/FederalAccountSummary-test.js
@@ -84,6 +84,18 @@ describe('FederalAccountSummary Model', () => {
             federalAccountSummary = new FederalAccountSummary(account, 5000000);
             expect(federalAccountSummary.percent).toEqual('Less than 0.01%');
         });
+        // 4. Percentage is Zero
+        it('should format a negative percent', () => {
+            account.total_transaction_obligated_amount = 0;
+            federalAccountSummary = new FederalAccountSummary(account, 5000000);
+            expect(federalAccountSummary.percent).toEqual('0%');
+        });
+        // 5. Percentage is Negative
+        it('should format a negative percent', () => {
+            account.total_transaction_obligated_amount = -100;
+            federalAccountSummary = new FederalAccountSummary(account, 5000000);
+            expect(federalAccountSummary.percent).toEqual('N/A');
+        });
     });
     describe('FederalAccountSummary Model fundingAgencyName', () => {
         // Test three scenarios


### PR DESCRIPTION
**High level description:**

Update Federal Accounts ListView to handle negative percentages.

**Technical details:**

* update error for getAllFederalAccounts to effect treemap flight and error

* update percent to handle negative to n/a and zero obligated amount to zero percent

* update fed account summary model to test for those scenarios

**JIRA Ticket:**
[DEV-1937](https://federal-spending-transparency.atlassian.net/browse/DEV-1937)

The following are ALL required for the PR to be merged:
- [ ] Code review
