### PR TITLE
Fix staged filter styling

### DIFF
--- a/src/js/components/search/filters/agency/ShownAgency.jsx
+++ b/src/js/components/search/filters/agency/ShownAgency.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as Icons from 'components/sharedComponents/icons/Icons';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const propTypes = {
     agency: PropTypes.object,
@@ -33,9 +33,10 @@ export default class ShownAgency extends React.Component {
                 onClick={this.toggleAgency}
                 title="Click to remove."
                 aria-label={`Applied filter: ${this.props.label}`}>
+                {this.props.label}
                 <span className="close">
-                    <Icons.Close className="usa-da-icon-close" alt="Close icon" />
-                </span> {this.props.label}
+                    <FontAwesomeIcon icon="times" />
+                </span>
             </button>
         );
     }

--- a/src/js/components/search/filters/awardAmount/SelectedAwardAmountBound.jsx
+++ b/src/js/components/search/filters/awardAmount/SelectedAwardAmountBound.jsx
@@ -5,8 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import { Close } from 'components/sharedComponents/icons/Icons';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 
 const propTypes = {
@@ -35,9 +34,10 @@ export default class SelectedAwardAmountBound extends React.Component {
                 onClick={this.removeFilter}
                 title="Click to remove."
                 aria-label={`Applied filter: ${label}`}>
+                {label}
                 <span className="close">
-                    <Close className="usa-da-icon-close" alt="Close icon" />
-                </span> {label}
+                    <FontAwesomeIcon icon="times" />
+                </span>
             </button>
         );
     }

--- a/src/js/components/search/filters/awardID/ShownAwardID.jsx
+++ b/src/js/components/search/filters/awardID/ShownAwardID.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as Icons from 'components/sharedComponents/icons/Icons';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const propTypes = {
     toggleAwardID: PropTypes.func,
@@ -21,9 +21,10 @@ export default class ShownAwardID extends React.Component {
                 onClick={this.props.toggleAwardID}
                 title="Click to remove filter."
                 aria-label={`Applied filter: ${this.props.label}`}>
+                {this.props.label}
                 <span className="close">
-                    <Icons.Close className="usa-da-icon-close" alt="Close icon" />
-                </span> {this.props.label}
+                    <FontAwesomeIcon icon="times" />
+                </span>
             </button>
         );
     }

--- a/src/js/components/search/filters/location/ShownLocation.jsx
+++ b/src/js/components/search/filters/location/ShownLocation.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as Icons from 'components/sharedComponents/icons/Icons';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const propTypes = {
     removeLocation: PropTypes.func,
@@ -21,9 +21,10 @@ export default class ShownLocation extends React.Component {
                 onClick={this.props.removeLocation}
                 title="Click to remove."
                 aria-label={`Applied filter: ${this.props.label}`}>
+                {this.props.label}
                 <span className="close">
-                    <Icons.Close className="usa-da-icon-close" alt="Close icon" />
-                </span> {this.props.label}
+                    <FontAwesomeIcon icon="times" />
+                </span>
             </button>
         );
     }

--- a/src/js/components/search/filters/recipient/ShownRecipient.jsx
+++ b/src/js/components/search/filters/recipient/ShownRecipient.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const propTypes = {
     toggleRecipient: PropTypes.func,
@@ -20,7 +21,10 @@ export default class ShownRecipient extends React.Component {
                 onClick={this.props.toggleRecipient}
                 title="Click to remove filter."
                 aria-label={`Applied filter: ${this.props.label}`}>
-                <span className="close" aria-hidden="true">x</span> {this.props.label}
+                {this.props.label}
+                <span className="close">
+                    <FontAwesomeIcon icon="times" />
+                </span>
             </button>
         );
     }

--- a/src/js/components/search/filters/timePeriod/DateRange.jsx
+++ b/src/js/components/search/filters/timePeriod/DateRange.jsx
@@ -6,10 +6,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import DatePicker from 'components/sharedComponents/DatePicker';
-import { Close } from 'components/sharedComponents/icons/Icons';
 import * as FiscalYearHelper from 'helpers/fiscalYearHelper';
-
 import IndividualSubmit from 'components/search/filters/IndividualSubmit';
 
 const defaultProps = {
@@ -185,12 +184,10 @@ export default class DateRange extends React.Component {
                         title="Click to remove filter."
                         aria-label={`Applied date range: ${dateLabel}`}
                         onClick={this.removeRange}>
-                        <span className="close">
-                            <Close
-                                className="usa-da-icon-close"
-                                alt="Close icon" />
-                        </span>
                         {dateLabel}
+                        <span className="close">
+                            <FontAwesomeIcon icon="times" />
+                        </span>
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
**High level description:**
Fixes a bug preventing the `x` icon from displaying in staged filter tags. 

**Technical details:**
Transitions all components that leverage the `shown-filter-button` class to FontAwesome.

**JIRA Ticket:**
This bug was introduced by changes made for [DEV-2917](https://federal-spending-transparency.atlassian.net/browse/DEV-2917.

**Before**
<img width="390" alt="before_label" src="https://user-images.githubusercontent.com/7108785/65465106-71748d80-de29-11e9-8ada-4cf3a9fa227e.png">

**After**
<img width="383" alt="after_label" src="https://user-images.githubusercontent.com/7108785/65465116-776a6e80-de29-11e9-848c-54dd964e6156.png">

The following are ALL required for the PR to be merged:
- [x] Code review
- N/A All `componentWillReceiveProps`, `componentWillMount`, and `componentWillUpdate` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3341](https://federal-spending-transparency.atlassian.net/browse/DEV-3341)
- [x] Verified cross-browser compatibility
