### PR TITLE
[DEV-2772] Follow up fixes to City Search Hot Fix

### DIFF
--- a/src/js/components/search/filters/location/EntityDropdown.jsx
+++ b/src/js/components/search/filters/location/EntityDropdown.jsx
@@ -303,7 +303,6 @@ export default class EntityDropdown extends React.Component {
                             toggleDropdown={this.toggleDropdown}
                             placeholder={this.props.placeholder}
                             context={this} // used to create dropdown ref
-                            expanded={this.state.expanded}
                             loading={loading} />
                     }
                     {dropdown}

--- a/src/js/components/search/filters/location/EntityDropdown.jsx
+++ b/src/js/components/search/filters/location/EntityDropdown.jsx
@@ -238,11 +238,11 @@ export default class EntityDropdown extends React.Component {
         let hideWarning = 'hide';
 
         if (this.state.expanded && !loading) {
-            const selectedItemKey = this.getSelectedItemIdentifier();
+            const selectedItem = this.getSelectedItemIdentifier();
             dropdown = (<EntityDropdownList
                 matchKey={this.props.matchKey}
                 scope={this.props.scope}
-                selectedItemKey={selectedItemKey}
+                selectedItem={selectedItem}
                 options={this.props.options}
                 clickedItem={this.clickedItem} />);
         }

--- a/src/js/components/search/filters/location/EntityDropdown.jsx
+++ b/src/js/components/search/filters/location/EntityDropdown.jsx
@@ -60,6 +60,8 @@ export default class EntityDropdown extends React.Component {
         this.clickedItem = this.clickedItem.bind(this);
         this.handleDeselection = this.handleDeselection.bind(this);
 
+        this.getSelectedItemKey = this.getSelectedItemKey.bind(this);
+
         this.mouseEnter = this.mouseEnter.bind(this);
         this.mouseLeave = this.mouseLeave.bind(this);
         this.handleTextInputChange = this.handleTextInputChange.bind(this);
@@ -69,6 +71,10 @@ export default class EntityDropdown extends React.Component {
         if (this.props.type === 'autocomplete' && (!isEqual(prevProps.options, this.props.options))) {
             this.openDropdown();
         }
+    }
+
+    getSelectedItemIdentifier() {
+        return this.props.value[this.props.matchKey];
     }
 
     handleTextInputChange(e) {
@@ -232,10 +238,11 @@ export default class EntityDropdown extends React.Component {
         let hideWarning = 'hide';
 
         if (this.state.expanded && !loading) {
+            const selectedItemKey = this.getSelectedItemIdentifier();
             dropdown = (<EntityDropdownList
                 matchKey={this.props.matchKey}
                 scope={this.props.scope}
-                value={this.props.value}
+                selectedItemKey={selectedItemKey}
                 options={this.props.options}
                 clickedItem={this.clickedItem} />);
         }

--- a/src/js/components/search/filters/location/EntityDropdown.jsx
+++ b/src/js/components/search/filters/location/EntityDropdown.jsx
@@ -60,7 +60,7 @@ export default class EntityDropdown extends React.Component {
         this.clickedItem = this.clickedItem.bind(this);
         this.handleDeselection = this.handleDeselection.bind(this);
 
-        this.getSelectedItemKey = this.getSelectedItemKey.bind(this);
+        this.getSelectedItemIdentifier = this.getSelectedItemIdentifier.bind(this);
 
         this.mouseEnter = this.mouseEnter.bind(this);
         this.mouseLeave = this.mouseLeave.bind(this);

--- a/src/js/components/search/filters/location/EntityDropdown.jsx
+++ b/src/js/components/search/filters/location/EntityDropdown.jsx
@@ -222,6 +222,8 @@ export default class EntityDropdown extends React.Component {
         } = this.props;
 
         const isAutocomplete = (type === 'autocomplete');
+        const autocompleteClass = isAutocomplete ? 'geo-entity-dropdown_autocomplete' : null;
+        const warningField = title.split(" (")[0];
 
         let dropdown = null;
         let placeholder = '';
@@ -250,7 +252,6 @@ export default class EntityDropdown extends React.Component {
             hideWarning = '';
         }
 
-        const autocompleteClass = isAutocomplete ? 'geo-entity-dropdown_autocomplete' : null;
         return (
             <div
                 className="geo-entity-item">
@@ -312,7 +313,7 @@ export default class EntityDropdown extends React.Component {
                     id={this.state.warningId}
                     aria-hidden={hideWarning === 'hide'}>
                     <EntityWarning
-                        message={generateWarning(title)} />
+                        message={generateWarning(warningField)} />
                 </div>
             </div>
         );

--- a/src/js/components/search/filters/location/EntityDropdownAutocomplete.jsx
+++ b/src/js/components/search/filters/location/EntityDropdownAutocomplete.jsx
@@ -32,7 +32,6 @@ export const EntityDropdownAutocomplete = ({
     toggleDropdown,
     placeholder,
     context, // the $this variable
-    expanded,
     loading
 }) => (
     <div className="autocomplete__input">

--- a/src/js/components/search/filters/location/EntityDropdownAutocomplete.jsx
+++ b/src/js/components/search/filters/location/EntityDropdownAutocomplete.jsx
@@ -49,8 +49,6 @@ export const EntityDropdownAutocomplete = ({
                 self.dropdown = dropdown;
             }} />
         <div className="icon">
-            {expanded && !loading && <FontAwesomeIcon onClick={toggleDropdown} icon="chevron-up" />}
-            {!expanded && !loading && <FontAwesomeIcon onClick={toggleDropdown} icon="chevron-down" />}
             {loading && <FontAwesomeIcon onClick={toggleDropdown} icon="spinner" spin />}
         </div>
     </div>

--- a/src/js/components/search/filters/location/EntityDropdownList.jsx
+++ b/src/js/components/search/filters/location/EntityDropdownList.jsx
@@ -11,16 +11,23 @@ const propTypes = {
     scope: PropTypes.string,
     matchKey: PropTypes.string,
     options: PropTypes.array,
-    value: PropTypes.object,
+    selectedItem: PropTypes.string,
     clickedItem: PropTypes.func
 };
 
 const alphabetRegex = /([a-z]|[0-9])/;
 
 const EntityDropdownList = (props) => {
-    const options = props.options.map((item, i) => {
+    const {
+        scope,
+        matchKey,
+        selectedItem,
+        options,
+        clickedItem
+    } = props;
+    const list = options.map((item, i) => {
         let active = '';
-        if (item.code === props.value.code && item.code !== '') {
+        if (item[matchKey] === selectedItem && selectedItem !== '') {
             active = 'active';
         }
 
@@ -28,14 +35,14 @@ const EntityDropdownList = (props) => {
         const noResultsFound = item.code === "NA-000" ? "no-matching-results" : "";
         // variable matchKeys allow us to match by numeric codes for congressional district
         // instead of display name
-        if (item[props.matchKey] !== '') {
-            const firstLetter = item[props.matchKey].substring(0, 1).toLowerCase();
+        if (item[matchKey] !== '') {
+            const firstLetter = item[matchKey].substring(0, 1).toLowerCase();
             if (alphabetRegex.test(firstLetter)) {
                 letterClass = firstLetter;
             }
         }
 
-        const handleSelection = props.clickedItem.bind(null, item);
+        const handleSelection = clickedItem.bind(null, item);
 
         return (
             <li
@@ -54,10 +61,10 @@ const EntityDropdownList = (props) => {
 
     return (
         <ul
-            id={`geo-dropdown-${props.scope}`}
+            id={`geo-dropdown-${scope}`}
             className="geo-entity-list"
             role="listbox">
-            {options}
+            {list}
         </ul>
     );
 };

--- a/src/js/components/search/filters/location/LocationPicker.jsx
+++ b/src/js/components/search/filters/location/LocationPicker.jsx
@@ -91,7 +91,7 @@ export default class LocationPicker extends React.Component {
     }
 
     generateWarning(field) {
-        if (this.props.country.code === '') {
+        if (!this.props.country.code) {
             // no country provided
             return (
                 <span>
@@ -102,7 +102,14 @@ export default class LocationPicker extends React.Component {
             );
         }
         else if (this.props.country.code === 'USA') {
-            if (this.props.state.code === '') {
+            const {
+                state,
+                district,
+                county,
+                city
+            } = this.props;
+            const countyOrDistrictSelected = (district.district || county.code);
+            if (!state.code) {
                 // no state
                 return (
                     <span>
@@ -112,11 +119,11 @@ export default class LocationPicker extends React.Component {
                     </span>
                 );
             }
-            else if (this.props.county.code !== '' || this.props.district.district !== '') {
-                // county selected
+            else if (countyOrDistrictSelected || (city.code && (!district.district || !county.code))) {
+                const selectedField = (district.district) ? "congressional district" : "county"; // if evaluates to county, double check it's not actually city
                 return (
                     <span>
-                        You cannot select both a <span className="field">county</span> and a <span className="field">congressional district</span>.
+                        You cannot select both a <span className="field">{(selectedField === "county" && county.code) ? selectedField : "city"}</span> and a <span className="field"> {field}</span>.
                     </span>
                 );
             }
@@ -130,22 +137,39 @@ export default class LocationPicker extends React.Component {
     }
 
     render() {
+        const isCityEnabled = (
+            this.props.country.code !== "" &&
+            !this.props.county.code &&
+            !this.props.district.district
+        );
+        const isCountyEnabled = (
+            this.props.state.code !== "" &&
+            !this.props.district.district &&
+            !this.props.city.code
+        );
+        const isDistrictEnabled = (
+            this.props.state.code !== "" &&
+            !this.props.county.code &&
+            !this.props.city.code
+        );
+        const isStateEnabled = (this.props.country.code === 'USA');
+
         let districtPlaceholder = 'Select a congressional district';
         if (this.props.state.code !== '' && this.props.availableDistricts.length === 0) {
             // no districts in this state
             districtPlaceholder = 'No congressional districts in territory';
         }
 
-        let disabled = true;
+        let isAddFilterDisabled = true;
         if (this.props.country.code !== '') {
             // enable the button if at least some filters are selected
-            disabled = false;
+            isAddFilterDisabled = false;
 
             // check to see if the location is already selected
             const location = this.props.createLocationObject();
             if (location && this.props.selectedLocations.has(location.identifier)) {
                 // it is already selected
-                disabled = true;
+                isAddFilterDisabled = true;
             }
         }
 
@@ -172,7 +196,7 @@ export default class LocationPicker extends React.Component {
                             value={this.props.state}
                             selectEntity={this.props.selectEntity}
                             options={this.props.availableStates}
-                            enabled={this.props.country.code === 'USA'}
+                            enabled={isStateEnabled}
                             generateWarning={this.generateWarning} />
                     </div>
                     <div className="location-item">
@@ -183,7 +207,7 @@ export default class LocationPicker extends React.Component {
                             value={this.props.county}
                             selectEntity={this.props.selectEntity}
                             options={this.props.availableCounties}
-                            enabled={this.props.state.code !== '' && this.props.district.district === ''}
+                            enabled={isCountyEnabled}
                             generateWarning={this.generateWarning} />
                     </div>
                     {this.props.enableCitySearch &&
@@ -197,7 +221,7 @@ export default class LocationPicker extends React.Component {
                                 value={this.props.city}
                                 options={this.props.availableCities}
                                 selectEntity={this.props.selectEntity}
-                                enabled={this.props.country.code !== ''}
+                                enabled={isCityEnabled}
                                 generateWarning={this.generateWarning}
                                 setSearchString={this.props.setCitySearchString}
                                 searchString={this.props.citySearchString} />
@@ -211,14 +235,14 @@ export default class LocationPicker extends React.Component {
                             value={this.props.district}
                             selectEntity={this.props.selectEntity}
                             options={this.props.availableDistricts}
-                            enabled={this.props.state.code !== '' && this.props.county.code === ''}
+                            enabled={isDistrictEnabled}
                             generateWarning={this.generateWarning} />
                     </div>
                     <button
                         className="add-location"
                         onClick={this.props.addLocation}
                         aria-controls="award-search-selected-locations"
-                        disabled={disabled}>
+                        disabled={isAddFilterDisabled}>
                         Add Filter
                     </button>
                 </form>

--- a/src/js/components/search/filters/location/LocationPicker.jsx
+++ b/src/js/components/search/filters/location/LocationPicker.jsx
@@ -54,7 +54,8 @@ export default class LocationPicker extends React.Component {
         const stateChanged = (prevProps.state.code !== this.props.state.code);
         const countryChanged = (prevProps.country.code !== this.props.country.code);
         const isCityInState = ( // if selected city is inside the selected state, don't clear the selected city!
-            this.props.state.code === this.props.city.code
+            this.props.state.code === this.props.city.code &&
+            this.props.state.code && this.props.city.code
         );
 
         if (countryChanged && this.props.country.code === "USA") {

--- a/src/js/components/search/filters/location/LocationPicker.jsx
+++ b/src/js/components/search/filters/location/LocationPicker.jsx
@@ -72,14 +72,15 @@ export default class LocationPicker extends React.Component {
             //  since USA isn't selected and wasn't previously selected, only clear cities
             this.props.clearCitiesAndSelectedCity();
         }
-        if (stateChanged && this.props.state.code && !isCityInState) {
-            // state code changed, load the counties
+        if (stateChanged && this.props.state.code) {
+            // state code changed, load the counties & districts
             this.props.loadCounties(this.props.state.code.toLowerCase());
-            // also the districts
             this.props.loadDistricts(this.props.state.code.toLowerCase());
-            this.props.clearCitiesAndSelectedCity();
+            if (!isCityInState) {
+                this.props.clearCitiesAndSelectedCity();
+            }
         }
-        else if (stateChanged && !this.props.state.code && !isCityInState) {
+        else if (stateChanged && !this.props.state.code) {
             this.props.clearCounties();
             this.props.clearDistricts();
             this.props.clearCitiesAndSelectedCity();

--- a/src/js/components/search/filters/location/LocationPicker.jsx
+++ b/src/js/components/search/filters/location/LocationPicker.jsx
@@ -124,7 +124,7 @@ export default class LocationPicker extends React.Component {
                 const selectedField = (district.district) ? "congressional district" : "county"; // if evaluates to county, double check it's not actually city
                 return (
                     <span>
-                        You cannot select both a <span className="field">{(selectedField === "county" && county.code) ? selectedField : "city"}</span> and a <span className="field"> {field}</span>.
+                        You cannot select both a <span className="field">{(selectedField === "county" && !county.code) ? "city" : selectedField}</span> and a <span className="field"> {field}</span>.
                     </span>
                 );
             }

--- a/src/js/components/search/filters/location/LocationPicker.jsx
+++ b/src/js/components/search/filters/location/LocationPicker.jsx
@@ -192,7 +192,7 @@ export default class LocationPicker extends React.Component {
                                 type="autocomplete"
                                 loading={this.props.loading}
                                 scope="city"
-                                placeholder="Enter a city"
+                                placeholder="Enter a City"
                                 title="CITY"
                                 value={this.props.city}
                                 options={this.props.availableCities}

--- a/src/js/components/search/filters/location/LocationPicker.jsx
+++ b/src/js/components/search/filters/location/LocationPicker.jsx
@@ -63,8 +63,12 @@ export default class LocationPicker extends React.Component {
             this.props.clearCitiesAndSelectedCity();
         }
         else if (countryChanged && prevProps.country.code === 'USA') {
-            // the user previously selected USA but it is no longer selected
+            // the user previously selected USA, need to clear these out
             this.props.clearStates();
+            this.props.clearCitiesAndSelectedCity();
+        }
+        else if (countryChanged) {
+            //  since USA isn't selected and wasn't previously selected, only clear cities
             this.props.clearCitiesAndSelectedCity();
         }
         if (stateChanged && this.props.state.code && !isCityInState) {

--- a/src/js/containers/search/filters/location/LocationPickerContainer.jsx
+++ b/src/js/containers/search/filters/location/LocationPickerContainer.jsx
@@ -278,7 +278,8 @@ export default class LocationPickerContainer extends React.Component {
 
     selectEntity(level, value) {
         if (level === 'city' && this.state.state.code !== value.code && value.code) {
-            this.setState({ state: this.state.availableStates.find((state) => state.code === value.code) });
+            const selectedState = this.state.availableStates.find((state) => state.code === value.code) || defaultSelections.state;
+            this.setState({ state: selectedState });
         }
 
         this.setState({

--- a/src/js/containers/search/filters/location/LocationPickerContainer.jsx
+++ b/src/js/containers/search/filters/location/LocationPickerContainer.jsx
@@ -111,6 +111,9 @@ export default class LocationPickerContainer extends React.Component {
                 this.debouncedCitySearch();
             }
         });
+        if (!citySearchString) {
+            this.clearCitiesAndSelectedCity();
+        }
     }
 
     loadCountries() {

--- a/src/js/containers/search/filters/location/LocationPickerContainer.jsx
+++ b/src/js/containers/search/filters/location/LocationPickerContainer.jsx
@@ -105,7 +105,8 @@ export default class LocationPickerContainer extends React.Component {
     }
 
     setCitySearchString(citySearchString, performFetch = true) {
-        this.setState({ citySearchString }, () => {
+        // we don't perform fetch when the user is clicking on a city search dropdown option
+        this.setState({ citySearchString, availableCities: [] }, () => {
             if (citySearchString.length > 2 && performFetch) {
                 this.debouncedCitySearch();
             }


### PR DESCRIPTION
**High level description:**
Fixes two issues:

1. Loading Counties/districts for a state when the state is auto-populated by a city selection
2. Allowing for selection of international city

**Technical details:**
- Tells `componentDidUpdate` to load counties/districts when state is automatically updated via city selection
- Only sets selected state automatically on city selection if it matches an actual state object in the states array.

**JIRA Ticket:**
[DEV-2772](https://federal-spending-transparency.atlassian.net/browse/DEV-2772)

The following are ALL required for the PR to be merged:
- [ ] Code review
