### PR TITLE
[as2.0-glossary-links] glossary links were pointing to awards_v2

### DIFF
--- a/src/js/components/awardv2/contract/ContractContent.jsx
+++ b/src/js/components/awardv2/contract/ContractContent.jsx
@@ -30,7 +30,7 @@ const ContractContent = ({ awardId, overview, jumpToSection }) => {
     const [activeTab, setActiveTab] = useState('transaction');
     const glossarySlug = glossaryLinks[overview.type];
     const glossaryLink = glossarySlug
-        ? `/#/award_v2/${awardId}?glossary=${glossarySlug}`
+        ? `/#/award/${awardId}?glossary=${glossarySlug}`
         : null;
 
     const jumpToFederalAccountsHistory = () => {

--- a/src/js/components/awardv2/financialAssistance/FinancialAssistanceContent.jsx
+++ b/src/js/components/awardv2/financialAssistance/FinancialAssistanceContent.jsx
@@ -44,7 +44,7 @@ const FinancialAssistanceContent = ({
     const [activeTab, setActiveTab] = useState("transaction");
 
     const glossaryLink = glossaryLinks[overview.type]
-        ? `/#/award_v2/${awardId}?glossary=${glossaryLinks[overview.type]}`
+        ? `/#/award/${awardId}?glossary=${glossaryLinks[overview.type]}`
         : null;
 
     const jumpToTransactionHistoryTable = () => {


### PR DESCRIPTION
**High level description:**
Smoke testing AS2.0 in DEV saw that glossary links weren't working.

**Technical details:**
Link url was to awards_v2

**JIRA Ticket:**
[DEV-3439](https://federal-spending-transparency.atlassian.net/browse/DEV-3439)

The following are ALL required for the PR to be merged:
- [x] Code review