### PR TITLE
Case-insensitive Availability Type Code

### DIFF
--- a/src/js/components/search/filters/programSource/ProgramSourceSection.jsx
+++ b/src/js/components/search/filters/programSource/ProgramSourceSection.jsx
@@ -100,7 +100,7 @@ export default class ProgramSourceSection extends React.Component {
             });
         }
         else {
-            const identifier = `${components.ata || '***'}-${components.aid}-${components.bpoa || '****'}-${components.epoa || '****'}-${components.a || '*'}-${components.main || '****'}-${components.sub || '***'}`;
+            const identifier = `${components.ata || '***'}-${components.aid}-${components.bpoa || '****'}/${components.epoa || '****'}-${components.a || '*'}-${components.main || '****'}-${components.sub || '***'}`;
             this.props.updateTreasuryAccountComponents({
                 identifier,
                 values: components

--- a/src/js/components/search/filters/programSource/ProgramSourceSection.jsx
+++ b/src/js/components/search/filters/programSource/ProgramSourceSection.jsx
@@ -107,17 +107,7 @@ export default class ProgramSourceSection extends React.Component {
             });
         }
         // Clear the values after they have been applied
-        this.setState({
-            components: {
-                ata: '',
-                aid: '',
-                bpoa: '',
-                epoa: '',
-                a: '',
-                main: '',
-                sub: ''
-            }
-        });
+        this.clearValues();
     }
 
     removeFilter(identifier) {
@@ -131,6 +121,21 @@ export default class ProgramSourceSection extends React.Component {
                 identifier, values: {}
             });
         }
+        this.clearValues();
+    }
+
+    clearValues() {
+        this.setState({
+            components: {
+                ata: '',
+                aid: '',
+                bpoa: '',
+                epoa: '',
+                a: '',
+                main: '',
+                sub: ''
+            }
+        });
     }
 
     render() {

--- a/src/js/containers/search/filters/programSource/ProgramSourceAutocompleteContainer.jsx
+++ b/src/js/containers/search/filters/programSource/ProgramSourceAutocompleteContainer.jsx
@@ -58,7 +58,8 @@ export default class ProgramSourceAutocompleteContainer extends React.Component 
 
         // Make a copy of the current selections
         let filters = Object.assign({}, this.props.selectedSources);
-        filters[this.props.component.code] = input;
+        // All the components are numbers except Availability Type Code, which we want to be case insensitive
+        filters[this.props.component.code] = input.toUpperCase();
         // Exclude filters with empty values
         filters = pickBy(filters);
 


### PR DESCRIPTION
**High level description:**

- Makes the Availability Type Code autocomplete request case-insensitive
- Changes the `-` between BPOA and EPOA in filter tags to a `/`
- Fixes a bug that caused the input values to get cleared after a filter tag is removed, but the internal component state was not cleared

**JIRA Ticket:**
[DEV-3230](https://federal-spending-transparency.atlassian.net/browse/DEV-3230)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Verified cross-browser compatibility
