### PR TITLE
[DEV-2735] Note on Federal Accounts Section explaining difference between table/treemap view

### DIFF
--- a/src/_scss/pages/awardV2/idv/_awardFundingSummary.scss
+++ b/src/_scss/pages/awardV2/idv/_awardFundingSummary.scss
@@ -104,6 +104,7 @@
   .federal-accounts__section--note {
     font-size: 14px;
     padding-top: $global-pad;
+    width: 100%;
     strong {
       font-weight: 600;
     }

--- a/src/_scss/pages/awardV2/idv/_awardFundingSummary.scss
+++ b/src/_scss/pages/awardV2/idv/_awardFundingSummary.scss
@@ -101,6 +101,13 @@
       }
     }
   }
+  .federal-accounts__section--note {
+    font-size: 14px;
+    padding-top: $global-pad;
+    strong {
+      font-weight: 600;
+    }
+  }
   .federal-accounts-summary__section {
     .award-funding-summary__table {
       margin-bottom: rem(10);

--- a/src/js/components/awardv2/idv/federalAccounts/FederalAccountsSection.jsx
+++ b/src/js/components/awardv2/idv/federalAccounts/FederalAccountsSection.jsx
@@ -144,7 +144,7 @@ export default class FederalAccountsSection extends React.Component {
                         </div>
                     </div>
                     <span className="federal-accounts__section--note">
-                        <strong>NOTE: </strong>result count may differ between treemap view and table view. Treemap view only displays accounts with a positive combined obligated amount, while table view displays all accounts.
+                        <strong>NOTE: </strong>Result count may differ between treemap view and table view. Treemap view only displays accounts with a positive combined obligated amount, while table view displays all accounts.
                     </span>
                     <FederalAccountsSummary {...this.props} />
                 </div>

--- a/src/js/components/awardv2/idv/federalAccounts/FederalAccountsSection.jsx
+++ b/src/js/components/awardv2/idv/federalAccounts/FederalAccountsSection.jsx
@@ -143,6 +143,9 @@ export default class FederalAccountsSection extends React.Component {
                                 hideTooltip={this.hideTooltip} />}
                         </div>
                     </div>
+                    <span className="federal-accounts__section--note">
+                        <strong>NOTE: </strong>result count may differ between treemap view and table view. Treemap view only displays accounts with a positive combined obligated amount, while table view displays all accounts.
+                    </span>
                     <FederalAccountsSummary {...this.props} />
                 </div>
             </div>


### PR DESCRIPTION
**High level description:**
Simple mark up added to explain difference between the treemap and table view

**Technical details:**
Adds markup and SCSS.

**JIRA Ticket:**
[DEV-2735](https://federal-spending-transparency.atlassian.net/browse/DEV-2735)

**Mockup:**
https://bahdigital.invisionapp.com/share/ENIAAIY6K2P#/screens/296008376_Award_Summary_2-0_-_IDV_-Future-_-Fed_Acct_List_View-

**Screenshot:**
![image](https://user-images.githubusercontent.com/12897813/59376984-3d180e00-8d1f-11e9-8994-166a2b05f456.png)

The following are ALL required for the PR to be merged:
- [ ] Code review
- [x] Design review (if applicable)
- [x] Verified cross-browser compatibility
