### PR TITLE
[DEV-2904 & 2787] Auto-populate foreign country on city selection, handling city deselection as well

### DIFF
--- a/src/js/components/search/filters/location/LocationPicker.jsx
+++ b/src/js/components/search/filters/location/LocationPicker.jsx
@@ -53,6 +53,7 @@ export default class LocationPicker extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
+        // a state that was autoPopulated and then removed via city de-selection will have prevProps.state.autoPopulated === true
         const manuallyPopulatedStateChanged = (!prevProps.state.autoPopulated && (prevProps.state.code !== this.props.state.code));
         const manuallyPopulatedCountryChanged = (!this.props.country.autoPopulated && (prevProps.country.code !== this.props.country.code));
         const stateChanged = (prevProps.state.code !== this.props.state.code);

--- a/src/js/components/search/filters/location/LocationPicker.jsx
+++ b/src/js/components/search/filters/location/LocationPicker.jsx
@@ -54,25 +54,32 @@ export default class LocationPicker extends React.Component {
 
     componentDidUpdate(prevProps) {
         const manuallyPopulatedStateChanged = (!prevProps.state.autoPopulated && (prevProps.state.code !== this.props.state.code));
+        const manuallyPopulatedCountryChanged = (!this.props.country.autoPopulated && (prevProps.country.code !== this.props.country.code));
         const stateChanged = (prevProps.state.code !== this.props.state.code);
         const countryChanged = (prevProps.country.code !== this.props.country.code);
         const isCityInState = ( // selected city is w/in the selected state
+            this.props.country.code === 'USA' &&
             this.props.state.code === this.props.city.code &&
             this.props.state.code && this.props.city.code
         );
+
         const cityDeselected = (prevProps.city.name && !this.props.city.name);
 
         if (countryChanged && this.props.country.code === "USA") {
             // user has selected USA, load the state list
             this.props.loadStates();
-            this.props.clearCitiesAndSelectedCity();
+            if (manuallyPopulatedCountryChanged) {
+                this.props.clearCitiesAndSelectedCity();
+            }
         }
         else if (countryChanged && prevProps.country.code === 'USA') {
             // the user previously selected USA, need to clear these out
             this.props.clearStates();
-            this.props.clearCitiesAndSelectedCity();
+            if (manuallyPopulatedCountryChanged) {
+                this.props.clearCitiesAndSelectedCity();
+            }
         }
-        else if (countryChanged) {
+        else if (manuallyPopulatedCountryChanged) {
             //  since USA isn't selected and wasn't previously selected, only clear cities
             this.props.clearCitiesAndSelectedCity();
         }
@@ -96,6 +103,9 @@ export default class LocationPicker extends React.Component {
         if (cityDeselected && this.props.state.autoPopulated) {
             // city was deselected which auto populated state selection, so clear the state selection
             this.props.selectEntity('state', defaultLocationValues.state);
+        }
+        else if (cityDeselected && this.props.country.autoPopulated) {
+            this.props.selectEntity('country', { code: "FOREIGN", name: "ALL FOREIGN COUNTRIES", autoPopulated: true });
         }
     }
 

--- a/src/js/containers/search/filters/location/LocationPickerContainer.jsx
+++ b/src/js/containers/search/filters/location/LocationPickerContainer.jsx
@@ -317,10 +317,10 @@ export default class LocationPickerContainer extends React.Component {
         else if (shouldAutoPopulateCountry) {
             const countryFromCity = this.state.availableCountries
                 .filter((country) => country.code === value.code)
-                .reduce((acc, country) => ({ ...acc, ...country, autoPopulated: true }), {
-                    code: "FOREIGN",
-                    name: "ALL FOREIGN COUNTRIES"
-                });
+                .reduce(
+                    (acc, country) => ({ ...acc, ...country, autoPopulated: true }),
+                    { code: "FOREIGN", name: "ALL FOREIGN COUNTRIES" }
+                );
             this.setState({ country: countryFromCity });
         }
         this.setState({

--- a/src/js/containers/search/filters/location/LocationPickerContainer.jsx
+++ b/src/js/containers/search/filters/location/LocationPickerContainer.jsx
@@ -3,14 +3,19 @@
  * Created by Kevin Li 10/30/17
  */
 
-import React from 'react';
-import PropTypes from 'prop-types';
-import { isCancel } from 'axios';
-import { concat, debounce } from 'lodash';
+import React from "react";
+import PropTypes from "prop-types";
+import { isCancel } from "axios";
+import { concat, debounce } from "lodash";
 
-import { fetchLocationList, performZIPGeocode, fetchCityResults, getCitySearchRequestObj } from 'helpers/mapHelper';
+import {
+    fetchLocationList,
+    performZIPGeocode,
+    fetchCityResults,
+    getCitySearchRequestObj
+} from "helpers/mapHelper";
 
-import LocationPicker from 'components/search/filters/location/LocationPicker';
+import LocationPicker from "components/search/filters/location/LocationPicker";
 
 const propTypes = {
     selectedLocations: PropTypes.object,
@@ -25,33 +30,34 @@ const defaultProps = {
 
 export const defaultLocationValues = {
     country: {
-        code: '',
-        name: ''
+        code: "",
+        name: "",
+        autoPopulated: false
     },
     state: {
-        code: '',
-        fips: '',
-        name: '',
+        code: "",
+        fips: "",
+        name: "",
         autoPopulated: false // from city selection
     },
     county: {
-        code: '',
-        fips: '',
-        state: '',
-        name: ''
+        code: "",
+        fips: "",
+        state: "",
+        name: ""
     },
     city: {
-        name: '',
-        code: ''
+        name: "",
+        code: ""
     },
     district: {
-        code: '',
-        district: '',
-        name: ''
+        code: "",
+        district: "",
+        name: ""
     },
     zip: {
-        valid: '',
-        invalid: ''
+        valid: "",
+        invalid: ""
     }
 };
 
@@ -71,7 +77,7 @@ export default class LocationPickerContainer extends React.Component {
             city: Object.assign({}, defaultLocationValues.city),
             district: Object.assign({}, defaultLocationValues.district),
             zip: Object.assign({}, defaultLocationValues.zip),
-            citySearchString: '',
+            citySearchString: "",
             loading: false
         };
 
@@ -122,7 +128,7 @@ export default class LocationPickerContainer extends React.Component {
             this.listRequest.cancel();
         }
 
-        this.listRequest = fetchLocationList('countries');
+        this.listRequest = fetchLocationList("countries");
 
         this.listRequest.promise
             .then((res) => {
@@ -137,16 +143,12 @@ export default class LocationPickerContainer extends React.Component {
 
     parseCountries(data) {
         // put USA and an "all foreign countries" option at the start of the list
-        const countries = concat([{
-            code: 'USA',
-            name: 'UNITED STATES'
-        }, {
-            code: 'FOREIGN',
-            name: 'ALL FOREIGN COUNTRIES'
-        }, {
-            code: '',
-            name: '---'
-        }], data.countries);
+        const countries = [
+            { code: "USA", name: "UNITED STATES" },
+            { code: "FOREIGN", name: "ALL FOREIGN COUNTRIES" },
+            { code: "", name: "---" },
+            ...data.countries
+        ].map((country) => ({ ...country, autoPopulated: false }));
         this.setState({
             availableCountries: countries
         });
@@ -157,7 +159,7 @@ export default class LocationPickerContainer extends React.Component {
             this.listRequest.cancel();
         }
 
-        this.listRequest = fetchLocationList('states');
+        this.listRequest = fetchLocationList("states");
 
         this.listRequest.promise
             .then((res) => {
@@ -173,8 +175,10 @@ export default class LocationPickerContainer extends React.Component {
     parseStates(data) {
         // prepend a blank state to act as a de-select option
         if (data.states.length > 0) {
-            const states = [{ ...defaultLocationValues.state, name: 'All states' }, ...data.states]
-                .map((state) => ({ ...state, autoPopulated: false }));
+            const states = [
+                { ...defaultLocationValues.state, name: "All states" },
+                ...data.states
+            ].map((state) => ({ ...state, autoPopulated: false }));
             this.setState({
                 availableStates: states
             });
@@ -195,7 +199,7 @@ export default class LocationPickerContainer extends React.Component {
         this.setState({
             availableCities: [],
             city: defaultLocationValues.city,
-            citySearchString: ''
+            citySearchString: ""
         });
     }
 
@@ -221,9 +225,14 @@ export default class LocationPickerContainer extends React.Component {
         // prepend a blank county to act as a de-select option
         let counties = [];
         if (data.counties.length > 0) {
-            counties = concat([Object.assign({}, defaultLocationValues.county, {
-                name: 'All counties'
-            })], data.counties);
+            counties = concat(
+                [
+                    Object.assign({}, defaultLocationValues.county, {
+                        name: "All counties"
+                    })
+                ],
+                data.counties
+            );
         }
         this.setState({
             availableCounties: counties,
@@ -260,9 +269,14 @@ export default class LocationPickerContainer extends React.Component {
         // prepend a blank district to act as a de-select option
         let districts = [];
         if (data.districts.length > 0) {
-            districts = concat([Object.assign({}, defaultLocationValues.district, {
-                name: 'All congressional districts'
-            })], data.districts);
+            districts = concat(
+                [
+                    Object.assign({}, defaultLocationValues.district, {
+                        name: "All congressional districts"
+                    })
+                ],
+                data.districts
+            );
         }
 
         this.setState({
@@ -280,15 +294,34 @@ export default class LocationPickerContainer extends React.Component {
 
     selectEntity(level, value) {
         const shouldAutoPopulateState = (
-            level === 'city' &&
+            level === "city" &&
+            this.state.country.code === "USA" &&
             this.state.state.code !== value.code &&
+            value.code
+        );
+        const shouldAutoPopulateCountry = (
+            level === "city" &&
+            this.state.country.code !== "USA" &&
+            this.state.country.code !== value.code &&
             value.code
         );
         if (shouldAutoPopulateState) {
             const stateFromCity = this.state.availableStates
                 .filter((state) => state.code === value.code)
-                .reduce((acc, state) => ({ ...acc, ...state, autoPopulated: true }), defaultLocationValues.state);
+                .reduce(
+                    (acc, state) => ({ ...acc, ...state, autoPopulated: true }),
+                    defaultLocationValues.state
+                );
             this.setState({ state: stateFromCity });
+        }
+        else if (shouldAutoPopulateCountry) {
+            const countryFromCity = this.state.availableCountries
+                .filter((country) => country.code === value.code)
+                .reduce((acc, country) => ({ ...acc, ...country, autoPopulated: true }), {
+                    code: "FOREIGN",
+                    name: "ALL FOREIGN COUNTRIES"
+                });
+            this.setState({ country: countryFromCity });
         }
         this.setState({
             [level]: value
@@ -298,49 +331,49 @@ export default class LocationPickerContainer extends React.Component {
     createLocationObject() {
         // create a location object
         const location = {};
-        let title = '';
-        let standalone = '';
-        let entity = '';
-        let identifier = '';
-        if (this.state.country.code === '') {
+        let title = "";
+        let standalone = "";
+        let entity = "";
+        let identifier = "";
+        if (this.state.country.code === "") {
             // do nothing, it's an empty filter
             return null;
         }
         location.country = this.state.country.code;
         title = this.state.country.name;
         standalone = this.state.country.name;
-        entity = 'Country';
+        entity = "Country";
         identifier += this.state.country.code;
 
-        if (this.state.state.code !== '') {
+        if (this.state.state.code !== "") {
             location.state = this.state.state.code;
             title = this.state.state.name;
             standalone = this.state.state.name;
-            entity = 'State';
+            entity = "State";
             identifier += `_${this.state.state.code}`;
         }
 
-        if (this.state.county.code !== '') {
+        if (this.state.county.code !== "") {
             location.county = this.state.county.fips;
             title = this.state.county.name;
             standalone = `${this.state.county.name}, ${this.state.state.code}`;
-            entity = 'County';
+            entity = "County";
             identifier += `_${this.state.county.fips}`;
         }
-        else if (this.state.district.code !== '') {
+        else if (this.state.district.code !== "") {
             location.district = this.state.district.district;
             title = this.state.district.name;
             standalone = this.state.district.name;
-            entity = 'Congressional district';
+            entity = "Congressional district";
             identifier += `_${this.state.district.district}`;
         }
 
-        if (this.state.city.name !== '') {
-            const city = this.state.city.name.split(',')[0];
+        if (this.state.city.name !== "") {
+            const city = this.state.city.name.split(",")[0];
             location.city = city;
             title = this.state.city.name;
             standalone = `${this.state.city.name}`;
-            entity = 'City';
+            entity = "City";
             identifier += `_${city}`;
         }
 
@@ -366,7 +399,7 @@ export default class LocationPickerContainer extends React.Component {
     }
 
     addZip() {
-        if (this.state.zip.valid === '') {
+        if (this.state.zip.valid === "") {
             // no zip
             return;
         }
@@ -376,11 +409,11 @@ export default class LocationPickerContainer extends React.Component {
             identifier: `USA_${this.state.zip.valid}`,
             display: {
                 title: this.state.zip.valid,
-                entity: 'ZIP Code',
+                entity: "ZIP Code",
                 standalone: this.state.zip.valid
             },
             filter: {
-                country: 'USA',
+                country: "USA",
                 zip: this.state.zip.valid
             }
         };
@@ -426,7 +459,9 @@ export default class LocationPickerContainer extends React.Component {
             this.setState({ loading: true });
         }
 
-        this.cityRequest = fetchCityResults(getCitySearchRequestObj(citySearchString, state.code, country.code, this.props.scope));
+        this.cityRequest = fetchCityResults(
+            getCitySearchRequestObj(citySearchString, state.code, country.code, this.props.scope)
+        );
 
         this.cityRequest.promise
             .then((res) => {
@@ -454,9 +489,10 @@ export default class LocationPickerContainer extends React.Component {
     parseCities(results) {
         this.setState({
             availableCities: results.map((city) => ({
-                name: (city.state_code === "NA-000" || !city.state_code) // NA-000 is no results found
-                    ? city.city_name
-                    : `${city.city_name}, ${city.state_code}`,
+                name:
+                    city.state_code === "NA-000" || !city.state_code // NA-000 is no results found
+                        ? city.city_name
+                        : `${city.city_name}, ${city.state_code}`,
                 code: city.state_code
             }))
         });
@@ -475,21 +511,24 @@ export default class LocationPickerContainer extends React.Component {
     invalidZip(zip) {
         this.setState({
             zip: {
-                valid: '',
+                valid: "",
                 invalid: zip
             }
         });
     }
 
     validZip(zip) {
-        this.setState({
-            zip: {
-                valid: zip,
-                invalid: ''
+        this.setState(
+            {
+                zip: {
+                    valid: zip,
+                    invalid: ""
+                }
+            },
+            () => {
+                this.addZip(zip);
             }
-        }, () => {
-            this.addZip(zip);
-        });
+        );
     }
 
     render() {

--- a/tests/components/search/filters/location/LocationPicker-test.jsx
+++ b/tests/components/search/filters/location/LocationPicker-test.jsx
@@ -67,9 +67,15 @@ describe('componentDidMount', () => {
             expect(defaultProps.loadCounties).toHaveBeenCalledTimes(1);
             expect(defaultProps.loadDistricts).toHaveBeenCalledTimes(1);
         });
+
         it('does not clear the selected city if it is within the newly selected state', () => {
-            const wrapper = shallow(<LocationPicker {...{ ...defaultProps, state: { ...defaultProps.state, code: "GA" }, city: { ...defaultProps.city, code: "GA" } }} />);
-            wrapper.instance().componentDidUpdate({ ...defaultProps, state: { ...defaultProps.state, code: "SC" }, city: { ...defaultProps.city, code: "SC" } });
+            const wrapper = shallow(<LocationPicker {...{
+                ...defaultProps,
+                country: { ...defaultProps.country, code: "USA" },
+                state: { ...defaultProps.state, code: "GA" },
+                city: { ...defaultProps.city, code: "GA" }
+            }} />);
+            wrapper.instance().componentDidUpdate({ ...defaultProps, country: { ...defaultProps.country, code: "USA" }, state: { ...defaultProps.state, code: "SC" }, city: { ...defaultProps.city, code: "SC" } });
             expect(defaultProps.clearCitiesAndSelectedCity).not.toHaveBeenCalled();
         });
 
@@ -116,7 +122,7 @@ describe('componentDidMount', () => {
         });
     });
 
-    describe('When the selected city changes', () => {
+    describe('When the selected city is deselected', () => {
         it('clears the selected state if the previous state selection was auto-populated', () => {
             const wrapper = shallow(<LocationPicker {...{ ...defaultProps, state: { ...defaultProps.state, code: 'GA', autoPopulated: true } }} />).instance();
             wrapper.componentDidUpdate({ ...defaultProps, city: { ...defaultProps.city, name: "Atlanta" }, state: { ...defaultProps.state, code: 'GA', autoPopulated: true } });
@@ -128,6 +134,25 @@ describe('componentDidMount', () => {
         it('persists the selected state if (a) the city is within the state and (b) the state was selected manually', () => {
             const wrapper = shallow(<LocationPicker {...{ ...defaultProps, state: { ...defaultProps.state, code: 'GA' } }} />).instance();
             wrapper.componentDidUpdate({ ...defaultProps, city: { ...defaultProps.city, name: "Atlanta" }, state: { ...defaultProps.state, code: 'GA' } });
+            expect(defaultProps.selectEntity).not.toHaveBeenCalled();
+        });
+
+        it('clears the selected country if it was auto-populated', () => {
+            const countrySelection = { ...defaultProps.country, code: 'GBR', autoPopulated: true };
+            const citySelection = { ...defaultProps.city, name: "London" };
+            const wrapper = shallow(<LocationPicker {...{ ...defaultProps, country: countrySelection }} />).instance();
+            wrapper.componentDidUpdate({ ...defaultProps, city: citySelection, country: countrySelection });
+            expect(defaultProps.selectEntity).toHaveBeenCalledWith('country', { code: "FOREIGN", name: "ALL FOREIGN COUNTRIES", autoPopulated: true });
+        });
+
+        jest.resetAllMocks();
+
+        it('persists the selected country if (a) the city is within the country and (b) the country was manually selected', () => {
+            const previousCountry = { ...defaultProps.country, code: 'FOREIGN', autoPopulated: true };
+            const currentCountry = { ...defaultProps.country, code: 'GBR', autoPopulated: false };
+            const citySelection = { ...defaultProps.city, name: "London", code: 'GBR' };
+            const wrapper = shallow(<LocationPicker {...{ ...defaultProps, city: citySelection, country: currentCountry }} />).instance();
+            wrapper.componentDidUpdate({ ...defaultProps, city: citySelection, country: previousCountry });
             expect(defaultProps.selectEntity).not.toHaveBeenCalled();
         });
     });

--- a/tests/containers/search/filters/location/LocationPickerContainer-test.jsx
+++ b/tests/containers/search/filters/location/LocationPickerContainer-test.jsx
@@ -193,9 +193,12 @@ describe('LocationPickerContainer', () => {
 
         it('if level is city, should auto-populate selected country to city\'s country (if different)', () => {
             const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
-            container.instance().setState({ availableStates: [{ code: 'TST' }], country: { code: "FOREIGN" } });
+            container.instance().setState({
+                availableCountries: [{ code: 'GBR' }, { code: 'FOREIGN' }, { code: 'USA' }],
+                country: { code: "FOREIGN" }
+            });
             container.instance().selectEntity('city', { name: 'test', code: 'GBR' });
-            expect(container.state().state.code).toEqual('GBR');
+            expect(container.state().country.code).toEqual('GBR');
             expect(container.state().city.name).toEqual('test');
         });
     });

--- a/tests/containers/search/filters/location/LocationPickerContainer-test.jsx
+++ b/tests/containers/search/filters/location/LocationPickerContainer-test.jsx
@@ -27,16 +27,20 @@ describe('LocationPickerContainer', () => {
             expect(container.state().availableCountries).toEqual([
                 {
                     code: 'USA',
-                    name: 'UNITED STATES'
+                    name: 'UNITED STATES',
+                    autoPopulated: false
                 }, {
                     code: 'FOREIGN',
-                    name: 'ALL FOREIGN COUNTRIES'
+                    name: 'ALL FOREIGN COUNTRIES',
+                    autoPopulated: false
                 }, {
                     code: '',
-                    name: '---'
+                    name: '---',
+                    autoPopulated: false
                 }, {
                     code: 'ABC',
-                    name: 'A Big Country'
+                    name: 'A Big Country',
+                    autoPopulated: false
                 }
             ]);
         });
@@ -163,24 +167,35 @@ describe('LocationPickerContainer', () => {
             const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
             expect(container.state().country).toEqual({
                 code: '',
-                name: ''
+                name: '',
+                autoPopulated: false
             });
 
             container.instance().selectEntity('country', {
                 code: 'ABC',
-                name: 'A Big Country'
+                name: 'A Big Country',
+                autoPopulated: false
             });
 
             expect(container.state().country).toEqual({
                 code: 'ABC',
-                name: 'A Big Country'
+                name: 'A Big Country',
+                autoPopulated: false
             });
         });
-        it('if level is city, should auto-populate corresponding state if different from previous state', () => {
+        it('if level is city, should auto-populate selected state to city\'s state (if different)', () => {
             const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
-            container.instance().setState({ availableStates: [{ code: 'TST' }] });
+            container.instance().setState({ availableStates: [{ code: 'TST' }], country: { code: "USA" } });
             container.instance().selectEntity('city', { name: 'test', code: 'TST' });
             expect(container.state().state.code).toEqual('TST');
+            expect(container.state().city.name).toEqual('test');
+        });
+
+        it('if level is city, should auto-populate selected country to city\'s country (if different)', () => {
+            const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
+            container.instance().setState({ availableStates: [{ code: 'TST' }], country: { code: "FOREIGN" } });
+            container.instance().selectEntity('city', { name: 'test', code: 'GBR' });
+            expect(container.state().state.code).toEqual('GBR');
             expect(container.state().city.name).toEqual('test');
         });
     });


### PR DESCRIPTION
**High level description:**
2 things addressed in this PR: 

1. Auto-selecting a country after foreign city selection
2. Handling city de-selection on back space:
- If city-selection resulted in auto-population of country selection, then deselect country

**Technical details:**
### LocationPickerContainer
- parseCountries changes `this.state.state`to now has property `autoPopulated`
- `this.selectEntity()` auto-selects country based when country selection is "All Foreign countries"
- All the rest of the updates are prettier updates (my bad!!)

### LocationPicker
- lots of logic in componentDidUpdate 
- Lots of unit tests for logic

**JIRA Ticket:**
[DEV-2904](https://federal-spending-transparency.atlassian.net/browse/DEV-2904)

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] local demo confirming UX w/ Melissa
- [x] ~Elastic search re-indexed (no pr open yet)~ will be re-indexed during deploy, these changes do not break anything.