### PR TITLE
[DEV-1663] Bug introduced in previous PR, adds logic to Handle IDVs

### DIFF
--- a/src/js/components/awardv2/idv/IdvContent.jsx
+++ b/src/js/components/awardv2/idv/IdvContent.jsx
@@ -75,6 +75,7 @@ const IdvContent = ({
                     awardId={awardId}
                     overview={overview} />
                 <AwardDescription
+                    isIdv
                     awardId={awardId}
                     description={overview.description}
                     naics={overview.additionalDetails.naicsCode}

--- a/src/js/components/awardv2/shared/description/AwardDescription.jsx
+++ b/src/js/components/awardv2/shared/description/AwardDescription.jsx
@@ -15,8 +15,9 @@ import LineTree from './LineTree';
 const propTypes = {
     awardId: PropTypes.string,
     description: PropTypes.string,
-    naics: PropTypes.object,
-    psc: PropTypes.object
+    naics: PropTypes.oneOfType(PropTypes.object, PropTypes.string), // string for IDVs
+    psc: PropTypes.oneOfType(PropTypes.object, PropTypes.string), // string for IDVs
+    isIdv: PropTypes.bool
 };
 
 const maxChars = 300;
@@ -26,7 +27,8 @@ const AwardDescription = ({
     awardId,
     description,
     naics = null,
-    psc = null
+    psc = null,
+    isIdv = false
 }) => {
     const [isExpanded, setExpanded] = useState(false);
     let value = description;
@@ -58,7 +60,8 @@ const AwardDescription = ({
                                     </a>
                                 </div>
                             </div>
-                            <LineTree type="naics" data={naics} />
+                            {!isIdv && <LineTree type="naics" data={naics} />}
+                            {isIdv && naics}
                         </div>
                         <div className="naics-psc__section naics-psc__section_psc">
                             <div className="naics-psc__heading">
@@ -69,7 +72,8 @@ const AwardDescription = ({
                                     </a>
                                 </div>
                             </div>
-                            <LineTree type="psc" data={{ additionalDataForPsc, ...psc }} />
+                            {!isIdv && <LineTree type="psc" data={{ additionalDataForPsc, ...psc }} />}
+                            {isIdv && psc}
                         </div>
                     </div>
                 )}

--- a/src/js/components/awardv2/shared/federalAccounts/FederalAccountsSummary.jsx
+++ b/src/js/components/awardv2/shared/federalAccounts/FederalAccountsSummary.jsx
@@ -62,3 +62,5 @@ const FederalAccountsSummary = ({ summary, inFlight, jumpToFederalAccountsHistor
 };
 
 FederalAccountsSummary.propTypes = propTypes;
+
+export default FederalAccountsSummary;

--- a/src/js/components/awardv2/shared/federalAccounts/FederalAccountsSummary.jsx
+++ b/src/js/components/awardv2/shared/federalAccounts/FederalAccountsSummary.jsx
@@ -5,21 +5,19 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { startCase } from 'lodash';
 import ResultsTableLoadingMessage from 'components/search/table/ResultsTableLoadingMessage';
 import JumpToSectionButton from '../awardAmountsSection/JumpToSectionButton';
 
 const propTypes = {
     summary: PropTypes.object,
     inFlight: PropTypes.bool,
-    category: PropTypes.string,
     jumpToFederalAccountsHistory: PropTypes.func
 };
 
-export default class FederalAccountsSummary extends React.Component {
-    generateTable() {
+const FederalAccountsSummary = ({ summary, inFlight, jumpToFederalAccountsHistory }) => {
+    const generateTable = () => {
         let table;
-        if (this.props.inFlight) {
+        if (inFlight) {
             table = (
                 <div className="results-table-message-container">
                     <ResultsTableLoadingMessage />
@@ -27,7 +25,6 @@ export default class FederalAccountsSummary extends React.Component {
             );
         }
         else {
-            const summary = this.props.summary;
             table = (
                 <div className="award-funding-summary__table">
                     <div className="award-funding-summary__data">
@@ -50,20 +47,18 @@ export default class FederalAccountsSummary extends React.Component {
             );
         }
         return table;
-    }
-    render() {
-        const category = this.props.category === 'idv' ? 'IDV' : startCase(this.props.category);
-        return (
-            <div className="federal-accounts-summary__section">
-                <h4>Summary of Federal Accounts used by this {category}</h4>
-                {this.generateTable()}
-                <JumpToSectionButton
-                    linkText="View federal funding submissions"
-                    icon="table"
-                    onClick={this.props.jumpToFederalAccountsHistory} />
-            </div>
-        );
-    }
-}
+    };
+
+    return (
+        <div className="federal-accounts-summary__section">
+            <h4>Summary of All Federal Accounts used by this Award</h4>
+            {generateTable()}
+            <JumpToSectionButton
+                linkText="View federal funding submissions"
+                icon="table"
+                onClick={jumpToFederalAccountsHistory} />
+        </div>
+    );
+};
 
 FederalAccountsSummary.propTypes = propTypes;

--- a/src/js/components/awardv2/shared/federalAccounts/FederalAccountsSummary.jsx
+++ b/src/js/components/awardv2/shared/federalAccounts/FederalAccountsSummary.jsx
@@ -32,17 +32,15 @@ export default class FederalAccountsSummary extends React.Component {
                 <div className="award-funding-summary__table">
                     <div className="award-funding-summary__data">
                         <span>Total Funding Obligated</span>
-                        <span>
-                            {summary.obligatedAmount}
-                        </span>
-                    </div>
-                    <div className="award-funding-summary__data">
-                        <span>Total Count of Awarding Agencies</span>
-                        <span>{summary.awardingAgencyCount}</span>
+                        <span>{summary.obligatedAmount}</span>
                     </div>
                     <div className="award-funding-summary__data">
                         <span>Total Count of Funding Agencies</span>
                         <span>{summary.fundingAgencyCount}</span>
+                    </div>
+                    <div className="award-funding-summary__data">
+                        <span>Total Count of Awarding Agencies</span>
+                        <span>{summary.awardingAgencyCount}</span>
                     </div>
                     <div className="award-funding-summary__data">
                         <span>Total Count of Federal Accounts</span>

--- a/src/js/containers/awardV2/shared/FederalAccountsSummaryContainer.jsx
+++ b/src/js/containers/awardV2/shared/FederalAccountsSummaryContainer.jsx
@@ -84,7 +84,6 @@ export class FederalAccountsSummaryContainer extends React.Component {
         return (
             <FederalAccountsSummary
                 {...this.state}
-                category={this.props.category}
                 jumpToFederalAccountsHistory={this.props.jumpToFederalAccountsHistory} />
         );
     }


### PR DESCRIPTION
**High level description:**
Do not render Line tree for IDVs.

**Technical details:**
Adds prop `isIdv` to AwardDescription section as we are showing the line tree w/ NAICs/PSC for Contract awards.

**JIRA Ticket:**
[DEV-1663](https://federal-spending-transparency.atlassian.net/browse/DEV-1663)

The following are ALL required for the PR to be merged:
- [ ] Code review