### PR TITLE
[Hotfix] Disabling City Search in Staging

### DIFF
--- a/src/js/containers/search/filters/location/POPFilterContainer.jsx
+++ b/src/js/containers/search/filters/location/POPFilterContainer.jsx
@@ -43,7 +43,7 @@ export class POPFilterContainer extends React.Component {
         return (
             <div>
                 <LocationPickerContainer
-                    enableCitySearch
+                    enableCitySearch={false}
                     scope="primary_place_of_performance"
                     selectedLocations={this.props.selectedLocations}
                     addLocation={this.addLocation} />

--- a/src/js/containers/search/filters/location/RecipientFilterContainer.jsx
+++ b/src/js/containers/search/filters/location/RecipientFilterContainer.jsx
@@ -43,7 +43,7 @@ export class RecipientFilterContainer extends React.Component {
         return (
             <div>
                 <LocationPickerContainer
-                    enableCitySearch
+                    enableCitySearch={false}
                     scope="recipient_location"
                     selectedLocations={this.props.selectedLocations}
                     addLocation={this.addLocation} />


### PR DESCRIPTION
**High level description:**
A performance concern was identified after a hotfix was delivered late in Sprint 84. This component was designed to be disabled via a prop for such a scenario.

**Technical details:**
The top-most City Search container was given boolean prop `enableCitySearch` which is now set to false.

This does two things:

1. Hides the city search component
2. Disables API call

The following are ALL required for the PR to be merged:
- [x] Code review
