### PR TITLE
DEV-2829 Disable download button

### DIFF
--- a/src/js/components/search/header/DownloadButton.jsx
+++ b/src/js/components/search/header/DownloadButton.jsx
@@ -42,7 +42,7 @@ export default class DownloadButton extends React.Component {
 
     onClick(e) {
         e.preventDefault();
-        if (this.props.downloadAvailable || !this.props.downloadInFlight) {
+        if (this.props.downloadAvailable && !this.props.downloadInFlight) {
             this.props.onClick();
         }
     }


### PR DESCRIPTION
**High level description:**

Fixes a bug causing the download button to be clickable even though it appeared disabled. 

**Technical details:**

The `onClick` function was checking for `downloadAvailable` OR `!downloadInFlight` and by default evaluating to `true` because on initial load, a download is not in flight. This PR ANDs the two conditions. 

**JIRA Ticket:**
[DEV-2829](https://federal-spending-transparency.atlassian.net/browse/DEV-2829)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Sprint 83 Staging PR #1122 merged (this ticket is in Sprint 84)