### PR TITLE
Base Award Models now storing .id as apiData.id rather than apiData.piid

### DIFF
--- a/src/js/components/awardv2/AwardV2.jsx
+++ b/src/js/components/awardv2/AwardV2.jsx
@@ -93,7 +93,7 @@ export default class Award extends React.Component {
         let content = null;
         let summaryBar = null;
         const { overview } = this.props.award;
-        const { isV2url } = this.props;
+        const { isV2url, awardId } = this.props;
         if (overview) {
             summaryBar = (
                 <SummaryBar
@@ -104,7 +104,7 @@ export default class Award extends React.Component {
             if (overview.category === 'contract') {
                 content = (
                     <ContractContent
-                        awardId={this.props.awardId}
+                        awardId={awardId}
                         overview={overview}
                         jumpToSection={this.jumpToSection} />
                 );
@@ -113,7 +113,7 @@ export default class Award extends React.Component {
                 content = (
                     <IdvContent
                         isV2url={isV2url}
-                        awardId={this.props.awardId}
+                        awardId={awardId}
                         overview={overview}
                         counts={this.props.award.counts}
                         jumpToSection={this.jumpToSection} />
@@ -122,7 +122,7 @@ export default class Award extends React.Component {
             else {
                 content = (
                     <FinancialAssistanceContent
-                        awardId={this.props.awardId}
+                        awardId={awardId}
                         overview={overview}
                         jumpToSection={this.jumpToSection} />
                 );

--- a/src/js/components/awardv2/contract/ContractContent.jsx
+++ b/src/js/components/awardv2/contract/ContractContent.jsx
@@ -49,7 +49,7 @@ const ContractContent = ({ awardId, overview, jumpToSection }) => {
     return (
         <AwardPageWrapper
             glossaryLink={glossaryLink}
-            identifier={overview.id}
+            identifier={overview.piid}
             title={overview.title}
             lastModifiedDateLong={overview.periodOfPerformance.lastModifiedDateLong}
             awardType="contract">

--- a/src/js/components/awardv2/idv/IdvContent.jsx
+++ b/src/js/components/awardv2/idv/IdvContent.jsx
@@ -53,7 +53,7 @@ const IdvContent = ({
             title={overview.title}
             lastModifiedDateLong={overview.dates.lastModifiedDateLong}
             glossaryLink={glossaryLink}
-            identifier={overview.id}>
+            identifier={overview.piid}>
             <AwardSection type="row" className="award-overview" id="award-overivew">
                 <AgencyRecipient
                     jumpToSection={jumpToSection}

--- a/src/js/models/v2/awardsV2/BaseContract.js
+++ b/src/js/models/v2/awardsV2/BaseContract.js
@@ -18,7 +18,7 @@ const BaseContract = Object.create(CoreAward);
 BaseContract.populate = function populate(data) {
     // reformat some fields that are required by the CoreAward
     const coreData = {
-        id: data.piid,
+        id: data.id,
         generatedId: data.generated_unique_award_id,
         type: data.type,
         typeDescription: data.type_description,
@@ -129,8 +129,8 @@ BaseContract.populate = function populate(data) {
     this.parentAward = data.parent_award_piid || '--';
     this.parentId = data.parent_generated_unique_award_id || '';
     this.pricing = data.latest_transaction_contract_data || '--';
-
     this._amount = parseFloat(data.base_and_all_options) || 0;
+    this.piid = data.piid || '';
 };
 
 

--- a/src/js/models/v2/awardsV2/BaseFinancialAssistance.js
+++ b/src/js/models/v2/awardsV2/BaseFinancialAssistance.js
@@ -27,6 +27,7 @@ const getLargestCfda = (acc, cfdaItem) => {
 BaseFinancialAssistance.populate = function populate(data) {
     // reformat some fields that are required by the CoreAward
     const coreData = {
+        id: data.id,
         generatedId: data.generated_unique_award_id,
         type: data.type,
         typeDescription: data.type_description,

--- a/src/js/models/v2/awardsV2/BaseIdv.js
+++ b/src/js/models/v2/awardsV2/BaseIdv.js
@@ -17,7 +17,7 @@ const BaseIdv = Object.create(CoreAward);
 BaseIdv.populate = function populate(data) {
     // reformat some fields that are required by the CoreAward
     const coreData = {
-        id: data.piid,
+        id: data.id,
         generatedId: data.generated_unique_award_id,
         type: data.type,
         typeDescription: data.type_description,
@@ -117,6 +117,7 @@ BaseIdv.populate = function populate(data) {
     const executiveDetails = Object.create(CoreExecutiveDetails);
     executiveDetails.populateCore(data.executive_details);
     this.executiveDetails = executiveDetails;
+    this.piid = data.piid || '';
 };
 
 export default BaseIdv;


### PR DESCRIPTION
**High level description:**
Updating models so the `redux.awardsV2.overview.id` value can be used for all award types.

**Technical details:**
We were not passing the `id` property for assistance type awards b/c in the idv/contract awards the `id` property in `redux.awardsv2.overview` was actually the piid.

5948959 This updates the models so that the `piid` is stored in our models/redux specifically as the `piid` rather than as `id`. This allows us to store the `id` for asst type awards in our models and redux.

53ed392 Also refactored our use of `overview.id` in our components to `overview.piid`

The following are ALL required for the PR to be merged:
- [x] Code review