### PR TITLE
Dev-2909 IDV Activity Chart API Integration

### DIFF
--- a/src/_scss/pages/awardV2/idv/activity/idvActivity.scss
+++ b/src/_scss/pages/awardV2/idv/activity/idvActivity.scss
@@ -108,7 +108,6 @@ $obligated-green: #94BFA2;
           }
         }
         .visualization-legend {
-          margin-left: 10px;
             .visualization-legend__circle {
                 background-color: #D8D8D8;
                 &.visualization-legend__circle_obligated {

--- a/src/js/components/awardv2/idv/activity/ActivityChartTooltip.jsx
+++ b/src/js/components/awardv2/idv/activity/ActivityChartTooltip.jsx
@@ -202,7 +202,7 @@ export default class IdvActivityTooltip extends React.Component {
                                     PIID
                                 </h6>
                                 <div className="tooltip-body__row-info-data">
-                                    {this.getLinks(`award/${data.piid}`, data.piid)}
+                                    {this.getLinks(`award/${data.id}`, data.piid)}
                                 </div>
                             </div>
                             <div className="tooltip-body__row-info">
@@ -213,7 +213,7 @@ export default class IdvActivityTooltip extends React.Component {
                                     {
                                         this.getLinks(
                                             `award/${data.parentAwardId}`,
-                                            data.parentAwardId
+                                            data.parentAwardPIID
                                         )
                                     }
                                 </div>

--- a/src/js/containers/awardV2/idv/IdvActivityContainer.jsx
+++ b/src/js/containers/awardV2/idv/IdvActivityContainer.jsx
@@ -15,8 +15,12 @@ export class IdvActivityContainer extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            page: 1,
+            hasNext: false,
+            hasPrevious: null,
             limit: 10,
+            next: 0,
+            page: 1,
+            previous: null,
             total: 0,
             awards: [],
             xSeries: [],
@@ -55,6 +59,12 @@ export class IdvActivityContainer extends React.Component {
         try {
             const { data } = await this.idvActivityRequest.promise;
             this.setState({
+                hasNext: data.page_metadata.hasNext,
+                hasPrevious: data.page_metadata.hasPrevious,
+                limit: data.page_metadata.limit,
+                next: data.page_metadata.next,
+                page: data.page_metadata.page,
+                previous: data.page_metadata.previous,
                 total: data.page_metadata.total,
                 error: false
             }, () => this.parseAwards(data.results));

--- a/src/js/helpers/idvHelper.js
+++ b/src/js/helpers/idvHelper.js
@@ -121,67 +121,15 @@ export const fetchAwardFederalAccounts = (data) => {
     };
 };
 
-export const fetchIdvActivity = () => {
+export const fetchIdvActivity = (data) => {
     const source = CancelToken.source();
     return {
-        promise: new Promise((resolve) => {
-            window.setTimeout(() => {
-                resolve({
-                    data: {
-                        results: [{
-                            award_id: 69138778,
-                            awarding_agency: "DEPARTMENT OF THE INTERIOR (DOI)",
-                            awarding_agency_id: 228,
-                            generated_unique_award_id: "CONT_AW_1425_4730_INR17PA00008_GS23F0170L",
-                            last_date_to_order: "2019-11-30",
-                            obligated_amount: 8000.0,
-                            awarded_amount: 10000.0,
-                            period_of_performance_start_date: "2016-01-14",
-                            piid: "INR17PA00008",
-                            recipient_name: "Booz Allen Hamilton",
-                            recipient_id: "543ee6af-9096-f32a-abaa-834106bead6a-P",
-                            grandchild: false
-                        }, {
-                            award_id: 69054107,
-                            awarding_agency: "GENERAL SERVICES ADMINISTRATION (GSA)",
-                            awarding_agency_id: 634,
-                            generated_unique_award_id: "CONT_AW_4732_4730_GS33FCA001_GS23F0170L",
-                            last_date_to_order: "2017-09-30",
-                            obligated_amount: 2257.24,
-                            awarded_amount: 20000.0,
-                            period_of_performance_start_date: "2014-10-01",
-                            piid: "GS33FCA001",
-                            recipient_name: "Booz Allen Hamilton (BAH)",
-                            recipient_id: "9a277fc5-50fc-685f-0f77-be0d96420a17-C",
-                            grandchild: false
-                        },
-                        {
-                            award_id: 69216438,
-                            awarding_agency: "DEPARTMENT OF AGRICULTURE (USDA)",
-                            awarding_agency_id: 153,
-                            generated_unique_award_id: "CONT_AW_12D2_4730_AG3151B140009_GS23F0170L",
-                            last_date_to_order: "2015-04-06",
-                            awarded_amount: 47840.0,
-                            obligated_amount: 12000.0,
-                            period_of_performance_start_date: "2014-04-07",
-                            piid: "AG3151B140009",
-                            recipient_name: "Booz Allen Hamilton (BAH)",
-                            recipient_id: "9a277fc5-50fc-685f-0f77-be0d96420a17-C",
-                            grandchild: true
-                        }],
-                        page_metadata: {
-                            hasNext: true,
-                            count: 40,
-                            hasPrevious: false,
-                            limit: 10,
-                            next: 2,
-                            page: 1,
-                            previous: null,
-                            total: 111
-                        }
-                    }
-                }, 500);
-            });
+        promise: Axios.request({
+            url: 'v2/awards/idvs/activity/',
+            baseURL: kGlobalConstants.API,
+            method: 'post',
+            data,
+            cancelToken: source.token
         }),
         cancel() {
             source.cancel();

--- a/src/js/models/v2/awardsV2/BaseIdvActivityBar.js
+++ b/src/js/models/v2/awardsV2/BaseIdvActivityBar.js
@@ -13,10 +13,12 @@ const BaseIdvActivityBar = {
         this.awardingAgencyName = data.awarding_agency || '--';
         this.parentAwardId = data.parent_award_id || '--';
         this.awardingAgencyId = (data.awarding_agency_id && `${data.awarding_agency_id}`) || '--';
-        this._endDate = (data.last_date_to_order && parseDate(data.last_date_to_order)) || '--';
+        this._endDate = data.last_date_to_order ? parseDate(data.last_date_to_order) : '--';
         this._awardedAmount = data.awarded_amount || 0;
         this._obligatedAmount = data.obligated_amount || 0;
-        this._startDate = (data.period_of_performance_start_date && parseDate(data.period_of_performance_start_date)) || null;
+        this._startDate =
+        data.period_of_performance_start_date ?
+            parseDate(data.period_of_performance_start_date) : '--';
         this.piid = data.piid || '--';
         this.recipientName = data.recipient_name || '--';
         this.recipientId = data.recipient_id || '--';
@@ -35,10 +37,10 @@ const BaseIdvActivityBar = {
         ${units.unitLabel}`;
     },
     get startDate() {
-        return this._startDate ? formatDate(this._startDate) : '--';
+        return (this._startDate !== '--') ? formatDate(this._startDate) : this._endDate;
     },
     get endDate() {
-        return this._endDate ? formatDate(this._endDate) : '--';
+        return (this._endDate !== '--') ? formatDate(this._endDate) : this._endDate;
     }
 };
 

--- a/src/js/models/v2/awardsV2/BaseIdvActivityBar.js
+++ b/src/js/models/v2/awardsV2/BaseIdvActivityBar.js
@@ -12,6 +12,7 @@ const BaseIdvActivityBar = {
         this.generatedId = data.generated_unique_award_id || '--';
         this.awardingAgencyName = data.awarding_agency || '--';
         this.parentAwardId = data.parent_award_id || '--';
+        this.parentAwardPIID = data.parent_award_piid || '--';
         this.awardingAgencyId = (data.awarding_agency_id && `${data.awarding_agency_id}`) || '--';
         this._endDate = data.last_date_to_order ? parseDate(data.last_date_to_order) : '--';
         this._awardedAmount = data.awarded_amount || 0;

--- a/tests/containers/awardV2/idv/IdvActivityContainer-test.jsx
+++ b/tests/containers/awardV2/idv/IdvActivityContainer-test.jsx
@@ -1,0 +1,66 @@
+/**
+ * IdvActivityContainer-test.js
+ * Created by Jonathan Hill 6/26/2019
+**/
+
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+
+import { IdvActivityContainer } from 'containers/awardV2/idv/IdvActivityContainer';
+import BaseIdvActivityBar from 'models/v2/awardsV2/BaseIdvActivityBar';
+import { mockRedux, mockActions } from '../mockAward';
+import { mockIdvActivity } from '../../../models/awardsV2/mockAwardApi';
+
+jest.mock('helpers/idvHelper', () => require('../awardV2Helper'));
+
+// mock the child component by replacing it with a function that returns a null element
+// jest.mock('components/awardv2/idv/amounts/AggregatedAwardAmounts.jsx', () => jest.fn(() => null));
+
+describe('IdvActivityContainer', () => {
+    const loadAwards = jest.fn();
+    const parseAwards = jest.fn();
+    it('should make an API call for the awards on mount', async () => {
+        const container = mount(<IdvActivityContainer {...mockActions} {...mockRedux} />);
+
+        container.instance().loadAwards = loadAwards;
+        container.instance().parseAwards = parseAwards;
+        await container.instance().componentDidMount();
+
+        expect(loadAwards).toHaveBeenCalled();
+    });
+
+    it('should make an API call when the award ID props changes', async () => {
+        const container = shallow(<IdvActivityContainer awardId="1234" />);
+
+        container.instance().loadAwards = loadAwards;
+
+        await container.instance().componentDidMount();
+
+        container.setProps({ awardId: "456" });
+
+        expect(loadAwards).toHaveBeenCalled();
+    });
+
+    it('should parse returned awards and set the state', () => {
+        const container = shallow(<IdvActivityContainer awardId="1234" />);
+
+        const awards = mockIdvActivity.results.map((award) => {
+            const idvActivityBar = Object.create(BaseIdvActivityBar);
+            idvActivityBar.populate(award);
+            return idvActivityBar;
+        });
+
+        container.instance().parseAwards(mockIdvActivity.results);
+
+        expect(container.state().awards).toEqual(awards);
+    });
+
+    it('should change the page and update state and call api', () => {
+        const container = shallow(<IdvActivityContainer awardId="1234" />);
+        container.instance().loadAwards = loadAwards;
+        container.instance().changePage(2);
+
+        expect(container.state().page).toEqual(2);
+        expect(loadAwards).toHaveBeenCalled();
+    });
+});

--- a/tests/containers/awardV2/idv/mockIdvHelper.js
+++ b/tests/containers/awardV2/idv/mockIdvHelper.js
@@ -1,4 +1,4 @@
-import { mockAwardFederalAccounts, mockReferencedAwardCounts, mockReferencedAwards, mockFederalAccountFunding, mockAwardFundingMetaData } from '../../../models/awardsV2/mockAwardApi';
+import { mockAwardFederalAccounts, mockReferencedAwardCounts, mockReferencedAwards, mockFederalAccountFunding, mockAwardFundingMetaData, mockIdvActivity } from '../../../models/awardsV2/mockAwardApi';
 
 export const fetchReferencedAwardsCounts = () => (
     {
@@ -55,6 +55,15 @@ export const fetchAwardFederalAccounts = () => ({
     promise: new Promise((resolve) => {
         process.nextTick(() => {
             resolve({ data: mockAwardFederalAccounts });
+        });
+    }),
+    cancel: jest.fn()
+});
+
+export const fetchIdvActivity = () => ({
+    promise: new Promise((resolve) => {
+        process.nextTick(() => {
+            resolve({ data: mockIdvActivity });
         });
     }),
     cancel: jest.fn()

--- a/tests/models/awardsV2/mockAwardApi.js
+++ b/tests/models/awardsV2/mockAwardApi.js
@@ -474,3 +474,56 @@ export const mockAwardFederalAccounts = {
     ],
     total: 271716259.64
 };
+
+export const mockIdvActivity = {
+    page_metadata: {
+        hasNext: true,
+        count: 40,
+        hasPrevious: false,
+        limit: 10,
+        next: 2,
+        page: 1,
+        previous: null,
+        total: 111
+    },
+    results: [{
+        award_id: 69138778,
+        awarding_agency: "DEPARTMENT OF THE INTERIOR (DOI)",
+        awarding_agency_id: 228,
+        generated_unique_award_id: "CONT_AW_1425_4730_INR17PA00008_GS23F0170L",
+        last_date_to_order: "2019-11-30",
+        obligated_amount: 8000.0,
+        awarded_amount: 10000.0,
+        period_of_performance_start_date: "2016-01-14",
+        piid: "INR17PA00008",
+        recipient_name: "Booz Allen Hamilton",
+        recipient_id: "543ee6af-9096-f32a-abaa-834106bead6a-P",
+        grandchild: false
+    }, {
+        award_id: 69054107,
+        awarding_agency: "GENERAL SERVICES ADMINISTRATION (GSA)",
+        awarding_agency_id: 634,
+        generated_unique_award_id: "CONT_AW_4732_4730_GS33FCA001_GS23F0170L",
+        last_date_to_order: "2017-09-30",
+        obligated_amount: 2257.24,
+        awarded_amount: 20000.0,
+        period_of_performance_start_date: "2014-10-01",
+        piid: "GS33FCA001",
+        recipient_name: "Booz Allen Hamilton",
+        recipient_id: "9a277fc5-50fc-685f-0f77-be0d96420a17-C",
+        grandchild: false
+    }, {
+        award_id: 69216438,
+        awarding_agency: "DEPARTMENT OF AGRICULTURE (USDA)",
+        awarding_agency_id: 153,
+        generated_unique_award_id: "CONT_AW_12D2_4730_AG3151B140009_GS23F0170L",
+        last_date_to_order: "2015-04-06",
+        awarded_amount: 47840.0,
+        obligated_amount: 12000.0,
+        period_of_performance_start_date: "2014-04-07",
+        piid: "AG3151B140009",
+        recipient_name: "Booz Allen Hamilton",
+        recipient_id: "9a277fc5-50fc-685f-0f77-be0d96420a17-C",
+        grandchild: true
+    }]
+};


### PR DESCRIPTION
**Do Not Merge**
- [x] https://github.com/fedspendingtransparency/usaspending-website/pull/1144 Loading messages
- [x] Considering Ross's comments in Slack `since this chart only shows contract award children/grandchildren of a given IDV, and not contract IDV children, we would expect ordering_period_end_date to be blank for everything shown here. if ordering_period_end_date is being returned as part of the API contract for this chart, or the basis for anything displayed on this chart, there seems to be a mistake and it needs to be remapped`. We are going to hold off on merging this PR until we figure out the correct mapping with design and the backend team.
https://federal-spending-transparency.atlassian.net/browse/DEV-2970

**High level description:**

Add API Call to IDV Activity Chart

**Technical details:**

* update api call
* add tests
* update mock api
* update mock data

**JIRA Ticket:**
[DEV-2909](https://federal-spending-transparency.atlassian.net/browse/DEV-2909)

The following are ALL required for the PR to be merged:
- [ ] Code review
