### PR TITLE
[DEV-2878] Primary Place of Performance Foreign City Disclaimer

### DIFF
--- a/src/_scss/pages/search/filters/location/location.scss
+++ b/src/_scss/pages/search/filters/location/location.scss
@@ -61,6 +61,9 @@
                     svg {
                         color: $color-gray;
                     }
+                    .usa-da-icon-exclamation-triangle {
+                        fill: #fdb81e;
+                    }
                 }
             }
             @import "./geo-entity-list";

--- a/src/js/components/search/filters/location/EntityDropdown.jsx
+++ b/src/js/components/search/filters/location/EntityDropdown.jsx
@@ -23,7 +23,7 @@ const propTypes = {
     selectEntity: PropTypes.func,
     field: PropTypes.string,
     enabled: PropTypes.bool,
-    generateWarning: PropTypes.func,
+    generateDisclaimer: PropTypes.func,
     matchKey: PropTypes.string,
     setSearchString: PropTypes.func,
     searchString: PropTypes.string,
@@ -239,7 +239,7 @@ export default class EntityDropdown extends React.Component {
 
     render() {
         const {
-            type, field, generateWarning, title, enabled, options, value, searchString, loading
+            type, field, generateDisclaimer, title, enabled, options, value, searchString, loading
         } = this.props;
 
         const isAutocomplete = (type === 'autocomplete');
@@ -338,7 +338,7 @@ export default class EntityDropdown extends React.Component {
                     id={this.state.warningId}
                     aria-hidden={hideWarning === 'hide'}>
                     <EntityWarning
-                        message={generateWarning(warningField)} />
+                        message={generateDisclaimer(warningField)} />
                 </div>
             </div>
         );

--- a/src/js/components/search/filters/location/EntityDropdown.jsx
+++ b/src/js/components/search/filters/location/EntityDropdown.jsx
@@ -219,8 +219,8 @@ export default class EntityDropdown extends React.Component {
     }
 
     mouseEnter() {
-        if (this.props.enabled) {
-            // active filter, do nothing
+        if (this.props.enabled && !this.props.showDisclaimer) {
+            // active filter, w/ no disclaimer/warning do nothing
             return;
         }
 
@@ -270,7 +270,8 @@ export default class EntityDropdown extends React.Component {
             disabled = 'disabled';
         }
 
-        if (!this.props.enabled && this.state.showWarning) {
+        if (this.state.showWarning) {
+            // even if this is enabled, still showWarning b/c we're also showingDisclaimer now
             hideWarning = '';
         }
 
@@ -326,6 +327,7 @@ export default class EntityDropdown extends React.Component {
                             handleTextInputChange={this.handleTextInputChange}
                             toggleDropdown={this.toggleDropdown}
                             placeholder={this.props.placeholder}
+                            showDisclaimer={this.props.showDisclaimer}
                             context={this} // used to create dropdown ref
                             loading={loading} />
                     }

--- a/src/js/components/search/filters/location/EntityDropdown.jsx
+++ b/src/js/components/search/filters/location/EntityDropdown.jsx
@@ -21,21 +21,23 @@ const propTypes = {
     title: PropTypes.string,
     options: PropTypes.array,
     selectEntity: PropTypes.func,
-    scope: PropTypes.string,
+    field: PropTypes.string,
     enabled: PropTypes.bool,
     generateWarning: PropTypes.func,
     matchKey: PropTypes.string,
     setSearchString: PropTypes.func,
     searchString: PropTypes.string,
     loading: PropTypes.bool,
-    type: PropTypes.oneOf(["autocomplete", "button"])
+    type: PropTypes.oneOf(["autocomplete", "button"]),
+    showDisclaimer: PropTypes.bool
 };
 
 const defaultProps = {
     enabled: true,
     matchKey: 'name',
     type: "button",
-    loading: false
+    loading: false,
+    showDisclaimer: false
 };
 
 const alphabetRegex = /([a-z]|[0-9])/;
@@ -81,7 +83,7 @@ export default class EntityDropdown extends React.Component {
     }
 
     resetSelectedItem() {
-        this.props.selectEntity(this.props.scope, defaultLocationValues[this.props.scope]);
+        this.props.selectEntity(this.props.field, defaultLocationValues[this.props.field]);
     }
 
     handleTextInputChange(e) {
@@ -134,7 +136,7 @@ export default class EntityDropdown extends React.Component {
             this.props.setSearchString(item.name, false);
         }
         if (item.code !== "NA-000") {
-            this.props.selectEntity(this.props.scope, item);
+            this.props.selectEntity(this.props.field, item);
         }
         this.closeDropdown();
     }
@@ -237,7 +239,7 @@ export default class EntityDropdown extends React.Component {
 
     render() {
         const {
-            type, scope, generateWarning, title, enabled, options, value, searchString, loading
+            type, field, generateWarning, title, enabled, options, value, searchString, loading
         } = this.props;
 
         const isAutocomplete = (type === 'autocomplete');
@@ -254,7 +256,7 @@ export default class EntityDropdown extends React.Component {
             const selectedItem = this.getSelectedItemIdentifier();
             dropdown = (<EntityDropdownList
                 matchKey={this.props.matchKey}
-                scope={this.props.scope}
+                scope={this.props.field}
                 selectedItem={selectedItem}
                 options={this.props.options}
                 clickedItem={this.clickedItem} />);
@@ -277,11 +279,11 @@ export default class EntityDropdown extends React.Component {
                 className="geo-entity-item">
                 <label
                     className={`location-label ${disabled}`}
-                    htmlFor={`${scope}-${type}`}>
+                    htmlFor={`${field}-${type}`}>
                     {this.props.title}
                 </label>
                 <div
-                    id={`${scope}-${type}`}
+                    id={`${field}-${type}`}
                     className={`geo-entity-dropdown ${disabled} ${autocompleteClass}`}
                     onMouseOver={this.mouseEnter}
                     onFocus={this.mouseEnter}
@@ -293,14 +295,14 @@ export default class EntityDropdown extends React.Component {
                     }}>
                     {!isAutocomplete &&
                         <button
-                            id={`${scope}-button`}
+                            id={`${field}-button`}
                             className={`active-selection ${placeholder}`}
                             onClick={this.toggleDropdown}
                             title={label}
                             aria-label={label}
                             aria-haspopup="true"
                             aria-expanded={this.state.expanded}
-                            aria-owns={`geo-dropdown-${scope}`}
+                            aria-owns={`geo-dropdown-${field}`}
                             aria-describedby={this.state.warningId}
                             disabled={!enabled || options.length === 0}
                             ref={(dd) => {

--- a/src/js/components/search/filters/location/EntityDropdownAutocomplete.jsx
+++ b/src/js/components/search/filters/location/EntityDropdownAutocomplete.jsx
@@ -7,6 +7,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
+import { ExclamationTriangle } from 'components/sharedComponents/icons/Icons';
+
 const propTypes = {
     searchString: PropTypes.string,
     placeholder: PropTypes.string,
@@ -17,7 +19,8 @@ const propTypes = {
     context: PropTypes.shape({}), // the $this variable of the parent, used to create a ref
     expanded: PropTypes.bool,
     enabled: PropTypes.bool,
-    loading: PropTypes.bool
+    loading: PropTypes.bool,
+    showDisclaimer: PropTypes.bool
 };
 
 const defaultProps = {
@@ -34,7 +37,8 @@ export const EntityDropdownAutocomplete = ({
     placeholder,
     context, // the $this variable
     loading,
-    handleOnKeyDown
+    handleOnKeyDown,
+    showDisclaimer
 }) => (
     <div className="autocomplete__input">
         <input
@@ -52,6 +56,7 @@ export const EntityDropdownAutocomplete = ({
             }} />
         <div className="icon">
             {loading && <FontAwesomeIcon onClick={toggleDropdown} icon="spinner" spin />}
+            {!loading && showDisclaimer && <ExclamationTriangle alt="warning" />}
         </div>
     </div>
 );

--- a/src/js/components/search/filters/location/LocationPicker.jsx
+++ b/src/js/components/search/filters/location/LocationPicker.jsx
@@ -127,6 +127,13 @@ export default class LocationPicker extends React.Component {
                 </span>
             );
         }
+        else if (this.props.country.code !== 'USA' && field === 'CITY' && this.props.scope === "primary_place_of_performance") {
+            return (
+                <span>
+                    Place of Performance data for foreign cities is limited and may return fewer results.
+                </span>
+            );
+        }
         else if (this.props.country.code === 'USA') {
             const {
                 state,
@@ -142,13 +149,6 @@ export default class LocationPicker extends React.Component {
                         Please select a&nbsp;
                         <span className="field">state</span> before selecting a&nbsp;
                         <span className="field">{field}</span>.
-                    </span>
-                );
-            }
-            else if (this.props.country.code !== 'USA' && field === 'CITY' && this.props.scope === "primary_place_of_performance") {
-                return (
-                    <span>
-                        Place of Performance data for foreign cities is limited and may return fewer results.
                     </span>
                 );
             }

--- a/src/js/components/search/filters/location/LocationPicker.jsx
+++ b/src/js/components/search/filters/location/LocationPicker.jsx
@@ -50,7 +50,7 @@ export default class LocationPicker extends React.Component {
         super(props);
 
         this.submitForm = this.submitForm.bind(this);
-        this.generateWarning = this.generateWarning.bind(this);
+        this.generateDisclaimer = this.generateDisclaimer.bind(this);
     }
 
     componentDidUpdate(prevProps) {
@@ -116,7 +116,7 @@ export default class LocationPicker extends React.Component {
         e.preventDefault();
     }
 
-    generateWarning(field) {
+    generateDisclaimer(field) {
         if (!this.props.country.code) {
             // no country provided
             return (
@@ -226,7 +226,7 @@ export default class LocationPicker extends React.Component {
                             value={this.props.country}
                             selectEntity={this.props.selectEntity}
                             options={this.props.availableCountries}
-                            generateWarning={this.generateWarning} />
+                            generateDisclaimer={this.generateDisclaimer} />
                     </div>
                     <div className="location-item">
                         <EntityDropdown
@@ -237,7 +237,7 @@ export default class LocationPicker extends React.Component {
                             selectEntity={this.props.selectEntity}
                             options={this.props.availableStates}
                             enabled={isUSA}
-                            generateWarning={this.generateWarning} />
+                            generateDisclaimer={this.generateDisclaimer} />
                     </div>
                     <div className="location-item">
                         <EntityDropdown
@@ -248,7 +248,7 @@ export default class LocationPicker extends React.Component {
                             selectEntity={this.props.selectEntity}
                             options={this.props.availableCounties}
                             enabled={isCountyEnabled}
-                            generateWarning={this.generateWarning} />
+                            generateDisclaimer={this.generateDisclaimer} />
                     </div>
                     {this.props.enableCitySearch &&
                         <div className="location-item">
@@ -263,7 +263,7 @@ export default class LocationPicker extends React.Component {
                                 options={this.props.availableCities}
                                 selectEntity={this.props.selectEntity}
                                 enabled={isCityEnabled}
-                                generateWarning={this.generateWarning}
+                                generateDisclaimer={this.generateDisclaimer}
                                 setSearchString={this.props.setCitySearchString}
                                 searchString={this.props.citySearchString}
                                 showDisclaimer={showDisclaimer} />
@@ -278,7 +278,7 @@ export default class LocationPicker extends React.Component {
                             selectEntity={this.props.selectEntity}
                             options={this.props.availableDistricts}
                             enabled={isDistrictEnabled}
-                            generateWarning={this.generateWarning} />
+                            generateDisclaimer={this.generateDisclaimer} />
                     </div>
                     <button
                         className="add-location"
@@ -292,7 +292,7 @@ export default class LocationPicker extends React.Component {
                 <div className="location-item">
                     <div className="geo-entity-item">
                         <ZIPField
-                            generateWarning={this.generateWarning}
+                            generateDisclaimer={this.generateDisclaimer}
                             isUSA={isUSA}
                             zip={this.props.zip}
                             validateZip={this.props.validateZip} />

--- a/src/js/components/search/filters/location/LocationPicker.jsx
+++ b/src/js/components/search/filters/location/LocationPicker.jsx
@@ -37,7 +37,8 @@ const propTypes = {
     setCitySearchString: PropTypes.func,
     citySearchString: PropTypes.string,
     loading: PropTypes.bool,
-    enableCitySearch: PropTypes.bool
+    enableCitySearch: PropTypes.bool,
+    scope: PropTypes.oneOf(["primary_place_of_performance", "recipient_location"])
 };
 
 const defaultProps = {
@@ -206,7 +207,7 @@ export default class LocationPicker extends React.Component {
                     onSubmit={this.submitForm}>
                     <div className="location-item">
                         <EntityDropdown
-                            scope="country"
+                            field="country"
                             placeholder="Select a country"
                             title="COUNTRY"
                             value={this.props.country}
@@ -216,7 +217,7 @@ export default class LocationPicker extends React.Component {
                     </div>
                     <div className="location-item">
                         <EntityDropdown
-                            scope="state"
+                            field="state"
                             placeholder="Select a state"
                             title="STATE (US ONLY)"
                             value={this.props.state}
@@ -227,7 +228,7 @@ export default class LocationPicker extends React.Component {
                     </div>
                     <div className="location-item">
                         <EntityDropdown
-                            scope="county"
+                            field="county"
                             placeholder="Select a county"
                             title="COUNTY (US ONLY)"
                             value={this.props.county}
@@ -241,7 +242,8 @@ export default class LocationPicker extends React.Component {
                             <EntityDropdown
                                 type="autocomplete"
                                 loading={this.props.loading}
-                                scope="city"
+                                field="city"
+                                scope={this.props.scope}
                                 placeholder="Enter a City"
                                 title="CITY"
                                 value={this.props.city}
@@ -250,11 +252,12 @@ export default class LocationPicker extends React.Component {
                                 enabled={isCityEnabled}
                                 generateWarning={this.generateWarning}
                                 setSearchString={this.props.setCitySearchString}
-                                searchString={this.props.citySearchString} />
+                                searchString={this.props.citySearchString}
+                                showDisclaimer={showDisclaimer} />
                         </div>}
                     <div className="location-item">
                         <EntityDropdown
-                            scope="district"
+                            field="district"
                             matchKey="district"
                             placeholder={districtPlaceholder}
                             title="CONGRESSIONAL DISTRICT (US ONLY)"

--- a/src/js/components/search/filters/location/LocationPicker.jsx
+++ b/src/js/components/search/filters/location/LocationPicker.jsx
@@ -145,6 +145,13 @@ export default class LocationPicker extends React.Component {
                     </span>
                 );
             }
+            else if (this.props.country.code !== 'USA' && field === 'CITY' && this.props.scope === "primary_place_of_performance") {
+                return (
+                    <span>
+                        Place of Performance data for foreign cities is limited and may return fewer results.
+                    </span>
+                );
+            }
             else if (countyOrDistrictSelected || (city.code && (!district.district || !county.code))) {
                 const selectedField = (district.district) ? "congressional district" : "county"; // if evaluates to county, double check it's not actually city
                 return (
@@ -199,6 +206,12 @@ export default class LocationPicker extends React.Component {
                 isAddFilterDisabled = true;
             }
         }
+
+        const showDisclaimer = (
+            this.props.scope === 'primary_place_of_performance' &&
+            this.props.country.code !== 'USA' &&
+            this.props.country.code !== ''
+        );
 
         return (
             <div>

--- a/src/js/components/search/filters/location/ZIPField.jsx
+++ b/src/js/components/search/filters/location/ZIPField.jsx
@@ -13,7 +13,7 @@ import EntityWarning from 'components/search/filters/location/EntityWarning';
 const propTypes = {
     zip: PropTypes.object,
     validateZip: PropTypes.func,
-    generateWarning: PropTypes.func,
+    generateDisclaimer: PropTypes.func,
     isUSA: PropTypes.bool
 };
 
@@ -105,7 +105,7 @@ export default class ZIPField extends React.Component {
                 <div
                     className={`geo-warning ${this.state.showNonUsWarning ? '' : 'hide'}`}
                     aria-hidden={!this.state.showNonUsWarning}>
-                    <EntityWarning message={this.props.generateWarning('ZIP CODE')} />
+                    <EntityWarning message={this.props.generateDisclaimer('ZIP CODE')} />
                 </div>
             </form>
         );

--- a/src/js/containers/search/filters/location/LocationPickerContainer.jsx
+++ b/src/js/containers/search/filters/location/LocationPickerContainer.jsx
@@ -20,7 +20,7 @@ import LocationPicker from "components/search/filters/location/LocationPicker";
 const propTypes = {
     selectedLocations: PropTypes.object,
     addLocation: PropTypes.func,
-    scope: PropTypes.string, // one of "recipient_location", "primary_place_of_performance"
+    scope: PropTypes.oneOf(["primary_place_of_performance", "recipient_location"]),
     enableCitySearch: PropTypes.bool
 };
 
@@ -512,6 +512,7 @@ export default class LocationPickerContainer extends React.Component {
         return (
             <LocationPicker
                 {...this.state}
+                scope={this.props.scope}
                 enableCitySearch={this.props.enableCitySearch}
                 selectedLocations={this.props.selectedLocations}
                 loadStates={this.loadStates}


### PR DESCRIPTION
**High level description:**
Adding new disclaimer to LocationPicker when a foreign country is selected and the Primary Place of Performance tab is active.

**Technical details:**
- Adds new logic to `generateMessage` for the appropriate disclaimer message
- Adds icon, shown conditionally, on autoComplete component.


**JIRA Ticket:**
[DEV-2878](https://federal-spending-transparency.atlassian.net/browse/DEV-2878)

**Mockup:**
https://bahdigital.invisionapp.com/share/ZWIAAZHCY5G#/screens/296016970/comments

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Design review (if applicable)
- [x] Verified cross-browser compatibility
