### PR TITLE
[DEV-1663] Displaying PSC Type and TopTier Code except for R&D where we only show type

### DIFF
--- a/src/js/components/awardv2/shared/description/LineTree.jsx
+++ b/src/js/components/awardv2/shared/description/LineTree.jsx
@@ -16,6 +16,8 @@ const LineTree = ({
         .sort((tierType1, tierType2) => {
             const first = data[tierType1].code;
             const second = data[tierType2].code;
+            if (first === "--") return -1;
+            if (second === "--") return 1;
             if (first.length < second.length) return -1;
             if (second.length < first.length) return 1;
             return 0;

--- a/src/js/models/v2/awardsV2/BaseContract.js
+++ b/src/js/models/v2/awardsV2/BaseContract.js
@@ -27,7 +27,7 @@ const getPscTypeByToptierCode = (toptierCode) => {
 
     const topTierCodeAsInt = parseInt(toptierCode, 10);
     if (isNaN(topTierCodeAsInt)) {
-        if (toptierCode && toptierCode.toUpperCase() === 'A') {
+        if (toptierCode && toptierCode[0].toUpperCase() === 'A') {
             return 'RESEARCH AND DEVELOPMENT';
         }
         // all letters other than 'A' are services
@@ -39,15 +39,14 @@ const getPscTypeByToptierCode = (toptierCode) => {
 
 const deducePscType = (acc, keyValueArray) => {
     const [key, value] = keyValueArray;
+    const description = getPscTypeByToptierCode(value.code);
     if (key === 'toptier_code') {
-        return {
-            ...acc,
-            [key]: {
-                // if toptier_code is undefined, provide this value so it is sorted to the top
-                code: value.code || "0",
-                description: getPscTypeByToptierCode(value.code)
-            }
-        };
+        const pscType = { code: "--", description };
+        if (description === 'RESEARCH AND DEVELOPMENT') {
+            // replace toptier_code w/ psc type
+            return { ...acc, pscType };
+        }
+        return { ...acc, pscType, [key]: value };
     }
     return { ...acc, [key]: value };
 };

--- a/tests/models/awardsV2/BaseContract-test.js
+++ b/tests/models/awardsV2/BaseContract-test.js
@@ -71,7 +71,7 @@ describe('BaseContract', () => {
                     }
                 };
                 contract.populate(mockData);
-                expect(contract.psc.toptier_code.description).toEqual(result);
+                expect(contract.psc.pscType.description).toEqual(result);
             }
         );
     });


### PR DESCRIPTION
**High level description:**
I had a lot of confusion with this design for the PSC section of the Description section:
![image](https://user-images.githubusercontent.com/12897813/67522312-8b98ca00-f67a-11e9-99aa-89d57eb92262.png)

This PR ensures we show the `M: blah blah blah` line, which in staging is currently being replaced by Services.

The API is not returning the PSC Type but it is easily inferred based on the value of the `toptier_code` which in this case is `M` which translates to `SERVICES`.

**Technical details:**
- Model turns payload from API into new object with the new property `pscType` based on the top tier code
- If the `pscType` is R&D we treat this as a special case and do not show the `toptier_code` because it is always the same as the psc type
- If the pscType is not R&D we attempt to display all the different tier-types of the psc

**JIRA Ticket:**
[DEV-1663](https://federal-spending-transparency.atlassian.net/browse/DEV-1663)

**Mockup:**
see above

The following are ALL required for the PR to be merged (in ascending LOE):
- [x] Link to this PR in JIRA ticket
- [x] Tagged Design, Testing, and Code Reviewers in `#us-ux-frontend` Slack Channel in the thread under the Post from Github for their SA
- [x] Scheduled demo including Design/Testing/Front-end `if applicable`
- [x] Provided instructions for testing in JIRA (for benefit of testing) and PR (for benefit of code reviewer) `if applicable`
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [x] Design review complete `if applicable`
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- `N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- `N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged `if applicable`
- [ ] Code review complete
