### PR TITLE
Hotfix Dev-3171 tooltip idv activity

### DIFF
--- a/src/js/components/awardv2/idv/activity/ActivityChartTooltip.jsx
+++ b/src/js/components/awardv2/idv/activity/ActivityChartTooltip.jsx
@@ -190,6 +190,17 @@ export default class IdvActivityTooltip extends React.Component {
         // 70px = 10px ( Left padding ) + 30px ( Right padding of first div )
         // + 10px ( Right spacing for end of tooltip )
         let theTooltipWidth = awardingAgencyNameDiv + recipientNameDiv + 50;
+        // getting the first row
+        const piidDiv = this.piidDiv.getBoundingClientRect().width;
+        const parentDiv = this.parentDiv.getBoundingClientRect().width;
+        // with the addition of the granparent section in the first row
+        // the first row can now be longer than the second row
+        // we will check for that below and set the starting width for the tooltip
+        if (this.grandparentDiv) {
+            const grandparentDiv = this.grandparentDiv.getBoundingClientRect().width;
+            const totalFirstRowWidth = piidDiv + parentDiv + grandparentDiv + 90;
+            if (totalFirstRowWidth > theTooltipWidth) theTooltipWidth = totalFirstRowWidth;
+        }
         // x Position of the Award Bar ( start )
         let xPosition = data.x;
         // distance from the top of the graph to the middle of the bar
@@ -230,9 +241,6 @@ export default class IdvActivityTooltip extends React.Component {
             const startDateDiv = this.startDateDiv.getBoundingClientRect().width;
             const endDateDiv = this.endDateDiv.getBoundingClientRect().width;
             const amountsDiv = this.amountsDiv.getBoundingClientRect().width;
-            // getting the first row
-            const piidDiv = this.piidDiv.getBoundingClientRect().width;
-            const parentDiv = this.parentDiv.getBoundingClientRect().width;
             // this is the width of the last row
             // the smallest width allowed since we have to keep it inline
             // 100px = 10px ( Left of Row ) + 60px ( Two divs padding right )


### PR DESCRIPTION
**High level description:**

The IDV Activity Chart Tooltips now compare the first and second row widths when the tooltips are not being truncated due to the addition of the grandparent section the first row can now be longer than the second row.

**Technical details:**

Compare the first two rows of the IDV Activity Tooltip when not truncating.

**JIRA Ticket:**
[DEV-3171](https://federal-spending-transparency.atlassian.net/browse/DEV-3171)

The following are ALL required for the PR to be merged:
- [ ] Code review
