### PR TITLE
Dev-3680 Hot Fix Homepage Fiscal Year and Spending

### DIFF
--- a/src/js/components/homepage/hero/Hero.jsx
+++ b/src/js/components/homepage/hero/Hero.jsx
@@ -10,9 +10,10 @@ import HeroButton from './HeroButton';
 import HeroTooltip from './HeroTooltip';
 
 // Fiscal year, spending amount constants, to be updated yearly
-// last updated: 11/5/2018
-const fiscalYear = 2018;
-const fiscalSpendingAmount = `$4.11 trillion`;
+// last updated: 10/10/2019
+const fiscalYear = 2019;
+// TODO - update this amount on 10/18/19 when we get the number from Ross
+const fiscalSpendingAmount = 'TBD';
 
 export default class Hero extends React.Component {
     constructor(props) {


### PR DESCRIPTION
**High level description:**

Updates the homepage to include the current year and spending.

**JIRA Ticket:**
[DEV-3680](https://federal-spending-transparency.atlassian.net/browse/DEV-3680)

The following are ALL required for the PR to be merged:
- [x] Code review

- [ ] The fiscal spending for the homepage has been updated ( We are getting this from Ross, most likely on 10/18/19 )

- [x] Verified cross-browser compatibility
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] Link to this PR in JIRA ticket