### PR TITLE
[DEV-1663] Updating PSC per PO Request - Removing "Services" header and first PSC Code

### DIFF
--- a/src/js/components/awardv2/shared/description/AwardDescription.jsx
+++ b/src/js/components/awardv2/shared/description/AwardDescription.jsx
@@ -21,7 +21,6 @@ const propTypes = {
 };
 
 const maxChars = 300;
-const additionalDataForPsc = { code: 'SERVICES', description: '' };
 
 const AwardDescription = ({
     awardId,
@@ -72,7 +71,7 @@ const AwardDescription = ({
                                     </a>
                                 </div>
                             </div>
-                            {!isIdv && <LineTree type="psc" data={{ additionalDataForPsc, ...psc }} />}
+                            {!isIdv && <LineTree type="psc" data={psc} />}
                             {isIdv && psc}
                         </div>
                     </div>

--- a/src/js/components/awardv2/shared/description/LineTree.jsx
+++ b/src/js/components/awardv2/shared/description/LineTree.jsx
@@ -16,8 +16,6 @@ const LineTree = ({
         .sort((tierType1, tierType2) => {
             const first = data[tierType1].code;
             const second = data[tierType2].code;
-            if (first === 'SERVICES') return -1;
-            if (second === 'SERVICES') return 1;
             if (first.length < second.length) return -1;
             if (second.length < first.length) return 1;
             return 0;
@@ -39,7 +37,10 @@ const LineTree = ({
         <div className={`line-tree-${type}`}>
             {getTierData(0) && (
                 <div className="tier--1">
-                    <span>{`${getTierData(0).code}: ${getTierData(0).description}`}</span>
+                    <span>{type === 'psc'
+                        ? getTierData(0).description
+                        : `${getTierData(0).code} : ${getTierData(0).description}`}
+                    </span>
                     {getTierData(1) && (
                         <div className={`tier--2 ${numberOfSections <= 2 ? 'tier--last' : ''}`}>
                             <span>{`${getTierData(1).code}: ${getTierData(1).description}`}</span>

--- a/src/js/models/v2/awardsV2/BaseContract.js
+++ b/src/js/models/v2/awardsV2/BaseContract.js
@@ -24,7 +24,7 @@ const getPscType = (toptierCode) => {
         }
         return 'SERVICES';
     }
-    return 'PRODUCT';
+    return 'PRODUCTS';
 };
 
 const deducePscType = (acc, keyValueArray) => {

--- a/src/js/models/v2/awardsV2/BaseContract.js
+++ b/src/js/models/v2/awardsV2/BaseContract.js
@@ -2,8 +2,6 @@
  * BaseContract.js
  * Created by David Trinh 10/9/18
  */
-import { forEach } from 'lodash';
-
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 import CoreLocation from 'models/v2/CoreLocation';
 import BaseAwardRecipient from './BaseAwardRecipient';

--- a/src/js/models/v2/awardsV2/BaseContract.js
+++ b/src/js/models/v2/awardsV2/BaseContract.js
@@ -2,6 +2,7 @@
  * BaseContract.js
  * Created by David Trinh 10/9/18
  */
+import { forEach } from 'lodash';
 
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 import CoreLocation from 'models/v2/CoreLocation';
@@ -14,6 +15,31 @@ import CoreExecutiveDetails from '../awardsV2/CoreExecutiveDetails';
 import CorePeriodOfPerformance from '../awardsV2/CorePeriodOfPerformance';
 
 const BaseContract = Object.create(CoreAward);
+
+const getPscType = (toptierCode) => {
+    const topTierCodeAsInt = parseInt(toptierCode, 10);
+    if (isNaN(topTierCodeAsInt)) {
+        if (toptierCode.toUpperCase() === 'A') {
+            return 'RESEARCH AND DEVELOPMENT';
+        }
+        return 'SERVICES';
+    }
+    return 'PRODUCT';
+};
+
+const deducePscType = (acc, keyValueArray) => {
+    const [key, value] = keyValueArray;
+    if (key === 'toptier_code') {
+        return {
+            ...acc,
+            [key]: {
+                code: value.code,
+                description: getPscType(value.code)
+            }
+        };
+    }
+    return { ...acc, [key]: value };
+};
 
 BaseContract.populate = function populate(data) {
     // reformat some fields that are required by the CoreAward
@@ -31,7 +57,7 @@ BaseContract.populate = function populate(data) {
         dateSigned: data.date_signed,
         baseAndAllOptions: data.base_and_all_options,
         naics: data.naics_hierarchy,
-        psc: data.psc_hierarchy
+        psc: Object.entries(data.psc_hierarchy).reduce(deducePscType, {})
     };
     this.populateCore(coreData);
 

--- a/tests/models/awardsV2/BaseContract-test.js
+++ b/tests/models/awardsV2/BaseContract-test.js
@@ -52,4 +52,26 @@ describe('BaseContract', () => {
             expect(Object.getPrototypeOf(contract.executiveDetails)).toEqual(CoreExecutiveDetails);
         });
     });
+    describe('Deducing the PSC Type based on the PSC Top Tier Code from the API', () => {
+        it.each([
+            ['PRODUCT', '4'],
+            ['RESEARCH AND DEVELOPMENT', 'A'],
+            ['SERVICES', 'B']
+        ])(
+            ('psc.toptier_code.description should be %s when %s is the psc.toptier_code.code'),
+            (result, pscCode) => {
+                const mockData = {
+                    ...mockContract,
+                    psc_hierarchy: {
+                        toptier_code: {
+                            code: pscCode,
+                            description: ''
+                        }
+                    }
+                };
+                contract.populate(mockData);
+                expect(contract.psc.toptier_code.description).toEqual(result);
+            }
+        );
+    });
 });

--- a/tests/models/awardsV2/BaseContract-test.js
+++ b/tests/models/awardsV2/BaseContract-test.js
@@ -54,7 +54,7 @@ describe('BaseContract', () => {
     });
     describe('Deducing the PSC Type based on the PSC Top Tier Code from the API', () => {
         it.each([
-            ['PRODUCT', '4'],
+            ['PRODUCTS', '4'],
             ['RESEARCH AND DEVELOPMENT', 'A'],
             ['SERVICES', 'B']
         ])(

--- a/tests/models/awardsV2/mockAwardApi.js
+++ b/tests/models/awardsV2/mockAwardApi.js
@@ -118,7 +118,9 @@ export const mockContract = {
             name: 'Jake Doe',
             amount: null
         }]
-    }
+    },
+    psc_hierarchy: {},
+    naics_hierarchy: {}
 };
 
 export const mockGrant = {


### PR DESCRIPTION
**High level description:**
Fixing two things from Ross' feedback:
1. Not including "SERVICES" header for PSC
2. Not including PSC Code for the first PSC item

**Technical details:**
0d2318f - removing SERVICES header
912c3b9 - not including PSC Code for first PSC Item and not sorting SERVICES header to top as it no longer exists 

**JIRA Ticket:**
[DEV-1663](https://federal-spending-transparency.atlassian.net/browse/DEV-1663)

**Mockup:**
Needs to be updated!

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA (if applicable)
- [x] Tagged Designer in `#us-ux-frontend` Slack Channel in the thread under the Post from Github for their SA
- [x] Verified cross-browser compatibility
- [x] Link to this PR in JIRA ticket