### PR TITLE
DEV-3714 Fix financial assistance glossary links and data mapping

### DIFF
--- a/src/js/components/awardv2/AwardV2.jsx
+++ b/src/js/components/awardv2/AwardV2.jsx
@@ -122,7 +122,7 @@ export default class Award extends React.Component {
             else {
                 content = (
                     <FinancialAssistanceContent
-                        awardId={overview.id}
+                        awardId={this.props.awardId}
                         overview={overview}
                         jumpToSection={this.jumpToSection} />
                 );

--- a/src/js/dataMapping/search/awardType.js
+++ b/src/js/dataMapping/search/awardType.js
@@ -37,10 +37,10 @@ export const awardTypeCodes = {
 
 export const glossaryLinks = {
     'A': 'blanket-purchase-agreement-bpa',
-    'B': '',
+    'B': 'purchase-order',
     'C': 'delivery-order-contract',
     'D': 'definitive-contract',
-    'E': '',
+    'E': '', // Unknown Type
     'F': 'cooperative-agreement',
     'G': '',
     'S': '',
@@ -55,7 +55,7 @@ export const glossaryLinks = {
     'IDV_E': 'blanket-purchase-agreement-bpa',
     '02': 'block-grant',
     '03': 'formula-grant',
-    '04': '',
+    '04': 'project-grant',
     '05': 'cooperative-agreement',
     '10': 'direct-payment-with-unrestricted-use',
     '06': 'direct-payment-for-specified-use',


### PR DESCRIPTION
**High level description:**
Fixes the Glossary icon on Financial Assistance pages. 

**Technical details:**
Also updates the mapping for a few award type codes that were missing glossary urls.

**JIRA Ticket:**
[DEV-3714](https://federal-spending-transparency.atlassian.net/browse/DEV-3714)

**Testing**
Purchase Order: `/award_v2/23325224`
Project Grant: `award_v2/45824393`

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA (if applicable)
- [x] Verified cross-browser compatibility
- [x] Link to this PR in JIRA ticket