### PR TITLE
New executive compensation response

### DIFF
--- a/src/js/components/award/details/additional/ContractAdditionalDetails.jsx
+++ b/src/js/components/award/details/additional/ContractAdditionalDetails.jsx
@@ -50,7 +50,7 @@ export default class ContractAdditionalDetails extends React.Component {
                     title="Additional Details" />
                 <hr className="additional-group-divider" />
                 <AdditionalGroup
-                    data={award.recipient.officers}
+                    data={award.additionalDetails.officers}
                     fields={DataFields.compensationFields}
                     title="Executive Compensation" />
             </div>

--- a/src/js/models/v2/awards/BaseAwardRecipient.js
+++ b/src/js/models/v2/awards/BaseAwardRecipient.js
@@ -4,7 +4,6 @@
  */
 
 import { getBusinessTypes } from 'helpers/businessTypesHelper';
-import { formatMoney } from 'helpers/moneyFormatter';
 import CoreLocation from 'models/v2/CoreLocation';
 
 const parseBusinessCategories = (data) => (
@@ -15,28 +14,6 @@ const parseBusinessCategories = (data) => (
         return parsed;
     }, [])
 );
-
-const parseExecutiveCompensation = (data) => {
-    const executiveCompensation = {};
-    if (data) {
-        for (let i = 1; i < 6; i++) {
-            const name = data[`officer_${i}_name`] || '';
-            const amount = formatMoney(data[`officer_${i}_amount`]) || 0;
-            if (name) {
-                executiveCompensation[`officer${i}`] = `${name} - ${amount}`;
-            }
-            else {
-                executiveCompensation[`officer${i}`] = '--';
-            }
-        }
-    }
-    else {
-        for (let i = 1; i < 6; i++) {
-            executiveCompensation[`officer${i}`] = '--';
-        }
-    }
-    return executiveCompensation;
-};
 
 const BaseAwardRecipient = {
     populate(data) {
@@ -69,15 +46,6 @@ const BaseAwardRecipient = {
         const location = Object.create(CoreLocation);
         location.populateCore(locationData);
         this.location = location;
-
-        // Executive Compensation
-        if (data.officers) {
-            this.officers = parseExecutiveCompensation(data.officers);
-        }
-        else {
-            // data.officers is undefined
-            this.officers = parseExecutiveCompensation(null);
-        }
     },
     get businessTypes() {
         if (this._businessTypes) {

--- a/src/js/models/v2/awards/additionalDetails/BaseContractAdditionalDetails.js
+++ b/src/js/models/v2/awards/additionalDetails/BaseContractAdditionalDetails.js
@@ -3,6 +3,23 @@
  * Created by Lizzie Salita 3/5/18
  */
 
+import { formatMoney } from 'helpers/moneyFormatter';
+
+const parseExecutiveCompensation = (data) => {
+    const executiveCompensation = {};
+    for (let i = 1; i < 6; i++) {
+        const name = data[`officer_${i}_name`] || '';
+        const amount = formatMoney(data[`officer_${i}_amount`]) || 0;
+        if (name) {
+            executiveCompensation[`officer${i}`] = `${name} - ${amount}`;
+        }
+        else {
+            executiveCompensation[`officer${i}`] = '--';
+        }
+    }
+    return executiveCompensation;
+};
+
 const BaseContractAdditionalDetails = {
     populate(data) {
         this.pricingCode = data.type_of_contract_pricing || '';
@@ -57,6 +74,9 @@ const BaseContractAdditionalDetails = {
         this.multiYearContract = data.multi_year_contract_desc || '--';
         this.purchaseCardAsPaymentMethod = data.purchase_card_as_paym_desc || '--';
         this.consolidated = data.consolidated_contract_desc || '--';
+
+        // Executive Compensation
+        this.officers = parseExecutiveCompensation(data);
     },
     get pscCode() {
         if (this._pscCode && this._pscCodeDescription) {

--- a/tests/containers/award/mockResults.js
+++ b/tests/containers/award/mockResults.js
@@ -237,20 +237,6 @@ export const mockApi = {
             "recipient_flag": true,
             "is_fpds": true,
             "transaction_unique_id": "NONE"
-        },
-        "officers": {
-            "legal_entity": 98140463,
-            "officer_1_name": "Thomas E Mason",
-            "officer_1_amount": "905226.00",
-            "officer_2_name": "Jeffrey W Smith",
-            "officer_2_amount": "713363.00",
-            "officer_3_name": "Michelle V Buchanan",
-            "officer_3_amount": "584927.00",
-            "officer_4_name": "Alan S Icenhour",
-            "officer_4_amount": "576762.00",
-            "officer_5_name": "James B Roberto",
-            "officer_5_amount": "573902.00",
-            "update_date": "2018-03-01"
         }
     },
     "place_of_performance": {
@@ -524,20 +510,6 @@ export const mockApi = {
                 "recipient_flag": true,
                 "is_fpds": true,
                 "transaction_unique_id": "NONE"
-            },
-            "officers": {
-                "legal_entity": 98140463,
-                "officer_1_name": "Thomas E Mason",
-                "officer_1_amount": "905226.00",
-                "officer_2_name": "Jeffrey W Smith",
-                "officer_2_amount": "713363.00",
-                "officer_3_name": "Michelle V Buchanan",
-                "officer_3_amount": "584927.00",
-                "officer_4_name": "Alan S Icenhour",
-                "officer_4_amount": "576762.00",
-                "officer_5_name": "James B Roberto",
-                "officer_5_amount": "573902.00",
-                "update_date": "2018-03-01"
             }
         },
         "place_of_performance": {
@@ -858,7 +830,17 @@ export const mockApi = {
             "last_modified": "2018-02-23 15:06:48",
             "initial_report_date": "2018-02-23",
             "created_at": "2018-02-24T11:43:43.257667",
-            "updated_at": "2018-02-25T11:36:45.751639"
+            "updated_at": "2018-02-25T11:36:45.751639",
+            "officer_1_name": "Thomas E Mason",
+            "officer_1_amount": "905226.00",
+            "officer_2_name": "Jeffrey W Smith",
+            "officer_2_amount": "713363.00",
+            "officer_3_name": "Michelle V Buchanan",
+            "officer_3_amount": "584927.00",
+            "officer_4_name": "Alan S Icenhour",
+            "officer_4_amount": "576762.00",
+            "officer_5_name": "James B Roberto",
+            "officer_5_amount": "573902.00"
         }
     }
 };
@@ -1324,8 +1306,7 @@ export const mockFinancialAssistanceApi = {
                 "recipient_flag": true,
                 "is_fpds": false,
                 "transaction_unique_id": "5_7530_1805NY5MAP_7530-227-1805NY5MAP-5-1-2018-93778-75-0512-NON"
-            },
-            "officers": null
+            }
         },
         "place_of_performance": {
             "location_id": 150868557,
@@ -1474,13 +1455,6 @@ export const mockParams = {
                     _countryCode: "",
                     _state: "IN",
                     _congressionalDistrict: ""
-                },
-                officers: {
-                    officer1: "George Washington - $9,000",
-                    officer2: "John Adams - $7,000",
-                    officer3: "Thomas Jefferson - $6,000",
-                    officer4: "James Madison - $5,000",
-                    officer5: "James Monroe - $5,000"
                 }
             },
             placeOfPerformance: {
@@ -1548,7 +1522,14 @@ export const mockParams = {
                 subcontractingPlan: "PLAN REQUIRED - INCENTIVE NOT INCLUDED ",
                 multiYearContract: "N",
                 purchaseCardAsPaymentMethod: "N",
-                consolidated: "NO"
+                consolidated: "NO",
+                officers: {
+                    officer1: "George Washington - $9,000",
+                    officer2: "John Adams - $7,000",
+                    officer3: "Thomas Jefferson - $6,000",
+                    officer4: "James Madison - $5,000",
+                    officer5: "James Monroe - $5,000"
+                }
             },
             parentAward: null,
             description: "mock description",

--- a/tests/models/awards/BaseAwardRecipient-test.js
+++ b/tests/models/awards/BaseAwardRecipient-test.js
@@ -17,15 +17,6 @@ describe('BaseAwardRecipient', () => {
             'Nonprofit Organization'
         ]);
     });
-    it('should parse executive compensation', () => {
-        expect(recipient.officers).toEqual({
-            officer1: 'George Washington - $9,000',
-            officer2: 'John Adams - $7,001',
-            officer3: 'Thomas Jefferson - $6,000',
-            officer4: 'James Madison - $5,000',
-            officer5: '--'
-        });
-    });
     it('should have a location property with CoreLocation in its prototype chain', () => {
         expect(Object.getPrototypeOf(recipient.location)).toEqual(CoreLocation);
     });

--- a/tests/models/awards/additionalDetails/BaseContractAdditionalDetails-test.js
+++ b/tests/models/awards/additionalDetails/BaseContractAdditionalDetails-test.js
@@ -3,9 +3,8 @@
  * Created by Lizzie Salita 3/20/18
  */
 
-
-import { mockContractApi } from '../mockAwardApi';
 import BaseContractAdditionalDetails from 'models/v2/awards/additionalDetails/BaseContractAdditionalDetails';
+import { mockContractApi } from '../mockAwardApi';
 
 const details = Object.create(BaseContractAdditionalDetails);
 details.populate(mockContractApi.latest_transaction.contract_data);
@@ -19,5 +18,14 @@ describe('BaseContractAdditionalDetails', () => {
     });
     it('should return -- for null values', () => {
         expect(details.clingerCohenAct).toEqual('--');
+    });
+    it('should parse executive compensation', () => {
+        expect(details.officers).toEqual({
+            officer1: 'George Washington - $9,000',
+            officer2: 'John Adams - $7,001',
+            officer3: 'Thomas Jefferson - $6,000',
+            officer4: 'James Madison - $5,000',
+            officer5: '--'
+        });
     });
 });

--- a/tests/models/awards/mockAwardApi.js
+++ b/tests/models/awards/mockAwardApi.js
@@ -24,7 +24,15 @@ export const mockContractApi = {
             product_or_service_co_desc: 'product/service description',
             naics: 'naics',
             naics_description: null,
-            clinger_cohen_act_planning: null
+            clinger_cohen_act_planning: null,
+            officer_1_name: 'George Washington',
+            officer_1_amount: '9000.00',
+            officer_2_name: 'John Adams',
+            officer_2_amount: '7000.99',
+            officer_3_name: 'Thomas Jefferson',
+            officer_3_amount: '6000.01',
+            officer_4_name: 'James Madison',
+            officer_4_amount: '5000.00'
         }
     },
     place_of_performance: {
@@ -48,16 +56,6 @@ export const mockContractApi = {
             city_name: 'Pawnee',
             state_code: 'IN',
             zip5: '12345'
-        },
-        officers: {
-            officer_1_name: 'George Washington',
-            officer_1_amount: '9000.00',
-            officer_2_name: 'John Adams',
-            officer_2_amount: '7000.99',
-            officer_3_name: 'Thomas Jefferson',
-            officer_3_amount: '6000.01',
-            officer_4_name: 'James Madison',
-            officer_4_amount: '5000.00'
         }
     }
 };


### PR DESCRIPTION
**High level description:**
Updates the frontend to correctly parse the updated `api/v1/awards` response.

**Technical details:**
- Executive compensation fields will move from the `recipient.officers` object to `latest_transaction.contract_data` object.
- Example contract summary page: https://dev.usaspending.gov/#/award/25886979 > Additional Details tab > Executive Compensation section (should be no impact to end user)
- Note - no API contract for v1 endpoint

**JIRA Ticket:**
[DEV-3040](https://federal-spending-transparency.atlassian.net/browse/DEV-3040), subtask of [DEV-2923](https://federal-spending-transparency.atlassian.net/browse/DEV-2923)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] [API changes](https://github.com/fedspendingtransparency/usaspending-api/pull/1924) merged
- [x] Executive comp data loaded