### PR TITLE
[DEV-2724] Center TAS data tooltip over icon

### DIFF
--- a/src/_scss/pages/search/filters/programSource/programSource.scss
+++ b/src/_scss/pages/search/filters/programSource/programSource.scss
@@ -30,8 +30,9 @@
                     padding-right: rem(5);
                 }
                 .tooltip-popover {
-                    left: 0;
-                    bottom: rem(30);
+                    // override the positioning to be centered over the icon
+                    left: rem(60);
+                    bottom: rem(32);
                 }
             }
 


### PR DESCRIPTION
**High level description:**
Moves the tooltip for "A note about our TAS data sources" to be centered over the info icon. 

**JIRA Ticket:**
[DEV-2724](https://federal-spending-transparency.atlassian.net/browse/DEV-2724) (Failed test)

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Verified cross-browser compatibility
