### PR TITLE
Dev-3778 Sub Award Tab Summary in Award History

### DIFF
--- a/src/js/components/awardv2/subawards/SubawardsTable.jsx
+++ b/src/js/components/awardv2/subawards/SubawardsTable.jsx
@@ -147,7 +147,7 @@ export default class SubawardsTable extends React.Component {
                 : <ResultsTableNoResults />;
         }
 
-        const totalSubAwardLabel = 'Total Count of Sub-Awards: ';
+        const totalSubAwardLabel = 'Total Count of Sub-Award Transactions: ';
         const totalSubAwardAmountLabel = 'Total Amount of Sub-Awards: ';
         return (
             <div>
@@ -170,7 +170,7 @@ export default class SubawardsTable extends React.Component {
                     </div>
                     <div className="total-item">
                         <span className="total-label">
-                            Percentage of Total Funded Amount:&nbsp;
+                            Percent of Prime Award Obligated Amount:&nbsp;
                         </span>
                         <span className="total-value">
                             {award.subAwardedPercent}

--- a/src/js/models/v2/awardsV2/CoreAward.js
+++ b/src/js/models/v2/awardsV2/CoreAward.js
@@ -65,9 +65,10 @@ const CoreAward = {
         return MoneyFormatter.formatMoney(this._totalObligation - this._baseAndAllOptions);
     },
     get subAwardedPercent() {
-        let percent = (this._subawardTotal / this._baseAndAllOptions) * 100;
+        let percent = (this._subawardTotal / this._totalObligation) * 100;
+        if (percent < 0) return '0%';
         percent = MoneyFormatter.formatNumberWithPrecision(percent, 1);
-        return percent > 0 ? `${percent}%` : '0%';
+        return `${percent}%`;
     },
     get title() {
         if (descriptionsForAwardTypes[this.type]) {

--- a/src/js/models/v2/awardsV2/CoreAward.js
+++ b/src/js/models/v2/awardsV2/CoreAward.js
@@ -66,7 +66,7 @@ const CoreAward = {
     },
     get subAwardedPercent() {
         let percent = (this._subawardTotal / this._totalObligation) * 100;
-        if (percent < 0) return '0%';
+        if (percent <= 0 || isNaN(percent)) return '0%';
         percent = MoneyFormatter.formatNumberWithPrecision(percent, 1);
         return `${percent}%`;
     },

--- a/tests/models/awardsV2/CoreAward-test.js
+++ b/tests/models/awardsV2/CoreAward-test.js
@@ -7,6 +7,7 @@ import CoreAward from 'models/v2/awardsV2/CoreAward';
 import { each, upperFirst } from 'lodash';
 import { descriptionsForAwardTypes }
     from 'dataMapping/awardsv2/descriptionsForAwardTypes';
+import { formatNumberWithPrecision } from 'helpers/moneyFormatter';
 
 const awardData = {
     subawardTotal: 12004.75,
@@ -23,11 +24,14 @@ describe('Core Award getter functions', () => {
         expect(award.subawardTotal).toEqual('$12,005');
     });
     it('should derive the subawardedPercent', () => {
-        expect(award.subAwardedPercent).toEqual('59.7%');
+        expect(award.subAwardedPercent)
+            .toEqual(`${formatNumberWithPrecision(((
+                awardData.subawardTotal / awardData.totalObligation
+            ) * 100), 1)}%`);
     });
     it('should handle zero subawardedPercent', () => {
         const zeroSubtotalAward = Object.create(CoreAward);
-        const data = { ...award, subawardTotal: 0 };
+        const data = { ...award, _subawardTotal: 0 };
         zeroSubtotalAward.populateCore(data);
         expect(zeroSubtotalAward.subAwardedPercent).toEqual('0%');
     });


### PR DESCRIPTION
**High level description:**

Updates the Header text and percentage for the sub award tab in Award History.

**JIRA Ticket:**
[DEV-3778](https://federal-spending-transparency.atlassian.net/browse/DEV-3778)

The following are ALL required for the PR to be merged (in ascending LOE):
- [x] Link to this PR in JIRA ticket
- [x] Tagged Design, Testing, and Code Reviewers in `#us-ux-frontend` Slack Channel in the thread under the Post from Github for their SA ( N/A )
- [x] Scheduled demo including Design/Testing/Front-end ( N/A )
- [x] Provided instructions for testing in JIRA (for benefit of testing) and PR (for benefit of code reviewer) ( N/A )
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions
- [x] Design review complete ( N/A )
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [ ] Code review complete
