### PR TITLE
Dev-3158 IDV Activity Chart Show Bars with Small Date Ranges

### DIFF
--- a/src/js/components/awardv2/idv/activity/chart/ActivityChart.jsx
+++ b/src/js/components/awardv2/idv/activity/chart/ActivityChart.jsx
@@ -177,6 +177,7 @@ export default class ActivityChart extends React.Component {
             const start = xScale(bar._startDate.valueOf()) + padding.left;
             const end = xScale(bar._endDate.valueOf()) + padding.left;
             data.barWidth = end - start;
+            if (data.barWidth < 1.5) data.barWidth = 1.5;
             // create a scale for obligated amount width using awarded amount
             // and the awarded amount width
             const obligatedAmountScale = scaleLinear()


### PR DESCRIPTION
**High level description:**

The IDV Activity Chart will now show bars even if their width's are scaled to zero.

**Technical details:**

Added a check while generating the bar data to set the bar width to 1.5 if the width is < 1.5. This should allow users to be able to see the bars are smaller screens and still scale wider on larger screens

**JIRA Ticket:**
[DEV-3158](https://federal-spending-transparency.atlassian.net/browse/DEV-3158)

**Mockup:**
Is in this [ticket Dev-3389](https://federal-spending-transparency.atlassian.net/browse/DEV-3389)

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] All `componentWillReceiveProps`, `componentWillMount`, and `componentWillUpdate` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3341](https://federal-spending-transparency.atlassian.net/browse/DEV-3341)
- [x] Design review (@AGuyNamedMarco )
- [ ] Verified cross-browser compatibility
