### PR TITLE
Hotfix Award v2 Federal Accounts treemap sort

### DIFF
--- a/src/js/components/awardv2/shared/federalAccounts/FederalAccountsTree.jsx
+++ b/src/js/components/awardv2/shared/federalAccounts/FederalAccountsTree.jsx
@@ -68,7 +68,7 @@ export default class FederalAccountsTree extends React.Component {
         })
             // tell D3 how to extract the monetary value out of the object
             .sum((d) => d._obligatedAmount)
-            .sort((a, b) => b._obligatedAmount - a._obligatedAmount); // sort the objects
+            .sort((a, b) => b.value - a.value); // sort the objects
 
         // set up a function for generating the treemap of the specified size and style
         const tree = treemap()


### PR DESCRIPTION
**High level description:**
Fixes a bug causing table sorting to affect how the treemap was displayed.

**Technical details:**
The treemap now uses d3 `sort` to sort the cells by their `value`

**JIRA Ticket:**
[DEV-1662](https://federal-spending-transparency.atlassian.net/browse/DEV-1662) (Failed test)

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Verified cross-browser compatibility
