### PR TITLE
[DEV-3296] Implementing the Download button on AS2.0 pages

### DIFF
--- a/src/js/components/awardv2/SummaryBarV2.jsx
+++ b/src/js/components/awardv2/SummaryBarV2.jsx
@@ -17,23 +17,19 @@ const propTypes = {
 
 export default class SummaryBar extends React.Component {
     render() {
-        let title = startCase(this.props.category);
-        let downloadBtn = null;
-        if (this.props.category === 'idv') {
-            title = 'Indefinite Delivery Vehicle';
-            downloadBtn = (
-                <DownloadButton
-                    downloadAvailable
-                    downloadInFlight={this.props.isDownloadPending}
-                    onClick={this.props.downloadData} />
-            );
-        }
+        const title = (this.props.category === 'idv')
+            ? 'Indefinite Delivery Vehicle'
+            : startCase(this.props.category);
+
         return (
             <div className="sticky-header__title">
                 <h1 tabIndex={-1} id="main-focus">
                     {title} Summary
                 </h1>
-                {downloadBtn}
+                <DownloadButton
+                    downloadAvailable
+                    downloadInFlight={this.props.isDownloadPending}
+                    onClick={this.props.downloadData} />
             </div>
         );
     }

--- a/src/js/containers/awardV2/AwardV2Container.jsx
+++ b/src/js/containers/awardV2/AwardV2Container.jsx
@@ -25,7 +25,7 @@ import {
 import BaseContract from 'models/v2/awardsV2/BaseContract';
 import BaseIdv from 'models/v2/awardsV2/BaseIdv';
 import BaseFinancialAssistance from 'models/v2/awardsV2/BaseFinancialAssistance';
-import { fetchIdvDownloadFile } from '../../helpers/idvHelper';
+import { fetchAwardDownloadFile } from '../../helpers/downloadHelper';
 
 require('pages/awardV2/awardPage.scss');
 
@@ -146,7 +146,7 @@ export class AwardContainer extends React.Component {
             this.downloadRequest.cancel();
         }
 
-        this.downloadRequest = fetchIdvDownloadFile(this.props.params.awardId);
+        this.downloadRequest = fetchAwardDownloadFile(this.props.award.category, this.props.params.awardId);
 
         try {
             const { data } = await this.downloadRequest.promise;

--- a/src/js/containers/awardV2/AwardV2Container.jsx
+++ b/src/js/containers/awardV2/AwardV2Container.jsx
@@ -139,7 +139,7 @@ export class AwardContainer extends React.Component {
         }
     }
 
-    fetchAwardDownloadFile(awardCategory, awardId) {
+    fetchAwardDownloadFile(awardCategory = this.props.award.category, awardId = this.props.params.awardId) {
         if (awardCategory === 'idv') {
             return fetchIdvDownloadFile(awardId);
         }

--- a/src/js/containers/awardV2/AwardV2Container.jsx
+++ b/src/js/containers/awardV2/AwardV2Container.jsx
@@ -25,7 +25,7 @@ import {
 import BaseContract from 'models/v2/awardsV2/BaseContract';
 import BaseIdv from 'models/v2/awardsV2/BaseIdv';
 import BaseFinancialAssistance from 'models/v2/awardsV2/BaseFinancialAssistance';
-import { fetchAwardDownloadFile } from '../../helpers/downloadHelper';
+import { fetchIdvDownloadFile, fetchContractDownloadFile, fetchAssistanceDownloadFile } from '../../helpers/downloadHelper';
 
 require('pages/awardV2/awardPage.scss');
 
@@ -53,6 +53,7 @@ export class AwardContainer extends React.Component {
             inFlight: false
         };
         this.downloadData = this.downloadData.bind(this);
+        this.fetchAwardDownloadFile = this.fetchAwardDownloadFile.bind(this);
     }
 
     componentDidMount() {
@@ -138,7 +139,18 @@ export class AwardContainer extends React.Component {
         }
     }
 
-    async downloadData() {
+    fetchAwardDownloadFile(awardCategory, awardId) {
+        if (awardCategory === 'idv') {
+            return fetchIdvDownloadFile(awardId);
+        }
+        else if (awardCategory === 'contract') {
+            return fetchContractDownloadFile(awardId);
+        }
+
+        return fetchAssistanceDownloadFile(awardId);
+    }
+
+    async downloadData(awardCategory = this.props.award.category, awardId = this.props.params.awardId) {
         // don't show a modal about the download
         this.props.setDownloadCollapsed(true);
 
@@ -146,7 +158,7 @@ export class AwardContainer extends React.Component {
             this.downloadRequest.cancel();
         }
 
-        this.downloadRequest = fetchAwardDownloadFile(this.props.award.category, this.props.params.awardId);
+        this.downloadRequest = this.fetchAwardDownloadFile(awardCategory, awardId);
 
         try {
             const { data } = await this.downloadRequest.promise;

--- a/src/js/dataMapping/awardsv2/awardTypes.js
+++ b/src/js/dataMapping/awardsv2/awardTypes.js
@@ -1,6 +1,0 @@
-export const financialAssistanceAwardTypes = [
-    'direct_payment',
-    'grant',
-    'loans',
-    'other'
-];

--- a/src/js/dataMapping/awardsv2/awardTypes.js
+++ b/src/js/dataMapping/awardsv2/awardTypes.js
@@ -1,0 +1,6 @@
+export const financialAssistanceAwardTypes = [
+    'direct_payment',
+    'grant',
+    'loans',
+    'other'
+];

--- a/src/js/helpers/downloadHelper.js
+++ b/src/js/helpers/downloadHelper.js
@@ -6,7 +6,6 @@
 import Axios, { CancelToken } from 'axios';
 
 import kGlobalConstants from 'GlobalConstants';
-import { fetchIdvDownloadFile } from './idvHelper';
 
 export const requestAwardTable = (params) => {
     const source = CancelToken.source();
@@ -110,13 +109,21 @@ export const fetchContractDownloadFile = (awardId) => {
     };
 };
 
-export const fetchAwardDownloadFile = (awardType, awardId) => {
-    if (awardType === 'idv') {
-        return fetchIdvDownloadFile(awardId);
-    }
-    else if (awardType === 'contract') {
-        return fetchContractDownloadFile(awardId);
-    }
-
-    return fetchAssistanceDownloadFile(awardId);
+export const fetchIdvDownloadFile = (awardId) => {
+    const source = CancelToken.source();
+    return {
+        promise: Axios.request({
+            url: 'v2/download/idv/',
+            baseURL: kGlobalConstants.API,
+            method: "post",
+            headers: {
+                "content-type": "application/json"
+            },
+            data: { award_id: awardId },
+            cancelToken: source.token
+        }),
+        cancel() {
+            source.cancel();
+        }
+    };
 };

--- a/src/js/helpers/downloadHelper.js
+++ b/src/js/helpers/downloadHelper.js
@@ -7,7 +7,6 @@ import Axios, { CancelToken } from 'axios';
 
 import kGlobalConstants from 'GlobalConstants';
 import { fetchIdvDownloadFile } from './idvHelper';
-import { financialAssistanceAwardTypes } from '../dataMapping/awardsv2/awardTypes';
 
 export const requestAwardTable = (params) => {
     const source = CancelToken.source();
@@ -112,13 +111,12 @@ export const fetchContractDownloadFile = (awardId) => {
 };
 
 export const fetchAwardDownloadFile = (awardType, awardId) => {
-    if (financialAssistanceAwardTypes.includes(awardType)) {
-        return fetchAssistanceDownloadFile(awardId);
-    }
-    else if (awardType === 'idv') {
+    if (awardType === 'idv') {
         return fetchIdvDownloadFile(awardId);
     }
     else if (awardType === 'contract') {
         return fetchContractDownloadFile(awardId);
     }
+
+    return fetchAssistanceDownloadFile(awardId);
 };

--- a/src/js/helpers/downloadHelper.js
+++ b/src/js/helpers/downloadHelper.js
@@ -78,12 +78,12 @@ export const fetchAssistanceDownloadFile = (awardId) => {
     return {
         promise: Axios.request({
             url: 'v2/download/assistance/',
-            baseURL: "http://localhost:5000/api/",
+            baseURL: kGlobalConstants.API,
             method: "post",
             headers: {
                 "content-type": "application/json"
             },
-            data: { award_id: "ASST_NON_12FA00PY52375933_12D2" },
+            data: { award_id: awardId },
             cancelToken: source.token
         }),
         cancel() {
@@ -97,12 +97,12 @@ export const fetchContractDownloadFile = (awardId) => {
     return {
         promise: Axios.request({
             url: 'v2/download/contract/',
-            baseURL: "http://localhost:5000/api/",
+            baseURL: kGlobalConstants.API,
             method: "post",
             headers: {
                 "content-type": "application/json"
             },
-            data: { award_id: "CONT_AWD_UZ02_9700_SPM2DV11D9200_9700" },
+            data: { award_id: awardId },
             cancelToken: source.token
         }),
         cancel() {
@@ -112,7 +112,6 @@ export const fetchContractDownloadFile = (awardId) => {
 };
 
 export const fetchAwardDownloadFile = (awardType, awardId) => {
-    console.log("awardType", awardType);
     if (financialAssistanceAwardTypes.includes(awardType)) {
         return fetchAssistanceDownloadFile(awardId);
     }

--- a/src/js/helpers/downloadHelper.js
+++ b/src/js/helpers/downloadHelper.js
@@ -6,6 +6,8 @@
 import Axios, { CancelToken } from 'axios';
 
 import kGlobalConstants from 'GlobalConstants';
+import { fetchIdvDownloadFile } from './idvHelper';
+import { financialAssistanceAwardTypes } from '../dataMapping/awardsv2/awardTypes';
 
 export const requestAwardTable = (params) => {
     const source = CancelToken.source();
@@ -69,4 +71,55 @@ export const requestDownloadCount = (params) => {
             source.cancel();
         }
     };
+};
+
+export const fetchAssistanceDownloadFile = (awardId) => {
+    const source = CancelToken.source();
+    return {
+        promise: Axios.request({
+            url: 'v2/download/assistance/',
+            baseURL: "http://localhost:5000/api/",
+            method: "post",
+            headers: {
+                "content-type": "application/json"
+            },
+            data: { award_id: "ASST_NON_12FA00PY52375933_12D2" },
+            cancelToken: source.token
+        }),
+        cancel() {
+            source.cancel();
+        }
+    };
+};
+
+export const fetchContractDownloadFile = (awardId) => {
+    const source = CancelToken.source();
+    return {
+        promise: Axios.request({
+            url: 'v2/download/contract/',
+            baseURL: "http://localhost:5000/api/",
+            method: "post",
+            headers: {
+                "content-type": "application/json"
+            },
+            data: { award_id: "CONT_AWD_UZ02_9700_SPM2DV11D9200_9700" },
+            cancelToken: source.token
+        }),
+        cancel() {
+            source.cancel();
+        }
+    };
+};
+
+export const fetchAwardDownloadFile = (awardType, awardId) => {
+    console.log("awardType", awardType);
+    if (financialAssistanceAwardTypes.includes(awardType)) {
+        return fetchAssistanceDownloadFile(awardId);
+    }
+    else if (awardType === 'idv') {
+        return fetchIdvDownloadFile(awardId);
+    }
+    else if (awardType === 'contract') {
+        return fetchContractDownloadFile(awardId);
+    }
 };

--- a/src/js/helpers/idvHelper.js
+++ b/src/js/helpers/idvHelper.js
@@ -86,25 +86,6 @@ export const fetchAwardFundingSummary = (awardId) => {
     };
 };
 
-export const fetchIdvDownloadFile = (awardId) => {
-    const source = CancelToken.source();
-    return {
-        promise: Axios.request({
-            url: 'v2/download/idv/',
-            baseURL: kGlobalConstants.API,
-            method: "post",
-            headers: {
-                "content-type": "application/json"
-            },
-            data: { award_id: awardId },
-            cancelToken: source.token
-        }),
-        cancel() {
-            source.cancel();
-        }
-    };
-};
-
 export const fetchAwardFederalAccounts = (data) => {
     const source = CancelToken.source();
     return {

--- a/tests/containers/awardV2/AwardV2Container-test.jsx
+++ b/tests/containers/awardV2/AwardV2Container-test.jsx
@@ -7,23 +7,22 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { AwardContainer } from 'containers/awardV2/AwardV2Container';
-
-import { mockParams, mockActions } from './mockAward';
-import { mockContract, mockLoan, mockIdv } from '../../models/awardsV2/mockAwardApi';
-
 import BaseContract from 'models/v2/awardsV2/BaseContract';
 import BaseIdv from 'models/v2/awardsV2/BaseIdv';
 import BaseFinancialAssistance from "models/v2/awardsV2/BaseFinancialAssistance";
 
+import { mockParams, mockActions } from './mockAward';
+import { mockContract, mockLoan, mockIdv } from '../../models/awardsV2/mockAwardApi';
+
 jest.mock('helpers/searchHelper', () => require('./awardV2Helper'));
-jest.mock("helpers/idvHelper", () => require("./awardV2Helper"));
+jest.mock("helpers/downloadHelper", () => require("./awardV2Helper"));
 
 // mock the child components by replacing them with functions that return null elements
 jest.mock('components/awardv2/AwardV2', () => jest.fn(() => null));
 jest.mock('containers/award/AwardContainer', () => jest.fn(() => null));
 
-const getAwardContainer = () => shallow(<AwardContainer
-    {...mockParams}
+const getAwardContainer = (params = mockParams) => shallow(<AwardContainer
+    {...params}
     {...mockActions} />);
 
 describe('AwardV2Container', () => {

--- a/tests/containers/awardV2/AwardV2Container-test.jsx
+++ b/tests/containers/awardV2/AwardV2Container-test.jsx
@@ -113,4 +113,25 @@ describe('AwardV2Container', () => {
             expect(downloadRequest.cancel).toHaveBeenCalled();
         });
     });
+
+    describe('fetchAwardDownloadFile', () => {
+        it('returns the contract helper for contract awards', async () => {
+            const awardContainer = getAwardContainer();
+            let result = await awardContainer.instance().fetchAwardDownloadFile();
+            result = await result.promise;
+            expect(result.data.file_name).toEqual('contract.zip');
+        });
+
+        it('returns the idv helper for idv awards', async () => {
+            const awardContainer = getAwardContainer({ ...mockParams, award: { ...mockParams.award, category: "idv" } });
+            const result = await awardContainer.instance().fetchAwardDownloadFile().promise;
+            expect(result.data.file_name).toEqual('idv.zip');
+        });
+
+        it('returns the assistance helper for assistance awards', async () => {
+            const awardContainer = getAwardContainer({ ...mockParams, award: { ...mockParams.award, category: "grant" } });
+            const result = await awardContainer.instance().fetchAwardDownloadFile().promise;
+            expect(result.data.file_name).toEqual('assistance.zip');
+        });
+    });
 });

--- a/tests/containers/awardV2/awardV2Helper.js
+++ b/tests/containers/awardV2/awardV2Helper.js
@@ -1,7 +1,9 @@
 import {
     mockContract,
     mockAwardAmounts,
-    mockFileDownloadResponse
+    mockFileDownloadResponseIdv,
+    mockFileDownloadResponseAssistance,
+    mockFileDownloadResponseContract
 } from "../../models/awardsV2/mockAwardApi";
 
 // Fetch Individual Awards
@@ -31,11 +33,33 @@ export const fetchAwardAmounts = () => (
     }
 );
 
-export const fetchAwardDownloadFile = () => ({
+export const fetchIdvDownloadFile = () => ({
     promise: new Promise((resolve) => {
         process.nextTick(() => {
             resolve({
-                data: mockFileDownloadResponse
+                data: mockFileDownloadResponseIdv
+            });
+        });
+    }),
+    cancel: jest.fn()
+});
+
+export const fetchContractDownloadFile = () => ({
+    promise: new Promise((resolve) => {
+        process.nextTick(() => {
+            resolve({
+                data: mockFileDownloadResponseContract
+            });
+        });
+    }),
+    cancel: jest.fn()
+});
+
+export const fetchAssistanceDownloadFile = () => ({
+    promise: new Promise((resolve) => {
+        process.nextTick(() => {
+            resolve({
+                data: mockFileDownloadResponseAssistance
             });
         });
     }),

--- a/tests/containers/awardV2/awardV2Helper.js
+++ b/tests/containers/awardV2/awardV2Helper.js
@@ -31,7 +31,7 @@ export const fetchAwardAmounts = () => (
     }
 );
 
-export const fetchIdvDownloadFile = () => ({
+export const fetchAwardDownloadFile = () => ({
     promise: new Promise((resolve) => {
         process.nextTick(() => {
             resolve({

--- a/tests/models/awardsV2/mockAwardApi.js
+++ b/tests/models/awardsV2/mockAwardApi.js
@@ -429,9 +429,29 @@ export const mockAwardFundingMetaData = {
     federal_account_count: 47
 };
 
-export const mockFileDownloadResponse = {
+export const mockFileDownloadResponseIdv = {
     total_size: 35.055,
-    file_name: `012_account_balances_20180613140845.zip`,
+    file_name: `idv.zip`,
+    total_rows: 652,
+    total_columns: 27,
+    url: `S3/path_to/bucket/012_account_balances_20180613140845.zip`,
+    status: `finished`,
+    seconds_elapsed: `10.061132`
+};
+
+export const mockFileDownloadResponseContract = {
+    total_size: 35.055,
+    file_name: `contract.zip`,
+    total_rows: 652,
+    total_columns: 27,
+    url: `S3/path_to/bucket/012_account_balances_20180613140845.zip`,
+    status: `finished`,
+    seconds_elapsed: `10.061132`
+};
+
+export const mockFileDownloadResponseAssistance = {
+    total_size: 35.055,
+    file_name: `assistance.zip`,
     total_rows: 652,
     total_columns: 27,
     url: `S3/path_to/bucket/012_account_balances_20180613140845.zip`,


### PR DESCRIPTION
## DNM until API is in place

**High level description:**
Adds download functionality for non-idv award summary pages: contract, financial-assistance.

**Technical details:**
Calls new function that returns correct service call based on award type.

**JIRA Ticket:**
[DEV-3296](https://federal-spending-transparency.atlassian.net/browse/DEV-3296)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Design review (if applicable)
- [x] [API #2006](https://github.com/fedspendingtransparency/usaspending-api/pull/2006) merged
- [x] Verified cross-browser compatibility
