### PR TITLE
Remove extra border from TAS autocomplete

### DIFF
--- a/src/_scss/pages/search/filters/programSource/programSource.scss
+++ b/src/_scss/pages/search/filters/programSource/programSource.scss
@@ -123,22 +123,6 @@
             }
             .program-source-select-filter__label {
                 @include display(flex);
-                position: relative;
-                background-color: $color-white;
-                border: 1px solid $color-gray-lighter;
-                input {
-                    border: 0;
-                    width: 100%;
-                }
-                .usa-da-typeahead__loading-icon {
-                    @include flex(0 0 auto);
-                    @include align-self(center);
-                    position: absolute;
-                    right: rem(15);
-                }
-            }
-            .program-source-select-filter__label {
-                @include display(flex);
 
                 .program-source-select-filter__label-required {
                     @include display(flex);


### PR DESCRIPTION
**High level description:**
Some duplicate scss code is causing extra borders around the TAS autocomplete labels:

<img width="320" alt="TASautocomplete" src="https://user-images.githubusercontent.com/7108785/63864327-a3efaf80-c97d-11e9-8b26-9cd5d57f0703.png">

The following are ALL required for the PR to be merged:
- [x] Code review
