### PR TITLE
[Bug/dev-2697/obstructed tt] Removes redundant info tool tip

### DIFF
--- a/src/js/components/awardv2/idv/InfoTooltipContent.jsx
+++ b/src/js/components/awardv2/idv/InfoTooltipContent.jsx
@@ -199,49 +199,6 @@ export const relatedAwardsInfo = (
     </div>
 );
 
-export const awardAmountsOverspendingInfo = (
-    <div>
-        <div className="info-tooltip__title">
-            Exceeds Combined Current Award Amount
-        </div>
-        <div className="info-tooltip__text">
-            <p>
-                The award orders underneath this IDV have a combined
-                obligated amount that exceeds their combined current award
-                amount. In other words, collectively speaking, the award
-                orders under this IDV have obligated more money than what
-                was made available to spend at this time (their combined
-                current awards amounts).
-            </p>
-            <p>
-                This can occur because of missing data, errors in the
-                data, or violations of procurement policy.
-            </p>
-        </div>
-    </div>
-);
-
-export const awardAmountsExtremeOverspendingInfo = (
-    <div>
-        <div className="info-tooltip__title">
-             Exceeds Combined Potential Award Amounts
-        </div>
-        <div className="info-tooltip__text">
-            <p>
-                The award orders made underneath this IDV have a combined obligated
-                amount that exceeds their combined potential award amounts. In other
-                words, collectively speaking, the award orders underneath this IDV
-                have obligated more money than what they reported would ultimately
-                be available to spend (their collective potential award amount).
-            </p>
-            <p>
-                This can occur because of missing data, errors in the data, or violations
-                of procurement policy.
-            </p>
-        </div>
-    </div>
-);
-
 export const summaryRelatedAwardsInfo = (
     <div>
         <div className="info-tooltip__title">

--- a/src/js/components/awardv2/idv/amounts/charts/ExceedsCurrentChart.jsx
+++ b/src/js/components/awardv2/idv/amounts/charts/ExceedsCurrentChart.jsx
@@ -6,8 +6,6 @@
 import React from 'react';
 import { generatePercentage } from 'helpers/aggregatedAmountsHelper';
 
-import InfoTooltip from 'components/awardv2/idv/InfoTooltip';
-import { awardAmountsOverspendingInfo } from 'components/awardv2/idv/InfoTooltipContent';
 import { AWARD_V2_AGGREGATED_AMOUNTS_PROPS, TOOLTIP_PROPS } from '../../../../../propTypes';
 import TooltipWrapper from "../../../../sharedComponents/TooltipWrapper";
 
@@ -77,7 +75,7 @@ export default class ExceedsCurrentChart extends React.Component {
                             onClick={exceedsCurrentTooltipProps.controlledProps.showTooltip}>
                             <strong>{this.props.awardAmounts.overspendingFormatted}</strong><br />
                             <div className="award-amounts-viz__desc-text-wrapper">
-                                <InfoTooltip>{awardAmountsOverspendingInfo}</InfoTooltip> Exceeds Combined Current Award Amounts
+                                Exceeds Combined Current Award Amounts
                             </div>
                         </div>
                         <div className="award-amounts-viz__legend-line award-amounts-viz__legend-line_overspending" />

--- a/src/js/components/awardv2/idv/amounts/charts/ExceedsPotentialChart.jsx
+++ b/src/js/components/awardv2/idv/amounts/charts/ExceedsPotentialChart.jsx
@@ -7,8 +7,6 @@ import React from 'react';
 
 import { generatePercentage } from 'helpers/aggregatedAmountsHelper';
 
-import InfoTooltip from 'components/awardv2/idv/InfoTooltip';
-import { awardAmountsExtremeOverspendingInfo } from 'components/awardv2/idv/InfoTooltipContent';
 import TooltipWrapper from "../../../../sharedComponents/TooltipWrapper";
 
 import { AWARD_V2_AGGREGATED_AMOUNTS_PROPS, TOOLTIP_PROPS } from '../../../../../propTypes';
@@ -99,9 +97,6 @@ export default class ExceedsPotentialChart extends React.Component {
                             <strong>{this.props.awardAmounts.extremeOverspendingFormatted}</strong>
                             <br />
                             <div className="award-amounts-viz__desc-text-wrapper">
-                                <InfoTooltip>
-                                    {awardAmountsExtremeOverspendingInfo}
-                                </InfoTooltip>
                                 Exceeds Combined Potential Award Amounts
                             </div>
                         </div>


### PR DESCRIPTION
**High level description:**
Info tool tip previously used for exceeds current/potential award amounts is redundant

**Technical details:**
Removes info tool tip component

**JIRA Ticket:**
[DEV-2697](https://federal-spending-transparency.atlassian.net/browse/DEV-2697)

The following are ALL required for the PR to be merged:
- [x] Code review
- ~[ ] Design review (if applicable)~ Not necessary per [this comment](https://federal-spending-transparency.atlassian.net/browse/DEV-2697) in JIRA
