### PR TITLE
[DEV-3698] Hiding Subawards Tab and Grant Activity Section

### DIFF
--- a/src/js/components/awardv2/financialAssistance/FinancialAssistanceContent.jsx
+++ b/src/js/components/awardv2/financialAssistance/FinancialAssistanceContent.jsx
@@ -74,6 +74,7 @@ const FinancialAssistanceContent = ({
     awardAmountData.populate(overview, overview.category);
 
     const [idLabel, identifier] = isAwardAggregate(overview.generatedId) ? ['URI', overview.uri] : ['FAIN', overview.fain];
+    const isGrant = overview.category === 'grant';
 
     return (
         <AwardPageWrapper
@@ -102,15 +103,23 @@ const FinancialAssistanceContent = ({
                 <AwardDescription description={overview.description} awardId={awardId} />
             </AwardSection>
             <AwardSection type="row">
-                <ComingSoonSection title="Grant Activity" icon="chart-area" includeHeader />
+                {isGrant && <ComingSoonSection title="Grant Activity" icon="chart-area" includeHeader />}
+                {!isGrant && (
+                    <ComingSoonSection
+                        title="CFDA Program / Assistance Listing Information"
+                        icon="hands-helping"
+                        includeHeader />
+                )}
                 <FederalAccountsSection jumpToFederalAccountsHistory={jumpToFederalAccountsHistory} />
             </AwardSection>
-            <AwardSection type="row">
-                <ComingSoonSection
-                    title="CFDA Program / Assistance Listing Information"
-                    icon="hands-helping"
-                    includeHeader />
-            </AwardSection>
+            {isGrant && (
+                <AwardSection type="row">
+                    <ComingSoonSection
+                        title="CFDA Program / Assistance Listing Information"
+                        icon="hands-helping"
+                        includeHeader />
+                </AwardSection>
+            )}
             <AwardSection type="row">
                 <AwardHistory awardId={awardId} overview={overview} setActiveTab={setActiveTab} activeTab={activeTab} />
             </AwardSection>

--- a/src/js/components/awardv2/shared/awardHistorySection/TablesSection.jsx
+++ b/src/js/components/awardv2/shared/awardHistorySection/TablesSection.jsx
@@ -8,13 +8,12 @@ import PropTypes from 'prop-types';
 
 import TransactionsTableContainer from 'containers/awardV2/table/TransactionsTableContainer';
 import FederalAccountTableContainer from 'containers/awardV2/table/FederalAccountTableContainer';
-import { tabs } from 'dataMapping/awardsv2/awardHistorySection';
+import { tabs, awardTypesWithSubawards } from 'dataMapping/awardsv2/awardHistorySection';
 
 import SubawardsContainer from '../../../../containers/awardV2/table/SubawardsContainer';
 import DetailsTabBar from '../../../award/details/DetailsTabBar';
 import ResultsTablePicker from '../../../search/table/ResultsTablePicker';
 import { getAwardHistoryCounts } from "../../../../helpers/awardHistoryHelper";
-import { awardTypesWithSubawards } from '../../../../dataMapping/awardsv2/awardHistorySection';
 
 const propTypes = {
     overview: PropTypes.object,

--- a/src/js/dataMapping/awardsv2/awardHistorySection.js
+++ b/src/js/dataMapping/awardsv2/awardHistorySection.js
@@ -1,0 +1,31 @@
+import {
+    federalAccountFundingInfo,
+    transactionHistoryInfo,
+    subAwardsTab
+} from 'components/awardv2/shared/InfoTooltipContent';
+
+export const tabs = [
+    {
+        label: "Transaction History",
+        internal: "transaction",
+        enabled: true,
+        tooltipContent: transactionHistoryInfo,
+        tooltipProps: { wide: true }
+    },
+    {
+        label: "Sub-Awards",
+        internal: "subaward",
+        enabled: true,
+        tooltipContent: subAwardsTab,
+        tooltipProps: { wide: true }
+    },
+    {
+        label: "Federal Account Funding",
+        internal: "federal_account",
+        enabled: true,
+        tooltipContent: federalAccountFundingInfo,
+        tooltipProps: { wide: true }
+    }
+];
+
+export const awardTypesWithSubawards = ['grant', 'contract'];


### PR DESCRIPTION
**High level description:**
Hides sections in FinancialAssistance awards that are specific to grants for non-grant awards.

**Technical details:**
Removed subaward tab via `.filter()`. There's an existing PR that should fix the tooltip content that was inaccurately showing grant specific info for non grant awards. This PR will have conflicts with that PR.

**JIRA Ticket:**
[DEV-3698](https://federal-spending-transparency.atlassian.net/browse/DEV-3698)

The following are ALL required for the PR to be merged:
- [x] Code review
- [x] Verified cross-browser compatibility
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] Link to this PR in JIRA ticket