### PR TITLE
[DEV-3017] Searching for Cities with Commas & Refactor of Tests + Class Method 

### DIFF
--- a/src/js/containers/search/filters/location/LocationPickerContainer.jsx
+++ b/src/js/containers/search/filters/location/LocationPickerContainer.jsx
@@ -61,6 +61,16 @@ export const defaultLocationValues = {
     }
 };
 
+const locationProperties = ["country", "state", "district", "county", "city"];
+// Map to unique value for this.state.locationProperty
+const locationPropertyAccessorMap = {
+    country: 'code',
+    city: 'name',
+    district: 'district',
+    state: 'code',
+    county: 'fips'
+};
+
 export default class LocationPickerContainer extends React.Component {
     constructor(props) {
         super(props);
@@ -329,66 +339,33 @@ export default class LocationPickerContainer extends React.Component {
     }
 
     createLocationObject() {
-        // create a location object
-        const location = {};
-        let title = "";
-        let standalone = "";
-        let entity = "";
-        let identifier = "";
-        if (this.state.country.code === "") {
-            // do nothing, it's an empty filter
-            return null;
-        }
-        location.country = this.state.country.code;
-        title = this.state.country.name;
-        standalone = this.state.country.name;
-        entity = "Country";
-        identifier += this.state.country.code;
-
-        if (this.state.state.code !== "") {
-            location.state = this.state.state.code;
-            title = this.state.state.name;
-            standalone = this.state.state.name;
-            entity = "State";
-            identifier += `_${this.state.state.code}`;
-        }
-
-        if (this.state.county.code !== "") {
-            location.county = this.state.county.fips;
-            title = this.state.county.name;
-            standalone = `${this.state.county.name}, ${this.state.state.code}`;
-            entity = "County";
-            identifier += `_${this.state.county.fips}`;
-        }
-        else if (this.state.district.code !== "") {
-            location.district = this.state.district.district;
-            title = this.state.district.name;
-            standalone = this.state.district.name;
-            entity = "Congressional district";
-            identifier += `_${this.state.district.district}`;
-        }
-
-        if (this.state.city.name !== "") {
-            const city = this.state.city.name.split(", ").filter((str) => str !== this.state.city.code).join(", ");
-            location.city = city;
-            title = this.state.city.name;
-            standalone = `${this.state.city.name}`;
-            entity = "City";
-            identifier += `_${city}`;
-        }
-
-        // generate a display tag
-        const display = {
-            title,
-            entity,
-            standalone
-        };
-
-        return {
-            identifier,
-            display,
-            filter: location
-        };
+        return Object.keys(this.state)
+            .filter((prop) => locationProperties.includes(prop) && this.state[prop].code !== '')
+            .reduce((acc, prop) => {
+                const accessor = locationPropertyAccessorMap[prop];
+                // removes ', <State/Country>' appended to city
+                const parsedKeyValue = prop === 'city'
+                    ? this.state.city.name.split(", ").filter((str) => str !== this.state.city.code).join(", ")
+                    : this.state[prop][accessor];
+                return {
+                    identifier: prop === 'country' // init identifier value w/o appended '_'
+                        ? this.state.country.code
+                        : `${acc.identifier}_${parsedKeyValue}`,
+                    filter: {
+                        ...acc.filter,
+                        [prop]: parsedKeyValue
+                    },
+                    display: {
+                        entity: prop === 'district'
+                            ? 'Congressional district'
+                            : `${prop.substr(0, 1).toUpperCase()}${prop.substr(1)}`,
+                        standalone: prop === 'county'
+                            ? `${this.state.county.name}, ${this.state.state.code}`
+                            : this.state[prop].name,
+                        title: this.state[prop].name
+                    }
+                };
+            }, { identifier: '', display: { entity: '', title: '', standalone: '' }, filter: {} });
     }
 
     addLocation() {

--- a/src/js/containers/search/filters/location/LocationPickerContainer.jsx
+++ b/src/js/containers/search/filters/location/LocationPickerContainer.jsx
@@ -369,7 +369,7 @@ export default class LocationPickerContainer extends React.Component {
         }
 
         if (this.state.city.name !== "") {
-            const city = this.state.city.name.split(",")[0];
+            const city = this.state.city.name.split(", ").filter((str) => str !== this.state.city.code).join(", ");
             location.city = city;
             title = this.state.city.name;
             standalone = `${this.state.city.name}`;

--- a/tests/containers/search/filters/location/LocationPickerContainer-test.jsx
+++ b/tests/containers/search/filters/location/LocationPickerContainer-test.jsx
@@ -205,6 +205,7 @@ describe('LocationPickerContainer', () => {
 
     describe('createLocationObject', () => {
         describe('location identifiers', () => {
+            // COUNTRY IDENTIFIER
             it('should create an identifier that is equal to the country code if only a country is selected', () => {
                 const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
                 container.setState({
@@ -217,6 +218,7 @@ describe('LocationPickerContainer', () => {
                 const location = container.instance().createLocationObject();
                 expect(location.identifier).toEqual('ABC');
             });
+            // STATE IDENTIFIER
             it('should create an identifier that contains the country code and state code if a state is selected', () => {
                 const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
                 container.setState({
@@ -234,6 +236,7 @@ describe('LocationPickerContainer', () => {
                 const location = container.instance().createLocationObject();
                 expect(location.identifier).toEqual('ABC_AK');
             });
+            // COUNTY IDENTIFIER
             it('should create an identifier that contains the country, state, and county codes if a county is selected', () => {
                 const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
                 container.setState({
@@ -257,6 +260,7 @@ describe('LocationPickerContainer', () => {
                 const location = container.instance().createLocationObject();
                 expect(location.identifier).toEqual('ABC_AK_000');
             });
+            // DISTRICT IDENTIFIER
             it('when a district is selected -- identifier should contain the country, state, and district codes', () => {
                 const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
                 container.setState({
@@ -279,6 +283,8 @@ describe('LocationPickerContainer', () => {
                 const location = container.instance().createLocationObject();
                 expect(location.identifier).toEqual('ABC_AK_99');
             });
+
+            // CITY IDENTIFIER
             it('when a city is selected -- identifier should contain the city details', () => {
                 const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
                 container.setState({
@@ -296,37 +302,38 @@ describe('LocationPickerContainer', () => {
                 const location = container.instance().createLocationObject();
                 expect(location.identifier).toEqual('ABC_TST_test');
             });
-        });
-
-        it('should handle cities with commas', () => {
-            const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
-            container.setState({
-                country: {
-                    code: 'GBR',
-                    name: 'United Kingdom'
-                },
-                city: {
-                    code: "GBR",
-                    name: "London, Kent"
-                }
-            });
-
-            const location = container.instance().createLocationObject();
-            expect(location).toEqual({
-                identifier: 'GBR_London, Kent',
-                display: {
-                    title: 'London, Kent',
-                    entity: 'City',
-                    standalone: 'London, Kent'
-                },
-                filter: {
-                    country: 'GBR',
-                    city: 'London, Kent'
-                }
+            // CITY w/ COMMAS IDENTIFIER
+            it('should handle cities with commas', () => {
+                const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
+                container.setState({
+                    country: {
+                        code: 'GBR',
+                        name: 'United Kingdom'
+                    },
+                    city: {
+                        code: "GBR",
+                        name: "London, Kent"
+                    }
+                });
+    
+                const location = container.instance().createLocationObject();
+                expect(location).toEqual({
+                    identifier: 'GBR_London, Kent',
+                    display: {
+                        title: 'London, Kent',
+                        entity: 'City',
+                        standalone: 'London, Kent'
+                    },
+                    filter: {
+                        country: 'GBR',
+                        city: 'London, Kent'
+                    }
+                });
             });
         });
 
         describe('API filter object', () => {
+            // COUNTRY API REQUEST OBJECT
             it('should create a filter object that contains only the country code if only a country is selected', () => {
                 const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
                 container.setState({
@@ -341,6 +348,7 @@ describe('LocationPickerContainer', () => {
                     country: 'ABC'
                 });
             });
+            // STATE API REQUEST OBJECT
             it('should create filter object that contains the country code and state code if a state is selected', () => {
                 const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
                 container.setState({
@@ -361,6 +369,7 @@ describe('LocationPickerContainer', () => {
                     state: 'AK'
                 });
             });
+            // COUNTY API REQUEST OBJECT
             it('should create a filter object that contains the country, state, and county codes if a county is selected', () => {
                 const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
                 container.setState({
@@ -388,6 +397,7 @@ describe('LocationPickerContainer', () => {
                     county: '000'
                 });
             });
+            // DISTRICT API REQUEST OBJECT
             it('should create a filter object that contains the country, state, and district codes if a district is selected', () => {
                 const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
                 container.setState({
@@ -414,6 +424,7 @@ describe('LocationPickerContainer', () => {
                     district: '99'
                 });
             });
+            // CITY API REQUEST OBJECT
         });
 
 

--- a/tests/containers/search/filters/location/LocationPickerContainer-test.jsx
+++ b/tests/containers/search/filters/location/LocationPickerContainer-test.jsx
@@ -298,6 +298,34 @@ describe('LocationPickerContainer', () => {
             });
         });
 
+        it('should handle cities with commas', () => {
+            const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
+            container.setState({
+                country: {
+                    code: 'GBR',
+                    name: 'United Kingdom'
+                },
+                city: {
+                    code: "GBR",
+                    name: "London, Kent"
+                }
+            });
+
+            const location = container.instance().createLocationObject();
+            expect(location).toEqual({
+                identifier: 'GBR_London, Kent',
+                display: {
+                    title: 'London, Kent',
+                    entity: 'City',
+                    standalone: 'London, Kent'
+                },
+                filter: {
+                    country: 'GBR',
+                    city: 'London, Kent'
+                }
+            });
+        });
+
         describe('API filter object', () => {
             it('should create a filter object that contains only the country code if only a country is selected', () => {
                 const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);

--- a/tests/containers/search/filters/location/LocationPickerContainer-test.jsx
+++ b/tests/containers/search/filters/location/LocationPickerContainer-test.jsx
@@ -204,318 +204,195 @@ describe('LocationPickerContainer', () => {
     });
 
     describe('createLocationObject', () => {
-        describe('location identifiers', () => {
-            // COUNTRY IDENTIFIER
-            it('should create an identifier that is equal to the country code if only a country is selected', () => {
-                const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
-                container.setState({
-                    country: {
-                        code: 'ABC',
-                        name: 'A Big Country'
-                    }
-                });
-
-                const location = container.instance().createLocationObject();
+        describe('Country selection', () => {
+            const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
+            container.setState({
+                country: {
+                    code: 'ABC',
+                    name: 'A Big Country'
+                }
+            });
+            const location = container.instance().createLocationObject();
+            it('locationObject.identifier is correct', () => {
                 expect(location.identifier).toEqual('ABC');
             });
-            // STATE IDENTIFIER
-            it('should create an identifier that contains the country code and state code if a state is selected', () => {
-                const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
-                container.setState({
-                    country: {
-                        code: 'ABC',
-                        name: 'A Big Country'
-                    },
-                    state: {
-                        code: 'AK',
-                        fips: 'XX',
-                        name: 'Alaska'
-                    }
-                });
 
-                const location = container.instance().createLocationObject();
-                expect(location.identifier).toEqual('ABC_AK');
-            });
-            // COUNTY IDENTIFIER
-            it('should create an identifier that contains the country, state, and county codes if a county is selected', () => {
-                const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
-                container.setState({
-                    country: {
-                        code: 'ABC',
-                        name: 'A Big Country'
-                    },
-                    state: {
-                        code: 'AK',
-                        fips: 'XX',
-                        name: 'Alaska'
-                    },
-                    county: {
-                        code: 'XX000',
-                        fips: '000',
-                        state: 'AK',
-                        name: 'Fake County'
-                    }
-                });
-
-                const location = container.instance().createLocationObject();
-                expect(location.identifier).toEqual('ABC_AK_000');
-            });
-            // DISTRICT IDENTIFIER
-            it('when a district is selected -- identifier should contain the country, state, and district codes', () => {
-                const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
-                container.setState({
-                    country: {
-                        code: 'ABC',
-                        name: 'A Big Country'
-                    },
-                    state: {
-                        code: 'AK',
-                        fips: 'XX',
-                        name: 'Alaska'
-                    },
-                    district: {
-                        code: 'XX',
-                        district: '99',
-                        name: 'AK-99'
-                    }
-                });
-
-                const location = container.instance().createLocationObject();
-                expect(location.identifier).toEqual('ABC_AK_99');
-            });
-
-            // CITY IDENTIFIER
-            it('when a city is selected -- identifier should contain the city details', () => {
-                const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
-                container.setState({
-                    country: {
-                        code: 'ABC',
-                        name: 'A Big Country'
-                    },
-                    city: { name: "test, TST", code: "TST" },
-                    state: {
-                        name: "test",
-                        code: "TST"
-                    }
-                });
-
-                const location = container.instance().createLocationObject();
-                expect(location.identifier).toEqual('ABC_TST_test');
-            });
-            // CITY w/ COMMAS IDENTIFIER
-            it('should handle cities with commas', () => {
-                const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
-                container.setState({
-                    country: {
-                        code: 'GBR',
-                        name: 'United Kingdom'
-                    },
-                    city: {
-                        code: "GBR",
-                        name: "London, Kent"
-                    }
-                });
-    
-                const location = container.instance().createLocationObject();
-                expect(location).toEqual({
-                    identifier: 'GBR_London, Kent',
-                    display: {
-                        title: 'London, Kent',
-                        entity: 'City',
-                        standalone: 'London, Kent'
-                    },
-                    filter: {
-                        country: 'GBR',
-                        city: 'London, Kent'
-                    }
-                });
-            });
-        });
-
-        describe('API filter object', () => {
-            // COUNTRY API REQUEST OBJECT
-            it('should create a filter object that contains only the country code if only a country is selected', () => {
-                const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
-                container.setState({
-                    country: {
-                        code: 'ABC',
-                        name: 'A Big Country'
-                    }
-                });
-
-                const location = container.instance().createLocationObject();
+            it('locationObject.filter is correct', () => {
                 expect(location.filter).toEqual({
                     country: 'ABC'
                 });
             });
-            // STATE API REQUEST OBJECT
-            it('should create filter object that contains the country code and state code if a state is selected', () => {
-                const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
-                container.setState({
-                    country: {
-                        code: 'ABC',
-                        name: 'A Big Country'
-                    },
-                    state: {
-                        code: 'AK',
-                        fips: 'XX',
-                        name: 'Alaska'
-                    }
-                });
+            it('locationObject.display is correct', () => {
 
-                const location = container.instance().createLocationObject();
+            });
+        });
+        describe('State selection', () => {
+            const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
+            container.setState({
+                country: {
+                    code: 'ABC',
+                    name: 'A Big Country'
+                },
+                state: {
+                    code: 'AK',
+                    fips: 'XX',
+                    name: 'Alaska'
+                }
+            });
+            const location = container.instance().createLocationObject();
+
+            it('locationObject.identifier is correct', () => {
+                expect(location.identifier).toEqual('ABC_AK');
+            });
+            it('locationObject.filter is correct', () => {
                 expect(location.filter).toEqual({
                     country: 'ABC',
                     state: 'AK'
                 });
             });
-            // COUNTY API REQUEST OBJECT
-            it('should create a filter object that contains the country, state, and county codes if a county is selected', () => {
-                const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
-                container.setState({
-                    country: {
-                        code: 'ABC',
-                        name: 'A Big Country'
-                    },
-                    state: {
-                        code: 'AK',
-                        fips: 'XX',
-                        name: 'Alaska'
-                    },
-                    county: {
-                        code: 'XX000',
-                        fips: '000',
-                        state: 'AK',
-                        name: 'Fake County'
-                    }
-                });
+            it('locationObject.display is correct', () => {
 
-                const location = container.instance().createLocationObject();
+            });
+        });
+        describe('City selection', () => {
+            const domesticContainer = shallow(<LocationPickerContainer {...mockPickerRedux} />);
+            // Test for handling cities w/ commas
+            const commaContainer = shallow(<LocationPickerContainer {...mockPickerRedux} />);
+
+            domesticContainer.setState({
+                country: {
+                    code: 'USA',
+                    name: 'United States'
+                },
+                city: { name: "Atlanta, GA", code: "GA" },
+                state: {
+                    name: "Georgia",
+                    code: "GA"
+                }
+            });
+            commaContainer.setState({
+                country: {
+                    code: 'GBR',
+                    name: 'United Kingdom'
+                },
+                city: {
+                    code: "GBR",
+                    name: "London, Kent"
+                }
+            });
+
+            const domesticLocation = domesticContainer.instance().createLocationObject();
+            const commaLocation = commaContainer.instance().createLocationObject();
+
+            it('locationObject.identifier is correct', () => {
+                expect(domesticLocation.identifier).toEqual('USA_GA_Atlanta');
+                expect(commaLocation.identifier).toEqual('GBR_London, Kent');
+            });
+            it('locationObject.filter is correct', () => {
+                expect(domesticLocation.filter).toEqual({
+                    country: 'USA',
+                    state: 'GA',
+                    city: 'Atlanta'
+                });
+                expect(commaLocation.filter).toEqual({
+                    country: 'GBR',
+                    city: 'London, Kent'
+                });
+            });
+            it('locationObject.display is correct', () => {
+                expect(domesticLocation.display).toEqual({
+                    title: 'Atlanta, GA',
+                    entity: 'City',
+                    standalone: 'Atlanta, GA'
+                });
+                expect(commaLocation.display).toEqual({
+                    title: 'London, Kent',
+                    entity: 'City',
+                    standalone: 'London, Kent'
+                });
+            });
+        });
+        describe('County selection', () => {
+            const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
+            container.setState({
+                country: {
+                    code: 'ABC',
+                    name: 'A Big Country'
+                },
+                state: {
+                    code: 'AK',
+                    fips: 'XX',
+                    name: 'Alaska'
+                },
+                county: {
+                    code: 'XX000',
+                    fips: '000',
+                    state: 'AK',
+                    name: 'Fake County'
+                }
+            });
+
+            const location = container.instance().createLocationObject();
+
+            it('locationObject.identifier is correct', () => {
+                expect(location.identifier).toEqual('ABC_AK_000');
+            });
+            it('locationObject.filter is correct', () => {
                 expect(location.filter).toEqual({
                     country: 'ABC',
                     state: 'AK',
                     county: '000'
                 });
             });
-            // DISTRICT API REQUEST OBJECT
-            it('should create a filter object that contains the country, state, and district codes if a district is selected', () => {
-                const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
-                container.setState({
-                    country: {
-                        code: 'ABC',
-                        name: 'A Big Country'
-                    },
-                    state: {
-                        code: 'AK',
-                        fips: 'XX',
-                        name: 'Alaska'
-                    },
-                    district: {
-                        code: 'XX',
-                        district: '99',
-                        name: 'AK-99'
-                    }
+            it('locationObject.display is correct', () => {
+                expect(location.display).toEqual({
+                    standalone: 'Fake County, AK',
+                    entity: 'County',
+                    title: 'Fake County'
                 });
+            });
+        });
+        describe('District selection', () => {
+            const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
+            container.setState({
+                country: {
+                    code: 'ABC',
+                    name: 'A Big Country'
+                },
+                state: {
+                    code: 'AK',
+                    fips: 'XX',
+                    name: 'Alaska'
+                },
+                district: {
+                    code: 'XX',
+                    district: '99',
+                    name: 'AK-99'
+                }
+            });
 
-                const location = container.instance().createLocationObject();
+            const location = container.instance().createLocationObject();
+
+            it('locationObject.identifier is correct', () => {
+                expect(location.identifier).toEqual('ABC_AK_99');
+            });
+            it('locationObject.filter is correct', () => {
                 expect(location.filter).toEqual({
                     country: 'ABC',
                     state: 'AK',
                     district: '99'
                 });
             });
-            // CITY API REQUEST OBJECT
-        });
-
-
-        it('should generate a standalone title for counties in county, state format', () => {
-            const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
-            container.setState({
-                country: {
-                    code: 'ABC',
-                    name: 'A Big Country'
-                },
-                state: {
-                    code: 'AK',
-                    fips: 'XX',
-                    name: 'Alaska'
-                },
-                county: {
-                    code: 'XX000',
-                    fips: '000',
-                    state: 'AK',
-                    name: 'Fake County'
-                }
-            });
-
-            const location = container.instance().createLocationObject();
-            expect(location.display.standalone).toEqual('Fake County, AK');
-        });
-
-        it('should generate a display object with title, standalone title, and entity values that are used for location tags', () => {
-            const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
-            container.setState({
-                country: {
-                    code: 'ABC',
-                    name: 'A Big Country'
-                },
-                state: {
-                    code: 'AK',
-                    fips: 'XX',
-                    name: 'Alaska'
-                },
-                county: {
-                    code: 'XX000',
-                    fips: '000',
-                    state: 'AK',
-                    name: 'Fake County'
-                }
-            });
-
-            const location = container.instance().createLocationObject();
-            expect(location.display).toEqual({
-                title: 'Fake County',
-                entity: 'County',
-                standalone: 'Fake County, AK'
-            });
-        });
-
-        it('should output an object with identifier code, display object, and an object formatted for the API', () => {
-            const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
-            container.setState({
-                country: {
-                    code: 'ABC',
-                    name: 'A Big Country'
-                },
-                state: {
-                    code: 'AK',
-                    fips: 'XX',
-                    name: 'Alaska'
-                },
-                county: {
-                    code: 'XX000',
-                    fips: '000',
-                    state: 'AK',
-                    name: 'Fake County'
-                }
-            });
-
-            const location = container.instance().createLocationObject();
-            expect(location).toEqual({
-                identifier: 'ABC_AK_000',
-                display: {
-                    title: 'Fake County',
-                    entity: 'County',
-                    standalone: 'Fake County, AK'
-                },
-                filter: {
-                    country: 'ABC',
-                    state: 'AK',
-                    county: '000'
-                }
+            it('locationObject.display is correct', () => {
+                expect(location.display).toEqual({
+                    entity: 'Congressional district',
+                    title: 'AK-99',
+                    standalone: 'AK-99'
+                });
             });
         });
     });
+
     describe('addLocation', () => {
         it('should call the addLocation prop to add the location to Redux', () => {
             const mockAdd = jest.fn();

--- a/tests/containers/search/filters/location/LocationPickerContainer-test.jsx
+++ b/tests/containers/search/filters/location/LocationPickerContainer-test.jsx
@@ -279,20 +279,14 @@ describe('LocationPickerContainer', () => {
                 const location = container.instance().createLocationObject();
                 expect(location.identifier).toEqual('ABC_AK_99');
             });
-            it('when a city is selected -- identifier should countain the city details', () => {
+            it('when a city is selected -- identifier should contain the city details', () => {
                 const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
                 container.setState({
                     country: {
                         code: 'ABC',
                         name: 'A Big Country'
                     },
-                    city: { name: "test, TST" },
-                    county: {
-                        code: 'XX000',
-                        fips: '000',
-                        state: 'AK',
-                        name: 'Fake County'
-                    },
+                    city: { name: "test, TST", code: "TST" },
                     state: {
                         name: "test",
                         code: "TST"
@@ -300,7 +294,7 @@ describe('LocationPickerContainer', () => {
                 });
 
                 const location = container.instance().createLocationObject();
-                expect(location.identifier).toEqual('ABC_TST_000_test');
+                expect(location.identifier).toEqual('ABC_TST_test');
             });
         });
 


### PR DESCRIPTION
**High level description:**
### Description of Bug:
In Prod when searching by a city with commas, we are splitting the string by comma and only using the first part of the string before the first comma:
`strWithComma.split(", ")[0]`;

### Solution:
1. Still splitting city by comma as above, but now including all items in resulting array, except items in the array that are equivalent to `city.code` which is not necessary to include.
2. Re-ogranized the tests on the relevant class method `createLocationObject` to ensure each property on the return object is correct for each scenario: 
1. Searching by country
2. Searching by state
3. Searching by domestic/foreign city
4. Searching by county
5. Searching by congressional district

This was already being done but in a disorganized manner.

3. Refactored class method `createLocationObject` to use `.reduce` to build the resulting object instead of numerous `if` statements.

**Technical details:**
Very small change w/ including all items in resulting `.split` array on the city string, but lots of code clean up. Cleaning up tests / refactoring method.

**JIRA Ticket:**
[DEV-3017](https://federal-spending-transparency.atlassian.net/browse/DEV-3017)

**SS of CreateLocationObject Tests**:
![image](https://user-images.githubusercontent.com/12897813/60843592-1c6b9880-a1a5-11e9-894a-f20b00ba255d.png)

The following are ALL required for the PR to be merged:
- [x] Code review
