### PR TITLE
Add Release Notes to About page

### DIFF
--- a/src/_scss/elements/_buttons.scss
+++ b/src/_scss/elements/_buttons.scss
@@ -200,6 +200,18 @@ button,
     @include button-unstyled;
 }
 
+@mixin button-link {
+    @include button-unstyled;
+    color: $color-primary;
+    cursor: pointer;
+    width: fit-content;
+    display: inline-block;
+    &:hover {
+        color: $color-primary-darker;
+        text-decoration: underline;
+    }
+}
+
 .usa-button-link {
     @include button-unstyled;
     color: $color-primary;

--- a/src/_scss/pages/about/_section.scss
+++ b/src/_scss/pages/about/_section.scss
@@ -57,6 +57,10 @@
             margin: rem(19) 0 rem(38);
             padding: rem(16) rem(32);
             text-decoration: none;
+            &.usa-button-link {
+                @include button-link;
+                font-size: rem(18);
+            }
         }
 
         .about-section-content-inline-buttons {

--- a/src/js/components/about/AboutContent.jsx
+++ b/src/js/components/about/AboutContent.jsx
@@ -16,6 +16,7 @@ import DataSources from './DataSources';
 import DataQuality from './DataQuality';
 import MoreInfo from './MoreInfo';
 import Contact from './Contact';
+import Development from './Development';
 
 const aboutSections = [
     {
@@ -33,6 +34,10 @@ const aboutSections = [
     {
         section: 'data-quality',
         label: 'Data Quality'
+    },
+    {
+        section: 'development',
+        label: 'Development and Releases'
     },
     {
         section: 'more-info',
@@ -229,6 +234,7 @@ export default class AboutContent extends React.Component {
                         <Background />
                         <DataSources />
                         <DataQuality />
+                        <Development />
                         <MoreInfo />
                         <Contact />
                     </div>

--- a/src/js/components/about/Development.jsx
+++ b/src/js/components/about/Development.jsx
@@ -1,0 +1,46 @@
+/**
+ * Development.jsx
+ * Created by Lizzie Salita 7/10/19
+ */
+
+import React from 'react';
+
+import * as redirectHelper from 'helpers/redirectHelper';
+
+export default class Development extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.clickedLink = this.clickedLink.bind(this);
+    }
+
+    clickedLink() {
+        redirectHelper.showRedirectModal('https://github.com/fedspendingtransparency/usaspending-website/wiki');
+    }
+    render() {
+        return (
+            <div
+                className="about-section-wrapper"
+                id="about-development">
+                <h2 className="about-section-title">
+                    Development and Release Notes
+                </h2>
+                <div className="about-section-content">
+                    <p>
+                        USAspending is developed using agile methods. Our current release approach begins with a two-week development sprint, followed by a two-week testing period (concurrent with the subsequent development sprint). As such, about four weeks pass between the start of a sprint and its updates reaching production; however, because we concurrently test the previous sprint while developing the next sprint, the end result is still website updates roughly every two weeks. If you would like to receive regular release notes via e-mail, please&nbsp;
+                        <a
+                            href="mailto:join-usaspending@lists.fiscal.treasury.gov?subject=Yes!%20I'd%20like%20to%20receive%20updates.">
+                            sign up here
+                        </a>. We maintain a collection of all previous release notes&nbsp;
+                        <button
+                            className="usa-button-link"
+                            role="link"
+                            onClick={this.clickedLink}>
+                            here
+                        </button>.
+                    </p>
+                </div>
+            </div>
+        );
+    }
+}

--- a/src/js/components/about/Development.jsx
+++ b/src/js/components/about/Development.jsx
@@ -23,15 +23,15 @@ export default class Development extends React.Component {
                 className="about-section-wrapper"
                 id="about-development">
                 <h2 className="about-section-title">
-                    Development and Release Notes
+                    Development and Releases
                 </h2>
                 <div className="about-section-content">
                     <p>
-                        USAspending is developed using agile methods. Our current release approach begins with a two-week development sprint, followed by a two-week testing period (concurrent with the subsequent development sprint). As such, about four weeks pass between the start of a sprint and its updates reaching production; however, because we concurrently test the previous sprint while developing the next sprint, the end result is still website updates roughly every two weeks. If you would like to receive regular release notes via e-mail, please&nbsp;
+                        USAspending.gov is developed using agile methods. Our current release approach is a two-week development sprint, followed by a two-week testing period, followed by public release. We begin coding the next sprint at the same time we&rsquo;re testing the first sprint, so updates are published to the website about every two weeks. If you want us to send you the Release Notes when an update goes out, please&nbsp;
                         <a
                             href="mailto:join-usaspending@lists.fiscal.treasury.gov?subject=Yes!%20I'd%20like%20to%20receive%20updates.">
                             sign up here
-                        </a>. We maintain a collection of all previous release notes&nbsp;
+                        </a>. Previous Release Notes are available&nbsp;
                         <button
                             className="usa-button-link"
                             role="link"


### PR DESCRIPTION
**High level description:**
Adds a "Development and Releases" section to the About page.

**Technical details:**
- Utilizes the shared redirect modal component for links that point to sites outside the Fiscal Service domain.
- Adds a CSS mixin for buttons that look like links

**JIRA Ticket:**
[DEV-1234](https://federal-spending-transparency.atlassian.net/browse/DEV-1234)

**Mockup:**
https://bahdigital.invisionapp.com/share/MKIAAZFD7S9#/screens

The following are ALL required for the PR to be merged:
- [x] Design and copy finalized / approved
- [x] Code review
- [x] Design review
- [x] Verified cross-browser compatibility
