### PR TITLE
[DEV-2788] Adds test for base parent award details model file per comment in #1145

### DIFF
--- a/tests/models/awardsV2/BaseParentAwardDetails-test.js
+++ b/tests/models/awardsV2/BaseParentAwardDetails-test.js
@@ -1,0 +1,30 @@
+/**
+ * Base Parent Award Details test
+ * Created by maxwell kendall 06/28/19
+ */
+
+import parentAwardDetails from "../../../src/js/models/v2/awardsV2/BaseParentAwardDetails";
+
+const mockData = {
+    award_id: 'test_award_id',
+    idv_type_description: 'test_idv_type_description',
+    type_of_idc_description: 'test_',
+    agency_id: 'test_agency_id',
+    agency_name: 'test_agency_name',
+    multiple_or_single_aw_desc: 'test_multiple_or_single_aw_desc',
+    piid: 'test_piid'
+};
+
+describe('parentAwardDetails', () => {
+    it('successfully populates the object with the expected shape and value', () => {
+        const result = Object.create(parentAwardDetails);
+        result.populateCore(mockData);
+        expect(result.awardId).toEqual(mockData.award_id);
+        expect(result.idvType).toEqual(mockData.idv_type_description);
+        expect(result.idcType).toEqual(mockData.type_of_idc_description);
+        expect(result.agencyId).toEqual(mockData.agency_id);
+        expect(result.agencyName).toEqual(mockData.agency_name);
+        expect(result.multipleOrSingle).toEqual(mockData.multiple_or_single_aw_desc);
+        expect(result.piid).toEqual(mockData.piid);
+    });
+});

--- a/tests/models/awardsV2/BaseParentAwardDetails-test.js
+++ b/tests/models/awardsV2/BaseParentAwardDetails-test.js
@@ -4,21 +4,13 @@
  */
 
 import parentAwardDetails from "../../../src/js/models/v2/awardsV2/BaseParentAwardDetails";
-
-const mockData = {
-    award_id: 'test_award_id',
-    idv_type_description: 'test_idv_type_description',
-    type_of_idc_description: 'test_',
-    agency_id: 'test_agency_id',
-    agency_name: 'test_agency_name',
-    multiple_or_single_aw_desc: 'test_multiple_or_single_aw_desc',
-    piid: 'test_piid'
-};
+import { mockIdv } from "./mockAwardApi";
 
 describe('parentAwardDetails', () => {
+    const mockData = mockIdv.parent_award;
     it('successfully populates the object with the expected shape and value', () => {
         const result = Object.create(parentAwardDetails);
-        result.populateCore(mockData);
+        result.populateCore(mockIdv.parent_award);
         expect(result.awardId).toEqual(mockData.award_id);
         expect(result.idvType).toEqual(mockData.idv_type_description);
         expect(result.idcType).toEqual(mockData.type_of_idc_description);

--- a/tests/models/awardsV2/mockAwardApi.js
+++ b/tests/models/awardsV2/mockAwardApi.js
@@ -245,6 +245,7 @@ export const mockIdv = {
         idv_type_description: 'test',
         type_of_idc_description: 'r3w',
         agency_id: '123',
+        agency_name: 'test',
         multiple_or_single_aw_desc: 'something',
         piid: '345'
     },


### PR DESCRIPTION
**High level description:**
Adds simple test for baseParentAwardDetails.js mentioned in comment in PR #1145

**Technical details:**
Tests `populateCore` method

**JIRA Ticket:**
[DEV-2788](https://federal-spending-transparency.atlassian.net/browse/DEV-2788)

The following are ALL required for the PR to be merged:
- [x] Code review
