### PR TITLE
Dev-3098 Award V2 Related Awards Section for Contracts

### DIFF
--- a/src/js/components/awardv2/contract/ContractContent.jsx
+++ b/src/js/components/awardv2/contract/ContractContent.jsx
@@ -10,6 +10,7 @@ import { glossaryLinks } from 'dataMapping/search/awardType';
 import BaseAwardAmounts from 'models/v2/awardsV2/BaseAwardAmounts';
 import AdditionalInfo from '../shared/additionalInfo/AdditionalInfo';
 import AgencyRecipient from '../shared/overview/AgencyRecipient';
+import RelatedAwards from '../shared/overview/RelatedAwards';
 import AwardDates from '../shared/overview/AwardDates';
 import FederalAccountsSection from '../shared/federalAccounts/FederalAccountsSection';
 import AwardPageWrapper from '../shared/AwardPageWrapper';
@@ -48,6 +49,8 @@ export default class ContractContent extends React.Component {
                             recipient={overview.recipient} />
                     </AwardSection>
                     <AwardSection type="column" className="award-amountdates">
+                        <RelatedAwards
+                            overview={this.props.overview} />
                         <AwardDates overview={overview} />
                     </AwardSection>
                 </AwardSection>

--- a/src/js/components/awardv2/idv/InfoTooltip.jsx
+++ b/src/js/components/awardv2/idv/InfoTooltip.jsx
@@ -44,9 +44,11 @@ export default class InfoTooltip extends React.Component {
     }
 
     showTooltip() {
-        this.setState({
-            showInfoTooltip: true
-        });
+        if (this.props.children) {
+            this.setState({
+                showInfoTooltip: true
+            });
+        }
     }
 
     closeTooltip() {

--- a/src/js/components/awardv2/shared/overview/RelatedAwards.jsx
+++ b/src/js/components/awardv2/shared/overview/RelatedAwards.jsx
@@ -91,8 +91,15 @@ export default class RelatedAwards extends React.Component {
 
     tooltipInfo() {
         const { overview } = this.props;
-        if (overview.category === 'idv') return summaryRelatedAwardsInfo;
-        if (overview.category === 'contract') return null;
+        const awardType = overview.category;
+        if (awardType === 'idv') return summaryRelatedAwardsInfo;
+        if (awardType === 'contract') return null;
+        if (awardType === 'definitive contract') return null;
+        if (awardType === 'grant') return null;
+        if (awardType === 'loan') return null;
+        if (awardType === 'direct payment') return null;
+        if (awardType === 'other') return null;
+
         return null;
     }
 

--- a/src/js/components/awardv2/shared/overview/RelatedAwards.jsx
+++ b/src/js/components/awardv2/shared/overview/RelatedAwards.jsx
@@ -89,7 +89,15 @@ export default class RelatedAwards extends React.Component {
         );
     }
 
+    tooltipInfo() {
+        const { overview } = this.props;
+        if (overview.category === 'idv') return summaryRelatedAwardsInfo;
+        if (overview.category === 'contract') return null;
+        return null;
+    }
+
     render() {
+        const tooltipInfo = this.tooltipInfo();
         let parentLink = 'N/A';
         if (this.props.overview.parentAward && this.props.overview.parentId) {
             parentLink = (
@@ -106,7 +114,7 @@ export default class RelatedAwards extends React.Component {
                 <div className="award-overview__title related-awards__title">
                     Related Awards
                     <InfoTooltip left>
-                        {summaryRelatedAwardsInfo}
+                        {tooltipInfo}
                     </InfoTooltip>
                 </div>
                 <div className="related-awards__parent">

--- a/src/js/models/v2/awardsV2/BaseContract.js
+++ b/src/js/models/v2/awardsV2/BaseContract.js
@@ -112,6 +112,7 @@ BaseContract.populate = function populate(data) {
     this.executiveDetails = executiveDetails;
 
     this.parentAward = data.parent_award_piid || '--';
+    this.parentId = data.parent_generated_unique_award_id || '';
     this.pricing = data.latest_transaction_contract_data || '--';
 
     this._amount = parseFloat(data.base_and_all_options) || 0;


### PR DESCRIPTION
**High level description:**

Award V2 Contract Pages have a Related Awards Section

**Technical details:**

Add Related Awards Section to Contract Content
Update tooltip logic in Related Awards Section 

**JIRA Ticket:**
[DEV-3098](https://federal-spending-transparency.atlassian.net/browse/DEV-3098)

**Mockup:**
Please refer to the ticket

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] All `componentWillReceiveProps`, `componentWillMount`, and `componentWillUpdate` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3341](https://federal-spending-transparency.atlassian.net/browse/DEV-3341)
- [x] Design review (@AGuyNamedMarco )
- [x] [API contract](https://github.com/fedspendingtransparency/usaspending-api/blob/dev/usaspending_api/api_contracts/contracts/v2/awards/award_id.md) updated
- [x] [API #2043](https://github.com/fedspendingtransparency/usaspending-api/pull/2043) merged
- [x] Verified cross-browser compatibility
