### PR TITLE
[DEV-3705] Updating Award Amount Visualization for Grant Awards

### DIFF
--- a/src/js/components/awardv2/idv/amounts/AggregatedAwardAmounts.jsx
+++ b/src/js/components/awardv2/idv/amounts/AggregatedAwardAmounts.jsx
@@ -50,7 +50,7 @@ export default class AggregatedAwardAmounts extends React.Component {
         }
 
         const { awardAmounts } = this.props;
-        const spendingScenario = determineSpendingScenario(...getAscendingSpendingCategoriesByAwardType('idv', awardAmounts));
+        const spendingScenario = determineSpendingScenario('idv', awardAmounts);
         return (
             <div className="award-amounts__content">
                 <AwardsBanner

--- a/src/js/components/awardv2/idv/amounts/AggregatedAwardAmounts.jsx
+++ b/src/js/components/awardv2/idv/amounts/AggregatedAwardAmounts.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { formatNumber } from 'helpers/moneyFormatter';
 
-import { determineSpendingScenario, getAscendingSpendingCategoriesByAwardType } from 'helpers/awardAmountHelper';
+import { determineSpendingScenario } from 'helpers/awardAmountHelper';
 import ChartError from 'components/search/visualizations/ChartError';
 import AwardsBanner from './AwardsBanner';
 import { AWARD_V2_AGGREGATED_AMOUNTS_PROPS } from '../../../../propTypes';

--- a/src/js/components/awardv2/shared/awardAmountsSection/AwardAmountsSection.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/AwardAmountsSection.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { determineSpendingScenario, getAscendingSpendingCategoriesByAwardType } from 'helpers/awardAmountHelper';
+import { determineSpendingScenarioByAwardType } from 'helpers/awardAmountHelper';
 import AwardSection from '../AwardSection';
 import AwardSectionHeader from '../AwardSectionHeader';
 import AwardAmountsChart from './charts/AwardAmountsChart';
@@ -27,7 +27,7 @@ const AwardAmountsSection = ({
     awardType,
     jumpToTransactionHistoryTable
 }) => {
-    const spendingScenario = determineSpendingScenario(...getAscendingSpendingCategoriesByAwardType(awardType, awardOverview));
+    const spendingScenario = determineSpendingScenarioByAwardType(awardType, awardOverview);
     const tooltip = tooltipByAwardType[awardType];
     return (
         <AwardSection type="column" className="award-viz award-amounts">

--- a/src/js/components/awardv2/shared/awardAmountsSection/charts/GrantChart.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/charts/GrantChart.jsx
@@ -60,22 +60,19 @@ const GrantChart = ({ awardAmounts }) => {
 
     const nonFederalFundingBarStyle = {
         width: generatePercentage(nonFederalFunding / totalFunding),
-        backgroundColor: nonFederalFundingIsZero ? 'none' : '#4773aa',
-        right: obligatedBarStyle.width
+        backgroundColor: nonFederalFundingIsZero ? 'none' : '#47AAA7'
     };
 
     const totalFundingColor = "#FFF";
 
     const nonFederalFundingLabelStyle = {
-        width: nonFederalFundingIsZero ? '100%' : generatePercentage(nonFederalFunding / totalFunding)
+        width: nonFederalFundingIsZero ? '100%' : generatePercentage(nonFederalFunding / totalFunding),
+        left: nonFederalFundingIsZero ? '0' : generatePercentage(obligation / totalFunding),
+        position: 'relative'
     };
 
     const nonFFTooltipStyles = {
-        width: nonFederalFundingBarStyle.width,
-        right: nonFederalFundingBarStyle.right,
-        border: nonFederalFundingIsZero ? 'none' : "5px solid #47AAA7",
-        padding: nonFederalFundingIsZero ? '0px' : '3.5px',
-        position: 'relative'
+        width: nonFederalFundingBarStyle.width
     };
 
     const propsForObligatedTooltip = buildTooltipProps("obligated", (activeTooltip === "obligated"), showObligatedTooltip);
@@ -134,7 +131,7 @@ const GrantChart = ({ awardAmounts }) => {
                         </React.Fragment>
                     )}
                     {nonFederalFundingIsZero &&
-                        <TooltipWrapper {...propsForNonFederalFundingTooltip} styles={{ ...nonFFTooltipStyles, width: 'auto', right: 0 }}>
+                        <TooltipWrapper {...propsForNonFederalFundingTooltip}>
                             <div className="award-amounts-viz__desc-text" role="button" tabIndex="0">
                                 <strong>{awardAmounts.nonFederalFundingAbbreviated}</strong><br />Non-Federal Funding
                             </div>

--- a/src/js/dataMapping/awardsv2/awardAmountsSection.js
+++ b/src/js/dataMapping/awardsv2/awardAmountsSection.js
@@ -7,9 +7,7 @@
 
 // eslint-disable-next-line import/prefer-default-export
 export const spendingCategoriesByAwardType = {
-    grant: ['_totalObligation', '_nonFederalFunding', '_baseAndAllOptions'],
     loan: ['_subsidy', '_faceValue'],
-    other: [],
     contract: ['_totalObligation', '_baseExercisedOptions', '_baseAndAllOptions'],
     idv: ['_totalObligation', '_baseExercisedOptions', '_baseAndAllOptions']
 };

--- a/src/js/helpers/awardAmountHelper.js
+++ b/src/js/helpers/awardAmountHelper.js
@@ -38,8 +38,26 @@ export const getAscendingSpendingCategoriesByAwardType = (awardType, awardAmount
     return [];
 };
 
+// includes logic for grant, loan, insurance, and other award types
+export const determineSpendingScenarioAsstAwards = (awardAmountObj) => {
+    const { _totalObligation, _nonFederalFunding, _totalFunding } = awardAmountObj;
+    // if any of the values are negative, return insufficient data
+    if (_totalObligation < 0 || _nonFederalFunding < 0 || _totalObligation < 0) {
+        return 'insufficientData';
+    }
+    // if total funding is sum of obligation and non federal funding, return normal
+    else if ((_totalObligation + _nonFederalFunding) === _totalFunding) {
+        return 'normal';
+    }
+    // if totalObligation equals totalFunding or is less than total funding while nonFederalFunding is null or zero
+    else if ((_totalObligation <= _totalFunding) && !_nonFederalFunding) {
+        return 'normal';
+    }
+    return 'insufficientData';
+};
+
+// includes logic for idvs, contracts, loan award types
 export const determineSpendingScenario = (small = 0, bigger = 0, biggest = null) => {
-    // Small, bigger, and biggest define the expected ratio between spending category
     const allCategoriesAreInPlay = (small && bigger && biggest);
     if (small === 0 && bigger === 0 && biggest === 0) {
         return null;
@@ -65,6 +83,18 @@ export const determineSpendingScenario = (small = 0, bigger = 0, biggest = null)
     }
 
     return 'insufficientData';
+};
+
+// similar relationship between spending categories
+const asstAwardTypesWithSimilarAwardAmountData = ['grant', 'other', 'insurance', 'direct payment'];
+
+export const determineSpendingScenarioByAwardType = (awardType, awardAmountObj) => {
+    if (asstAwardTypesWithSimilarAwardAmountData.includes(awardType)) {
+        return determineSpendingScenarioAsstAwards(awardAmountObj);
+    }
+    // Small, bigger, and biggest define the expected ratio between spending categories
+    const [small, bigger, biggest] = getAscendingSpendingCategoriesByAwardType(awardType, awardAmountObj);
+    return determineSpendingScenario(small, bigger, biggest);
 };
 
 export const generatePercentage = (value) => `${(value * 100).toFixed(2)}%`;


### PR DESCRIPTION
**High level description:**
The Award Amount visualization was [not according to the mock](https://bahdigital.invisionapp.com/share/QMIAAWKND6B#/screens/295998954_Award_Summary_2-0_-_Grant).

**Technical details:**
10ea1a8 Refactored determineSpendingScenario logic to reflect the A/C in [3705](https://federal-spending-transparency.atlassian.net/browse/DEV-3705) and in anticipation of implementing this same design for the remaining financial-assistance type awards, which will use these new functions.
5de6552 conforming to mock up
e634738 adding tests

**JIRA Ticket:**
[DEV-3705](https://federal-spending-transparency.atlassian.net/browse/DEV-3705)

**Mockup:**
https://bahdigital.invisionapp.com/share/QMIAAWKND6B#/screens/295998954_Award_Summary_2-0_-_Grant

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Scheduled Demo including Design/Testing/Front-end
- [x] Tagged Designer in `#us-ux-frontend` Slack Channel in the thread under the Post from Github for their SA
- [x] Verified cross-browser compatibility
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] Link to this PR in JIRA ticket