### PR TITLE
Hotfix sub-award recipient links

### DIFF
--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -84,6 +84,12 @@ export default class ResultsTable extends React.Component {
             props.id = this.props.results[rowIndex].recipient_id;
             props.column = 'recipient';
         }
+        else if (column.columnName === 'Prime Recipient Name' && this.props.results[rowIndex].prime_award_recipient_id) {
+            // for Sub-Awards
+            cellClass = ResultsTableLinkCell;
+            props.id = this.props.results[rowIndex].prime_award_recipient_id;
+            props.column = 'recipient';
+        }
 
         return React.createElement(
             cellClass,

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -313,7 +313,7 @@ export class ResultsTableContainer extends React.Component {
             }
         });
 
-        requestFields.push('recipient_id');
+        requestFields.push('recipient_id', 'prime_award_recipient_id');
 
         // parse the redux search order into the API-consumable format
         const searchOrder = this.state.sort;


### PR DESCRIPTION
**High level description:**
Adds links to the `Prime Recipient Name` column in Advanced Search Spending by Award table (when searching for Sub-Awards)

**Technical details:**
- Updated the Results table to generate a link cell when the column is `Prime Recipient Name` and `prime_award_recipient_id` is truthy
- Note: test with staging API

**JIRA Ticket:**
[DEV-872](https://federal-spending-transparency.atlassian.net/browse/DEV-872)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:
- [x] Code review
- N/A All `componentWillReceiveProps`, `componentWillMount`, and `componentWillUpdate` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3341](https://federal-spending-transparency.atlassian.net/browse/DEV-3341)
- N/A Design review (if applicable)
- [x] [API contract](https://github.com/fedspendingtransparency/usaspending-api/blob/staging/usaspending_api/api_contracts/contracts/v2/search/spending_by_award.md#spendingbyawardresponse-object) updated
- [x] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/2029/files) merged
- [x] Verified cross-browser compatibility
