### PR TITLE
[DEV-3635] Financial Award Types show FAIN rather than PIID

### DIFF
--- a/src/js/components/awardv2/AwardV2.jsx
+++ b/src/js/components/awardv2/AwardV2.jsx
@@ -122,7 +122,7 @@ export default class Award extends React.Component {
             else {
                 content = (
                     <FinancialAssistanceContent
-                        awardId={this.props.awardId}
+                        awardId={overview.id}
                         overview={overview}
                         jumpToSection={this.jumpToSection} />
                 );

--- a/src/js/components/awardv2/financialAssistance/FinancialAssistanceContent.jsx
+++ b/src/js/components/awardv2/financialAssistance/FinancialAssistanceContent.jsx
@@ -69,6 +69,7 @@ const FinancialAssistanceContent = ({ awardId, overview, jumpToSection }) => {
     return (
         <AwardPageWrapper
             identifier={awardId}
+            awardType={overview.category}
             glossaryLink={glossaryLink}
             awardTypeDescription={overview.typeDescription}
             lastModifiedDateLong={overview.periodOfPerformance.lastModifiedDateLong}

--- a/src/js/components/awardv2/shared/AwardPageWrapper.jsx
+++ b/src/js/components/awardv2/shared/AwardPageWrapper.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { startCase } from 'lodash';
 
 import { Glossary } from '../../sharedComponents/icons/Icons';
-import { AWARD_PAGE_WRAPPER_PROPS } from "../../../propTypes/index";
+import { AWARD_PAGE_WRAPPER_PROPS } from '../../../propTypes/index';
+import { financialAssistanceAwardTypes } from '../../../models/v2/awardsV2/BaseFinancialAssistance';
 
 const AwardPageWrapper = ({
     awardType,
@@ -11,32 +12,35 @@ const AwardPageWrapper = ({
     glossaryLink,
     identifier,
     children
-}) => (
-    <div className={`award award-${awardType}`}>
-        <div className="award__heading">
-            <div className="award__info">
-                <div className="award__heading-text">{startCase(awardTypeDescription)}</div>
-                <div className="award__heading-icon">
-                    <a href={glossaryLink}>
-                        <Glossary />
-                    </a>
+}) => {
+    const idLabel = financialAssistanceAwardTypes.includes(awardType) ? 'FAIN' : 'PIID' || '';
+    return (
+        <div className={`award award-${awardType}`}>
+            <div className="award__heading">
+                <div className="award__info">
+                    <div className="award__heading-text">{startCase(awardTypeDescription)}</div>
+                    <div className="award__heading-icon">
+                        <a href={glossaryLink}>
+                            <Glossary />
+                        </a>
+                    </div>
+                    <div className="award__heading-id">
+                        <div className="award__heading-label">{idLabel}</div>
+                        <div>{identifier}</div>
+                    </div>
                 </div>
-                <div className="award__heading-id">
-                    <div className="award__heading-label">{identifier ? 'PIID' : ''}</div>
-                    <div>{identifier}</div>
+                <div className="award__last-modified">
+                Last Modified On:{" "}
+                    <span className="award__last-modified award__last-modified_date">
+                        {lastModifiedDateLong}
+                    </span>
                 </div>
             </div>
-            <div className="award__last-modified">
-            Last Modified On:{" "}
-                <span className="award__last-modified award__last-modified_date">
-                    {lastModifiedDateLong}
-                </span>
-            </div>
+            <hr />
+            {children}
         </div>
-        <hr />
-        {children}
-    </div>
-);
+    );
+};
 
 AwardPageWrapper.propTypes = AWARD_PAGE_WRAPPER_PROPS;
 export default AwardPageWrapper;

--- a/src/js/components/awardv2/shared/awardAmountsSection/AwardAmountsSection.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/AwardAmountsSection.jsx
@@ -9,6 +9,7 @@ import { AWARD_OVERVIEW_AWARD_AMOUNTS_SECTION_PROPS, AWARD_TYPE_PROPS } from '..
 import { determineSpendingScenario } from '../../../../helpers/aggregatedAmountsHelper';
 import JumpToSectionButton from './JumpToSectionButton';
 import { ContractAwardAmountsInfo, GrantAwardAmountsInfo, LoanAwardAmountsInfo } from '../InfoTooltipContent';
+import { financialAssistanceAwardTypes } from '../../../../models/v2/awardsV2/BaseFinancialAssistance';
 
 const propTypes = {
     awardType: AWARD_TYPE_PROPS,
@@ -16,7 +17,7 @@ const propTypes = {
     jumpToTransactionHistoryTable: PropTypes.func
 };
 
-const financialAssistanceAwardTypes = ['grant', 'direct payment', 'loan', 'other'];
+
 const tooltipByAwardType = {
     contract: ContractAwardAmountsInfo,
     grant: GrantAwardAmountsInfo,

--- a/src/js/models/v2/awardsV2/BaseFinancialAssistance.js
+++ b/src/js/models/v2/awardsV2/BaseFinancialAssistance.js
@@ -12,6 +12,8 @@ import CoreExecutiveDetails from '../awardsV2/CoreExecutiveDetails';
 
 const BaseFinancialAssistance = Object.create(CoreAward);
 
+export const financialAssistanceAwardTypes = ['grant', 'direct payment', 'loan', 'other'];
+
 BaseFinancialAssistance.populate = function populate(data) {
     // reformat some fields that are required by the CoreAward
     const coreData = {


### PR DESCRIPTION
**High level description:**
Showing the FAIN identifier (Financial Award Identifier(?) Number) on the Award Summary Page 2.0 for Financial Type awards.

**Technical details:**
[Model already stores the `FAIN` as `redux.awardV2.overview.id`](https://github.com/fedspendingtransparency/usaspending-website/blob/dev/src/js/models/v2/awardsV2/BaseFinancialAssistance.js#L18). If it's undefined, it will show the `URI`.

Only work was to pass the awardType to the AwardPageWrapper and render the award id label conditionally based on the award type.

**JIRA Ticket:**
[DEV-3635](https://federal-spending-transparency.atlassian.net/browse/DEV-3635)

**Mockup:**
https://bahdigital.invisionapp.com/d/main#/console/14220692/295998954/preview

The following are ALL required for the PR to be merged:
- [ ] Code review
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA (if applicable)
- [x] Tagged Designer in `#us-ux-frontend` Slack Channel in the thread under the Post from Github for their SA
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] Link to this PR in JIRA ticket