### PR TITLE
Award Summary 2.0 Console Errors & Removing truthy check from CFDA Model

### DIFF
--- a/src/js/components/award/details/DetailsTabItem.jsx
+++ b/src/js/components/award/details/DetailsTabItem.jsx
@@ -19,7 +19,7 @@ const propTypes = {
     clickTab: PropTypes.func,
     tooltipContent: PropTypes.node,
     tooltipProps: PropTypes.shape({ wide: PropTypes.bool }),
-    count: PropTypes.number
+    count: PropTypes.oneOfType([PropTypes.number, PropTypes.string]) // int or 'N/A'
 };
 
 export default class DetailsTabItem extends React.Component {

--- a/src/js/components/awardv2/shared/InfoTooltipContent.jsx
+++ b/src/js/components/awardv2/shared/InfoTooltipContent.jsx
@@ -633,7 +633,10 @@ export const CFDAOverviewInfo = (
             CFDA Program / Assistance Listing Information
         </div>
         <div className="info-tooltip__text">
-            <p>Tooltip text not yet approved.</p>
+            <p>
+                The Catalog of Federal Domestic Assistance (CFDA), also known as Assistance Listings, is a collection of federal financial assistance programs that provides benefits to the American public. Every assistance award must be categorized under a CFDA program, and every CFDA program must be specifically authorized by congressional statute before an agency can begin to issue awards under it.
+            </p>
+            <p>The CFDA number(s) and title(s) listed here identify the program(s) associated with this award.</p>
         </div>
     </div>
 );

--- a/src/js/containers/awardV2/idv/IdvActivityContainer.jsx
+++ b/src/js/containers/awardV2/idv/IdvActivityContainer.jsx
@@ -45,6 +45,12 @@ export class IdvActivityContainer extends React.Component {
         }
     }
 
+    componentWillUnmount() {
+        if (this.idvActivityRequest) {
+            this.idvActivityRequest.cancel();
+        }
+    }
+
     async loadAwards() {
         if (this.idvActivityRequest) {
             this.idvActivityRequest.cancel();

--- a/src/js/containers/awardV2/idv/ReferencedAwardsContainer.jsx
+++ b/src/js/containers/awardV2/idv/ReferencedAwardsContainer.jsx
@@ -88,6 +88,12 @@ export class ReferencedAwardsContainer extends React.Component {
         if (this.props.tableType !== prevProps.tableType) this.loadResults();
     }
 
+    componentWillUnmount() {
+        if (this.request) {
+            this.request.cancel();
+        }
+    }
+
     loadResults() {
         if (this.request) {
             this.request.cancel();

--- a/src/js/containers/awardV2/shared/FederalAccountsSummaryContainer.jsx
+++ b/src/js/containers/awardV2/shared/FederalAccountsSummaryContainer.jsx
@@ -45,6 +45,12 @@ export class FederalAccountsSummaryContainer extends React.Component {
         }
     }
 
+    componentWillUnmount() {
+        if (this.request) {
+            this.request.cancel();
+        }
+    }
+
     async getAwardMetaData() {
         if (this.request) {
             this.request.cancel();

--- a/src/js/containers/awardV2/shared/FederalAccountsVizContainer.jsx
+++ b/src/js/containers/awardV2/shared/FederalAccountsVizContainer.jsx
@@ -53,6 +53,12 @@ export class FederalAccountsVizContainer extends React.Component {
         }
     }
 
+    componentWillUnmount() {
+        if (this.request) {
+            this.request.cancel();
+        }
+    }
+
     async getFederalAccounts() {
         if (this.request) {
             this.request.cancel();

--- a/src/js/models/v2/awardsV2/BaseFinancialAssistance.js
+++ b/src/js/models/v2/awardsV2/BaseFinancialAssistance.js
@@ -12,13 +12,13 @@ import CoreExecutiveDetails from '../awardsV2/CoreExecutiveDetails';
 
 const BaseFinancialAssistance = Object.create(CoreAward);
 export const emptyCfda = {
-    total_funding_amount: 0,
+    total_funding_amount: -Infinity,
     cfda_title: '',
     cfda_number: ''
 };
 
 const getLargestCfda = (acc, cfdaItem) => {
-    if (cfdaItem.total_funding_amount && cfdaItem.total_funding_amount > acc.total_funding_amount) {
+    if (cfdaItem.total_funding_amount > acc.total_funding_amount) {
         return cfdaItem;
     }
     return acc;

--- a/src/js/propTypes/index.js
+++ b/src/js/propTypes/index.js
@@ -27,7 +27,7 @@ export const AWARD_V2_COUNTS_PROPS = PropTypes.shape({
 });
 
 
-export const AWARD_TYPE_PROPS = PropTypes.oneOf(['idv', 'contract', 'grant', 'loan']);
+export const AWARD_TYPE_PROPS = PropTypes.oneOf(['idv', 'contract', 'grant', 'loan', 'direct payment', 'other']);
 
 export const TOOLTIP_PROPS = PropTypes.shape({
     isControlled: PropTypes.bool,


### PR DESCRIPTION
**High level description:**
- Removes console errors by adding componentWillUnmount methods
- 60fe320 -- Fixes issue where CFDA with 0 award amount was not being displayed due to truthy check on property with value of `0` evaluating to falsy. 
- 47aa99a -- adds tooltip copy

**Technical details:**
- Console errors fixed by CWUnmount 
- CFDA's with `total_funding_amount` of zero were not displaying because there was a truthy check on `total_funding_amount` which was evaluating to falsy.
- Still one console error occurring on the Award Summary 2.0 page due to componentDidMount lifecycle method firing twice -- once after render, once after componentWillUnmount -- wondering if the root cause of this is actually a routing issue?

The following are ALL required for the PR to be merged:
- [ ] Code review