### PR TITLE
[count-endpoint-hotfix] POST --> GET

### DIFF
--- a/src/js/helpers/awardHistoryHelper.js
+++ b/src/js/helpers/awardHistoryHelper.js
@@ -33,8 +33,7 @@ export const getAwardHistoryCounts = (type, awardId) => {
         promise: Axios.request({
             url: `v2/awards/count/${type}/${awardId}`,
             baseURL: kGlobalConstants.API,
-            method: 'post',
-            data: { award_id: awardId },
+            method: 'get',
             cancelToken: source.token
         }),
         cancel() {


### PR DESCRIPTION
**High level description:**

Changes count API requests from POST to GET

**Technical details:**
Was observing 5 requests per service call, realized it was supposed to be a GET not a POST. 

Was also getting 301s in google chrome, but not seeing any issues in SAFARI or FIREFOX... must be some weird google chrome thing?

Hitting the endpoints in POSTMAN with the request header from chrome returns a 200 everytime.

**JIRA Ticket:**
Relates to the award history section tickets:

[DEV-3099](https://federal-spending-transparency.atlassian.net/browse/DEV-3099)
[DEV-3100](https://federal-spending-transparency.atlassian.net/browse/DEV-3100)
[DEV-3101](https://federal-spending-transparency.atlassian.net/browse/DEV-3101)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:
- [x] Code review
- [ ] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA (if applicable)
- [ ] Tagged Designer in `#us-ux-frontend` Slack Channel in the thread under the Post from Github for their SA
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated (if applicable)
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged (if applicable)
- [ ] Verified cross-browser compatibility
- [ ] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [ ] Link to this PR in JIRA ticket