### PR TITLE
[dev-2780] restoring federalAccountsInfo tooltip

### DIFF
--- a/src/js/components/awardv2/idv/federalAccounts/FederalAccountsSection.jsx
+++ b/src/js/components/awardv2/idv/federalAccounts/FederalAccountsSection.jsx
@@ -10,7 +10,8 @@ import FederalAccountsTreeTooltip from
 import FederalAccountsTable from './FederalAccountsTable';
 import FederalAccountsTree from './FederalAccountsTree';
 import FederalAccountsSummary from './FederalAccountsSummary';
-
+import InfoToolTip from "../InfoTooltip";
+import { federalAccountsInfo } from "../InfoTooltipContent";
 
 const propTypes = {
     totalTransactionObligatedAmount: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -112,6 +113,9 @@ export default class FederalAccountsSection extends React.Component {
                             <FontAwesomeIcon size="lg" icon="chart-pie" />
                         </div>
                         <h3 className="award-viz__title">Federal Accounts</h3>
+                        <InfoToolTip left wide>
+                            {federalAccountsInfo}
+                        </InfoToolTip>
                     </div>
                     <hr />
                     <div className="federal-accounts__section">


### PR DESCRIPTION
**High level description:**
Federal Accounts tooltip was accidentally deleted, restoring it.

**Technical details:**
Reusing `InfoToolTip` and `federalAccountsInfo` tooltip content.

**JIRA Ticket:**
[DEV-2780](https://federal-spending-transparency.atlassian.net/browse/DEV-2780)

The following are ALL required for the PR to be merged:
- [x] Code review
- N/A Design review 
