### PR TITLE
Dev-3094 v2 Award Title

### DIFF
--- a/src/js/components/awardv2/contract/ContractContent.jsx
+++ b/src/js/components/awardv2/contract/ContractContent.jsx
@@ -50,7 +50,7 @@ const ContractContent = ({ awardId, overview, jumpToSection }) => {
         <AwardPageWrapper
             glossaryLink={glossaryLink}
             identifier={overview.id}
-            awardTypeDescription={overview.typeDescription}
+            title={overview.title}
             lastModifiedDateLong={overview.periodOfPerformance.lastModifiedDateLong}
             awardType="contract">
             <AwardSection type="row" className="award-overview" id="award-overview">

--- a/src/js/components/awardv2/financialAssistance/FinancialAssistanceContent.jsx
+++ b/src/js/components/awardv2/financialAssistance/FinancialAssistanceContent.jsx
@@ -76,22 +76,13 @@ const FinancialAssistanceContent = ({
 
     const [idLabel, identifier] = isAwardAggregate(overview.generatedId) ? ['URI', overview.uri] : ['FAIN', overview.fain];
 
-    let title = overview.typeDescription;
-    // removes the award type and only capitalizes the first letter of each word
-    // e.g. PROJECT GRANT (B) => Project Grant
-    // e.g. PROJECT GRANT => Project Grant
-    if (overview.category === 'grant') {
-        const titleArray = title.split(' ').map((word) => upperFirst(word.toLowerCase()));
-        if (titleArray.length === 3) titleArray.pop();
-        title = titleArray.join(' ');
-    }
     return (
         <AwardPageWrapper
             identifier={identifier}
             idLabel={idLabel}
             awardType={overview.category}
             glossaryLink={glossaryLink}
-            awardTypeDescription={title}
+            title={overview.title}
             lastModifiedDateLong={overview.periodOfPerformance.lastModifiedDateLong}
             className="award-financial-assistance">
             <AwardSection type="row" className="award-overview" id="award-overview">

--- a/src/js/components/awardv2/financialAssistance/FinancialAssistanceContent.jsx
+++ b/src/js/components/awardv2/financialAssistance/FinancialAssistanceContent.jsx
@@ -5,7 +5,6 @@
 
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { upperFirst } from 'lodash';
 
 import { glossaryLinks } from 'dataMapping/search/awardType';
 import BaseAwardAmounts from 'models/v2/awardsV2/BaseAwardAmounts';

--- a/src/js/components/awardv2/idv/IdvContent.jsx
+++ b/src/js/components/awardv2/idv/IdvContent.jsx
@@ -50,7 +50,7 @@ const IdvContent = ({
     return (
         <AwardPageWrapper
             awardType="idv"
-            awardTypeDescription={overview.longTypeDescription}
+            title={overview.title}
             lastModifiedDateLong={overview.dates.lastModifiedDateLong}
             glossaryLink={glossaryLink}
             identifier={overview.id}>

--- a/src/js/components/awardv2/shared/AwardPageWrapper.jsx
+++ b/src/js/components/awardv2/shared/AwardPageWrapper.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { startCase } from 'lodash';
 
 import { Glossary } from '../../sharedComponents/icons/Icons';
 import { AWARD_PAGE_WRAPPER_PROPS } from '../../../propTypes/index';
 
 const AwardPageWrapper = ({
     awardType,
-    awardTypeDescription,
+    title,
     lastModifiedDateLong,
     glossaryLink,
     identifier,
@@ -16,7 +15,7 @@ const AwardPageWrapper = ({
     <div className={`award award-${awardType}`}>
         <div className="award__heading">
             <div className="award__info">
-                <h2 className="award__heading-text">{startCase(awardTypeDescription)}</h2>
+                <h2 className="award__heading-text">{title}</h2>
                 <div className="award__heading-icon">
                     <a href={glossaryLink}>
                         <Glossary />

--- a/src/js/components/awardv2/shared/overview/AwardDates.jsx
+++ b/src/js/components/awardv2/shared/overview/AwardDates.jsx
@@ -22,6 +22,7 @@ const titles = {
     grant: ['Start Date', 'Current End Date'],
     loan: ['Start Date', 'Current End Date'],
     'direct payment': ['Start Date', 'Current End Date'],
+    insurance: ['Start Date', 'Current End Date'],
     other: ['Start Date', 'Current End Date']
 };
 
@@ -33,6 +34,7 @@ export default class AwardDates extends React.Component {
         if (awardType === 'definitive contract') return null;
         if (awardType === 'grant') return null;
         if (awardType === 'loan') return null;
+        if (awardType === 'insurance') return null;
         if (awardType === 'direct payment') return null;
         if (awardType === 'other') return null;
         return null;

--- a/src/js/containers/awardV2/AwardV2Container.jsx
+++ b/src/js/containers/awardV2/AwardV2Container.jsx
@@ -25,7 +25,11 @@ import {
 import BaseContract from 'models/v2/awardsV2/BaseContract';
 import BaseIdv from 'models/v2/awardsV2/BaseIdv';
 import BaseFinancialAssistance from 'models/v2/awardsV2/BaseFinancialAssistance';
-import { fetchIdvDownloadFile, fetchContractDownloadFile, fetchAssistanceDownloadFile } from '../../helpers/downloadHelper';
+import {
+    fetchIdvDownloadFile,
+    fetchContractDownloadFile,
+    fetchAssistanceDownloadFile
+} from '../../helpers/downloadHelper';
 
 require('pages/awardV2/awardPage.scss');
 

--- a/src/js/dataMapping/awardsv2/descriptionsForAwardTypes.js
+++ b/src/js/dataMapping/awardsv2/descriptionsForAwardTypes.js
@@ -4,16 +4,16 @@
  */
 
 export const descriptionsForAwardTypes = {
-    A: 'Blanket Purchase Agreements (BPA) Call',
-    B: 'Purchase Orders (PO)',
-    C: 'Delivery Orders (DO)',
+    A: 'Blanket Purchase Agreement (BPA) Call',
+    B: 'Purchase Order (PO)',
+    C: 'Delivery Order (DO)',
     D: 'Definitive Contract',
     E: 'Unknown Type',
     F: 'Cooperative Agreement',
     G: 'Grant for Research',
     S: 'Funded Space Act Agreement',
     T: 'Training Grant',
-    IDV_A: "Government Wide Acquisition Contract",
+    IDV_A: "Government-Wide Acquisition Contract",
     IDV_B: "Indefinite Delivery Contract",
     IDV_B_A: "Indefinite Delivery / Requirements Contract",
     IDV_B_B: "Indefinite Delivery / Indefinite Quantity (IDIQ) Contract",

--- a/src/js/dataMapping/awardsv2/descriptionsForAwardTypes.js
+++ b/src/js/dataMapping/awardsv2/descriptionsForAwardTypes.js
@@ -1,9 +1,9 @@
 /**
- * awardTypeDescriptions.js
+ * awardTypeDescriptions.js => descriptionsForAwardTypes.js
  * Created by Max Kendall 3/8/19
  */
 
-export const longTypeDescriptionsByAwardTypes = {
+export const descriptionsForAwardTypes = {
     A: 'Blanket Purchase Agreements (BPA) Call',
     B: 'Purchase Orders (PO)',
     C: 'Delivery Orders (DO)',
@@ -35,8 +35,7 @@ export const longTypeDescriptionsByAwardTypes = {
 
 /**
  * NOTE:
- *   The values in this map are not identical with lookups/lookups.py awardTypeMapping;
- *   specifically, in lookups.py the values for the IDV award types are prepended with an acronym.
- *   I have decided to remove this prepended acronym for these types as the wireframes
- *   suggest this is the desired format in the UI
+ *   These values are not a direct one to one map of award types and descriptions.
+ *   These descriptions have been edited to be displayed to the user on the
+ *   Award Pages.
  */

--- a/src/js/dataMapping/awardsv2/longAwardTypeDescriptions.js
+++ b/src/js/dataMapping/awardsv2/longAwardTypeDescriptions.js
@@ -4,6 +4,15 @@
  */
 
 export const longTypeDescriptionsByAwardTypes = {
+    A: 'Blanket Purchase Agreements (BPA) Call',
+    B: 'Purchase Orders (PO)',
+    C: 'Delivery Orders (DO)',
+    D: 'Definitive Contract',
+    E: 'Unknown Type',
+    F: 'Cooperative Agreement',
+    G: 'Grant for Research',
+    S: 'Funded Space Act Agreement',
+    T: 'Training Grant',
     IDV_A: "Government Wide Acquisition Contract",
     IDV_B: "Indefinite Delivery Contract",
     IDV_B_A: "Indefinite Delivery / Requirements Contract",
@@ -11,7 +20,17 @@ export const longTypeDescriptionsByAwardTypes = {
     IDV_B_C: "Indefinite Delivery / Definite Quantity Contract",
     IDV_C: "Federal Supply Schedule",
     IDV_D: "Basic Ordering Agreement",
-    IDV_E: "Blanket Purchase Agreement"
+    IDV_E: "Blanket Purchase Agreement",
+    '02': 'Block Grant',
+    '03': 'Formula Grant',
+    '04': 'Project Grant',
+    '05': 'Cooperative Agreement',
+    10: 'Direct Payment with Unrestricted Use',
+    '06': 'Direct Payment for Specified Use',
+    '07': 'Direct Loan',
+    '08': 'Guaranteed/Insured Loan',
+    '09': 'Insurance',
+    11: 'Other Financial Assistance'
 };
 
 /**

--- a/src/js/models/v2/awardsV2/CoreAward.js
+++ b/src/js/models/v2/awardsV2/CoreAward.js
@@ -2,10 +2,11 @@
  * CoreAward.js
  * Created by David Trinh 10/9/18
  */
-import { startCase } from 'lodash';
+import { upperFirst } from 'lodash';
 import * as MoneyFormatter from 'helpers/moneyFormatter';
+import { longTypeDescriptionsByAwardTypes }
+    from 'dataMapping/awardsv2/longAwardTypeDescriptions';
 import { parseDate, formatDate } from './CorePeriodOfPerformance';
-import { longTypeDescriptionsByAwardTypes } from "../../../dataMapping/awardsv2/longAwardTypeDescriptions";
 
 const CoreAward = {
     populateCore(data) {
@@ -14,10 +15,6 @@ const CoreAward = {
         this.generatedId = data.generatedId || '';
         this.type = data.type || '';
         this.typeDescription = data.typeDescription || "--";
-        this.longTypeDescription =
-          longTypeDescriptionsByAwardTypes[data.type] ||
-          startCase(data.typeDescription) ||
-          "--";
         this.description = data.description || '--';
         this._subawardTotal = parseFloat(data.subawardTotal) || 0;
         this.subawardCount = parseFloat(data.subawardCount) || 0;
@@ -71,6 +68,18 @@ const CoreAward = {
         let percent = (this._subawardTotal / this._baseAndAllOptions) * 100;
         percent = MoneyFormatter.formatNumberWithPrecision(percent, 1);
         return percent > 0 ? `${percent}%` : '0%';
+    },
+    get title() {
+        if (longTypeDescriptionsByAwardTypes[this.type]) {
+            return longTypeDescriptionsByAwardTypes[this.type];
+        }
+        if (this.category) {
+            if (this.category === 'idv') {
+                return 'IDV';
+            }
+            return upperFirst(this.category);
+        }
+        return '--';
     }
 };
 

--- a/src/js/models/v2/awardsV2/CoreAward.js
+++ b/src/js/models/v2/awardsV2/CoreAward.js
@@ -4,8 +4,8 @@
  */
 import { upperFirst } from 'lodash';
 import * as MoneyFormatter from 'helpers/moneyFormatter';
-import { longTypeDescriptionsByAwardTypes }
-    from 'dataMapping/awardsv2/longAwardTypeDescriptions';
+import { descriptionsForAwardTypes }
+    from 'dataMapping/awardsv2/descriptionsForAwardTypes';
 import { parseDate, formatDate } from './CorePeriodOfPerformance';
 
 const CoreAward = {
@@ -70,8 +70,8 @@ const CoreAward = {
         return percent > 0 ? `${percent}%` : '0%';
     },
     get title() {
-        if (longTypeDescriptionsByAwardTypes[this.type]) {
-            return longTypeDescriptionsByAwardTypes[this.type];
+        if (descriptionsForAwardTypes[this.type]) {
+            return descriptionsForAwardTypes[this.type];
         }
         if (this.category) {
             if (this.category === 'idv') {

--- a/src/js/propTypes/index.js
+++ b/src/js/propTypes/index.js
@@ -7,7 +7,7 @@ export const AWARD_V2_OVERVIEW_PROPS = PropTypes.shape({
     generatedId: PropTypes.string,
     type: PropTypes.string,
     typeDescription: PropTypes.string,
-    longTypeDescription: PropTypes.string,
+    title: PropTypes.string,
     description: PropTypes.string,
     _subawardTotal: PropTypes.number,
     subawardCount: PropTypes.number,

--- a/src/js/propTypes/index.js
+++ b/src/js/propTypes/index.js
@@ -27,7 +27,7 @@ export const AWARD_V2_COUNTS_PROPS = PropTypes.shape({
 });
 
 
-export const AWARD_TYPE_PROPS = PropTypes.oneOf(['idv', 'contract', 'grant', 'loan', 'direct payment', 'other']);
+export const AWARD_TYPE_PROPS = PropTypes.oneOf(['idv', 'contract', 'grant', 'loan', 'direct payment', 'insurance', 'other']);
 
 export const TOOLTIP_PROPS = PropTypes.shape({
     isControlled: PropTypes.bool,

--- a/tests/models/awardsV2/CoreAward-test.js
+++ b/tests/models/awardsV2/CoreAward-test.js
@@ -5,8 +5,8 @@
 
 import CoreAward from 'models/v2/awardsV2/CoreAward';
 import { each, upperFirst } from 'lodash';
-import { longTypeDescriptionsByAwardTypes }
-    from 'dataMapping/awardsv2/longAwardTypeDescriptions';
+import { descriptionsForAwardTypes }
+    from 'dataMapping/awardsv2/descriptionsForAwardTypes';
 
 const awardData = {
     subawardTotal: 12004.75,
@@ -31,7 +31,7 @@ describe('Core Award getter functions', () => {
         zeroSubtotalAward.populateCore(data);
         expect(zeroSubtotalAward.subAwardedPercent).toEqual('0%');
     });
-    each(longTypeDescriptionsByAwardTypes, (value, key) => {
+    each(descriptionsForAwardTypes, (value, key) => {
         const fakeAwardData = { type: key };
         const fakeAward = Object.create(CoreAward);
         fakeAward.populateCore(fakeAwardData);
@@ -52,7 +52,7 @@ describe('Core Award getter functions', () => {
             }
         });
     });
-    each(longTypeDescriptionsByAwardTypes, () => {
+    each(descriptionsForAwardTypes, () => {
         const fakeAwardData = { type: '', category: '' };
         const fakeAward = Object.create(CoreAward);
         fakeAward.populateCore(fakeAwardData);

--- a/tests/models/awardsV2/CoreAward-test.js
+++ b/tests/models/awardsV2/CoreAward-test.js
@@ -31,33 +31,41 @@ describe('Core Award getter functions', () => {
         zeroSubtotalAward.populateCore(data);
         expect(zeroSubtotalAward.subAwardedPercent).toEqual('0%');
     });
-    each(descriptionsForAwardTypes, (value, key) => {
-        const fakeAwardData = { type: key };
-        const fakeAward = Object.create(CoreAward);
-        fakeAward.populateCore(fakeAwardData);
-        it(`should map Award Type [${key}] to an Award Title ${value}`, () => {
-            expect(fakeAward.title).toEqual(value);
+    describe('Test the title method', () => {
+        describe('Case where Award Type Exists', () => {
+            each(descriptionsForAwardTypes, (value, key) => {
+                const fakeAwardData = { type: key };
+                const fakeAward = Object.create(CoreAward);
+                fakeAward.populateCore(fakeAwardData);
+                it(`should map Award Type [${key}] to an Award Title ${value}`, () => {
+                    expect(fakeAward.title).toEqual(value);
+                });
+            });
         });
-    });
-    each(['idv', 'contract', 'grant', 'loan', 'other'], (category) => {
-        const fakeAwardData = { type: '', category };
-        const fakeAward = Object.create(CoreAward);
-        fakeAward.populateCore(fakeAwardData);
-        it(`should map Award Category [${category}] to an Award Title`, () => {
-            if (category !== 'idv') {
-                expect(fakeAward.title).toEqual(upperFirst(category));
-            }
-            else {
-                expect(fakeAward.title).toEqual('IDV');
-            }
+        describe('Case where Award Type does not exist, use category', () => {
+            each(['idv', 'contract', 'grant', 'loan', 'other'], (category) => {
+                const fakeAwardData = { type: '', category };
+                const fakeAward = Object.create(CoreAward);
+                fakeAward.populateCore(fakeAwardData);
+                it(`should map Award Category [${category}] to an Award Title`, () => {
+                    if (category !== 'idv') {
+                        expect(fakeAward.title).toEqual(upperFirst(category));
+                    }
+                    else {
+                        expect(fakeAward.title).toEqual('IDV');
+                    }
+                });
+            });
         });
-    });
-    each(descriptionsForAwardTypes, () => {
-        const fakeAwardData = { type: '', category: '' };
-        const fakeAward = Object.create(CoreAward);
-        fakeAward.populateCore(fakeAwardData);
-        it(`should map Award with no type or category to --`, () => {
-            expect(fakeAward.title).toEqual('--');
+        describe('Case where Award Type and Category do not exist', () => {
+            each(descriptionsForAwardTypes, () => {
+                const fakeAwardData = { type: '', category: '' };
+                const fakeAward = Object.create(CoreAward);
+                fakeAward.populateCore(fakeAwardData);
+                it(`should map Award with no type or category to --`, () => {
+                    expect(fakeAward.title).toEqual('--');
+                });
+            });
         });
     });
 });

--- a/tests/models/awardsV2/CoreAward-test.js
+++ b/tests/models/awardsV2/CoreAward-test.js
@@ -4,6 +4,9 @@
  */
 
 import CoreAward from 'models/v2/awardsV2/CoreAward';
+import { each, upperFirst } from 'lodash';
+import { longTypeDescriptionsByAwardTypes }
+    from 'dataMapping/awardsv2/longAwardTypeDescriptions';
 
 const awardData = {
     subawardTotal: 12004.75,
@@ -27,5 +30,34 @@ describe('Core Award getter functions', () => {
         const data = { ...award, subawardTotal: 0 };
         zeroSubtotalAward.populateCore(data);
         expect(zeroSubtotalAward.subAwardedPercent).toEqual('0%');
+    });
+    each(longTypeDescriptionsByAwardTypes, (value, key) => {
+        const fakeAwardData = { type: key };
+        const fakeAward = Object.create(CoreAward);
+        fakeAward.populateCore(fakeAwardData);
+        it(`should map Award Type [${key}] to an Award Title ${value}`, () => {
+            expect(fakeAward.title).toEqual(value);
+        });
+    });
+    each(['idv', 'contract', 'grant', 'loan', 'other'], (category) => {
+        const fakeAwardData = { type: '', category };
+        const fakeAward = Object.create(CoreAward);
+        fakeAward.populateCore(fakeAwardData);
+        it(`should map Award Category [${category}] to an Award Title`, () => {
+            if (category !== 'idv') {
+                expect(fakeAward.title).toEqual(upperFirst(category));
+            }
+            else {
+                expect(fakeAward.title).toEqual('IDV');
+            }
+        });
+    });
+    each(longTypeDescriptionsByAwardTypes, () => {
+        const fakeAwardData = { type: '', category: '' };
+        const fakeAward = Object.create(CoreAward);
+        fakeAward.populateCore(fakeAwardData);
+        it(`should map Award with no type or category to --`, () => {
+            expect(fakeAward.title).toEqual('--');
+        });
     });
 });


### PR DESCRIPTION
**High level description:**

Page titles will now be sourced from a data object based on award type. Similar to the Advanced Search but differing when plural.

**Technical details:**

* remove long type description
* update long type description data mapping to include all awards, remove plurals, but leave IDV's that were there alone.
* add title to core award and tests
* update a bug in dates section to include insurance

**JIRA Ticket:**
[DEV-3094](https://federal-spending-transparency.atlassian.net/browse/DEV-3094)


The following are ALL required for the PR to be merged:
- [ ] Code review
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA (if applicable)
- [x] Tagged Designer in `#us-ux-frontend` Slack Channel in the thread under the Post from Github for their SA
- [x] Verified cross-browser compatibility
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] Link to this PR in JIRA ticket