### PR TITLE
[DEV-1564] Reusing Components for Contract Award Summary Page, Award Amounts Section

### DIFF
--- a/src/_scss/pages/awardV2/awardContract.scss
+++ b/src/_scss/pages/awardV2/awardContract.scss
@@ -1,4 +1,6 @@
 /* Styles specific to Contracts */
+@import "./idv/awardAmounts/awardAmounts";
 
 .award-contract {
+
 }

--- a/src/_scss/pages/awardV2/awardPage.scss
+++ b/src/_scss/pages/awardV2/awardPage.scss
@@ -44,7 +44,7 @@
                     }
                 }
             }
-            .award__heading-lable {
+            .award__heading-label {
                 font-weight: $font-normal;
                 display: inline-block;
                 padding-right: rem(10);

--- a/src/js/components/awardv2/contract/AwardAmounts.jsx
+++ b/src/js/components/awardv2/contract/AwardAmounts.jsx
@@ -85,6 +85,20 @@ const AwardAmounts = ({
                 <div>
                     <div className="award-amounts__content">
                         {visualization}
+                        <div className="award-amounts__data-wrapper">
+                            <div className="award-amounts__data-content">
+                                <div><span className="award-amounts__data-icon award-amounts__data-icon_blue" />Obligated Amounts</div>
+                                <span>{awardAmountsProps.obligation}</span>
+                            </div>
+                            <div className="award-amounts__data-content">
+                                <div><span className="award-amounts__data-icon award-amounts__data-icon_gray" />Current Award Amounts</div>
+                                <span>{awardAmountsProps.combinedCurrentAwardAmounts}</span>
+                            </div>
+                            <div className="award-amounts__data-content">
+                                <div><span className="award-amounts__data-icon award-amounts__data-icon_transparent" />Potential Award Amounts</div>
+                                <span>{awardAmountsProps.combinedPotentialAwardAmounts}</span>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/js/components/awardv2/contract/AwardAmounts.jsx
+++ b/src/js/components/awardv2/contract/AwardAmounts.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { AwardSection, AwardSectionHeader } from '../shared';
+import { determineSpendingScenario } from "../../../helpers/aggregatedAmountsHelper";
+import NormalChart from '../shared/charts/NormalChart';
+import ExceedsCurrentChart from '../shared/charts/ExceedsCurrentChart';
+import ExceedsPotentialChart from '../shared/charts/ExceedsPotentialChart';
+import NoResultsMessage from '../../sharedComponents/NoResultsMessage';
+
+const propTypes = {
+    awardAmountsProps: PropTypes.shape({
+        id: PropTypes.string,
+        generatedId: PropTypes.string,
+        _obligation: PropTypes.number,
+        obligation: PropTypes.string,
+        obligationFormatted: PropTypes.string,
+        _combinedCurrentAwardAmounts: PropTypes.number,
+        combinedCurrentAwardAmounts: PropTypes.string,
+        combinedCurrentAwardAmountsFormatted: PropTypes.string,
+        _combinedPotentialAwardAmounts: PropTypes.number,
+        combinedPotentialAwardAmounts: PropTypes.string,
+        combinedPotentialAwardAmountsFormatted: PropTypes.string,
+        baseExercisedOptionsFormated: PropTypes.string
+    }),
+    tooltipProps: PropTypes.shape({
+        controlledProps: PropTypes.shape({
+            isControlled: PropTypes.bool,
+            isVisible: PropTypes.bool,
+            closeCurrentTooltip: PropTypes.func,
+            showTooltip: PropTypes.func
+        })
+    })
+};
+
+const AwardAmounts = ({
+    awardAmountsProps,
+    tooltipProps
+}) => {
+    const renderChart = (awardAmounts = awardAmountsProps) => {
+        switch (determineSpendingScenario(awardAmounts)) {
+            case "exceedsCurrent":
+                return (
+                    <ExceedsCurrentChart
+                        awardAmounts={awardAmounts}
+                        obligatedTooltipProps={tooltipProps}
+                        currentTooltipProps={tooltipProps}
+                        potentialTooltipProps={tooltipProps}
+                        exceedsCurrentTooltipProps={tooltipProps} />
+                );
+            case "exceedsPotential":
+                return (
+                    <ExceedsPotentialChart
+                        awardAmounts={awardAmounts}
+                        obligatedTooltipProps={tooltipProps}
+                        currentTooltipProps={tooltipProps}
+                        potentialTooltipProps={tooltipProps}
+                        exceedsPotentialTooltipProps={tooltipProps} />
+                );
+            case "normal":
+                return (
+                    <NormalChart
+                        awardAmounts={awardAmounts}
+                        obligatedTooltipProps={tooltipProps}
+                        currentTooltipProps={tooltipProps}
+                        potentialTooltipProps={tooltipProps} />
+                );
+            default:
+                return (
+                    <div className="results-table-message-container">
+                        <NoResultsMessage
+                            title="Chart Not Available"
+                            message="Data in this instance is not suitable for charting" />
+                    </div>
+                );
+        }
+    };
+
+    const visualization = renderChart(awardAmountsProps);
+
+    return (
+        <AwardSection type="column" className="award-viz award-amounts">
+            <div className="award__col__content">
+                <AwardSectionHeader title="$ Award Amounts" />
+                <div>
+                    <div className="award-amounts__content">
+                        {visualization}
+                    </div>
+                </div>
+            </div>
+        </AwardSection>
+    );
+};
+
+AwardAmounts.propTypes = propTypes;
+
+export default AwardAmounts;

--- a/src/js/components/awardv2/contract/ContractContent.jsx
+++ b/src/js/components/awardv2/contract/ContractContent.jsx
@@ -15,8 +15,9 @@ import NormalChart from '../shared/charts/NormalChart';
 import ExceedsCurrentChart from '../shared/charts/ExceedsCurrentChart';
 import ExceedsPotentialChart from '../shared/charts/ExceedsPotentialChart';
 
-import { AwardSection, AwardPageWrapper } from '../shared';
+import { AwardSection, AwardPageWrapper, AwardSectionHeader } from '../shared';
 import ComingSoonSection from '../shared/ComingSoonSection';
+import NoResultsMessage from '../../sharedComponents/NoResultsMessage';
 
 const propTypes = {
     awardId: PropTypes.string,
@@ -24,28 +25,25 @@ const propTypes = {
     jumpToSection: PropTypes.func
 };
 
-const awardAmountProperties = [
+const overviewProperties = [
     "id",
     "generatedId",
     "_totalObligation",
     "_baseExercisedOptions",
-    "_amount",
+    "_baseAndAllOptions",
     "totalObligation",
-    "totalObligationFormatted",
     "baseExercisedOptions",
     "baseExercisedOptionsFormatted",
-    "amount",
-    "amountFormatted"
+    "baseAndAllOptions"
 ];
 // Does this need to go in a model or a data mapping?
-const awardAmountMap = {
+const awardAmountValueByOverviewKey = {
     _totalObligation: "_obligation",
     _baseExercisedOptions: "_combinedCurrentAwardAmounts",
-    _amount: "_combinedPotentialAwardAmounts",
-    totalObligationFormatted: "obligationFormatted",
-    baseExercisedOptionsFormatted: "combinedCurrentAwardAmountsFormatted",
-    amountFormatted: "combinedPotentialAwardAmountsFormatted",
-    amount: "combinedPotentialAwardAmounts"
+    _baseAndAllOptions: "_combinedPotentialAwardAmounts",
+    totalObligation: "obligationFormatted",
+    baseExercisedOptions: "combinedCurrentAwardAmountsFormatted",
+    baseAndAllOptions: "combinedPotentialAwardAmountsFormatted"
 };
 
 const defaultTooltipProps = {
@@ -63,32 +61,31 @@ export default class ContractContent extends React.Component {
         this.renderChart = this.renderChart.bind(this);
     }
     renderChart(overview = this.props.overview) {
-        const awardAmounts = awardAmountProperties
+        const awardAmounts = overviewProperties
             .reduce((acc, key) => ({
                 ...acc,
-                [awardAmountMap[key] || key]: overview[key]
+                [awardAmountValueByOverviewKey[key] || key]: overview[key]
             }), { _obligation: 0, _combinedCurrentAwardAmounts: 0, _combinedPotentialAwardAmounts: 0 });
         switch (determineSpendingScenario(awardAmounts)) {
             case "exceedsCurrent":
-                console.log("exceedsCurrent");
                 return (
                     <ExceedsCurrentChart
                         awardAmounts={awardAmounts}
                         obligatedTooltipProps={defaultTooltipProps}
                         currentTooltipProps={defaultTooltipProps}
-                        potentialTooltipProps={defaultTooltipProps} />
+                        potentialTooltipProps={defaultTooltipProps}
+                        exceedsCurrentTooltipProps={defaultTooltipProps} />
                 );
             case "exceedsPotential":
-                console.log("exceedsPotential");
                 return (
                     <ExceedsPotentialChart
                         awardAmounts={awardAmounts}
                         obligatedTooltipProps={defaultTooltipProps}
                         currentTooltipProps={defaultTooltipProps}
-                        potentialTooltipProps={defaultTooltipProps} />
+                        potentialTooltipProps={defaultTooltipProps}
+                        exceedsPotentialTooltipProps={defaultTooltipProps} />
                 );
             case "normal":
-                console.log("normal");
                 return (
                     <NormalChart
                         awardAmounts={awardAmounts}
@@ -97,7 +94,13 @@ export default class ContractContent extends React.Component {
                         potentialTooltipProps={defaultTooltipProps} />
                 );
             default:
-                return null;
+                return (
+                    <div className="results-table-message-container">
+                        <NoResultsMessage
+                            title="Chart Not Available"
+                            message="Data in this instance is not suitable for charting" />
+                    </div>
+                );
         }
     }
 
@@ -127,9 +130,12 @@ export default class ContractContent extends React.Component {
                 </AwardSection>
                 <AwardSection type="row">
                     <AwardSection type="column" className="award-viz award-amounts">
-                        <div>
-                            <div className="award-amounts__content">
-                                {visualization}
+                        <div className="award__col__content">
+                            <AwardSectionHeader title="$ Award Amounts" />
+                            <div>
+                                <div className="award-amounts__content">
+                                    {visualization}
+                                </div>
                             </div>
                         </div>
                     </AwardSection>

--- a/src/js/components/awardv2/contract/ContractContent.jsx
+++ b/src/js/components/awardv2/contract/ContractContent.jsx
@@ -12,6 +12,7 @@ import { glossaryLinks } from 'dataMapping/search/awardType';
 import AdditionalInfo from '../shared/additionalInfo/AdditionalInfo';
 import AgencyRecipient from '../shared/overview/AgencyRecipient';
 import AwardDates from '../shared/overview/AwardDates';
+import { AwardSection, AwardPageWrapper } from '../shared';
 
 const propTypes = {
     awardId: PropTypes.string,
@@ -31,35 +32,25 @@ export default class ContractContent extends React.Component {
             );
         }
         return (
-            <div className="award award-contract">
-                <div className="award__heading">
-                    <div className="award__heading-text">{startCase(this.props.overview.typeDescription)}</div>
-                    <div className="award__heading-icon">
-                        {glossaryLink}
-                    </div>
-                    <div className="award__heading-id">
-                        <div className="award__heading-lable">{this.props.overview.id ? 'PIID' : ''}</div>
-                        <div>{this.props.overview.id}</div>
-                    </div>
-                </div>
-                <hr />
-                <div className="award__row award-overview" id="award-overview">
-                    <AgencyRecipient
-                        jumpToSection={this.props.jumpToSection}
-                        awardingAgency={this.props.overview.awardingAgency}
-                        category="contract"
-                        recipient={this.props.overview.recipient} />
-                    <div className="award__col award-amountdates">
-                        <AwardDates
-                            overview={this.props.overview} />
-                    </div>
-                </div>
-
-                <div className="agency-additional" id="award-additional-information">
-                    <AdditionalInfo
-                        overview={this.props.overview} />
-                </div>
-            </div>
+            <AwardPageWrapper
+                glossaryLink={glossaryLink}
+                identifier={this.props.overview.id}
+                awardTypeDescription={this.props.overview.typeDescription}
+                awardType="contract">
+                <AwardSection type="row" className="award-overview" id="award-overview">
+                    <AwardSection type="column" className="award-amountdates">
+                        <AgencyRecipient
+                            jumpToSection={this.props.jumpToSection}
+                            awardingAgency={this.props.overview.awardingAgency}
+                            category="contract"
+                            recipient={this.props.overview.recipient} />
+                    </AwardSection>
+                    <AwardSection type="column" className="award-amountdates">
+                        <AwardDates overview={this.props.overview} />
+                    </AwardSection>
+                </AwardSection>
+                <AdditionalInfo overview={this.props.overview} />
+            </AwardPageWrapper>
         );
     }
 }

--- a/src/js/components/awardv2/contract/ContractContent.jsx
+++ b/src/js/components/awardv2/contract/ContractContent.jsx
@@ -24,11 +24,37 @@ const propTypes = {
     jumpToSection: PropTypes.func
 };
 
-const awardAmountProperties = ["_totalObligation", "_baseAndAllOptions", "_baseExercisedOptions"];
+const awardAmountProperties = [
+    "id",
+    "generatedId",
+    "_totalObligation",
+    "_baseExercisedOptions",
+    "_amount",
+    "totalObligation",
+    "totalObligationFormatted",
+    "baseExercisedOptions",
+    "baseExercisedOptionsFormatted",
+    "amount",
+    "amountFormatted"
+];
+// Does this need to go in a model or a data mapping?
 const awardAmountMap = {
-    _totalObligation: "_combinedCurrentAwardAmounts",
-    _baseAndAllOptions: "_combinedPotentialAwardAmounts",
-    _baseExercisedOptions: "_obligation"
+    _totalObligation: "_obligation",
+    _baseExercisedOptions: "_combinedCurrentAwardAmounts",
+    _amount: "_combinedPotentialAwardAmounts",
+    totalObligationFormatted: "obligationFormatted",
+    baseExercisedOptionsFormatted: "combinedCurrentAwardAmountsFormatted",
+    amountFormatted: "combinedPotentialAwardAmountsFormatted",
+    amount: "combinedPotentialAwardAmounts"
+};
+
+const defaultTooltipProps = {
+    controlledProps: {
+        isControlled: false,
+        isVisible: false,
+        closeCurrentTooltip: () => console.log("close tooltip"),
+        showTooltip: () => console.log("open tooltip")
+    }
 };
 
 export default class ContractContent extends React.Component {
@@ -37,27 +63,41 @@ export default class ContractContent extends React.Component {
         this.renderChart = this.renderChart.bind(this);
     }
     renderChart(overview = this.props.overview) {
-        const amounts = Object.keys(overview)
-            .filter((key) => awardAmountProperties.includes(key))
-            .reduce((acc, item) => ({
+        const awardAmounts = awardAmountProperties
+            .reduce((acc, key) => ({
                 ...acc,
-                [awardAmountMap[item]]: overview[item]
+                [awardAmountMap[key] || key]: overview[key]
             }), { _obligation: 0, _combinedCurrentAwardAmounts: 0, _combinedPotentialAwardAmounts: 0 });
-        switch (determineSpendingScenario(amounts)) {
+        switch (determineSpendingScenario(awardAmounts)) {
             case "exceedsCurrent":
                 console.log("exceedsCurrent");
-                return;
-                // return <ExceedsCurrentChart />;
+                return (
+                    <ExceedsCurrentChart
+                        awardAmounts={awardAmounts}
+                        obligatedTooltipProps={defaultTooltipProps}
+                        currentTooltipProps={defaultTooltipProps}
+                        potentialTooltipProps={defaultTooltipProps} />
+                );
             case "exceedsPotential":
                 console.log("exceedsPotential");
-                return;
-                // return <ExceedsPotentialChart />;
+                return (
+                    <ExceedsPotentialChart
+                        awardAmounts={awardAmounts}
+                        obligatedTooltipProps={defaultTooltipProps}
+                        currentTooltipProps={defaultTooltipProps}
+                        potentialTooltipProps={defaultTooltipProps} />
+                );
             case "normal":
                 console.log("normal");
-                return;
-                // return <NormalChart/>;
+                return (
+                    <NormalChart
+                        awardAmounts={awardAmounts}
+                        obligatedTooltipProps={defaultTooltipProps}
+                        currentTooltipProps={defaultTooltipProps}
+                        potentialTooltipProps={defaultTooltipProps} />
+                );
             default:
-                console.log("default");
+                return null;
         }
     }
 
@@ -66,7 +106,7 @@ export default class ContractContent extends React.Component {
         const glossaryLink = glossarySlug
             ? `/#/award_v2/${this.props.awardId}?glossary=${glossarySlug}`
             : null;
-        const vizualization = this.renderChart(this.props.overview);
+        const visualization = this.renderChart(this.props.overview);
         return (
             <AwardPageWrapper
                 glossaryLink={glossaryLink}
@@ -86,8 +126,12 @@ export default class ContractContent extends React.Component {
                     </AwardSection>
                 </AwardSection>
                 <AwardSection type="row">
-                    <AwardSection type="column">
-                        HI
+                    <AwardSection type="column" className="award-viz award-amounts">
+                        <div>
+                            <div className="award-amounts__content">
+                                {visualization}
+                            </div>
+                        </div>
                     </AwardSection>
                     <ComingSoonSection title="Description" includeHeader />
                 </AwardSection>

--- a/src/js/components/awardv2/contract/ContractContent.jsx
+++ b/src/js/components/awardv2/contract/ContractContent.jsx
@@ -50,7 +50,7 @@ const awardAmountValueByOverviewKey = {
 
 const defaultTooltipProps = {
     controlledProps: {
-        isControlled: false,
+        isControlled: true,
         isVisible: false,
         closeCurrentTooltip: () => console.log("close tooltip"),
         showTooltip: () => console.log("open tooltip")
@@ -59,9 +59,6 @@ const defaultTooltipProps = {
 
 export default class ContractContent extends React.Component {
     render() {
-        console.log("totalObligation", this.props.overview.totalObligation);
-        console.log("totalObligation formatted", this.props.overview.totalObligationFormatted);
-
         const glossarySlug = glossaryLinks[this.props.overview.type];
         const glossaryLink = glossarySlug
             ? `/#/award_v2/${this.props.awardId}?glossary=${glossarySlug}`

--- a/src/js/components/awardv2/contract/ContractContent.jsx
+++ b/src/js/components/awardv2/contract/ContractContent.jsx
@@ -5,14 +5,18 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { startCase } from 'lodash';
 
-import { Glossary } from 'components/sharedComponents/icons/Icons';
 import { glossaryLinks } from 'dataMapping/search/awardType';
 import AdditionalInfo from '../shared/additionalInfo/AdditionalInfo';
 import AgencyRecipient from '../shared/overview/AgencyRecipient';
 import AwardDates from '../shared/overview/AwardDates';
+import { determineSpendingScenario } from "../../../helpers/aggregatedAmountsHelper";
+import NormalChart from '../shared/charts/NormalChart';
+import ExceedsCurrentChart from '../shared/charts/ExceedsCurrentChart';
+import ExceedsPotentialChart from '../shared/charts/ExceedsPotentialChart';
+
 import { AwardSection, AwardPageWrapper } from '../shared';
+import ComingSoonSection from '../shared/ComingSoonSection';
 
 const propTypes = {
     awardId: PropTypes.string,
@@ -20,17 +24,49 @@ const propTypes = {
     jumpToSection: PropTypes.func
 };
 
+const awardAmountProperties = ["_totalObligation", "_baseAndAllOptions", "_baseExercisedOptions"];
+const awardAmountMap = {
+    _totalObligation: "_combinedCurrentAwardAmounts",
+    _baseAndAllOptions: "_combinedPotentialAwardAmounts",
+    _baseExercisedOptions: "_obligation"
+};
+
 export default class ContractContent extends React.Component {
+    constructor(props) {
+        super(props);
+        this.renderChart = this.renderChart.bind(this);
+    }
+    renderChart(overview = this.props.overview) {
+        const amounts = Object.keys(overview)
+            .filter((key) => awardAmountProperties.includes(key))
+            .reduce((acc, item) => ({
+                ...acc,
+                [awardAmountMap[item]]: overview[item]
+            }), { _obligation: 0, _combinedCurrentAwardAmounts: 0, _combinedPotentialAwardAmounts: 0 });
+        switch (determineSpendingScenario(amounts)) {
+            case "exceedsCurrent":
+                console.log("exceedsCurrent");
+                return;
+                // return <ExceedsCurrentChart />;
+            case "exceedsPotential":
+                console.log("exceedsPotential");
+                return;
+                // return <ExceedsPotentialChart />;
+            case "normal":
+                console.log("normal");
+                return;
+                // return <NormalChart/>;
+            default:
+                console.log("default");
+        }
+    }
+
     render() {
         const glossarySlug = glossaryLinks[this.props.overview.type];
-        let glossaryLink = null;
-        if (glossarySlug) {
-            glossaryLink = (
-                <a href={`/#/award_v2/${this.props.awardId}?glossary=${glossarySlug}`}>
-                    <Glossary />
-                </a>
-            );
-        }
+        const glossaryLink = glossarySlug
+            ? `/#/award_v2/${this.props.awardId}?glossary=${glossarySlug}`
+            : null;
+        const vizualization = this.renderChart(this.props.overview);
         return (
             <AwardPageWrapper
                 glossaryLink={glossaryLink}
@@ -48,6 +84,12 @@ export default class ContractContent extends React.Component {
                     <AwardSection type="column" className="award-amountdates">
                         <AwardDates overview={this.props.overview} />
                     </AwardSection>
+                </AwardSection>
+                <AwardSection type="row">
+                    <AwardSection type="column">
+                        HI
+                    </AwardSection>
+                    <ComingSoonSection title="Description" includeHeader />
                 </AwardSection>
                 <AdditionalInfo overview={this.props.overview} />
             </AwardPageWrapper>

--- a/src/js/components/awardv2/financialAssistance/FinancialAssistanceContent.jsx
+++ b/src/js/components/awardv2/financialAssistance/FinancialAssistanceContent.jsx
@@ -38,7 +38,7 @@ export default class FinancialAssistanceContent extends React.Component {
                         {glossaryLink}
                     </div>
                     <div className="award__heading-id">
-                        <div className="award__heading-lable">{this.props.overview.id ? 'ID' : ''}</div>
+                        <div className="award__heading-label">{this.props.overview.id ? 'ID' : ''}</div>
                         <div>{this.props.overview.id}</div>
                     </div>
                 </div>

--- a/src/js/components/awardv2/idv/IdvContent.jsx
+++ b/src/js/components/awardv2/idv/IdvContent.jsx
@@ -83,7 +83,7 @@ export default class IdvContent extends React.Component {
                             {glossaryLink}
                         </div>
                         <div className="award__heading-id">
-                            <div className="award__heading-lable">
+                            <div className="award__heading-label">
                                 {this.props.overview.id ? "PIID" : ""}
                             </div>
                             <div>{this.props.overview.id}</div>

--- a/src/js/components/awardv2/idv/amounts/AggregatedAwardAmounts.jsx
+++ b/src/js/components/awardv2/idv/amounts/AggregatedAwardAmounts.jsx
@@ -12,9 +12,9 @@ import ChartError from 'components/search/visualizations/ChartError';
 import { Table } from 'components/sharedComponents/icons/Icons';
 import NoResultsMessage from 'components/sharedComponents/NoResultsMessage';
 import AwardsBanner from './AwardsBanner';
-import NormalChart from './charts/NormalChart';
-import ExceedsCurrentChart from './charts/ExceedsCurrentChart';
-import ExceedsPotentialChart from './charts/ExceedsPotentialChart';
+import NormalChart from '../../shared/charts/NormalChart';
+import ExceedsCurrentChart from '../../shared/charts/ExceedsCurrentChart';
+import ExceedsPotentialChart from '../../shared/charts/ExceedsPotentialChart';
 import { AWARD_V2_AGGREGATED_AMOUNTS_PROPS } from '../../../../propTypes';
 import { CombinedObligatedAmounts, CombinedCurrentAmounts, CombinedPotentialAmounts, CombinedExceedsCurrentAmounts, CombinedExceedsPotentialAmounts } from '../../idv/TooltipContent';
 

--- a/src/js/components/awardv2/shared/ComingSoonSection.jsx
+++ b/src/js/components/awardv2/shared/ComingSoonSection.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-import InfoTooltip from './InfoTooltip';
+import InfoTooltip from '../idv/InfoTooltip';
+import { AwardSection } from '.';
 
 const propTypes = {
     title: PropTypes.string,
@@ -44,7 +45,7 @@ const ComingSoonSection = ({
 
     if (includeHeader) {
         return (
-            <div className="award__col award-viz">
+            <AwardSection type="column" className="award-viz">
                 <div className="award__col__content">
                     <div className="award-viz__heading">
                         {icon &&
@@ -63,7 +64,7 @@ const ComingSoonSection = ({
                         {renderChildren()}
                     </div>
                 </div>
-            </div>
+            </AwardSection>
         );
     }
     return (

--- a/src/js/components/awardv2/shared/additionalInfo/AdditionalInfo.jsx
+++ b/src/js/components/awardv2/shared/additionalInfo/AdditionalInfo.jsx
@@ -57,64 +57,66 @@ export default class AdditionalInfo extends React.Component {
             );
         }
         return (
-            <div id="award-additional-information" className="additional-info">
-                <div className="award-viz">
-                    <div className="award-viz__heading">
-                        <div className="award-viz__icon">
-                            <InfoCircle />
+            <div className="agency-additional" id="award-additional-information">
+                <div id="award-additional-information" className="additional-info">
+                    <div className="award-viz">
+                        <div className="award-viz__heading">
+                            <div className="award-viz__icon">
+                                <InfoCircle />
+                            </div>
+                            <h3 className="award-viz__title">Additional Information</h3>
                         </div>
-                        <h3 className="award-viz__title">Additional Information</h3>
-                    </div>
-                    <hr />
-                    <button
-                        className="award-viz__button"
-                        onClick={this.handleClick}>
-                        {this.state.globalToggle ? 'Collapse All' : 'Expand All'}
-                    </button>
-                    <div className="award__row">
-                        <div className="award__col">
-                            <Accordion
-                                globalToggle={this.state.globalToggle}
-                                accordionName="Agency Details"
-                                accordionIcon="landmark"
-                                accordionData={data.agencyDetails} />
-                            <Accordion
-                                globalToggle={this.state.globalToggle}
-                                accordionName="Parent Award Details"
-                                accordionIcon="level-up-alt"
-                                accordionData={data.parentAwardDetails} />
-                            {placeOfPerformance}
-                            {periodOfPerformance}
-                            <Accordion
-                                globalToggle={this.state.globalToggle}
-                                accordionName="Legislative Mandates"
-                                accordionIcon="pencil-alt"
-                                accordionData={data.legislativeMandates} />
-                            <Accordion
-                                globalToggle={this.state.globalToggle}
-                                accordionName="Executive Compensation"
-                                accordionIcon="user-tie"
-                                accordionData={awardData.executiveDetails.officers} />
-                        </div>
-                        <div className="award__col">
-                            <RecipientDetails
-                                data={this.props.overview.recipient}
-                                globalToggle={this.state.globalToggle} />
-                            <Accordion
-                                globalToggle={this.state.globalToggle}
-                                accordionName="Acquisition Details"
-                                accordionIcon="tag"
-                                accordionData={data.aquisitionDetails} />
-                            <Accordion
-                                globalToggle={this.state.globalToggle}
-                                accordionName="Competition Details"
-                                accordionIcon="chart-bar"
-                                accordionData={data.competitionDetails} />
-                            <Accordion
-                                globalToggle={this.state.globalToggle}
-                                accordionName="Additional Details"
-                                accordionIcon="ellipsis-h"
-                                accordionData={data.additionalDetails} />
+                        <hr />
+                        <button
+                            className="award-viz__button"
+                            onClick={this.handleClick}>
+                            {this.state.globalToggle ? 'Collapse All' : 'Expand All'}
+                        </button>
+                        <div className="award__row">
+                            <div className="award__col">
+                                <Accordion
+                                    globalToggle={this.state.globalToggle}
+                                    accordionName="Agency Details"
+                                    accordionIcon="landmark"
+                                    accordionData={data.agencyDetails} />
+                                <Accordion
+                                    globalToggle={this.state.globalToggle}
+                                    accordionName="Parent Award Details"
+                                    accordionIcon="level-up-alt"
+                                    accordionData={data.parentAwardDetails} />
+                                {placeOfPerformance}
+                                {periodOfPerformance}
+                                <Accordion
+                                    globalToggle={this.state.globalToggle}
+                                    accordionName="Legislative Mandates"
+                                    accordionIcon="pencil-alt"
+                                    accordionData={data.legislativeMandates} />
+                                <Accordion
+                                    globalToggle={this.state.globalToggle}
+                                    accordionName="Executive Compensation"
+                                    accordionIcon="user-tie"
+                                    accordionData={awardData.executiveDetails.officers} />
+                            </div>
+                            <div className="award__col">
+                                <RecipientDetails
+                                    data={this.props.overview.recipient}
+                                    globalToggle={this.state.globalToggle} />
+                                <Accordion
+                                    globalToggle={this.state.globalToggle}
+                                    accordionName="Acquisition Details"
+                                    accordionIcon="tag"
+                                    accordionData={data.aquisitionDetails} />
+                                <Accordion
+                                    globalToggle={this.state.globalToggle}
+                                    accordionName="Competition Details"
+                                    accordionIcon="chart-bar"
+                                    accordionData={data.competitionDetails} />
+                                <Accordion
+                                    globalToggle={this.state.globalToggle}
+                                    accordionName="Additional Details"
+                                    accordionIcon="ellipsis-h"
+                                    accordionData={data.additionalDetails} />
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/js/components/awardv2/shared/charts/ExceedsCurrentChart.jsx
+++ b/src/js/components/awardv2/shared/charts/ExceedsCurrentChart.jsx
@@ -6,8 +6,8 @@
 import React from 'react';
 import { generatePercentage } from 'helpers/aggregatedAmountsHelper';
 
-import { AWARD_V2_AGGREGATED_AMOUNTS_PROPS, TOOLTIP_PROPS } from '../../../../../propTypes';
-import TooltipWrapper from "../../../../sharedComponents/TooltipWrapper";
+import TooltipWrapper from "../../../sharedComponents/TooltipWrapper";
+import { AWARD_V2_AGGREGATED_AMOUNTS_PROPS, TOOLTIP_PROPS } from '../../../../propTypes/index';
 
 const propTypes = {
     awardAmounts: AWARD_V2_AGGREGATED_AMOUNTS_PROPS,

--- a/src/js/components/awardv2/shared/charts/ExceedsPotentialChart.jsx
+++ b/src/js/components/awardv2/shared/charts/ExceedsPotentialChart.jsx
@@ -6,10 +6,8 @@
 import React from 'react';
 
 import { generatePercentage } from 'helpers/aggregatedAmountsHelper';
-
-import TooltipWrapper from "../../../../sharedComponents/TooltipWrapper";
-
-import { AWARD_V2_AGGREGATED_AMOUNTS_PROPS, TOOLTIP_PROPS } from '../../../../../propTypes';
+import TooltipWrapper from "../../../sharedComponents/TooltipWrapper";
+import { AWARD_V2_AGGREGATED_AMOUNTS_PROPS, TOOLTIP_PROPS } from '../../../../propTypes/index';
 
 const propTypes = {
     awardAmounts: AWARD_V2_AGGREGATED_AMOUNTS_PROPS,

--- a/src/js/components/awardv2/shared/charts/NormalChart.jsx
+++ b/src/js/components/awardv2/shared/charts/NormalChart.jsx
@@ -5,8 +5,8 @@
 
 import React from 'react';
 import { generatePercentage } from 'helpers/aggregatedAmountsHelper';
-import TooltipWrapper from "../../../../sharedComponents/TooltipWrapper";
-import { AWARD_V2_AGGREGATED_AMOUNTS_PROPS, TOOLTIP_PROPS } from '../../../../../propTypes';
+import TooltipWrapper from "../../../sharedComponents/TooltipWrapper";
+import { AWARD_V2_AGGREGATED_AMOUNTS_PROPS, TOOLTIP_PROPS } from '../../../../propTypes/index';
 
 const propTypes = {
     awardAmounts: AWARD_V2_AGGREGATED_AMOUNTS_PROPS,

--- a/src/js/components/awardv2/shared/index.jsx
+++ b/src/js/components/awardv2/shared/index.jsx
@@ -39,7 +39,7 @@ const classMap = {
 export const AwardSection = ({
     id,
     type,
-    className,
+    className = "",
     children
 }) => <div id={id} className={`${classMap[type]} ${className}`}>{children}</div>;
 

--- a/src/js/components/awardv2/shared/index.jsx
+++ b/src/js/components/awardv2/shared/index.jsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { startCase } from 'lodash';
 
 import { Glossary } from '../../sharedComponents/icons/Icons';
-import { AWARD_SECTION_PROPS, AWARD_PAGE_WRAPPER_PROPS } from "../../../propTypes/index";
+import {
+    AWARD_SECTION_PROPS,
+    AWARD_PAGE_WRAPPER_PROPS,
+    AWARD_SECTION_HEADER_PROPS
+} from "../../../propTypes/index";
 
 export const AwardPageWrapper = ({
     awardType,
@@ -41,6 +45,28 @@ export const AwardSection = ({
     type,
     className = "",
     children
-}) => <div id={id} className={`${classMap[type]} ${className}`}>{children}</div>;
+}) => (
+    <div id={id} className={`${classMap[type]} ${className}`}>
+        {children}
+    </div>
+);
 
 AwardSection.propTypes = AWARD_SECTION_PROPS;
+
+export const AwardSectionHeader = ({
+    icon,
+    title
+}) => (
+    <React.Fragment>
+        <div className="award-viz__heading">
+            {icon && <div className="award-viz__icon">{icon}</div>}
+            <h3 className="award-viz__title">{title}</h3>
+            {/* <InfoToolTip left wide>
+                {federalAccountsInfo}
+            </InfoToolTip> */}
+        </div>
+        <hr />
+    </React.Fragment>
+);
+
+AwardSectionHeader.propTypes = AWARD_SECTION_HEADER_PROPS;

--- a/src/js/components/awardv2/shared/index.jsx
+++ b/src/js/components/awardv2/shared/index.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { startCase } from 'lodash';
+
+import { AWARD_SECTION_PROPS, AWARD_PAGE_WRAPPER_PROPS } from "../../../propTypes/index";
+
+export const AwardPageWrapper = ({
+    awardType,
+    awardTypeDescription,
+    glossaryLink,
+    identifier,
+    children
+}) => (
+    <div className={`award award-${awardType}`}>
+        <div className="award__heading">
+            <div className="award__heading-text">{startCase(awardTypeDescription)}</div>
+            <div className="award__heading-icon">{glossaryLink}</div>
+            <div className="award__heading-id">
+                <div className="award__heading-label">{identifier ? 'PIID' : ''}</div>
+                <div>{identifier}</div>
+            </div>
+            <hr />
+        </div>
+        {children}
+    </div>
+);
+
+AwardPageWrapper.propTypes = AWARD_PAGE_WRAPPER_PROPS;
+
+const classMap = {
+    row: "award__row",
+    column: "award__col"
+};
+
+export const AwardSection = ({
+    id,
+    type,
+    className,
+    children
+}) => <div id={id} className={`${classMap[type]} ${className}`}>{children}</div>;
+
+AwardSection.propTypes = AWARD_SECTION_PROPS;

--- a/src/js/components/awardv2/shared/index.jsx
+++ b/src/js/components/awardv2/shared/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { startCase } from 'lodash';
 
+import { Glossary } from '../../sharedComponents/icons/Icons';
 import { AWARD_SECTION_PROPS, AWARD_PAGE_WRAPPER_PROPS } from "../../../propTypes/index";
 
 export const AwardPageWrapper = ({
@@ -13,7 +14,11 @@ export const AwardPageWrapper = ({
     <div className={`award award-${awardType}`}>
         <div className="award__heading">
             <div className="award__heading-text">{startCase(awardTypeDescription)}</div>
-            <div className="award__heading-icon">{glossaryLink}</div>
+            <div className="award__heading-icon">
+                <a href={glossaryLink}>
+                    <Glossary />
+                </a>
+            </div>
             <div className="award__heading-id">
                 <div className="award__heading-label">{identifier ? 'PIID' : ''}</div>
                 <div>{identifier}</div>

--- a/src/js/components/awardv2/shared/overview/AgencyRecipient.jsx
+++ b/src/js/components/awardv2/shared/overview/AgencyRecipient.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as Icons from 'components/sharedComponents/icons/Icons';
+import { AwardSection } from '../index';
 
 const propTypes = {
     awardingAgency: PropTypes.object,
@@ -49,7 +50,7 @@ export default class AgencyRecipient extends React.Component {
             );
         }
         return (
-            <div className="award__col agency-recipient">
+            <AwardSection type="column" className="agency-recipient">
                 <div className="agency-recipient__wrapper">
                     <div className="agency-recipient__awarding">
                         <div className="agency-recipient__title">Awarding Agency</div>
@@ -67,7 +68,7 @@ export default class AgencyRecipient extends React.Component {
                     </div>
                 </div>
                 {additionalInfoLink}
-            </div>
+            </AwardSection>
         );
     }
 }

--- a/src/js/models/v2/awardsV2/BaseContract.js
+++ b/src/js/models/v2/awardsV2/BaseContract.js
@@ -27,7 +27,8 @@ BaseContract.populate = function populate(data) {
         subawardCount: data.subaward_count,
         totalObligation: data.total_obligation,
         baseExercisedOptions: data.base_exercised_options,
-        dateSigned: data.date_signed
+        dateSigned: data.date_signed,
+        baseAndAllOptions: data.base_and_all_options
     };
     this.populateCore(coreData);
 

--- a/src/js/propTypes/index.js
+++ b/src/js/propTypes/index.js
@@ -42,3 +42,17 @@ export const TOOLTIP_PROPS = PropTypes.shape({
     closeCurrentTooltip: PropTypes.func,
     showTooltip: PropTypes.func
 });
+
+export const AWARD_SECTION_PROPS = {
+    type: PropTypes.oneOf(["row", "column"]),
+    id: PropTypes.string,
+    children: PropTypes.node
+};
+
+export const AWARD_PAGE_WRAPPER_PROPS = {
+    awardType: PropTypes.oneOf(["idv", "contract", "grant"]),
+    awardTypeDescription: PropTypes.string,
+    glossaryLink: PropTypes.string,
+    identifier: PropTypes.string,
+    children: PropTypes.node
+};

--- a/src/js/propTypes/index.js
+++ b/src/js/propTypes/index.js
@@ -56,3 +56,8 @@ export const AWARD_PAGE_WRAPPER_PROPS = {
     identifier: PropTypes.string,
     children: PropTypes.node
 };
+
+export const AWARD_SECTION_HEADER_PROPS = {
+    icon: PropTypes.oneOf([PropTypes.string, PropTypes.node]),
+    title: PropTypes.string
+};

--- a/tests/models/awardsV2/BaseContract-test.js
+++ b/tests/models/awardsV2/BaseContract-test.js
@@ -27,6 +27,12 @@ describe('BaseContract', () => {
         it('should format the obligated amount', () => {
             expect(contract.totalObligationFormatted).toEqual('$123,231,313');
         });
+        it('should format the current (base_exercised_options) amount', () => {
+            expect(contract.baseExercisedOptionsFormatted).toEqual('$234,242');
+        });
+        it('should format the potential (base_and_all_options) amount', () => {
+            expect(contract.baseAndAllOptionsFormatted).toEqual('$234,234');
+        });
     });
     describe('agencies', () => {
         it('should only populate an awarding/funding agency if it is available in the API response', () => {


### PR DESCRIPTION
### URL for local testing: http://0.0.0.0:3000/#/award_v2/25881000

**High level description:**
Re-using the components in IDV page:

- Normal/Overspending/ExtremeOverSpending Chart.js
- Mark up for displaying table

**Technical details:**
CoreAward Model already generated relevant values for display, so minimal updates to the model were made. Only necessary thing was to pass `baseAndAllOptions` to `populateCore` within the `BasContract` Model which was merely extending the `CoreAward` model.

Created a defect around inconsistent model values which necessitated the use of a complicated data map to get the right props passed to `NormalChart` etc... I welcome any feedback on a cleaner solution!

Also added unit test to the reflect the updates to the Base Award model.

**JIRA Ticket:**
[DEV-1564](https://federal-spending-transparency.atlassian.net/browse/DEV-1564)

**Mockup:**
https://bahdigital.invisionapp.com/share/U9IAAWH7MA6#/screens/296011639_Award_Summary_2-0_-_Contract

The following are ALL required for the PR to be merged:
- [ ] Code review
- [ ] Design review (if applicable)
- [ ] Verified cross-browser compatibility
