### PR TITLE
[Hotfix/awardid/subawards] Passing consistent value for AwardId from AwardV2 Container

### DIFF
--- a/src/js/components/awardv2/AwardV2.jsx
+++ b/src/js/components/awardv2/AwardV2.jsx
@@ -93,7 +93,7 @@ export default class Award extends React.Component {
         let content = null;
         let summaryBar = null;
         const { overview } = this.props.award;
-        const { isV2url } = this.props;
+        const { isV2url, awardId } = this.props;
         if (overview) {
             summaryBar = (
                 <SummaryBar
@@ -104,7 +104,7 @@ export default class Award extends React.Component {
             if (overview.category === 'contract') {
                 content = (
                     <ContractContent
-                        awardId={this.props.awardId}
+                        awardId={awardId}
                         overview={overview}
                         jumpToSection={this.jumpToSection} />
                 );
@@ -113,7 +113,7 @@ export default class Award extends React.Component {
                 content = (
                     <IdvContent
                         isV2url={isV2url}
-                        awardId={this.props.awardId}
+                        awardId={awardId}
                         overview={overview}
                         counts={this.props.award.counts}
                         jumpToSection={this.jumpToSection} />
@@ -122,7 +122,7 @@ export default class Award extends React.Component {
             else {
                 content = (
                     <FinancialAssistanceContent
-                        awardId={overview.id}
+                        awardId={awardId}
                         overview={overview}
                         jumpToSection={this.jumpToSection} />
                 );


### PR DESCRIPTION
**High level description:**
Subawards table service call was being made with `""` value for awardId property in request object.

**Technical details:**
This was only happening for Asst type awards, root cause is we were passing different values as the `awardId` prop to `FinancialAssistanceContent.jsx` compared to `ContractContent.jsx` and `IdvContent.jsx`.

**Deeper Root Cause** 
A deeper root cause is arguably that in our IDV/Contract models, were are treating `redux.awardV2.overview.id` as the `piid` when in fact the api provides both a `piid` and an `id` value.

This is problematic because if `redux.awardV2.overview.id` is the `piid` then we cannot define an `redux.awardV2.overview.id` for asst type awards as they do not have a `piid`. 

I am opening another PR shortly to be more specific in our models so that we capture both the `id` and `piid` for contracts and idvs and just the `id` for asst type awards.

The following are ALL required for the PR to be merged:
- [ ] Code review