### PR TITLE
Hotfix Dev-2733 Today Line should not display when outside graph width

### DIFF
--- a/src/js/components/awardv2/idv/activity/chart/ActivityChart.jsx
+++ b/src/js/components/awardv2/idv/activity/chart/ActivityChart.jsx
@@ -296,6 +296,9 @@ export default class ActivityChart extends React.Component {
     render() {
         const bars = this.createBars();
         const { width, height, padding } = this.props;
+        const currentDate = Date.now();
+        console.log(' Current Date : ', currentDate);
+        console.log(' Type Of Current Date : ', currentDate);
         const {
             xScale,
             xRange,
@@ -334,8 +337,10 @@ export default class ActivityChart extends React.Component {
                             y1={-10}
                             y2={height - padding.bottom}
                             textY={0}
+                            text="Today"
                             xMax={xRange[1]}
                             xMin={xRange[0]}
+                            xValue={currentDate}
                             showTextPosition="top"
                             adjustmentX={padding.left} />}
                     </g>

--- a/src/js/components/awardv2/idv/activity/chart/ActivityChart.jsx
+++ b/src/js/components/awardv2/idv/activity/chart/ActivityChart.jsx
@@ -297,8 +297,6 @@ export default class ActivityChart extends React.Component {
         const bars = this.createBars();
         const { width, height, padding } = this.props;
         const currentDate = Date.now();
-        console.log(' Current Date : ', currentDate);
-        console.log(' Type Of Current Date : ', currentDate);
         const {
             xScale,
             xRange,

--- a/src/js/components/sharedComponents/VerticalLine.jsx
+++ b/src/js/components/sharedComponents/VerticalLine.jsx
@@ -82,37 +82,56 @@ export default class VerticalLine extends Component {
         this.setState({ textX: positionX, textY: modifiedTextY });
     }
 
-    render() {
+    verticalLine() {
         const {
-            text,
-            y1,
-            y2,
-            xValue,
-            xMax,
             xMin,
+            xMax,
+            xValue,
+            xScale,
             adjustmentX,
-            xScale
+            y1,
+            y2
         } = this.props;
-        const linePosition = xScale(xValue || Date.now()) + (adjustmentX || 0);
+        const linePosition = xScale(xValue) + (adjustmentX || 0);
+        // get x position of minimum
+        const minimumX = xScale(xMin);
+        // get x position of maximum
+        const maximumX = xScale(xMax);
+        if ((linePosition > maximumX) || (linePosition < minimumX)) return null;
+        return (
+            <line
+                id="vertical-line"
+                x1={linePosition}
+                x2={linePosition}
+                y1={y1}
+                y2={y2} />
+        );
+    }
+
+    text(lineIsDisplayed) {
+        const { text } = this.props;
+        if (!lineIsDisplayed || !text) return null;
+        return (
+            <text
+                id="vertical-line__text"
+                x={this.state.textX}
+                y={this.state.textY}
+                ref={this.setTextDiv}>
+                {text}
+            </text>
+        );
+    }
+
+    render() {
         // show nothing if not within x Range
-        if ((linePosition > xMax) || (linePosition < xMin)) return null;
+        const verticalLine = this.verticalLine();
+        const text = this.text(verticalLine);
         const description = this.props.description || 'A vertical line representing today\'s date';
         return (
             <g className="vertical-line__container">
                 <desc>{description}</desc>
-                <text
-                    id="vertical-line__text"
-                    x={this.state.textX}
-                    y={this.state.textY}
-                    ref={this.setTextDiv}>
-                    {text || 'Today'}
-                </text>
-                <line
-                    id="vertical-line"
-                    x1={linePosition}
-                    x2={linePosition}
-                    y1={y1}
-                    y2={y2} />
+                {text}
+                {verticalLine}
             </g>
         );
     }

--- a/src/js/components/sharedComponents/VerticalLine.jsx
+++ b/src/js/components/sharedComponents/VerticalLine.jsx
@@ -93,10 +93,10 @@ export default class VerticalLine extends Component {
             adjustmentX,
             xScale
         } = this.props;
-        // show nothing if not within x Range
-        if ((xValue > xMax) && (xValue < xMin)) return null;
-        const description = this.props.description || 'A vertical line representing today\'s date';
         const linePosition = xScale(xValue || Date.now()) + (adjustmentX || 0);
+        // show nothing if not within x Range
+        if ((linePosition > xMax) || (linePosition < xMin)) return null;
+        const description = this.props.description || 'A vertical line representing today\'s date';
         return (
             <g className="vertical-line__container">
                 <desc>{description}</desc>


### PR DESCRIPTION
**High level description:**

This PR will not display the Today Line when it's position is outside of the graphs date range.

**Technical details:**

- move line into own function due to the logic needed to display line

- move text into own function due to the logic needed to display text

- remove default values passed to increase reusability.

**JIRA Ticket:**
[DEV-2733](https://federal-spending-transparency.atlassian.net/browse/DEV-2733)

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Verified cross-browser compatibility
