### PR TITLE
Hotfix Spending by Category sub-award recipient links

### DIFF
--- a/src/js/containers/search/visualizations/rank/RankVisualizationWrapperContainer.jsx
+++ b/src/js/containers/search/visualizations/rank/RankVisualizationWrapperContainer.jsx
@@ -193,7 +193,7 @@ export class RankVisualizationWrapperContainer extends React.Component {
             labelSeries.push(result.name);
             dataSeries.push(result._amount);
 
-            if (this.state.scope === 'recipient_duns') {
+            if (this.state.scope === 'recipient_duns' && !this.props.subaward) {
                 const recipientLink = result.recipientId ? `#/recipient/${result.recipientId}` : '';
                 linkSeries.push(recipientLink);
             }


### PR DESCRIPTION
**High level description:**
Removes sub-award recipient links from the Spending by Category table, since we don’t have sub-award data on those pages

**Technical details:**
Adds a check that the sub-award boolean is false before creating recipient links

**JIRA Ticket:**
[DEV-872](https://federal-spending-transparency.atlassian.net/browse/DEV-872)

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Verified cross-browser compatibility
