### PR TITLE
Add Congressional District to Recipient Address

### DIFF
--- a/src/js/components/awardv2/shared/additionalInfo/RecipientDetails.jsx
+++ b/src/js/components/awardv2/shared/additionalInfo/RecipientDetails.jsx
@@ -102,6 +102,7 @@ export default class RecipientDetails extends React.Component {
                                 <td>
                                     <div>{this.props.data.location.streetAddress}</div>
                                     <div>{this.props.data.location.regionalAddress}</div>
+                                    <div>{this.props.data.location.fullCongressionalDistrict}</div>
                                 </td>
                             </tr>
                             <tr

--- a/src/js/components/awardv2/shared/additionalInfo/RecipientDetails.jsx
+++ b/src/js/components/awardv2/shared/additionalInfo/RecipientDetails.jsx
@@ -53,6 +53,20 @@ export default class RecipientDetails extends React.Component {
 
     render() {
         const onKeyDownHandler = createOnKeyDownHandler(this.handleClick);
+        // Format the location data
+        let address = (
+            <td>--</td>
+        );
+        const location = this.props.data.location;
+        if (location.streetAddress || location.regionalAddress || location.fullCongressionalDistrict) {
+            address = (
+                <td>
+                    <div>{location.streetAddress}</div>
+                    <div>{location.regionalAddress}</div>
+                    <div>{location.fullCongressionalDistrict}</div>
+                </td>
+            );
+        }
         return (
             <div className={this.state.open ? 'accordion accordion_open' : 'accordion'}>
                 <div
@@ -99,11 +113,7 @@ export default class RecipientDetails extends React.Component {
                             <tr
                                 className="accordion-table__row">
                                 <td>Address</td>
-                                <td>
-                                    <div>{this.props.data.location.streetAddress}</div>
-                                    <div>{this.props.data.location.regionalAddress}</div>
-                                    <div>{this.props.data.location.fullCongressionalDistrict}</div>
-                                </td>
+                                {address}
                             </tr>
                             <tr
                                 className="accordion-table__row">

--- a/src/js/components/awardv2/shared/additionalInfo/RecipientDetails.jsx
+++ b/src/js/components/awardv2/shared/additionalInfo/RecipientDetails.jsx
@@ -76,7 +76,7 @@ export default class RecipientDetails extends React.Component {
                                 className="accordion-table__row">
                                 <td>Recipient</td>
                                 <td>
-                                    {this.formatRecipientLink(this.props.data.internalId, this.props.data.name)}
+                                    {this.formatRecipientLink(this.props.data.internalId, this.props.data._name)}
                                 </td>
                             </tr>
                             <tr

--- a/src/js/components/awardv2/shared/overview/AgencyRecipient.jsx
+++ b/src/js/components/awardv2/shared/overview/AgencyRecipient.jsx
@@ -23,6 +23,15 @@ export default class AgencyRecipient extends React.Component {
     jumpToAdditionalInfo() {
         this.props.jumpToSection('additional-information');
     }
+    formatRecipientLink(internalId, name) {
+        if (internalId && name) {
+            return (<a href={`#/recipient/${internalId}`}>{name}</a>);
+        }
+        else if (internalId) {
+            return (<a href={`#/recipient/${internalId}`}>Unknown</a>);
+        }
+        return name;
+    }
     render() {
         let additionalInfoLink = null;
         if (this.props.category === 'contract' || this.props.category === 'idv') {
@@ -53,9 +62,7 @@ export default class AgencyRecipient extends React.Component {
                     <div className="agency-recipient__recipient">
                         <div className="agency-recipient__title">Recipient</div>
                         <div className="agency-recipient__detail">
-                            <a href={`/#/recipient/${this.props.recipient.internalId}`}>
-                                {this.props.recipient.name}
-                            </a>
+                            {this.formatRecipientLink(this.props.recipient.internalId, this.props.recipient.name)}
                         </div>
                     </div>
                 </div>

--- a/src/js/models/v2/awardsV2/BaseAwardRecipient.js
+++ b/src/js/models/v2/awardsV2/BaseAwardRecipient.js
@@ -8,7 +8,7 @@ import CoreLocation from 'models/v2/CoreLocation';
 const BaseAwardRecipient = {
     populate(data) {
         this.internalId = data.recipient_hash || '';
-        this.name = data.recipient_name || 'Unknown';
+        this._name = data.recipient_name || '';
         this.duns = data.recipient_unique_id || '--';
         this.parentName = data.parent_recipient_name || '';
         this.parentDuns = data.parent_recipient_unique_id || '--';
@@ -37,6 +37,9 @@ const BaseAwardRecipient = {
         const location = Object.create(CoreLocation);
         location.populateCore(locationData);
         this.location = location;
+    },
+    get name() {
+        return this._name || 'Unknown';
     }
 };
 


### PR DESCRIPTION
**High level description:**

Recipient Details Panel
- Adds Congressional District to the Recipient Address
- Displays `--` when no location information is available
- Displays `--` instead of `Unknown` in the panel when both recipient name and hash are null

Recipient Overview section
- Displays an unlinked name when recipient hash is null
- Displays `Unknown` when the recipient name is null

**JIRA Ticket:**
Follow up to [DEV-2740](https://federal-spending-transparency.atlassian.net/browse/DEV-2740) (Failed Test)

**Mockup:**
https://bahdigital.invisionapp.com/share/GVIAAHOBER9#/296001079_Award_Summary_2-0_-_IDV_-future-

The following are ALL required for the PR to be merged:
- [x] Code review