### PR TITLE
[DEV-2772] Hot-fix: City SearchFollow Up & Federal Accounts Tooltip

### DIFF
--- a/src/js/components/search/filters/location/LocationPicker.jsx
+++ b/src/js/components/search/filters/location/LocationPicker.jsx
@@ -72,14 +72,15 @@ export default class LocationPicker extends React.Component {
             //  since USA isn't selected and wasn't previously selected, only clear cities
             this.props.clearCitiesAndSelectedCity();
         }
-        if (stateChanged && this.props.state.code && !isCityInState) {
-            // state code changed, load the counties
+        if (stateChanged && this.props.state.code) {
+            // state code changed, load the counties & districts
             this.props.loadCounties(this.props.state.code.toLowerCase());
-            // also the districts
             this.props.loadDistricts(this.props.state.code.toLowerCase());
-            this.props.clearCitiesAndSelectedCity();
+            if (!isCityInState) {
+                this.props.clearCitiesAndSelectedCity();
+            }
         }
-        else if (stateChanged && !this.props.state.code && !isCityInState) {
+        else if (stateChanged && !this.props.state.code) {
             this.props.clearCounties();
             this.props.clearDistricts();
             this.props.clearCitiesAndSelectedCity();

--- a/src/js/containers/search/filters/location/LocationPickerContainer.jsx
+++ b/src/js/containers/search/filters/location/LocationPickerContainer.jsx
@@ -278,7 +278,8 @@ export default class LocationPickerContainer extends React.Component {
 
     selectEntity(level, value) {
         if (level === 'city' && this.state.state.code !== value.code && value.code) {
-            this.setState({ state: this.state.availableStates.find((state) => state.code === value.code) });
+            const selectedState = this.state.availableStates.find((state) => state.code === value.code) || defaultSelections.state;
+            this.setState({ state: selectedState });
         }
 
         this.setState({


### PR DESCRIPTION
**High level description:**
Fixes two issues:

- Loading Counties/districts for a state when the state is auto-populated by a city selection
- Allowing for selection of international city

**Technical details:**
- Tells componentDidUpdate to load counties/districts when state is automatically updated via city selection (42000a5)
- Only sets selected state automatically on city selection if it matches an actual state object in the states array. (930d1ba)

**JIRA Ticket:**
[DEV-2772](https://federal-spending-transparency.atlassian.net/browse/DEV-2772)

The following are ALL required for the PR to be merged:
- [x] Code review
