### PR TITLE
[DEV-3450] Grant Tooltips appear when non federal funding is zero

### DIFF
--- a/src/_scss/pages/awardV2/idv/awardAmounts/_charts.scss
+++ b/src/_scss/pages/awardV2/idv/awardAmounts/_charts.scss
@@ -134,14 +134,14 @@ $grants-line-color: #47AAA7;
     .award-amounts-viz__line::after {
         @extend %award-amounts-viz__line-indicator;
         border-left: 1px solid $border-light-gray;
-        top: -8.5px;
+        top: -9px;
         right: -1px;
     }
 
     .award-amounts-viz__line::before {
         @extend %award-amounts-viz__line-indicator;
         border-left: 1px solid $border-light-gray;
-        top: -8.5px;
+        top: -9px;
         left: -1px;
     }
 

--- a/src/js/components/awardv2/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
@@ -34,7 +34,7 @@ const createShowAndCloseTooltipMethod = (ctx, category) => {
     // ctx is `this`
     // type is one of: obligated, current, potential, exceedsCurrent, or exceedsPotential
     const titleCasedCategory = `${category[0].toUpperCase()}${category.substring(1)}`;
-    ctx[`show${titleCasedCategory}Tooltip`] = ctx.showSpendingCategoryTooltip.bind(ctx, category);
+    ctx[tooltipStateBySpendingCategory[category]] = ctx.showSpendingCategoryTooltip.bind(ctx, category);
     ctx[`close${titleCasedCategory}Tooltip`] = ctx.closeSpendingCategoryTooltip.bind(ctx, category);
 };
 
@@ -46,7 +46,9 @@ export default class AwardAmountsChart extends Component {
             showCurrentTooltip: false,
             showPotentialTooltip: false,
             showExceedsCurrentTooltip: false,
-            showExceedsPotentialTooltip: false
+            showExceedsPotentialTooltip: false,
+            showNonFederalFundingTooltip: false,
+            showTotalFundingTooltip: false
         };
         this.renderChart = this.renderChart.bind(this);
         this.getTooltipPropsBySpendingScenario = this.getTooltipPropsBySpendingScenario.bind(this);
@@ -122,6 +124,7 @@ export default class AwardAmountsChart extends Component {
         if (Object.keys(map).includes(awardType)) {
             return map[awardType][category];
         }
+
         return map.assistance[category];
     }
 

--- a/src/js/components/awardv2/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
@@ -34,8 +34,17 @@ const createShowAndCloseTooltipMethod = (ctx, category) => {
     // ctx is `this`
     // type is one of: obligated, current, potential, exceedsCurrent, or exceedsPotential
     const titleCasedCategory = `${category[0].toUpperCase()}${category.substring(1)}`;
-    ctx[tooltipStateBySpendingCategory[category]] = ctx.showSpendingCategoryTooltip.bind(ctx, category);
-    ctx[`close${titleCasedCategory}Tooltip`] = ctx.closeSpendingCategoryTooltip.bind(ctx, category);
+    ctx[tooltipStateBySpendingCategory[category]] = (e) => {
+        console.log(e.type.toUpperCase(), tooltipStateBySpendingCategory[category]);
+        e.stopPropagation();
+        e.preventDefault();
+        console.log("is propogation stopped for event? ", e.isPropagationStopped());
+        ctx.showSpendingCategoryTooltip.call(ctx, category);
+    };
+    ctx[`close${titleCasedCategory}Tooltip`] = (e) => {
+        console.log(e.type.toUpperCase());
+        ctx.closeSpendingCategoryTooltip.call(ctx, category);
+    };
 };
 
 export default class AwardAmountsChart extends Component {

--- a/src/js/components/awardv2/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
@@ -34,15 +34,10 @@ const createShowAndCloseTooltipMethod = (ctx, category) => {
     // ctx is `this`
     // type is one of: obligated, current, potential, exceedsCurrent, or exceedsPotential
     const titleCasedCategory = `${category[0].toUpperCase()}${category.substring(1)}`;
-    ctx[tooltipStateBySpendingCategory[category]] = (e) => {
-        console.log(e.type.toUpperCase(), tooltipStateBySpendingCategory[category]);
-        e.stopPropagation();
-        e.preventDefault();
-        console.log("is propogation stopped for event? ", e.isPropagationStopped());
+    ctx[tooltipStateBySpendingCategory[category]] = () => {
         ctx.showSpendingCategoryTooltip.call(ctx, category);
     };
-    ctx[`close${titleCasedCategory}Tooltip`] = (e) => {
-        console.log(e.type.toUpperCase());
+    ctx[`close${titleCasedCategory}Tooltip`] = () => {
         ctx.closeSpendingCategoryTooltip.call(ctx, category);
     };
 };

--- a/src/js/components/awardv2/shared/awardAmountsSection/charts/GrantChart.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/charts/GrantChart.jsx
@@ -24,6 +24,7 @@ export default class GrantChart extends React.Component {
         const obligation = this.props.awardAmounts._totalObligation;
         const nonFederalFunding = this.props.awardAmounts._nonFederalFunding;
         const totalFunding = this.props.awardAmounts._totalFunding;
+        const nonFederalFundingIsZero = (nonFederalFunding === 0);
 
         const obligatedBarStyle = {
             width: generatePercentage(obligation / totalFunding),
@@ -36,7 +37,7 @@ export default class GrantChart extends React.Component {
 
         const nonFederalFundingBarStyle = {
             width: generatePercentage(nonFederalFunding / totalFunding),
-            backgroundColor: '#4773aa',
+            backgroundColor: nonFederalFundingIsZero ? 'none' : '#4773aa',
             right: obligatedBarStyle.width
         };
 
@@ -46,14 +47,13 @@ export default class GrantChart extends React.Component {
             width: generatePercentage(nonFederalFunding / totalFunding)
         };
 
-        const nonFederalFundingIsZero = (nonFederalFunding === 0);
-
         const { nonFederalFundingTooltipProps, obligatedTooltipProps, totalFundingTooltipProps } = this.props;
+
         const nonFFTooltipStyles = {
             width: nonFederalFundingBarStyle.width,
             right: nonFederalFundingBarStyle.right,
-            border: "5px solid #47AAA7",
-            padding: '3.5px',
+            border: nonFederalFundingIsZero ? 'none' : "5px solid #47AAA7",
+            padding: nonFederalFundingIsZero ? '0px' : '3.5px',
             position: 'relative'
         };
 
@@ -75,25 +75,23 @@ export default class GrantChart extends React.Component {
                     <div className="award-amounts-viz__line-up" />
                 </div>
                 <div className="award-amounts-viz__bar-wrapper">
-                    <TooltipWrapper {...totalFundingTooltipProps} style={{ backgroundColor: totalFundingColor }}>
+                    <TooltipWrapper {...totalFundingTooltipProps} styles={{ backgroundColor: totalFundingColor }}>
                         <div className="award-amounts-viz__bar" style={{ backgroundColor: totalFundingColor }}>
                             <TooltipWrapper {...obligatedTooltipProps} styles={{ width: obligatedBarStyle.width }}>
                                 <div className="award-amounts-viz__obligated--grants" style={{ width: generatePercentage(1), backgroundColor: obligatedBarStyle.backgroundColor }} />
                             </TooltipWrapper>
-                            {!nonFederalFundingIsZero &&
-                                <TooltipWrapper {...nonFederalFundingTooltipProps} styles={{ ...nonFFTooltipStyles }}>
-                                    <div className="award-amounts-viz__non-federal-funding" style={{ backgroundColor: nonFederalFundingBarStyle.backgroundColor }} />
-                                </TooltipWrapper>
-                            }
+                            <TooltipWrapper {...nonFederalFundingTooltipProps} styles={{ ...nonFFTooltipStyles }}>
+                                <div className="award-amounts-viz__non-federal-funding" style={{ backgroundColor: nonFederalFundingBarStyle.backgroundColor }} />
+                                {/* <div className="award-amounts-viz__excerised" style={{ backgroundColor: nonFederalFundingBarStyle.backgroundColor }} /> */}
+                            </TooltipWrapper>
                         </div>
                     </TooltipWrapper>
                 </div>
                 <div className="award-amounts-viz__label" style={nonFederalFundingLabelStyle}>
                     {!nonFederalFundingIsZero > 0 && <div className="award-amounts-viz__line--non-federal-funding" style={{ backgroundColor: nonFederalFundingBarStyle.backgroundColor }} />}
-                    <div
-                        className={`${nonFederalFundingIsZero
-                            ? 'award-amounts-viz__desc award-amounts-viz__desc--nff-zero'
-                            : 'award-amounts-viz__desc'}`}>
+                    <div className={`${nonFederalFundingIsZero
+                        ? 'award-amounts-viz__desc award-amounts-viz__desc--nff-zero'
+                        : 'award-amounts-viz__desc'}`}>
                         <div
                             className="award-amounts-viz__desc-text"
                             role="button"
@@ -116,11 +114,26 @@ export default class GrantChart extends React.Component {
                             className="award-amounts-viz__desc-text"
                             role="button"
                             tabIndex="0"
-                            onBlur={totalFundingTooltipProps.controlledProps.closeTooltip}
-                            onFocus={totalFundingTooltipProps.controlledProps.showTooltip}
-                            onKeyPress={totalFundingTooltipProps.controlledProps.showTooltip}
-                            onMouseEnter={totalFundingTooltipProps.controlledProps.showTooltip}
-                            onMouseLeave={totalFundingTooltipProps.controlledProps.closeTooltip}
+                            onBlur={() => {
+                                console.log("onBlur");
+                                totalFundingTooltipProps.controlledProps.closeTooltip();
+                            }}
+                            onFocus={() => {
+                                console.log("onFocus");
+                                totalFundingTooltipProps.controlledProps.showTooltip();
+                            }}
+                            onKeyPress={() => {
+                                console.log("onKeyPress");
+                                totalFundingTooltipProps.controlledProps.showTooltip();
+                            }}
+                            onMouseEnter={() => {
+                                console.log("onMouseEnter");
+                                totalFundingTooltipProps.controlledProps.showTooltip();
+                            }}
+                            onMouseLeave={() => {
+                                console.log("onMouseLeave");
+                                totalFundingTooltipProps.controlledProps.closeTooltip();
+                            }}
                             onClick={totalFundingTooltipProps.controlledProps.showTooltip}>
                             <strong>{this.props.awardAmounts.totalFundingAbbreviated}</strong><br />Total Funding
                         </div>

--- a/src/js/components/awardv2/shared/awardAmountsSection/charts/GrantChart.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/charts/GrantChart.jsx
@@ -89,24 +89,25 @@ export default class GrantChart extends React.Component {
                     </TooltipWrapper>
                 </div>
                 <div className="award-amounts-viz__label" style={nonFederalFundingLabelStyle}>
-                    {!nonFederalFundingIsZero > 0 && <div className="award-amounts-viz__line--non-federal-funding" style={{ backgroundColor: nonFederalFundingBarStyle.backgroundColor }} />}
+                    {!nonFederalFundingIsZero && <div className="award-amounts-viz__line--non-federal-funding" style={{ backgroundColor: nonFederalFundingBarStyle.backgroundColor }} />}
                     <div className={`${nonFederalFundingIsZero ? 'award-amounts-viz__desc award-amounts-viz__desc--nff-zero' : 'award-amounts-viz__desc'}`}>
-                        {!nonFederalFundingIsZero &&
-                            <div
-                                className="award-amounts-viz__desc-text"
-                                role="button"
-                                tabIndex="0"
-                                onBlur={obligatedTooltipProps.controlledProps.closeTooltip}
-                                onFocus={obligatedTooltipProps.controlledProps.showTooltip}
-                                onKeyPress={obligatedTooltipProps.controlledProps.showTooltip}
-                                onMouseOver={obligatedTooltipProps.controlledProps.showTooltip}
-                                onMouseOut={obligatedTooltipProps.controlledProps.closeTooltip}
-                                onClick={obligatedTooltipProps.controlledProps.showTooltip}>
-                                <div className="award-amounts-viz__desc-text" role="button" tabIndex="0">
+                        {!nonFederalFundingIsZero && (
+                            <React.Fragment>
+                                <div
+                                    className="award-amounts-viz__desc-text"
+                                    role="button"
+                                    tabIndex="0"
+                                    onBlur={nonFederalFundingTooltipProps.controlledProps.closeTooltip}
+                                    onFocus={nonFederalFundingTooltipProps.controlledProps.showTooltip}
+                                    onKeyPress={nonFederalFundingTooltipProps.controlledProps.showTooltip}
+                                    onMouseOver={nonFederalFundingTooltipProps.controlledProps.showTooltip}
+                                    onMouseOut={nonFederalFundingTooltipProps.controlledProps.closeTooltip}
+                                    onClick={nonFederalFundingTooltipProps.controlledProps.showTooltip}>
                                     <strong>{this.props.awardAmounts.nonFederalFundingAbbreviated}</strong><br />Non-Federal Funding
                                 </div>
                                 <div className="award-amounts-viz__legend-line" style={{ backgroundColor: "#47AAA7" }} />
-                            </div>}
+                            </React.Fragment>
+                        )}
                         {nonFederalFundingIsZero &&
                             <TooltipWrapper {...nonFederalFundingTooltipProps} offsetAdjustments={{ top: 0 }} styles={{ ...nonFFTooltipStyles, width: 'auto', right: 0 }}>
                                 <div className="award-amounts-viz__desc-text" role="button" tabIndex="0">

--- a/src/js/components/awardv2/shared/awardAmountsSection/charts/GrantChart.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/charts/GrantChart.jsx
@@ -44,17 +44,7 @@ export default class GrantChart extends React.Component {
         const totalFundingColor = "#FFF";
 
         const nonFederalFundingLabelStyle = {
-            width: generatePercentage(nonFederalFunding / totalFunding)
-        };
-
-        const zeroNonFederalFundingTooltipProps = {
-            ...this.props.nonFederalFundingTooltipProps,
-            controlledProps: {
-                isControlled: true,
-                isVisible: this.props.nonFederalFundingTooltipProps.controlledProps.isVisible,
-                closeTooltip: () => false,
-                showTooltip: () => false
-            }
+            width: nonFederalFundingIsZero ? '100%' : generatePercentage(nonFederalFunding / totalFunding)
         };
 
         const { obligatedTooltipProps, nonFederalFundingTooltipProps, totalFundingTooltipProps } = this.props;
@@ -90,10 +80,6 @@ export default class GrantChart extends React.Component {
                             <TooltipWrapper {...obligatedTooltipProps} styles={{ width: obligatedBarStyle.width }}>
                                 <div className="award-amounts-viz__obligated--grants" style={{ width: generatePercentage(1), backgroundColor: obligatedBarStyle.backgroundColor }} />
                             </TooltipWrapper>
-                            {nonFederalFundingIsZero &&
-                                <TooltipWrapper {...zeroNonFederalFundingTooltipProps} styles={nonFFTooltipStyles}>
-                                    <div className="award-amounts-viz__non-federal-funding" style={{ backgroundColor: nonFederalFundingBarStyle.backgroundColor }} />
-                                </TooltipWrapper>}
                             {!nonFederalFundingIsZero &&
                                 <TooltipWrapper {...nonFederalFundingTooltipProps} styles={nonFFTooltipStyles}>
                                     <div className="award-amounts-viz__non-federal-funding" style={{ backgroundColor: nonFederalFundingBarStyle.backgroundColor }} />
@@ -104,22 +90,31 @@ export default class GrantChart extends React.Component {
                 </div>
                 <div className="award-amounts-viz__label" style={nonFederalFundingLabelStyle}>
                     {!nonFederalFundingIsZero > 0 && <div className="award-amounts-viz__line--non-federal-funding" style={{ backgroundColor: nonFederalFundingBarStyle.backgroundColor }} />}
-                    <div className={`${nonFederalFundingIsZero
-                        ? 'award-amounts-viz__desc award-amounts-viz__desc--nff-zero'
-                        : 'award-amounts-viz__desc'}`}>
-                        <div
-                            className="award-amounts-viz__desc-text"
-                            role="button"
-                            tabIndex="0"
-                            onBlur={nonFederalFundingTooltipProps.controlledProps.closeTooltip}
-                            onFocus={nonFederalFundingTooltipProps.controlledProps.showTooltip}
-                            onKeyPress={nonFederalFundingTooltipProps.controlledProps.showTooltip}
-                            onMouseOver={nonFederalFundingTooltipProps.controlledProps.showTooltip}
-                            onMouseOut={nonFederalFundingTooltipProps.controlledProps.closeTooltip}
-                            onClick={nonFederalFundingTooltipProps.controlledProps.showTooltip}>
-                            <strong>{this.props.awardAmounts.nonFederalFundingAbbreviated}</strong><br />Non-Federal Funding
-                        </div>
-                        <div className="award-amounts-viz__legend-line" style={{ backgroundColor: "#47AAA7" }} />
+                    <div className={`${nonFederalFundingIsZero ? 'award-amounts-viz__desc award-amounts-viz__desc--nff-zero' : 'award-amounts-viz__desc'}`}>
+                        {!nonFederalFundingIsZero &&
+                            <div
+                                className="award-amounts-viz__desc-text"
+                                role="button"
+                                tabIndex="0"
+                                onBlur={obligatedTooltipProps.controlledProps.closeTooltip}
+                                onFocus={obligatedTooltipProps.controlledProps.showTooltip}
+                                onKeyPress={obligatedTooltipProps.controlledProps.showTooltip}
+                                onMouseOver={obligatedTooltipProps.controlledProps.showTooltip}
+                                onMouseOut={obligatedTooltipProps.controlledProps.closeTooltip}
+                                onClick={obligatedTooltipProps.controlledProps.showTooltip}>
+                                <div className="award-amounts-viz__desc-text" role="button" tabIndex="0">
+                                    <strong>{this.props.awardAmounts.nonFederalFundingAbbreviated}</strong><br />Non-Federal Funding
+                                </div>
+                                <div className="award-amounts-viz__legend-line" style={{ backgroundColor: "#47AAA7" }} />
+                            </div>}
+                        {nonFederalFundingIsZero &&
+                            <TooltipWrapper {...nonFederalFundingTooltipProps} offsetAdjustments={{ top: 0 }} styles={{ ...nonFFTooltipStyles, width: 'auto', right: 0 }}>
+                                <div className="award-amounts-viz__desc-text" role="button" tabIndex="0">
+                                    <strong>{this.props.awardAmounts.nonFederalFundingAbbreviated}</strong><br />Non-Federal Funding
+                                </div>
+                                <div className="award-amounts-viz__legend-line" style={{ backgroundColor: "#47AAA7" }} />
+                            </TooltipWrapper>
+                        }
                     </div>
                 </div>
                 <div className="award-amounts-viz__label">

--- a/src/js/components/awardv2/shared/awardAmountsSection/charts/GrantChart.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/charts/GrantChart.jsx
@@ -47,7 +47,17 @@ export default class GrantChart extends React.Component {
             width: generatePercentage(nonFederalFunding / totalFunding)
         };
 
-        const { nonFederalFundingTooltipProps, obligatedTooltipProps, totalFundingTooltipProps } = this.props;
+        const zeroNonFederalFundingTooltipProps = {
+            ...this.props.nonFederalFundingTooltipProps,
+            controlledProps: {
+                isControlled: true,
+                isVisible: this.props.nonFederalFundingTooltipProps.controlledProps.isVisible,
+                closeTooltip: () => false,
+                showTooltip: () => false
+            }
+        };
+
+        const { obligatedTooltipProps, nonFederalFundingTooltipProps, totalFundingTooltipProps } = this.props;
 
         const nonFFTooltipStyles = {
             width: nonFederalFundingBarStyle.width,
@@ -66,8 +76,8 @@ export default class GrantChart extends React.Component {
                     onBlur={obligatedTooltipProps.controlledProps.closeTooltip}
                     onFocus={obligatedTooltipProps.controlledProps.showTooltip}
                     onKeyPress={obligatedTooltipProps.controlledProps.showTooltip}
-                    onMouseEnter={obligatedTooltipProps.controlledProps.showTooltip}
-                    onMouseLeave={obligatedTooltipProps.controlledProps.closeTooltip}
+                    onMouseOver={obligatedTooltipProps.controlledProps.showTooltip}
+                    onMouseOut={obligatedTooltipProps.controlledProps.closeTooltip}
                     onClick={obligatedTooltipProps.controlledProps.showTooltip}>
                     <strong>{this.props.awardAmounts.totalObligationAbbreviated}</strong><br />Obligated Amount
                 </div>
@@ -80,10 +90,15 @@ export default class GrantChart extends React.Component {
                             <TooltipWrapper {...obligatedTooltipProps} styles={{ width: obligatedBarStyle.width }}>
                                 <div className="award-amounts-viz__obligated--grants" style={{ width: generatePercentage(1), backgroundColor: obligatedBarStyle.backgroundColor }} />
                             </TooltipWrapper>
-                            <TooltipWrapper {...nonFederalFundingTooltipProps} styles={{ ...nonFFTooltipStyles }}>
-                                <div className="award-amounts-viz__non-federal-funding" style={{ backgroundColor: nonFederalFundingBarStyle.backgroundColor }} />
-                                {/* <div className="award-amounts-viz__excerised" style={{ backgroundColor: nonFederalFundingBarStyle.backgroundColor }} /> */}
-                            </TooltipWrapper>
+                            {nonFederalFundingIsZero &&
+                                <TooltipWrapper {...zeroNonFederalFundingTooltipProps} styles={nonFFTooltipStyles}>
+                                    <div className="award-amounts-viz__non-federal-funding" style={{ backgroundColor: nonFederalFundingBarStyle.backgroundColor }} />
+                                </TooltipWrapper>}
+                            {!nonFederalFundingIsZero &&
+                                <TooltipWrapper {...nonFederalFundingTooltipProps} styles={nonFFTooltipStyles}>
+                                    <div className="award-amounts-viz__non-federal-funding" style={{ backgroundColor: nonFederalFundingBarStyle.backgroundColor }} />
+                                </TooltipWrapper>
+                            }
                         </div>
                     </TooltipWrapper>
                 </div>
@@ -99,8 +114,8 @@ export default class GrantChart extends React.Component {
                             onBlur={nonFederalFundingTooltipProps.controlledProps.closeTooltip}
                             onFocus={nonFederalFundingTooltipProps.controlledProps.showTooltip}
                             onKeyPress={nonFederalFundingTooltipProps.controlledProps.showTooltip}
-                            onMouseEnter={nonFederalFundingTooltipProps.controlledProps.showTooltip}
-                            onMouseLeave={nonFederalFundingTooltipProps.controlledProps.closeTooltip}
+                            onMouseOver={nonFederalFundingTooltipProps.controlledProps.showTooltip}
+                            onMouseOut={nonFederalFundingTooltipProps.controlledProps.closeTooltip}
                             onClick={nonFederalFundingTooltipProps.controlledProps.showTooltip}>
                             <strong>{this.props.awardAmounts.nonFederalFundingAbbreviated}</strong><br />Non-Federal Funding
                         </div>
@@ -114,26 +129,11 @@ export default class GrantChart extends React.Component {
                             className="award-amounts-viz__desc-text"
                             role="button"
                             tabIndex="0"
-                            onBlur={() => {
-                                console.log("onBlur");
-                                totalFundingTooltipProps.controlledProps.closeTooltip();
-                            }}
-                            onFocus={() => {
-                                console.log("onFocus");
-                                totalFundingTooltipProps.controlledProps.showTooltip();
-                            }}
-                            onKeyPress={() => {
-                                console.log("onKeyPress");
-                                totalFundingTooltipProps.controlledProps.showTooltip();
-                            }}
-                            onMouseEnter={() => {
-                                console.log("onMouseEnter");
-                                totalFundingTooltipProps.controlledProps.showTooltip();
-                            }}
-                            onMouseLeave={() => {
-                                console.log("onMouseLeave");
-                                totalFundingTooltipProps.controlledProps.closeTooltip();
-                            }}
+                            onBlur={totalFundingTooltipProps.controlledProps.closeTooltip}
+                            onFocus={totalFundingTooltipProps.controlledProps.showTooltip}
+                            onKeyPress={totalFundingTooltipProps.controlledProps.showTooltip}
+                            onMouseOver={totalFundingTooltipProps.controlledProps.showTooltip}
+                            onMouseOut={totalFundingTooltipProps.controlledProps.closeTooltip}
                             onClick={totalFundingTooltipProps.controlledProps.showTooltip}>
                             <strong>{this.props.awardAmounts.totalFundingAbbreviated}</strong><br />Total Funding
                         </div>

--- a/src/js/components/sharedComponents/TooltipWrapper.jsx
+++ b/src/js/components/sharedComponents/TooltipWrapper.jsx
@@ -173,11 +173,26 @@ export default class TooltipWrapper extends React.Component {
                         role="button"
                         tabIndex="0"
                         className="tooltip__hover-wrapper"
-                        onBlur={this.closeTooltip}
-                        onFocus={this.showTooltip}
-                        onKeyPress={this.showTooltip}
-                        onMouseEnter={this.showTooltip}
-                        onMouseLeave={this.closeTooltip}
+                        onBlur={() => {
+                            console.log("blur from viz");
+                            this.closeTooltip();
+                        }}
+                        onFocus={() => {
+                            console.log("focus from viz");
+                            this.showTooltip();
+                        }}
+                        onKeyPress={() => {
+                            console.log("keypress from viz");
+                            this.showTooltip();
+                        }}
+                        onMouseEnter={() => {
+                            console.log("mouseenter from viz", this.props.styles.backgroundColor);
+                            this.showTooltip();
+                        }}
+                        onMouseLeave={() => {
+                            console.log("mouseleave from viz");
+                            this.closeTooltip();
+                        }}
                         onClick={this.showTooltip}>
                         {this.props.children}
                         {this.props.icon && tooltipIcons[this.props.icon]}

--- a/src/js/components/sharedComponents/TooltipWrapper.jsx
+++ b/src/js/components/sharedComponents/TooltipWrapper.jsx
@@ -176,8 +176,8 @@ export default class TooltipWrapper extends React.Component {
                         onBlur={this.closeTooltip}
                         onFocus={this.showTooltip}
                         onKeyPress={this.showTooltip}
-                        onMouseOver={this.showTooltip}
-                        onMouseOut={this.closeTooltip}
+                        onMouseEnter={this.showTooltip}
+                        onMouseLeave={this.closeTooltip}
                         onClick={this.showTooltip}>
                         {this.props.children}
                         {this.props.icon && tooltipIcons[this.props.icon]}

--- a/src/js/components/sharedComponents/TooltipWrapper.jsx
+++ b/src/js/components/sharedComponents/TooltipWrapper.jsx
@@ -71,25 +71,25 @@ export default class TooltipWrapper extends React.Component {
         window.removeEventListener("resize", this.measureOffset);
     }
 
-    showTooltip() {
+    showTooltip(e) {
         if (!this.props.controlledProps.isControlled) {
             this.setState({
                 showTooltip: true
             });
         }
         else {
-            this.props.controlledProps.showTooltip();
+            this.props.controlledProps.showTooltip(e);
         }
     }
 
-    closeTooltip() {
+    closeTooltip(e) {
         if (!this.props.controlledProps.isControlled) {
             this.setState({
                 showTooltip: false
             });
         }
         else {
-            this.props.controlledProps.closeTooltip();
+            this.props.controlledProps.closeTooltip(e);
         }
     }
 
@@ -173,26 +173,11 @@ export default class TooltipWrapper extends React.Component {
                         role="button"
                         tabIndex="0"
                         className="tooltip__hover-wrapper"
-                        onBlur={() => {
-                            console.log("blur from viz");
-                            this.closeTooltip();
-                        }}
-                        onFocus={() => {
-                            console.log("focus from viz");
-                            this.showTooltip();
-                        }}
-                        onKeyPress={() => {
-                            console.log("keypress from viz");
-                            this.showTooltip();
-                        }}
-                        onMouseEnter={() => {
-                            console.log("mouseenter from viz", this.props.styles.backgroundColor);
-                            this.showTooltip();
-                        }}
-                        onMouseLeave={() => {
-                            console.log("mouseleave from viz");
-                            this.closeTooltip();
-                        }}
+                        onBlur={this.closeTooltip}
+                        onFocus={this.showTooltip}
+                        onKeyPress={this.showTooltip}
+                        onMouseOver={this.showTooltip}
+                        onMouseOut={this.closeTooltip}
                         onClick={this.showTooltip}>
                         {this.props.children}
                         {this.props.icon && tooltipIcons[this.props.icon]}


### PR DESCRIPTION
**High level description:**
Previously, we weren't showing any non-federal-funding tool tips when the award had no non federal funding amount.

**Technical details:**
- Changed trigger event to `mouseOver` due to issues with bubbling (?).
- Changed hover area for tooltip triggering when non-federal-funding is zero

**JIRA Ticket:**
[DEV-3450](https://federal-spending-transparency.atlassian.net/browse/DEV-3450)

**Mockup:**
![image](https://user-images.githubusercontent.com/12897813/64990791-7e7c0480-d89e-11e9-8935-9461631c2749.png)

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] All `componentWillReceiveProps`, `componentWillMount`, and `componentWillUpdate` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3341](https://federal-spending-transparency.atlassian.net/browse/DEV-3341)
- [x] Design review (if applicable)