### PR TITLE
Remove extra Federal Accounts label

### DIFF
--- a/src/_scss/pages/awardV2/idv/_awardFundingSummary.scss
+++ b/src/_scss/pages/awardV2/idv/_awardFundingSummary.scss
@@ -64,9 +64,6 @@
       .federal-accounts-table-holder {
         width: 100%;
       }
-      #federal-account-treemap-title {
-        margin-top: 0;
-      }
       .explorer-cell-title {
         font-weight: bold;
       }

--- a/src/js/components/awardv2/idv/federalAccounts/FederalAccountsTree.jsx
+++ b/src/js/components/awardv2/idv/federalAccounts/FederalAccountsTree.jsx
@@ -238,7 +238,6 @@ export default class FederalAccountsTree extends React.Component {
         }
         return (
             <div>
-                <h4 id="federal-account-treemap-title">Federal Accounts</h4>
                 <div className="results-table-message-container">
                     {loadingMessage}
                     {errorMessage}


### PR DESCRIPTION
**High level description:**
- Removes extra "Federal Accounts" label from the IDV treemap

**JIRA Ticket:**
[DEV-2958](https://federal-spending-transparency.atlassian.net/browse/DEV-2958)

**Mockup:**
https://bahdigital.invisionapp.com/share/GVIAAHOBER9#/296001079_Award_Summary_2-0_-_IDV_-future-

The following are ALL required for the PR to be merged:
- [x] Code review
