### PR TITLE
[DEV-2988] Disabled EntityDropdown throws error onClick

### DIFF
--- a/src/js/components/search/filters/location/EntityDropdown.jsx
+++ b/src/js/components/search/filters/location/EntityDropdown.jsx
@@ -127,7 +127,7 @@ export default class EntityDropdown extends React.Component {
             return;
         }
 
-        this.openDropdown();
+        if (this.props.enabled) this.openDropdown();
     }
 
     clickedItem(item) {


### PR DESCRIPTION
**High level description:**
Disabled drop down still registers click and throws a big error.

**Technical details:**
Added condition to onClick handler that only fires when dropdown is `enabled`.

**JIRA Ticket:**
[DEV-2988](https://federal-spending-transparency.atlassian.net/browse/DEV-2988)

The following are ALL required for the PR to be merged:
- [x] Code review
