### PR TITLE
[DEV-2992] Adding infoTooltip for AwardAmounts Section and making other tooltips narrow

### DIFF
--- a/src/js/components/awardv2/shared/InfoTooltipContent.jsx
+++ b/src/js/components/awardv2/shared/InfoTooltipContent.jsx
@@ -617,9 +617,9 @@ export const ContractAwardAmountsInfo = (
             <p>
                 It&rsquo;s important to note that contracts are not paid in full on the date they are awarded,
                 but rather a specific amount is made available for spending by the funding agency.
-                This specific amount is known as the &rdquo;current award amount&ldquo; or &rdquo;current ceiling amount&ldquo;.
+                This specific amount is known as the &ldquo;current award amount&rdquo; or &ldquo;current ceiling amount&rdquo;.
                 During the period of performance of the contract, this current award amount can be grow to a maximum.
-                That maximum is known as the &rdquo;potential award amount&ldquo; or &rdquo;potential ceiling amount&ldquo;.
+                That maximum is known as the &ldquo;potential award amount&rdquo; or &ldquo;potential ceiling amount&rdquo;.
             </p>
             <p>This visual depicts the three amounts associated with contracts: obligated amounts, current award amounts, and potential award amounts.</p>
             <p>Hover over the chart for more information about the specific amounts displayed.</p>

--- a/src/js/components/awardv2/shared/InfoTooltipContent.jsx
+++ b/src/js/components/awardv2/shared/InfoTooltipContent.jsx
@@ -580,3 +580,50 @@ export const subAwardsTab = (
         </div>
     </div>
 );
+
+export const GrantAwardAmountsInfo = (
+    <div>
+        <div className="info-tooltip__title">
+            Award Amounts
+        </div>
+        <div className="info-tooltip__text">
+            <p>This section illustrates the awarded amount of this grant.</p>
+            <p>The total award amount of a grant is the combined value of its obligated amount and its non-federal funding.</p>
+            <p>Hover over the chart for more information about the specific amounts displayed.</p>
+        </div>
+    </div>
+);
+
+export const LoanAwardAmountsInfo = (
+    <div>
+        <div className="info-tooltip__title">
+            Award Amounts
+        </div>
+        <div className="info-tooltip__text">
+            <p>This section illustrates the awarded amount of this loan.</p>
+            <p>The total face value of the loan is shown with the original subsidy cost shown as a percentage of that face value.  The original subsidy cost can also be thought of the long-term estimated cost of this loan to the government.</p>
+            <p>Hover over the chart for more information about the specific amounts displayed.</p>
+        </div>
+    </div>
+);
+
+export const ContractAwardAmountsInfo = (
+    <div>
+        <div className="info-tooltip__title">
+            Award Amounts
+        </div>
+        <div className="info-tooltip__text">
+            <p>This section illustrates how much the government has spent on this award.</p>
+            <p>
+                It&rsquo;s important to note that contracts are not paid in full on the date they are awarded,
+                but rather a specific amount is made available for spending by the funding agency.
+                This specific amount is known as the &rdquo;current award amount&ldquo; or &rdquo;current ceiling amount&ldquo;.
+                During the period of performance of the contract, this current award amount can be grow to a maximum.
+                That maximum is known as the &rdquo;potential award amount&ldquo; or &rdquo;potential ceiling amount&ldquo;.
+            </p>
+            <p>This visual depicts the three amounts associated with contracts: obligated amounts, current award amounts, and potential award amounts.</p>
+            <p>Hover over the chart for more information about the specific amounts displayed.</p>
+        </div>
+    </div>
+);
+

--- a/src/js/components/awardv2/shared/awardAmountsSection/AwardAmountsSection.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/AwardAmountsSection.jsx
@@ -5,44 +5,52 @@ import AwardSection from '../AwardSection';
 import AwardSectionHeader from '../AwardSectionHeader';
 import AwardAmountsChart from './charts/AwardAmountsChart';
 import AwardAmountsTable from './AwardAmountsTable';
-import { AWARD_OVERVIEW_AWARD_AMOUNTS_SECTION_PROPS, TOOLTIP_PROPS, AWARD_TYPE_PROPS } from '../../../../propTypes';
+import { AWARD_OVERVIEW_AWARD_AMOUNTS_SECTION_PROPS, AWARD_TYPE_PROPS } from '../../../../propTypes';
 import { determineSpendingScenario } from '../../../../helpers/aggregatedAmountsHelper';
 import JumpToSectionButton from './JumpToSectionButton';
+import { ContractAwardAmountsInfo, GrantAwardAmountsInfo, LoanAwardAmountsInfo } from '../InfoTooltipContent';
 
 const propTypes = {
     awardType: AWARD_TYPE_PROPS,
     awardOverview: AWARD_OVERVIEW_AWARD_AMOUNTS_SECTION_PROPS,
-    tooltipProps: TOOLTIP_PROPS,
     jumpToTransactionHistoryTable: PropTypes.func
 };
 
 const financialAssistanceAwardTypes = ['grant', 'direct payment', 'loan', 'other'];
+const tooltipByAwardType = {
+    contract: ContractAwardAmountsInfo,
+    grant: GrantAwardAmountsInfo,
+    loan: LoanAwardAmountsInfo
+};
 
-export default class AwardAmounts extends React.Component {
-    render() {
-        const { awardOverview, awardType, jumpToTransactionHistoryTable } = this.props;
-        const spendingScenario = financialAssistanceAwardTypes.includes(awardType)
-            ? 'normal'
-            : determineSpendingScenario(awardOverview);
-        return (
-            <AwardSection type="column" className="award-viz award-amounts">
-                <div className="award__col__content">
-                    <AwardSectionHeader title="$ Award Amounts" />
-                    <div className="award-amounts__content">
-                        <AwardAmountsChart
-                            awardOverview={this.props.awardOverview}
-                            awardType={this.props.awardType}
-                            spendingScenario={spendingScenario} />
-                        <AwardAmountsTable
-                            awardData={awardOverview}
-                            awardType={awardType}
-                            spendingScenario={spendingScenario} />
-                    </div>
+const AwardAmountsSection = ({
+    awardOverview,
+    awardType,
+    jumpToTransactionHistoryTable
+}) => {
+    const spendingScenario = financialAssistanceAwardTypes.includes(awardType)
+        ? 'normal'
+        : determineSpendingScenario(awardOverview);
+    const tooltip = tooltipByAwardType[awardType];
+    return (
+        <AwardSection type="column" className="award-viz award-amounts">
+            <div className="award__col__content">
+                <AwardSectionHeader title="$ Award Amounts" tooltip={tooltip} />
+                <div className="award-amounts__content">
+                    <AwardAmountsChart
+                        awardOverview={awardOverview}
+                        awardType={awardType}
+                        spendingScenario={spendingScenario} />
+                    <AwardAmountsTable
+                        awardData={awardOverview}
+                        awardType={awardType}
+                        spendingScenario={spendingScenario} />
                 </div>
-                <JumpToSectionButton icon="table" linkText="View Transaction History" onClick={jumpToTransactionHistoryTable} />
-            </AwardSection>
-        );
-    }
-}
+            </div>
+            <JumpToSectionButton icon="table" linkText="View Transaction History" onClick={jumpToTransactionHistoryTable} />
+        </AwardSection>
+    );
+};
 
-AwardAmounts.propTypes = propTypes;
+AwardAmountsSection.propTypes = propTypes;
+export default AwardAmountsSection;

--- a/src/js/components/awardv2/shared/awardAmountsSection/charts/ExceedsCurrentChart.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/charts/ExceedsCurrentChart.jsx
@@ -34,9 +34,10 @@ const ExceedsCurrentChart = ({ awardAmounts, awardType }) => {
         showExceedsCurrentTooltip
     ] = useTooltips(["obligated", "current", "potential", "exceedsCurrent"]);
 
+    const isIdv = (awardType === 'idv');
     const buildTooltipProps = (spendingCategory, isVisible, showTooltip, type = awardType, data = awardAmounts) => ({
         ...getTooltipPropsByAwardTypeAndSpendingCategory(type, spendingCategory, data),
-        wide: true,
+        wide: isIdv,
         controlledProps: {
             isControlled: true,
             isVisible,
@@ -45,7 +46,6 @@ const ExceedsCurrentChart = ({ awardAmounts, awardType }) => {
         }
     });
 
-    const isIdv = (awardType === 'idv');
     const obligation = awardAmounts._totalObligation;
     const current = awardAmounts._baseExercisedOptions;
     const potential = awardAmounts._baseAndAllOptions;

--- a/src/js/components/awardv2/shared/awardAmountsSection/charts/ExceedsPotentialChart.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/charts/ExceedsPotentialChart.jsx
@@ -32,9 +32,10 @@ const ExceedsPotentialChart = ({ awardType, awardAmounts }) => {
         showExceedsPotentialTooltip
     ] = useTooltips(["obligated", "current", "potential", "exceedsPotential"]);
 
+    const isIdv = (awardType === 'idv');
     const buildTooltipProps = (spendingCategory, isVisible, showTooltip, type = awardType, data = awardAmounts) => ({
         ...getTooltipPropsByAwardTypeAndSpendingCategory(type, spendingCategory, data),
-        wide: true,
+        wide: isIdv,
         controlledProps: {
             isControlled: true,
             isVisible,
@@ -43,7 +44,6 @@ const ExceedsPotentialChart = ({ awardType, awardAmounts }) => {
         }
     });
 
-    const isIdv = (awardType === 'idv');
     const obligation = awardAmounts._totalObligation;
     const current = awardAmounts._baseExercisedOptions;
     const potential = awardAmounts._baseAndAllOptions;

--- a/src/js/components/awardv2/shared/awardAmountsSection/charts/GrantChart.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/charts/GrantChart.jsx
@@ -33,7 +33,7 @@ const GrantChart = ({ awardAmounts }) => {
 
     const buildTooltipProps = (spendingCategory, isVisible, showTooltip, data = awardAmounts) => ({
         ...getTooltipPropsByAwardTypeAndSpendingCategory('grant', spendingCategory, data),
-        wide: true,
+        wide: false,
         controlledProps: {
             isControlled: true,
             isVisible,

--- a/src/js/components/awardv2/shared/awardAmountsSection/charts/NormalChart.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/charts/NormalChart.jsx
@@ -35,7 +35,7 @@ const NormalChart = ({ awardType, awardAmounts }) => {
 
     const buildTooltipProps = (spendingCategory, isVisible, showTooltip, type = awardType, data = awardAmounts) => ({
         ...getTooltipPropsByAwardTypeAndSpendingCategory(type, spendingCategory, data),
-        wide: (awardType === 'idv'),
+        wide: isIdv,
         controlledProps: {
             isControlled: true,
             isVisible,

--- a/src/js/components/awardv2/shared/awardAmountsSection/charts/NormalChart.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/charts/NormalChart.jsx
@@ -35,7 +35,7 @@ const NormalChart = ({ awardType, awardAmounts }) => {
 
     const buildTooltipProps = (spendingCategory, isVisible, showTooltip, type = awardType, data = awardAmounts) => ({
         ...getTooltipPropsByAwardTypeAndSpendingCategory(type, spendingCategory, data),
-        wide: true,
+        wide: (awardType === 'idv'),
         controlledProps: {
             isControlled: true,
             isVisible,


### PR DESCRIPTION
**High level description:**
- Adding Tooltip to Award amount section
- Only making IDV visualization tooltips from Chart wide. All others are narrow.

**JIRA Ticket:**
[DEV-2992](https://federal-spending-transparency.atlassian.net/browse/DEV-2992)

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Design review (if applicable)
- [x] Verified cross-browser compatibility
