### PR TITLE
DEV-2752: Allow nullable agency abbreviations

### DIFF
--- a/src/js/containers/search/filters/AgencyListContainer.jsx
+++ b/src/js/containers/search/filters/AgencyListContainer.jsx
@@ -47,10 +47,10 @@ export default class AgencyListContainer extends React.Component {
             results.forEach((item) => {
                 let subAbbreviation = '';
                 let topAbbreviation = '';
-                if (item.subtier_agency.abbreviation !== '') {
+                if (item.subtier_agency.abbreviation !== '' && item.subtier_agency.abbreviation !== null) {
                     subAbbreviation = `(${item.subtier_agency.abbreviation})`;
                 }
-                if (item.toptier_agency.abbreviation !== '') {
+                if (item.toptier_agency.abbreviation !== '' && item.toptier_agency.abbreviation !== null) {
                     topAbbreviation = `(${item.toptier_agency.abbreviation})`;
                 }
 

--- a/src/js/containers/search/filters/AgencyListContainer.jsx
+++ b/src/js/containers/search/filters/AgencyListContainer.jsx
@@ -47,10 +47,10 @@ export default class AgencyListContainer extends React.Component {
             results.forEach((item) => {
                 let subAbbreviation = '';
                 let topAbbreviation = '';
-                if (item.subtier_agency.abbreviation !== '' && item.subtier_agency.abbreviation !== null) {
+                if (item.subtier_agency.abbreviation) {
                     subAbbreviation = `(${item.subtier_agency.abbreviation})`;
                 }
-                if (item.toptier_agency.abbreviation !== '' && item.toptier_agency.abbreviation !== null) {
+                if (item.toptier_agency.abbreviation) {
                     topAbbreviation = `(${item.toptier_agency.abbreviation})`;
                 }
 

--- a/src/js/models/v2/awardsV2/BaseContract.js
+++ b/src/js/models/v2/awardsV2/BaseContract.js
@@ -73,10 +73,10 @@ BaseContract.populate = function populate(data) {
         const awardingAgencyData = {
             id: data.awarding_agency.id,
             toptierName: data.awarding_agency.toptier_agency.name,
-            toptierAbbr: data.awarding_agency.toptier_agency.abbreviation,
+            toptierAbbr: data.awarding_agency.toptier_agency.abbreviation || '',
             toptierId: data.awarding_agency.toptier_agency.id,
             subtierName: data.awarding_agency.subtier_agency.name,
-            subtierAbbr: data.awarding_agency.subtier_agency.abbreviation,
+            subtierAbbr: data.awarding_agency.subtier_agency.abbreviation || '',
             subtierId: data.awarding_agency.subtier_agency.id,
             officeName: data.awarding_agency.office_agency_name,
             officeId: data.awarding_agency.office_agency_id
@@ -92,10 +92,10 @@ BaseContract.populate = function populate(data) {
     if (data.funding_agency) {
         const fundingAgencyData = {
             toptierName: data.funding_agency.toptier_agency.name,
-            toptierAbbr: data.funding_agency.toptier_agency.abbreviation,
+            toptierAbbr: data.funding_agency.toptier_agency.abbreviation || '',
             toptierId: data.funding_agency.toptier_agency.id,
             subtierName: data.funding_agency.subtier_agency.name,
-            subtierAbbr: data.funding_agency.subtier_agency.abbreviation,
+            subtierAbbr: data.funding_agency.subtier_agency.abbreviation || '',
             subtierId: data.funding_agency.subtier_agency.id,
             officeName: data.funding_agency.office_agency_name,
             officeId: data.funding_agency.office_agency_id

--- a/src/js/models/v2/awardsV2/BaseFinancialAssistance.js
+++ b/src/js/models/v2/awardsV2/BaseFinancialAssistance.js
@@ -67,10 +67,10 @@ BaseFinancialAssistance.populate = function populate(data) {
         const awardingAgencyData = {
             id: data.awarding_agency.id,
             toptierName: data.awarding_agency.toptier_agency.name,
-            toptierAbbr: data.awarding_agency.toptier_agency.abbreviation,
+            toptierAbbr: data.awarding_agency.toptier_agency.abbreviation || '',
             toptierId: data.awarding_agency.toptier_agency.id,
             subtierName: data.awarding_agency.subtier_agency.name,
-            subtierAbbr: data.awarding_agency.subtier_agency.abbreviation,
+            subtierAbbr: data.awarding_agency.subtier_agency.abbreviation || '',
             subtierId: data.awarding_agency.subtier_agency.id,
             officeName: data.awarding_agency.office_agency_name,
             officeId: data.awarding_agency.office_agency_id
@@ -86,10 +86,10 @@ BaseFinancialAssistance.populate = function populate(data) {
     if (data.funding_agency) {
         const fundingAgencyData = {
             toptierName: data.funding_agency.toptier_agency.name,
-            toptierAbbr: data.funding_agency.toptier_agency.abbreviation,
+            toptierAbbr: data.funding_agency.toptier_agency.abbreviation || '',
             toptierId: data.funding_agency.toptier_agency.id,
             subtierName: data.funding_agency.subtier_agency.name,
-            subtierAbbr: data.funding_agency.subtier_agency.abbreviation,
+            subtierAbbr: data.funding_agency.subtier_agency.abbreviation || '',
             subtierId: data.funding_agency.subtier_agency.id,
             officeName: data.funding_agency.office_agency_name,
             officeId: data.funding_agency.office_agency_id

--- a/src/js/models/v2/awardsV2/BaseIdv.js
+++ b/src/js/models/v2/awardsV2/BaseIdv.js
@@ -85,9 +85,9 @@ BaseIdv.populate = function populate(data) {
     if (data.funding_agency) {
         const fundingAgencyData = {
             toptierName: data.funding_agency.toptier_agency.name,
-            toptierAbbr: data.funding_agency.toptier_agency.abbreviation,
+            toptierAbbr: data.funding_agency.toptier_agency.abbreviation || '',
             subtierName: data.funding_agency.subtier_agency.name,
-            subtierAbbr: data.funding_agency.subtier_agency.abbreviation,
+            subtierAbbr: data.funding_agency.subtier_agency.abbreviation || '',
             officeName: data.funding_agency.office_agency_name
         };
         fundingAgency.populateCore(fundingAgencyData);
@@ -99,9 +99,9 @@ BaseIdv.populate = function populate(data) {
         const awardingAgencyData = {
             id: data.awarding_agency.id,
             toptierName: data.awarding_agency.toptier_agency.name,
-            toptierAbbr: data.awarding_agency.toptier_agency.abbreviation,
+            toptierAbbr: data.awarding_agency.toptier_agency.abbreviation || '',
             subtierName: data.awarding_agency.subtier_agency.name,
-            subtierAbbr: data.awarding_agency.subtier_agency.abbreviation,
+            subtierAbbr: data.awarding_agency.subtier_agency.abbreviation || '',
             officeName: data.awarding_agency.office_agency_name
         };
         awardingAgency.populateCore(awardingAgencyData);

--- a/tests/containers/search/filters/agencyFilter/AgencyListContainer-test.jsx
+++ b/tests/containers/search/filters/agencyFilter/AgencyListContainer-test.jsx
@@ -147,7 +147,7 @@ describe('AgencyListContainer', () => {
             expect(container.state().autocompleteAgencies[2].title).toEqual('DEF Agency (DEF)');
             expect(container.state().autocompleteAgencies[2].subtitle).toEqual('Sub-Agency of Department ABC (ABC)');
         });
-        it('should not contain agency abbreviations', async () => {
+        it('should not contain null agency abbreviations', async () => {
             const container = setupShallow(initialFilters);
             container.setState({
                 agencySearchString: 'abc'
@@ -155,7 +155,7 @@ describe('AgencyListContainer', () => {
 
             container.instance().parseAutocompleteAgencies(mockNullAgencyResults);
 
-            // Toptier agencies should have been moved to the top of the list
+            // Agency titles/subtitles should not have abbreviations.
             expect(container.state().autocompleteAgencies[0].title).toEqual('QQ Agency ');
             expect(container.state().autocompleteAgencies[0].subtitle).toEqual('Sub-Agency of Department QQ ');
         });

--- a/tests/containers/search/filters/agencyFilter/AgencyListContainer-test.jsx
+++ b/tests/containers/search/filters/agencyFilter/AgencyListContainer-test.jsx
@@ -5,13 +5,11 @@
 
 import React from 'react';
 import { mount, shallow } from 'enzyme';
-import sinon from 'sinon';
 import { OrderedMap } from 'immutable';
 
 import AgencyListContainer from 'containers/search/filters/AgencyListContainer';
 
-import { mockAgencies } from './mockAgencies';
-import { mockSecondaryResults, mockFemaResults, mockResults } from './mockLocalSearch';
+import { mockSecondaryResults, mockFemaResults, mockResults, mockNullAgencyResults } from './mockLocalSearch';
 
 jest.mock('helpers/searchHelper', () => require('../searchHelper'));
 jest.mock('js-search', () => require('./mockLocalSearch'));
@@ -63,7 +61,7 @@ describe('AgencyListContainer', () => {
 
         it('should make an autocomplete API call when more than one character has '
             + 'been input in the autocomplete text field', async () => {
-             // setup the agency list container and call the function to type a single letter
+            // setup the agency list container and call the function to type a single letter
             const agencyListContainer = setup(initialFilters);
             agencyListContainer.instance().parseAutocompleteAgencies = jest.fn();
             agencyListContainer.instance().queryAutocompleteAgencies('ABC');
@@ -148,6 +146,18 @@ describe('AgencyListContainer', () => {
             expect(container.state().autocompleteAgencies[1].title).toEqual('Department XYZ (XYZ)');
             expect(container.state().autocompleteAgencies[2].title).toEqual('DEF Agency (DEF)');
             expect(container.state().autocompleteAgencies[2].subtitle).toEqual('Sub-Agency of Department ABC (ABC)');
+        });
+        it('should not contain agency abbreviations', async () => {
+            const container = setupShallow(initialFilters);
+            container.setState({
+                agencySearchString: 'abc'
+            });
+
+            container.instance().parseAutocompleteAgencies(mockNullAgencyResults);
+
+            // Toptier agencies should have been moved to the top of the list
+            expect(container.state().autocompleteAgencies[0].title).toEqual('QQ Agency ');
+            expect(container.state().autocompleteAgencies[0].subtitle).toEqual('Sub-Agency of Department QQ ');
         });
         it('should not change the order of results when searching for FEMA', async () => {
             const container = setupShallow(initialFilters);

--- a/tests/containers/search/filters/agencyFilter/mockLocalSearch.js
+++ b/tests/containers/search/filters/agencyFilter/mockLocalSearch.js
@@ -121,3 +121,18 @@ export const mockResults = [
         }
     }
 ];
+
+export const mockNullAgencyResults = [
+    {
+        id: 14,
+        toptier_flag: false,
+        toptier_agency: {
+            abbreviation: null,
+            name: 'Department QQ'
+        },
+        subtier_agency: {
+            abbreviation: null,
+            name: 'QQ Agency'
+        }
+    }
+];


### PR DESCRIPTION
**High level description:**

Agency abbreviations are nullable.  Tweaks to prevent the word "null" from showing up when nulls are provided in the response.

**JIRA Ticket:**

[DEV-2752](https://federal-spending-transparency.atlassian.net/browse/DEV-2752)

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] API contract already has these fields marked as nullable
- [x] There is no dependency on back end code
- [x] Verified cross-browser compatibility