### PR TITLE
[DEV-2751] Advanced City Search only Includes *_scope property when country is "All Foreign countries"

### DIFF
--- a/src/js/models/search/SearchAwardsOperation.js
+++ b/src/js/models/search/SearchAwardsOperation.js
@@ -179,7 +179,7 @@ class SearchAwardsOperation {
         if (this.selectedRecipientLocations.length > 0) {
             const locationSet = [];
             this.selectedRecipientLocations.forEach((location) => {
-                if (location.filter.country && location.filter.country !== 'USA') {
+                if (location.filter.country && location.filter.country.toLowerCase() === 'foreign') {
                     filters[rootKeys.recipientLocationScope] = 'foreign';
                 }
                 locationSet.push(location.filter);
@@ -198,7 +198,7 @@ class SearchAwardsOperation {
         if (this.selectedLocations.length > 0) {
             const locationSet = [];
             this.selectedLocations.forEach((location) => {
-                if (location.filter.country && location.filter.country !== 'USA') {
+                if (location.filter.country && location.filter.country.toLowerCase() === 'foreign') {
                     filters[rootKeys.placeOfPerformanceScope] = 'foreign';
                 }
                 locationSet.push(location.filter);


### PR DESCRIPTION
**High level description:**
API was returning inaccurate payload because `primary_place_of_performance_scope` / `recipient_location_scope` was being included in request object when `country !== 'USA'`

**Technical details:**
Changed condition for including this property in the request object from `country !== USA` to `country === foreign`

**JIRA Ticket:**
[DEV-2751](https://federal-spending-transparency.atlassian.net/browse/DEV-2751)

The following are ALL required for the PR to be merged:
- [x] Code review
