### PR TITLE
TAS Autocomplete Bug Fix

### DIFF
--- a/src/js/components/sharedComponents/autocomplete/Autocomplete.jsx
+++ b/src/js/components/sharedComponents/autocomplete/Autocomplete.jsx
@@ -83,10 +83,8 @@ export default class Autocomplete extends React.Component {
         e.persist();
         this.checkValidity(e.target.value);
         let selectedIndex = 0;
-        if (e.target.value) {
-            this.props.handleTextInput(e);
-        }
-        else {
+        this.props.handleTextInput(e);
+        if (!e.target.value) {
             selectedIndex = -1;
             this.close();
         }

--- a/src/js/containers/search/filters/programSource/ProgramSourceAutocompleteContainer.jsx
+++ b/src/js/containers/search/filters/programSource/ProgramSourceAutocompleteContainer.jsx
@@ -127,6 +127,9 @@ export default class ProgramSourceAutocompleteContainer extends React.Component 
         if (event.target.value) {
             this.queryAutocompleteDebounced(event.target.value);
         }
+        else {
+            this.clearAutocompleteSuggestions();
+        }
     }
 
     render() {

--- a/src/js/containers/search/filters/programSource/ProgramSourceAutocompleteContainer.jsx
+++ b/src/js/containers/search/filters/programSource/ProgramSourceAutocompleteContainer.jsx
@@ -124,7 +124,9 @@ export default class ProgramSourceAutocompleteContainer extends React.Component 
     handleTextInput(event) {
         event.persist();
         this.props.clearSelection(this.props.component.code);
-        this.queryAutocompleteDebounced(event.target.value);
+        if (event.target.value) {
+            this.queryAutocompleteDebounced(event.target.value);
+        }
     }
 
     render() {


### PR DESCRIPTION
**High level description:**
Fixes a bug that caused TAS Component autocomplete selections to get staged after being deleted from the text input.

**Technical details:**
Previously, `handleInputText` was only getting called if the input value was truthy, which prevented `clearSelection` from getting called when the entire value was deleted.

**JIRA Ticket:**
[DEV-3219](https://federal-spending-transparency.atlassian.net/browse/DEV-3219)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Verified cross-browser compatibility
