### PR TITLE
DEV-2752: Display "not available" instead of "null" for missing agency values

### DIFF
--- a/src/js/components/agency/overview/AgencyOverview.jsx
+++ b/src/js/components/agency/overview/AgencyOverview.jsx
@@ -62,7 +62,7 @@ export default class AgencyOverview extends React.PureComponent {
         const { agency } = props;
         let logo = null;
         let hideLogo = 'hide';
-        if (agency.logo !== '') {
+        if (agency.logo) {
             hideLogo = '';
             logo = (<img
                 src={`graphics/agency/${agency.logo}`}
@@ -70,12 +70,12 @@ export default class AgencyOverview extends React.PureComponent {
         }
 
         let mission = 'Not available';
-        if (agency.mission !== '') {
+        if (agency.mission) {
             mission = agency.mission;
         }
 
         let website = 'Not available';
-        if (agency.website !== '') {
+        if (agency.website) {
             website = (
                 <a
                     className="agency-website"

--- a/src/js/components/search/filters/agency/SelectedAgencies.jsx
+++ b/src/js/components/search/filters/agency/SelectedAgencies.jsx
@@ -23,11 +23,11 @@ export default class SelectedAgencies extends React.Component {
             let label = agency.subtier_agency.name;
 
             if (agency.agencyType !== '' && agency.agencyType !== null) {
-                if (agency.agencyType === 'subtier' && agency.subtier_agency.abbreviation !== '') {
+                if (agency.agencyType === 'subtier' && agency.subtier_agency.abbreviation) {
                     label += ` (${agency.subtier_agency.abbreviation})`;
                 }
                 else if (agency.agencyType === 'toptier' &&
-                agency.toptier_agency.abbreviation !== '') {
+                agency.toptier_agency.abbreviation) {
                     label += ` (${agency.toptier_agency.abbreviation})`;
                 }
 

--- a/src/js/components/search/topFilterBar/filterGroups/AgencyFilterGroup.jsx
+++ b/src/js/components/search/topFilterBar/filterGroups/AgencyFilterGroup.jsx
@@ -45,10 +45,10 @@ export default class AgencyFilterGroup extends React.Component {
         agencies.forEach((value) => {
             let agencyTitle = value.subtier_agency.name;
 
-            if (value.agencyType === 'subtier' && value.subtier_agency.abbreviation !== '') {
+            if (value.agencyType === 'subtier' && value.subtier_agency.abbreviation) {
                 agencyTitle += ` (${value.subtier_agency.abbreviation})`;
             }
-            else if (value.agencyType === 'toptier' && value.toptier_agency.abbreviation !== '') {
+            else if (value.agencyType === 'toptier' && value.toptier_agency.abbreviation) {
                 agencyTitle += ` (${value.toptier_agency.abbreviation})`;
             }
             if (value.agencyType === 'subtier' && value.toptier_flag === false) {


### PR DESCRIPTION
**High level description:**

Trivial fix for certain agency values showing "null" instead of "not available".  Also found a couple of agency abbreviations not accounting for null.

**JIRA Ticket:**

[DEV-2752](https://federal-spending-transparency.atlassian.net/browse/DEV-2752)

The following are ALL required for the PR to be merged:
- [x] Code review