### PR TITLE
Hotfix/dev 1564/one decimal float

### DIFF
--- a/src/js/components/awardv2/contract/ContractContent.jsx
+++ b/src/js/components/awardv2/contract/ContractContent.jsx
@@ -26,7 +26,7 @@ const defaultTooltipProps = {
     controlledProps: {
         isControlled: true,
         isVisible: false,
-        closeCurrentTooltip: () => console.log("close tooltip"),
+        closeTooltip: () => console.log("close tooltip"),
         showTooltip: () => console.log("open tooltip")
     }
 };

--- a/src/js/components/awardv2/contract/ContractContent.jsx
+++ b/src/js/components/awardv2/contract/ContractContent.jsx
@@ -14,6 +14,7 @@ import AwardPageWrapper from '../shared/AwardPageWrapper';
 import AwardSection from '../shared/AwardSection';
 import ComingSoonSection from '../shared/ComingSoonSection';
 import AwardAmountsSection from '../shared/awardAmountsSection/AwardAmountsSection';
+import BaseAwardAmounts from '../../../models/v2/awardsV2/BaseAwardAmounts';
 
 const propTypes = {
     awardId: PropTypes.string,
@@ -32,38 +33,41 @@ const defaultTooltipProps = {
 
 export default class ContractContent extends React.Component {
     render() {
-        const glossarySlug = glossaryLinks[this.props.overview.type];
+        const { overview, awardId, jumpToSection } = this.props;
+        const glossarySlug = glossaryLinks[overview.type];
         const glossaryLink = glossarySlug
-            ? `/#/award_v2/${this.props.awardId}?glossary=${glossarySlug}`
+            ? `/#/award_v2/${awardId}?glossary=${glossarySlug}`
             : null;
+        const awardAmountData = Object.create(BaseAwardAmounts);
+        awardAmountData.populate(overview, overview.category);
 
         return (
             <AwardPageWrapper
                 glossaryLink={glossaryLink}
-                identifier={this.props.overview.id}
-                awardTypeDescription={this.props.overview.typeDescription}
+                identifier={overview.id}
+                awardTypeDescription={overview.typeDescription}
                 awardType="contract">
                 <AwardSection type="row" className="award-overview" id="award-overview">
                     <AwardSection type="column" className="award-amountdates">
                         <AgencyRecipient
-                            jumpToSection={this.props.jumpToSection}
-                            awardingAgency={this.props.overview.awardingAgency}
+                            jumpToSection={jumpToSection}
+                            awardingAgency={overview.awardingAgency}
                             category="contract"
-                            recipient={this.props.overview.recipient} />
+                            recipient={overview.recipient} />
                     </AwardSection>
                     <AwardSection type="column" className="award-amountdates">
-                        <AwardDates overview={this.props.overview} />
+                        <AwardDates overview={overview} />
                     </AwardSection>
                 </AwardSection>
                 <AwardSection type="row">
                     <AwardAmountsSection
-                        awardType={this.props.overview.category}
-                        jumpToSection={this.props.jumpToSection}
-                        awardOverview={this.props.overview}
+                        awardType={overview.category}
+                        jumpToSection={jumpToSection}
+                        awardOverview={awardAmountData}
                         tooltipProps={defaultTooltipProps} />
                     <ComingSoonSection title="Description" includeHeader />
                 </AwardSection>
-                <AdditionalInfo overview={this.props.overview} />
+                <AdditionalInfo overview={overview} />
             </AwardPageWrapper>
         );
     }

--- a/src/js/models/v2/awardsV2/BaseAwardAmounts.js
+++ b/src/js/models/v2/awardsV2/BaseAwardAmounts.js
@@ -29,10 +29,18 @@ const BaseAwardAmounts = {
         this._totalFunding = data._totalFunding;
         this._nonFederalFunding = data._nonFederalFunding;
     },
+    populateContract(data) {
+        this._totalObligation = data._totalObligation;
+        this._baseExercisedOptions = data._baseExercisedOptions;
+        this._baseAndAllOptions = data._baseAndAllOptions;
+    },
     populate(data, awardType) {
         this.populateBase(data);
         if (awardType === 'idv') {
             this.populateIdv(data);
+        }
+        else if (awardType === 'contract') {
+            this.populateContract(data);
         }
         else if (awardType === 'grant') {
             this.populateGrant(data);

--- a/src/js/models/v2/awardsV2/CoreAward.js
+++ b/src/js/models/v2/awardsV2/CoreAward.js
@@ -33,36 +33,6 @@ const CoreAward = {
         }
         return MoneyFormatter.formatMoneyWithPrecision(this._subawardTotal, 0);
     },
-    get totalObligationAbbreviated() {
-        if (this._totalObligation >= MoneyFormatter.unitValues.MILLION) {
-            const units = MoneyFormatter.calculateUnitForSingleValue(this._totalObligation);
-            return `${MoneyFormatter.formatMoneyWithPrecision(this._totalObligation / units.unit, 2)} ${units.longLabel}`;
-        }
-        return MoneyFormatter.formatMoneyWithPrecision(this._totalObligation, 0);
-    },
-    get totalObligationFormatted() {
-        return MoneyFormatter.formatMoney(this._totalObligation);
-    },
-    get baseExercisedOptionsAbbreviated() {
-        if (this._baseExercisedOptions >= MoneyFormatter.unitValues.MILLION) {
-            const units = MoneyFormatter.calculateUnitForSingleValue(this._baseExercisedOptions);
-            return `${MoneyFormatter.formatMoneyWithPrecision(this._baseExercisedOptions / units.unit, 2)} ${units.longLabel}`;
-        }
-        return MoneyFormatter.formatMoneyWithPrecision(this._baseExercisedOptions, 0);
-    },
-    get baseExercisedOptionsFormatted() {
-        return MoneyFormatter.formatMoney(this._baseExercisedOptions);
-    },
-    get baseAndAllOptionsAbbreviated() {
-        if (this._baseAndAllOptions >= MoneyFormatter.unitValues.MILLION) {
-            const units = MoneyFormatter.calculateUnitForSingleValue(this._baseAndAllOptions);
-            return `${MoneyFormatter.formatMoneyWithPrecision(this._baseAndAllOptions / units.unit, 2)} ${units.longLabel}`;
-        }
-        return MoneyFormatter.formatMoneyWithPrecision(this._baseAndAllOptions, 0);
-    },
-    get baseAndAllOptionsFormatted() {
-        return MoneyFormatter.formatMoney(this._baseAndAllOptions);
-    },
     get category() {
         if (this._category === 'loans') {
             return 'loan';

--- a/tests/models/awardsV2/BaseAwardAmounts-test.js
+++ b/tests/models/awardsV2/BaseAwardAmounts-test.js
@@ -40,7 +40,7 @@ awardAmountsOverspent.populate(overspending, "idv");
 awardAmountsExtremeOverspent.populate(extremeOverspending, "idv");
 
 describe('BaseAwardAmounts', () => {
-    describe('IDV Award Amounts', () => {
+    describe('IDV Award Type', () => {
         it('should have an empty string as a unique generated id if the field is null or undefined', () => {
             expect(awardAmounts.generatedId).toEqual('');
         });
@@ -84,11 +84,18 @@ describe('BaseAwardAmounts', () => {
             expect(awardAmountsOverspent.overspendingAbbreviated).toEqual('$2.5 M');
         });
     });
+    /*
+      * IDVs/Contracts/Grants all share the same getters tested above.
+      * The only difference is when an IDV Award is passed to BaseAwardAmounts.populate(awardType, data) fn
+      * The data parameter is coming straight from the api and so is snake_cased_like_this.
+      * For the Contract/FinancialAssistance award types, on the other hand, the data is expected to be in the following
+      * format: _likeThis because the data parameter in this context has already been parsed by the CoreAward
+      * Model
+    */
     describe('Contract Award Amounts', () => {
         const contractAwardAmounts = Object.create(BaseAwardAmounts);
         contractAwardAmounts.populate(mockContract, "contract");
         const arrayOfObjectProperties = Object.keys(contractAwardAmounts);
-
         it('does not create IDV specific properties', () => {
             expect(arrayOfObjectProperties.includes("childIDVCount")).toEqual(false);
             expect(arrayOfObjectProperties.includes("childAwardCount")).toEqual(false);

--- a/tests/models/awardsV2/BaseAwardAmounts-test.js
+++ b/tests/models/awardsV2/BaseAwardAmounts-test.js
@@ -4,7 +4,7 @@
  */
 
 import BaseAwardAmounts from 'models/v2/awardsV2/BaseAwardAmounts';
-import { mockAwardAmounts } from './mockAwardApi';
+import { mockAwardAmounts, mockContract, mockGrant } from './mockAwardApi';
 
 const awardAmounts = Object.create(BaseAwardAmounts);
 awardAmounts.populate(mockAwardAmounts, "idv");
@@ -84,17 +84,34 @@ describe('BaseAwardAmounts', () => {
             expect(awardAmountsOverspent.overspendingAbbreviated).toEqual('$2.5 M');
         });
     });
-    describe('Non-IDV Award Amounts', () => {
-        const nonIdvAwardAmounts = Object.create(BaseAwardAmounts);
-        nonIdvAwardAmounts.populate(mockAwardAmounts, "contract");
+    describe('Contract Award Amounts', () => {
+        const contractAwardAmounts = Object.create(BaseAwardAmounts);
+        contractAwardAmounts.populate(mockContract, "contract");
+        const arrayOfObjectProperties = Object.keys(contractAwardAmounts);
+
         it('does not create IDV specific properties', () => {
-            const arrayOfObjectProperties = Object.keys(nonIdvAwardAmounts);
             expect(arrayOfObjectProperties.includes("childIDVCount")).toEqual(false);
             expect(arrayOfObjectProperties.includes("childAwardCount")).toEqual(false);
             expect(arrayOfObjectProperties.includes("grandchildAwardCount")).toEqual(false);
-            expect(arrayOfObjectProperties.includes("_baseAndAllOptions")).toEqual(false);
-            expect(arrayOfObjectProperties.includes("_totalObligation")).toEqual(false);
-            expect(arrayOfObjectProperties.includes("_baseExercisedOptions")).toEqual(false);
+        });
+    });
+    describe('Grant Award Amounts', () => {
+        const grantAwardAmounts = Object.create(BaseAwardAmounts);
+        grantAwardAmounts.populate(mockGrant, "grant");
+        const arrayOfObjectProperties = Object.keys(grantAwardAmounts);
+
+        it('does not create IDV specific properties', () => {
+            expect(arrayOfObjectProperties.includes("childIDVCount")).toEqual(false);
+            expect(arrayOfObjectProperties.includes("childAwardCount")).toEqual(false);
+            expect(arrayOfObjectProperties.includes("grandchildAwardCount")).toEqual(false);
+        });
+        it('creates grant specific properties w/ correct formatting', () => {
+            expect(grantAwardAmounts._nonFederalFunding).toEqual(1130000);
+            expect(grantAwardAmounts.nonFederalFundingFormatted).toEqual("$1,130,000.00");
+            expect(grantAwardAmounts.nonFederalFundingAbbreviated).toEqual("$1.1 M");
+            expect(grantAwardAmounts._totalFunding).toEqual(1130000000);
+            expect(grantAwardAmounts.totalFundingFormatted).toEqual("$1,130,000,000.00");
+            expect(grantAwardAmounts.totalFundingAbbreviated).toEqual("$1.1 B");
         });
     });
 });

--- a/tests/models/awardsV2/BaseContract-test.js
+++ b/tests/models/awardsV2/BaseContract-test.js
@@ -17,23 +17,6 @@ const contract = Object.create(BaseContract);
 contract.populate(mockContract);
 
 describe('BaseContract', () => {
-    describe('monetary values', () => {
-        it('should format the contract amount', () => {
-            expect(contract.amount).toEqual('$234,234');
-        });
-        it('should format the obligated amount with a label', () => {
-            expect(contract.totalObligationAbbreviated).toEqual('$123.23 million');
-        });
-        it('should format the obligated amount', () => {
-            expect(contract.totalObligationFormatted).toEqual('$123,231,313');
-        });
-        it('should format the current (base_exercised_options) amount', () => {
-            expect(contract.baseExercisedOptionsFormatted).toEqual('$234,242');
-        });
-        it('should format the potential (base_and_all_options) amount', () => {
-            expect(contract.baseAndAllOptionsFormatted).toEqual('$234,234');
-        });
-    });
     describe('agencies', () => {
         it('should only populate an awarding/funding agency if it is available in the API response', () => {
             const emptyAgency = Object.create(CoreAwardAgency);

--- a/tests/models/awardsV2/CoreAward-test.js
+++ b/tests/models/awardsV2/CoreAward-test.js
@@ -18,10 +18,4 @@ describe('Core Award getter functions', () => {
     it('should format the subaward total', () => {
         expect(award.subawardTotal).toEqual('$12,005');
     });
-    it('should format the base exercised options', () => {
-        expect(award.baseExercisedOptionsAbbreviated).toEqual('$2.34 million');
-    });
-    it('should format the total obligation', () => {
-        expect(award.totalObligationAbbreviated).toEqual('$12.35 million');
-    });
 });

--- a/tests/models/awardsV2/mockAwardApi.js
+++ b/tests/models/awardsV2/mockAwardApi.js
@@ -122,6 +122,12 @@ export const mockContract = {
 
 };
 
+export const mockGrant = {
+    ...mockContract,
+    _totalFunding: 1130000000, // 1.13 Billion
+    _nonFederalFunding: 1130000 // 1.13 Million
+};
+
 export const mockLoan = {
     type: 'C',
     category: 'loan',
@@ -362,7 +368,6 @@ export const mockAwardAmounts = {
     grandchild_award_base_and_all_options_value: 53493660.55,
     child_award_total_obligation: 811660.51,
     grandchild_award_total_obligation: 811660.51
-
 };
 
 export const mockReferencedAwards = {


### PR DESCRIPTION
**High level description:**
The floats on the award amount section should only go to one decimal place on the label near the visualization. This was only happening for Contract Awards:

![image](https://user-images.githubusercontent.com/12897813/64443426-d72def00-d09f-11e9-8724-628d08f158d9.png)

**Technical details:**
Adjusted the models CoreAward and BaseAwardAmounts as this was only happening for contract-awards. The IDV's & Grants were using the `BaseAwardAmount` model which produced the appropriate float values while the contract awards were using the `CoreAward` model which produced the inappropriate float values.

**JIRA Ticket:**
[DEV-1564](https://federal-spending-transparency.atlassian.net/browse/DEV-1564)

**Mockup:**
https://bahdigital.invisionapp.com/share/U9IAAWH7MA6#/296011639_Award_Summary_2-0_-_Contract

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] All `componentWillReceiveProps`, `componentWillMount`, and `componentWillUpdate` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3341](https://federal-spending-transparency.atlassian.net/browse/DEV-3341)
- [x] Design review (if applicable)
- [x] Verified cross-browser compatibility
