### PR TITLE
[DEV-3099] Remove Count in AwardHistory Table for IDV Awards

### DIFF
--- a/src/js/components/awardv2/shared/awardHistorySection/TablesSection.jsx
+++ b/src/js/components/awardv2/shared/awardHistorySection/TablesSection.jsx
@@ -89,6 +89,9 @@ export default class TablesSection extends React.Component {
         const tabsWithCounts = tabs
             .filter((tab) => ((!isIdvOrLoan || tab.internal !== 'subaward')))
             .map(async (tab) => {
+                if (award.category === 'idv') {
+                    return tab;
+                }
                 this.countRequest = getAwardHistoryCounts(tab.internal, award.generatedId);
                 try {
                     const { data } = await this.countRequest.promise;


### PR DESCRIPTION
**High level description:**
Shouldn't be requesting counts for Transactions/Federal Accounts if award type is IDV. New endpoints are required for this which have not been yet built.

**Technical details:**
If `award.category` is idv, not making a request for counts

**JIRA Ticket:**
[DEV-3099](https://federal-spending-transparency.atlassian.net/browse/DEV-3099)

The following are ALL required for the PR to be merged:
- [x] Code review
- [ ] Scheduled Demo including Testing
- [ ] Tagged Melissa in `#us-ux-frontend` Slack Channel in the thread under the Post from Github for their SA
- [ ] Link to this PR in JIRA ticket