### PR TITLE
Dev-872 Advanced Search recipient links

### DIFF
--- a/src/js/components/account/awards/LegacyResultsTable.jsx
+++ b/src/js/components/account/awards/LegacyResultsTable.jsx
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import IBTable from 'components/sharedComponents/IBTable/IBTable';
 
 import ResultsTableGenericCell from 'components/search/table/cells/ResultsTableGenericCell';
-import ResultsTableAwardIdCell from 'components/search/table/cells/ResultsTableAwardIdCell';
+import ResultsTableLinkCell from 'components/search/table/cells/ResultsTableLinkCell';
 
 import AccountTableSearchFields from 'dataMapping/search/accountTableSearchFields';
 
@@ -77,11 +77,11 @@ export default class LegacyResultsTable extends React.Component {
 
         if (column.columnName === 'award_id') {
             return (
-                <ResultsTableAwardIdCell
+                <ResultsTableLinkCell
                     rowIndex={rowIndex}
                     id={this.props.results[rowIndex].internalId}
                     value={this.props.results[rowIndex].awardId}
-                    column={column.columnName}
+                    column="award"
                     isLastColumn={isLast} />
             );
         }

--- a/src/js/components/keyword/table/ResultsTable.jsx
+++ b/src/js/components/keyword/table/ResultsTable.jsx
@@ -11,7 +11,7 @@ import { keywordTableColumnTypes } from 'dataMapping/keyword/keywordTableColumnT
 import IBTable from 'components/sharedComponents/IBTable/IBTable';
 
 import ResultsTableFormattedCell from 'components/search/table/cells/ResultsTableFormattedCell';
-import ResultsTableAwardIdCell from 'components/search/table/cells/ResultsTableAwardIdCell';
+import ResultsTableLinkCell from 'components/search/table/cells/ResultsTableLinkCell';
 import ResultsTableHeaderCell from 'components/search/table/cells/ResultsTableHeaderCell';
 
 const propTypes = {
@@ -82,8 +82,9 @@ export default class ResultsTable extends React.Component {
         };
 
         if (column.columnName === 'Award ID') {
-            cellClass = ResultsTableAwardIdCell;
+            cellClass = ResultsTableLinkCell;
             props.id = parseInt(this.props.results[rowIndex].internal_id, 10);
+            props.column = 'award';
         }
 
         return React.createElement(

--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -12,7 +12,7 @@ import IBTable from 'components/sharedComponents/IBTable/IBTable';
 
 import ResultsTableHeaderCell from './cells/ResultsTableHeaderCell';
 import ResultsTableFormattedCell from './cells/ResultsTableFormattedCell';
-import ResultsTableAwardIdCell from './cells/ResultsTableAwardIdCell';
+import ResultsTableLinkCell from './cells/ResultsTableLinkCell';
 
 const propTypes = {
     results: PropTypes.array,
@@ -75,8 +75,14 @@ export default class ResultsTable extends React.Component {
         };
 
         if (column.columnName === 'Award ID') {
-            cellClass = ResultsTableAwardIdCell;
+            cellClass = ResultsTableLinkCell;
             props.id = this.props.results[rowIndex].internal_id;
+            props.column = 'award';
+        }
+        else if (column.columnName === 'Recipient' && this.props.results[rowIndex].recipient_id) {
+            cellClass = ResultsTableLinkCell;
+            props.id = this.props.results[rowIndex].recipient_id;
+            props.column = 'recipient';
         }
 
         return React.createElement(

--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -79,7 +79,7 @@ export default class ResultsTable extends React.Component {
             props.id = this.props.results[rowIndex].internal_id;
             props.column = 'award';
         }
-        else if (column.columnName === 'Recipient' && this.props.results[rowIndex].recipient_id) {
+        else if (column.columnName === 'Recipient Name' && this.props.results[rowIndex].recipient_id) {
             cellClass = ResultsTableLinkCell;
             props.id = this.props.results[rowIndex].recipient_id;
             props.column = 'recipient';

--- a/src/js/components/search/table/cells/ResultsTableLinkCell.jsx
+++ b/src/js/components/search/table/cells/ResultsTableLinkCell.jsx
@@ -1,5 +1,5 @@
 /**
-  * ResultsTableAwardIdCell.jsx
+  * ResultsTableLinkCell.jsx
   * Created by Emily Gullo 02/08/2017
   **/
 
@@ -14,7 +14,7 @@ const propTypes = {
     value: PropTypes.string
 };
 
-const ResultsTableAwardIdCell = (props) => {
+const ResultsTableLinkCell = (props) => {
     // cell needs to have some content or it will collapse
     // replace with a &nbsp; if there's no data
     let content = props.value;
@@ -36,7 +36,7 @@ const ResultsTableAwardIdCell = (props) => {
     return (
         <div className={`award-result-generic-cell ${rowClass}`}>
             <div className="cell-content">
-                <a href={`/#/award/${props.id}`}>
+                <a href={`/#/${props.column}/${props.id}`}>
                     {content}
                 </a>
             </div>
@@ -44,6 +44,6 @@ const ResultsTableAwardIdCell = (props) => {
     );
 };
 
-ResultsTableAwardIdCell.propTypes = propTypes;
+ResultsTableLinkCell.propTypes = propTypes;
 
-export default ResultsTableAwardIdCell;
+export default ResultsTableLinkCell;

--- a/src/js/components/search/table/cells/ResultsTableLinkCell.jsx
+++ b/src/js/components/search/table/cells/ResultsTableLinkCell.jsx
@@ -10,7 +10,7 @@ const propTypes = {
     rowIndex: PropTypes.number,
     column: PropTypes.string,
     isLastColumn: PropTypes.bool,
-    id: PropTypes.number,
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     value: PropTypes.string
 };
 

--- a/src/js/components/search/visualizations/rank/RankVisualization.jsx
+++ b/src/js/components/search/visualizations/rank/RankVisualization.jsx
@@ -24,6 +24,7 @@ const defaultProps = {
 
 const propTypes = {
     dataSeries: PropTypes.array,
+    linkSeries: PropTypes.array,
     descriptions: PropTypes.array,
     loading: PropTypes.bool,
     error: PropTypes.bool,

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -313,6 +313,8 @@ export class ResultsTableContainer extends React.Component {
             }
         });
 
+        requestFields.push('recipient_id');
+
         // parse the redux search order into the API-consumable format
         const searchOrder = this.state.sort;
         let sortDirection = searchOrder.direction;

--- a/src/js/containers/search/visualizations/rank/RankVisualizationWrapperContainer.jsx
+++ b/src/js/containers/search/visualizations/rank/RankVisualizationWrapperContainer.jsx
@@ -48,6 +48,7 @@ export class RankVisualizationWrapperContainer extends React.Component {
             labelSeries: [],
             dataSeries: [],
             descriptions: [],
+            linkSeries: [],
             page: 1,
             scope: 'awarding_agency',
             next: '',
@@ -173,6 +174,7 @@ export class RankVisualizationWrapperContainer extends React.Component {
         const labelSeries = [];
         const dataSeries = [];
         const descriptions = [];
+        const linkSeries = [];
 
         // iterate through each response object and break it up into groups, x series, and y series
         data.results.forEach((item) => {
@@ -191,6 +193,10 @@ export class RankVisualizationWrapperContainer extends React.Component {
             labelSeries.push(result.name);
             dataSeries.push(result._amount);
 
+            if (this.state.scope === 'recipient_duns') {
+                linkSeries.push(result.recipientId);
+            }
+
             const description = `Spending by ${result.name}: ${result.amount}`;
             descriptions.push(description);
         });
@@ -199,6 +205,7 @@ export class RankVisualizationWrapperContainer extends React.Component {
             labelSeries,
             dataSeries,
             descriptions,
+            linkSeries,
             loading: false,
             error: false,
             next: data.page_metadata.next,

--- a/src/js/containers/search/visualizations/rank/RankVisualizationWrapperContainer.jsx
+++ b/src/js/containers/search/visualizations/rank/RankVisualizationWrapperContainer.jsx
@@ -194,7 +194,8 @@ export class RankVisualizationWrapperContainer extends React.Component {
             dataSeries.push(result._amount);
 
             if (this.state.scope === 'recipient_duns') {
-                linkSeries.push(result.recipientId);
+                const recipientLink = result.recipientId ? `#/recipient/${result.recipientId}` : '';
+                linkSeries.push(recipientLink);
             }
 
             const description = `Spending by ${result.name}: ${result.amount}`;

--- a/src/js/models/v2/search/visualizations/rank/BaseSpendingByCategoryResult.js
+++ b/src/js/models/v2/search/visualizations/rank/BaseSpendingByCategoryResult.js
@@ -19,6 +19,7 @@ const BaseSpendingByCategoryResult = {
         this._name = data.name || '--';
         this._code = data.code || '';
         this._amount = data.amount || 0;
+        this.recipientId = data.recipient_id || '';
 
         this._nameTemplate = defaultNameTemplate;
     },

--- a/tests/containers/search/visualizations/mockVisualizations.js
+++ b/tests/containers/search/visualizations/mockVisualizations.js
@@ -111,12 +111,14 @@ export const recipient = {
         {
             id: '1',
             name: 'Multiple Recipients',
-            amount: '149620471458.92'
+            amount: '149620471458.92',
+            recipient_id: '123456-R'
         },
         {
             id: '113704139',
             name: 'Michigan',
-            amount: '6684225478.00'
+            amount: '6684225478.00',
+            recipient_id: '456789-C'
         }
     ]
 };

--- a/tests/containers/search/visualizations/rank/RankVisualizationWrapperContainer-test.jsx
+++ b/tests/containers/search/visualizations/rank/RankVisualizationWrapperContainer-test.jsx
@@ -5,16 +5,14 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
+import { RankVisualizationWrapperContainer } from
+    'containers/search/visualizations/rank/RankVisualizationWrapperContainer';
+import { Set } from 'immutable';
+import { defaultFilters } from '../../../../testResources/defaultReduxFilters';
+import { mockActions } from '../time/mockData';
 
 // mock the search helper
 jest.mock('helpers/searchHelper', () => require('./spendingByCategoryHelper'));
-
-import { RankVisualizationWrapperContainer } from
-    'containers/search/visualizations/rank/RankVisualizationWrapperContainer';
-
-import { defaultFilters } from '../../../../testResources/defaultReduxFilters';
-import { mockActions } from '../time/mockData';
-import { Set } from 'immutable';
 
 // mock the child components by replacing them with a function that returns a null element
 jest.mock('components/search/visualizations/rank/sections/SpendingByAgencySection', () =>
@@ -153,6 +151,7 @@ describe('RankVisualizationWrapperContainer', () => {
                 error: false,
                 labelSeries: ['First Agency (FA)', 'Second Agency (SA)'],
                 dataSeries: ['456', '123'],
+                linkSeries: [],
                 descriptions: ['Spending by First Agency (FA): $456', 'Spending by Second Agency (SA): $123'],
                 page: 1,
                 scope: 'awarding_agency',
@@ -163,6 +162,24 @@ describe('RankVisualizationWrapperContainer', () => {
             };
 
             expect(container.state()).toEqual(expectedState);
+        });
+        it('should add to the linkSeries for Spending by Recipient', async () => {
+            // mount the container
+            const container = mount(<RankVisualizationWrapperContainer
+                reduxFilters={defaultFilters}
+                {...mockActions} />);
+
+            // change the scope to industry code
+            container.instance().changeSpendingBy('recipient');
+
+            container.instance().componentDidMount();
+            await container.instance().apiRequest.promise;
+
+            // The mock helper is returning agency results,
+            // so when recipient ids are missing they should resolve to empty strings
+            const expectedLinkSeries = ['', ''];
+
+            expect(container.state().linkSeries).toEqual(expectedLinkSeries);
         });
     });
 


### PR DESCRIPTION
**High level description:**
Adds recipient links to Spending by Award and Spending by Category

**Technical details:**

- Changed `ResultsTableAwardIdCell` to a more robust `ResultsTableLinkCell` component
- Added the `linkSeries` array to hold `recipient_id`s in Rank Visualization components
- Updated the `BaseSpendingByCategoryResult` model to include recipient id

**JIRA Ticket:**
[DEV-872](https://federal-spending-transparency.atlassian.net/browse/DEV-872)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:
- [x] Code review
- N/A All `componentWillReceiveProps`, `componentWillMount`, and `componentWillUpdate` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3341](https://federal-spending-transparency.atlassian.net/browse/DEV-3341)
- [x] [API contracts](https://github.com/fedspendingtransparency/usaspending-api/pull/2022) updated
- [x] [API #2022](https://github.com/fedspendingtransparency/usaspending-api/pull/2022) merged
- [x] Verified cross-browser compatibility
