### PR TITLE
Dev-3688 Loan Transaction Table in Award History Split Columns

### DIFF
--- a/src/_scss/pages/awardV2/visualizations/_awardFundingSummary.scss
+++ b/src/_scss/pages/awardV2/visualizations/_awardFundingSummary.scss
@@ -74,7 +74,6 @@
     }
 }
   .federal-accounts__section {
-    height: 100%;
     width: 100%;
     .view-buttons {
       @include viewTypeButton();

--- a/src/js/components/award/table/TransactionsTable.jsx
+++ b/src/js/components/award/table/TransactionsTable.jsx
@@ -13,7 +13,6 @@ import loanTransactionHistoryTable from
     'dataMapping/awardsv2/transactionHistoryTable/loanTransactionHistoryTable';
 import contractMapping from 'dataMapping/contracts/transactionTable';
 import assistanceMapping from 'dataMapping/financialAssistance/financialAssistanceTransactionTable';
-import loanMapping from 'dataMapping/financialAssistance/loanTransactionTable';
 import IBTable from 'components/sharedComponents/IBTable/IBTable';
 
 import TransactionTableHeaderCell from './cells/TransactionTableHeaderCell';
@@ -64,9 +63,6 @@ export default class TransactionsTable extends React.Component {
         }
         else if (category === 'contract') {
             return contractMapping;
-        }
-        else if (category === 'loan') {
-            return loanMapping;
         }
         return assistanceMapping;
     }

--- a/src/js/containers/awardV2/table/TransactionsTableContainer.jsx
+++ b/src/js/containers/awardV2/table/TransactionsTableContainer.jsx
@@ -14,7 +14,7 @@ import * as SearchHelper from 'helpers/searchHelper';
 import * as awardActions from 'redux/actions/awardV2/awardActions';
 
 import BaseContractTransaction from 'models/v2/awards/transactions/BaseContractTransaction';
-
+import BaseLoanTransaction from 'models/v2/awards/transactions/BaseLoanTransaction';
 import TransactionsTable from 'components/award/table/TransactionsTable';
 
 const propTypes = {
@@ -106,12 +106,12 @@ export class TransactionsTableContainer extends React.Component {
     }
 
     parseTransactions(data, reset) {
-        const transactions = [];
-
-        data.results.forEach((item) => {
-            const transaction = Object.create(BaseContractTransaction);
+        const baseTransaction = this.props.category === 'loan' ?
+            BaseLoanTransaction : BaseContractTransaction;
+        const transactions = data.results.map((item) => {
+            const transaction = Object.create(baseTransaction);
             transaction.populate(item);
-            transactions.push(transaction);
+            return transaction;
         });
 
         // update the metadata

--- a/src/js/dataMapping/awardsv2/transactionHistoryTable/loanTransactionHistoryTable.js
+++ b/src/js/dataMapping/awardsv2/transactionHistoryTable/loanTransactionHistoryTable.js
@@ -7,16 +7,16 @@ const tableSearchFields = {
     columnWidths: {
         modificationNumber: 0,
         actionDate: 0,
-        federalActionObligation: 0,
-        originalLoanSubsidyCost: 0,
+        faceValue: 0,
+        subsidy: 0,
         actionTypeDescription: 380,
         description: 380
     },
     defaultSortDirection: {
         modificationNumber: 'desc',
         actionDate: 'desc',
-        federalActionObligation: 'desc',
-        originalLoanSubsidyCost: 'desc',
+        faceValue: 'desc',
+        subsidy: 'desc',
         action_type: 'asc',
         description: 'asc'
     },
@@ -24,23 +24,23 @@ const tableSearchFields = {
         _order: [
             'modificationNumber',
             'actionDate',
-            'federalActionObligation',
-            'originalLoanSubsidyCost',
+            'faceValue',
+            'subsidy',
             'actionTypeDescription',
             'description'
         ],
         _mapping: {
             modificationNumber: 'modification_number',
             actionDate: 'action_date',
-            federalActionObligation: 'federal_action_obligation',
-            originalLoanSubsidyCost: 'original_loan_subsidy_cost',
+            faceValue: 'face_value_loan_guarantee',
+            subsidy: 'original_loan_subsidy_cost',
             actionTypeDescription: 'action_type',
             description: 'description'
         },
         modificationNumber: 'Modification Number',
         actionDate: 'Action Date',
-        federalActionObligation: 'Face Value',
-        originalLoanSubsidyCost: 'Subsidy Cost',
+        faceValue: 'Face Value',
+        subsidy: 'Subsidy Cost',
         actionTypeDescription: 'Action Type',
         description: 'Description'
     }

--- a/src/js/models/v2/awards/transactions/BaseLoanTransaction.js
+++ b/src/js/models/v2/awards/transactions/BaseLoanTransaction.js
@@ -4,7 +4,6 @@
  */
 
 import { formatMoney } from 'helpers/moneyFormatter';
-import { actionTypes } from 'dataMapping/financialAssistance/assistanceActionTypes';
 import CoreTransaction from './CoreTransaction';
 
 const BaseLoanTransaction = Object.create(CoreTransaction);
@@ -16,13 +15,13 @@ BaseLoanTransaction.populate = function populate(data) {
         typeDescription: data.type_description,
         actionDate: data.action_date,
         actionType: data.action_type,
-        actionTypeDescription: (data.action_type && actionTypes[data.action_type.toUpperCase()]),
+        actionTypeDescription: data.action_type_description,
         modificationNumber: data.modification_number,
         description: data.description
     };
     this.populateCore(coreData);
 
-    this._faceValue = (data.assistance_data && parseFloat(data.assistance_data.face_value_loan_guarantee)) || 0;
+    this._faceValue = parseFloat(data.face_value_loan_guarantee) || 0;
     this._subsidy = parseFloat(data.original_loan_subsidy_cost) || 0;
 };
 

--- a/tests/models/awards/transactions/BaseTransactions-test.js
+++ b/tests/models/awards/transactions/BaseTransactions-test.js
@@ -17,10 +17,8 @@ const mockAssistanceTransaction = {
 };
 
 const mockLoanTransaction = {
-    original_loan_subsidy_cost: '234.58',
-    assistance_data: {
-        face_value_loan_guarantee: '1230.4'
-    }
+    face_value_loan_guarantee: '1230.4',
+    original_loan_subsidy_cost: '234.58'
 };
 
 const contractTransaction = Object.create(BaseContractTransaction);


### PR DESCRIPTION
**High level description:**

Splits the Amount Column in Loan Transaction Table in Award History Section to Face Value and Subsidy Cost

**Technical details:**

* remove double loan if

* update v2 loan transaction datamapping

* update tests

* update and use base loan transaction model

**JIRA Ticket:**
[DEV-3688](https://federal-spending-transparency.atlassian.net/browse/DEV-3688)

The following are ALL required for the PR to be merged (in ascending LOE):
- [x] Link to this PR in JIRA ticket
- [x] Tagged Design, Testing, and Code Reviewers in `#us-ux-frontend` Slack Channel in the thread under the Post from Github for their SA ( N/A )
- [x] Scheduled demo including Design/Testing/Front-end ( N/A )
- [x] Provided instructions for testing in JIRA (for benefit of testing) and PR (for benefit of code reviewer) ( N/A )
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions
- [x] Design review complete ( N/A )
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [ ] Code review complete
