### PR TITLE
Production Hotfix loading a saved search via url hash

### DIFF
--- a/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
+++ b/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
@@ -317,7 +317,7 @@ export class TopFilterBarContainer extends React.Component {
             values: []
         };
 
-        if (props.federalAccounts.count() > 0) {
+        if (props.federalAccounts && props.federalAccounts.count() > 0) {
             // federal account components have been selected
             selected = true;
             filter.values = props.federalAccounts.toArray();
@@ -337,7 +337,7 @@ export class TopFilterBarContainer extends React.Component {
             values: []
         };
 
-        if (props.treasuryAccounts.count() > 0) {
+        if (props.treasuryAccounts && props.treasuryAccounts.count() > 0) {
             // treasury account components have been selected
             selected = true;
             filter.values = props.federalAccounts.toArray();


### PR DESCRIPTION
**High level description:**
Fixes loading a saved search via url hash. A bug is causing the advanced search page to load with a blank screen in production.

**Technical details:**
The function that creates the top filter bar tags is expecting Treasury Accounts and Federal Accounts to exist in the filter object, but those aren't returned by the API yet in the endpoint that converts url hashes to the filter object. This change check for the presence of the filters before trying to access their `count`. 

**JIRA Ticket:**
[DEV-3199](https://federal-spending-transparency.atlassian.net/browse/DEV-3199)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Verified cross-browser compatibility
