### PR TITLE
[DEV-2681] Updates the verbiage on IDV Page and the Advanced Search Page

### DIFF
--- a/src/js/dataMapping/awardsv2/longAwardTypeDescriptions.js
+++ b/src/js/dataMapping/awardsv2/longAwardTypeDescriptions.js
@@ -6,9 +6,9 @@
 export const longTypeDescriptionsByAwardTypes = {
     IDV_A: "Government Wide Acquisition Contract",
     IDV_B: "Indefinite Delivery Contract",
-    IDV_B_A: "Indefinite Delivery Contract / Requirements",
-    IDV_B_B: "Indefinite Delivery Contract / Indefinite Quantity",
-    IDV_B_C: "Indefinite Delivery Contract / Definite Quantity",
+    IDV_B_A: "Indefinite Delivery / Requirements Contract",
+    IDV_B_B: "Indefinite Delivery / Indefinite Quantity (IDIQ) Contract",
+    IDV_B_C: "Indefinite Delivery / Definite Quantity Contract",
     IDV_C: "Federal Supply Schedule",
     IDV_D: "Basic Ordering Agreement",
     IDV_E: "Blanket Purchase Agreement"

--- a/src/js/dataMapping/search/awardType.js
+++ b/src/js/dataMapping/search/awardType.js
@@ -3,21 +3,26 @@
   * Created by Kevin Li 11/4/16
   **/
 
-import { longTypeDescriptionsByAwardTypes } from "../../dataMapping/awardsv2/longAwardTypeDescriptions";
-
 /* eslint-disable quote-props */
 // disable quote-props for consistency sake (we need leading zeroes)
 export const awardTypeCodes = {
-    A: 'Blanket Purchase Agreements (BPA) Calls',
-    B: 'Purchase Orders (PO)',
-    C: 'Delivery Orders (DO)',
-    D: 'Definitive Contracts',
-    E: 'Unknown Type',
-    F: 'Cooperative Agreement',
-    G: 'Grant for Research',
-    S: 'Funded Space Act Agreement',
-    T: 'Training Grant',
-    ...longTypeDescriptionsByAwardTypes,
+    'A': 'Blanket Purchase Agreements (BPA) Calls',
+    'B': 'Purchase Orders (PO)',
+    'C': 'Delivery Orders (DO)',
+    'D': 'Definitive Contracts',
+    'E': 'Unknown Type',
+    'F': 'Cooperative Agreement',
+    'G': 'Grant for Research',
+    'S': 'Funded Space Act Agreement',
+    'T': 'Training Grant',
+    'IDV_A': 'Government-Wide Acquisition Contract (GWAC)',
+    'IDV_B': 'Multi-Agency Contract, Other Indefinite Delivery Contract (IDC)',
+    'IDV_B_A': 'Indefinite Delivery / Requirements Contract',
+    'IDV_B_B': 'Indefinite Delivery / Indefinite Quantity (IDIQ) Contract',
+    'IDV_B_C': 'Indefinite Delivery / Definite Quantity Contract',
+    'IDV_C': 'Federal Supply Schedule (FSS)',
+    'IDV_D': 'Basic Ordering Agreement (BOA)',
+    'IDV_E': 'Blanket Purchase Agreements (BPA)',
     '02': 'Block Grant',
     '03': 'Formula Grant',
     '04': 'Project Grant',

--- a/src/js/dataMapping/search/awardType.js
+++ b/src/js/dataMapping/search/awardType.js
@@ -3,26 +3,21 @@
   * Created by Kevin Li 11/4/16
   **/
 
+import { longTypeDescriptionsByAwardTypes } from "../../dataMapping/awardsv2/longAwardTypeDescriptions";
+
 /* eslint-disable quote-props */
 // disable quote-props for consistency sake (we need leading zeroes)
 export const awardTypeCodes = {
-    'A': 'Blanket Purchase Agreements (BPA) Calls',
-    'B': 'Purchase Orders (PO)',
-    'C': 'Delivery Orders (DO)',
-    'D': 'Definitive Contracts',
-    'E': 'Unknown Type',
-    'F': 'Cooperative Agreement',
-    'G': 'Grant for Research',
-    'S': 'Funded Space Act Agreement',
-    'T': 'Training Grant',
-    'IDV_A': 'Government-Wide Acquisition Contract (GWAC)',
-    'IDV_B': 'Multi-Agency Contract, Other Indefinite Delivery Contract (IDC)',
-    'IDV_B_A': 'IDC Indefinite Delivery Contract / Requirements',
-    'IDV_B_B': 'IDC Indefinite Delivery Contract / Indefinite Quantity',
-    'IDV_B_C': 'IDC Indefinite Delivery Contract / Definite Quantity',
-    'IDV_C': 'Federal Supply Schedule (FSS)',
-    'IDV_D': 'Basic Ordering Agreement (BOA)',
-    'IDV_E': 'Blanket Purchase Agreements (BPA)',
+    A: 'Blanket Purchase Agreements (BPA) Calls',
+    B: 'Purchase Orders (PO)',
+    C: 'Delivery Orders (DO)',
+    D: 'Definitive Contracts',
+    E: 'Unknown Type',
+    F: 'Cooperative Agreement',
+    G: 'Grant for Research',
+    S: 'Funded Space Act Agreement',
+    T: 'Training Grant',
+    ...longTypeDescriptionsByAwardTypes,
     '02': 'Block Grant',
     '03': 'Formula Grant',
     '04': 'Project Grant',


### PR DESCRIPTION
**High level description:**
Updates the verbiage for three IDV Award types on the IDV Page and the Advanced Search Page

**Technical details:**
Updated two data maps on related to the IDV page, the other to the advanced search page.

`Indefinite Delivery, Definite Quantity Contract`
`Indefinite Delivery, Requirements Contract`
`Indefinite Delivery, Indefinite Quantity (IDIQ) Contract`

should be replaced respectively with....

`Indefinite Delivery / Definite Quantity Contract`
`Indefinite Delivery / Requirements Contract`
`Indefinite Delivery / Indefinite Quantity (IDIQ) Contract`

**JIRA Ticket:**
[DEV-2681](https://federal-spending-transparency.atlassian.net/browse/DEV-2681)

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Design review
- [x] [API #1813](https://github.com/fedspendingtransparency/usaspending-api/pull/1813) merged 
- [x] Changes deployed via execution of manage script by OPS team ([JIRA Ticket](https://federal-spending-transparency.atlassian.net/browse/OPS-693))