### PR TITLE
[DEV-3167] Handling City Selection on Advanced Search for City with invalid Country Code

### DIFF
--- a/src/js/containers/search/filters/location/LocationPickerContainer.jsx
+++ b/src/js/containers/search/filters/location/LocationPickerContainer.jsx
@@ -360,7 +360,10 @@ export default class LocationPickerContainer extends React.Component {
                     if (filterData.city && filterData.country.toLowerCase() === 'foreign') {
                         return {
                             ...acc,
-                            country: this.state.city.code
+                            filter: {
+                                ...acc.filter,
+                                country: this.state.city.code
+                            }
                         };
                     }
                 }

--- a/src/js/containers/search/filters/location/LocationPickerContainer.jsx
+++ b/src/js/containers/search/filters/location/LocationPickerContainer.jsx
@@ -400,7 +400,7 @@ export default class LocationPickerContainer extends React.Component {
                     }
                 };
             }, { identifier: '', display: { entity: '', title: '', standalone: '' }, filter: {} });
-        
+
         return this.cleanBadLocationData(locationObject);
     }
 

--- a/src/js/containers/search/filters/location/LocationPickerContainer.jsx
+++ b/src/js/containers/search/filters/location/LocationPickerContainer.jsx
@@ -115,6 +115,7 @@ export default class LocationPickerContainer extends React.Component {
         this.setCitySearchString = this.setCitySearchString.bind(this);
         this.fetchCityAutocomplete = this.fetchCityAutocomplete.bind(this);
         this.debouncedCitySearch = debounce(this.fetchCityAutocomplete, 500).bind(this);
+        this.cleanBadLocationData = this.cleanBadLocationData.bind(this);
     }
 
     componentDidMount() {
@@ -307,13 +308,13 @@ export default class LocationPickerContainer extends React.Component {
             level === "city" &&
             this.state.country.code === "USA" &&
             this.state.state.code !== value.code &&
-            value.code
+            (value.code)
         );
         const shouldAutoPopulateCountry = (
             level === "city" &&
             this.state.country.code !== "USA" &&
             this.state.country.code !== value.code &&
-            value.code
+            (value.code)
         );
         if (shouldAutoPopulateState) {
             const stateFromCity = this.state.availableStates
@@ -338,8 +339,38 @@ export default class LocationPickerContainer extends React.Component {
         });
     }
 
+    /**
+     * This function was necessary to handle bad location data.
+     * It overrides local state, which is an anti-pattern.
+     * The specific condition this handles is when a city is returned from the api
+     * which does not have a country code associated with it that exists within our availableCountries array in local state.
+     * In this case, the back end team has requested we pass them the country code associated with the city itself in the API response.
+     * That is what this function is intended to accomplish.
+     * We are not setting this value (city.code) to this.state.country because it would have additional
+     * side effects across the component's children and introduce even greater complexity.
+     * The specific example this was created to handle was searching by city, recipient location, londonderry.
+     **/
+
+    cleanBadLocationData(locationObject) {
+        const cleanLocationObject = Object.keys(locationObject)
+            .reduce((acc, locationProperty) => {
+                if (locationProperty === 'filter') {
+                    // only cleaning data passed to api which is the .filter property
+                    const filterData = locationObject[locationProperty];
+                    if (filterData.city && filterData.country.toLowerCase() === 'foreign') {
+                        return {
+                            ...acc,
+                            country: this.state.city.code
+                        };
+                    }
+                }
+                return acc;
+            }, locationObject);
+        return cleanLocationObject;
+    }
+
     createLocationObject() {
-        return Object.keys(this.state)
+        const locationObject = Object.keys(this.state)
             .filter((prop) => locationProperties.includes(prop) && this.state[prop].code !== '')
             .reduce((acc, prop) => {
                 const accessor = locationPropertyAccessorMap[prop];
@@ -366,6 +397,8 @@ export default class LocationPickerContainer extends React.Component {
                     }
                 };
             }, { identifier: '', display: { entity: '', title: '', standalone: '' }, filter: {} });
+        
+        return this.cleanBadLocationData(locationObject);
     }
 
     addLocation() {

--- a/src/js/models/search/SearchAwardsOperation.js
+++ b/src/js/models/search/SearchAwardsOperation.js
@@ -199,12 +199,11 @@ class SearchAwardsOperation {
         }
 
         if (this.selectedRecipientLocations.length > 0) {
-            const locationSet = [];
-            this.selectedRecipientLocations.forEach((location) => {
-                if (location.filter.country && location.filter.country.toLowerCase() === 'foreign') {
+            const locationSet = this.selectedRecipientLocations.map((location) => {
+                if (!location.filter.city && location.filter.country && location.filter.country.toLowerCase() === 'foreign') {
                     filters[rootKeys.recipientLocationScope] = 'foreign';
                 }
-                locationSet.push(location.filter);
+                return location.filter;
             });
 
             if (locationSet.length > 0) {
@@ -218,12 +217,11 @@ class SearchAwardsOperation {
 
         // Add Locations
         if (this.selectedLocations.length > 0) {
-            const locationSet = [];
-            this.selectedLocations.forEach((location) => {
-                if (location.filter.country && location.filter.country.toLowerCase() === 'foreign') {
+            const locationSet = this.selectedLocations.map((location) => {
+                if (!location.filter.city && location.filter.country && location.filter.country.toLowerCase() === 'foreign') {
                     filters[rootKeys.placeOfPerformanceScope] = 'foreign';
                 }
-                locationSet.push(location.filter);
+                return location.filter;
             });
 
             if (locationSet.length > 0) {

--- a/tests/containers/search/filters/location/LocationPickerContainer-test.jsx
+++ b/tests/containers/search/filters/location/LocationPickerContainer-test.jsx
@@ -416,6 +416,38 @@ describe('LocationPickerContainer', () => {
         });
     });
 
+    describe('cleanBadLocationData', () => {
+        const container = shallow(<LocationPickerContainer {...mockPickerRedux} />);
+        container.setState({
+            country: {
+                code: 'GBR',
+                name: 'United Kingdom'
+            },
+            city: {
+                code: 'United Kingdom',
+                name: 'Londonderry'
+            }
+        });
+        const goodLocationData = container.instance().createLocationObject();
+        const badLocationData = {
+            ...goodLocationData,
+            filter: {
+                ...goodLocationData.filter,
+                country: 'FOREIGN'
+            }
+        };
+
+        it('badLocationData to be cleaned up', () => {
+            const cleanData = container.instance().cleanBadLocationData(badLocationData);
+            expect(cleanData.filter.country).toEqual(container.instance().state.city.code);
+        });
+
+        it('goodLocationData to be unchanged', () => {
+            const newLocationObject = container.instance().cleanBadLocationData(goodLocationData);
+            expect(newLocationObject.filter.country).toEqual(goodLocationData.filter.country);
+        });
+    });
+
     describe('addLocation', () => {
         it('should call the addLocation prop to add the location to Redux', () => {
             const mockAdd = jest.fn();

--- a/tests/containers/search/filters/location/LocationPickerContainer-test.jsx
+++ b/tests/containers/search/filters/location/LocationPickerContainer-test.jsx
@@ -258,6 +258,8 @@ describe('LocationPickerContainer', () => {
             const domesticContainer = shallow(<LocationPickerContainer {...mockPickerRedux} />);
             // Test for handling cities w/ commas
             const commaContainer = shallow(<LocationPickerContainer {...mockPickerRedux} />);
+            // Test for handling cities w/ a code that doesn't match any countries
+            const invalidCountryCodeContainer = shallow(<LocationPickerContainer {...mockPickerRedux} />);
 
             domesticContainer.setState({
                 country: {
@@ -280,13 +282,25 @@ describe('LocationPickerContainer', () => {
                     name: "London, Kent"
                 }
             });
+            invalidCountryCodeContainer.setState({
+                country: {
+                    code: 'FOREIGN',
+                    name: 'ALL FOREIGN COUNTRIES'
+                },
+                city: {
+                    code: "United Kingdom",
+                    name: "Londonderry, United Kingdom"
+                }
+            });
 
             const domesticLocation = domesticContainer.instance().createLocationObject();
             const commaLocation = commaContainer.instance().createLocationObject();
+            const invalidCountryCodeLocation = invalidCountryCodeContainer.instance().createLocationObject();
 
             it('locationObject.identifier is correct', () => {
                 expect(domesticLocation.identifier).toEqual('USA_GA_Atlanta');
                 expect(commaLocation.identifier).toEqual('GBR_London, Kent');
+                expect(invalidCountryCodeLocation.identifier).toEqual('FOREIGN_Londonderry');
             });
             it('locationObject.filter is correct', () => {
                 expect(domesticLocation.filter).toEqual({
@@ -297,6 +311,10 @@ describe('LocationPickerContainer', () => {
                 expect(commaLocation.filter).toEqual({
                     country: 'GBR',
                     city: 'London, Kent'
+                });
+                expect(invalidCountryCodeLocation.filter).toEqual({
+                    country: 'United Kingdom',
+                    city: 'Londonderry'
                 });
             });
             it('locationObject.display is correct', () => {
@@ -309,6 +327,11 @@ describe('LocationPickerContainer', () => {
                     title: 'London, Kent',
                     entity: 'City',
                     standalone: 'London, Kent'
+                });
+                expect(invalidCountryCodeLocation.display).toEqual({
+                    title: 'Londonderry, United Kingdom',
+                    entity: 'City',
+                    standalone: 'Londonderry, United Kingdom'
                 });
             });
         });


### PR DESCRIPTION
**High level description:**
When an invalid country code is associated with a city, the request object should include the country code returned in the api response, even though it does not match one of our availableCountries.

**Technical details:**
Adds a wrapper function to the return statement within `createLocationObject` that transforms the object's `.filter` property which is used to build the AwardSearch API Request object.

Changing the `locationObject.filter.country` property from `FOREIGN` to whatever `this.state.city.code` is.

This is an antipattern as we're overriding the local state, which should be the single source of truth in the component.

**JIRA Ticket:**
[DEV-3167](https://federal-spending-transparency.atlassian.net/browse/DEV-3167)

The following are ALL required for the PR to be merged:
- [x] Code review
