### PR TITLE
[hotfix] changing name of cookie so that all users will see the banner until they dismiss it

### DIFF
--- a/src/js/components/sharedComponents/header/Header.jsx
+++ b/src/js/components/sharedComponents/header/Header.jsx
@@ -15,6 +15,8 @@ const clickedHeaderLink = (route) => {
     });
 };
 
+export const twentyNineteenFiscalDataCookie = 'usaspending_2019_fiscal_data';
+
 export default class Header extends React.Component {
     constructor(props) {
         super(props);
@@ -28,7 +30,7 @@ export default class Header extends React.Component {
     }
     componentWillMount() {
         // check if the info banner cookie exists
-        if (!Cookies.get('usaspending_info_banner')) {
+        if (!Cookies.get(twentyNineteenFiscalDataCookie)) {
             // cookie does not exist, show the banner
             this.setState({
                 showInfoBanner: true

--- a/src/js/components/sharedComponents/header/InfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/InfoBanner.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import Analytics from 'helpers/analytics/Analytics';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
+import { twentyNineteenFiscalDataCookie } from './Header';
+
 const propTypes = {
     closeBanner: PropTypes.func
 };
@@ -14,7 +16,7 @@ export default class InfoBanner extends React.Component {
     }
 
     bannerClosed() {
-        this.props.closeBanner('showInfoBanner', 'usaspending_info_banner');
+        this.props.closeBanner('showInfoBanner', twentyNineteenFiscalDataCookie);
     }
 
     clickedBannerLink = () => {


### PR DESCRIPTION
**High level description:**
Changed the name of the cookie so that we're showing the banner to all users until they dismiss it.

**Technical details:**
Ensures users who had dismissed old info-banners are not missing out on this new one.

**JIRA Ticket:**
[DEV-3382](https://federal-spending-transparency.atlassian.net/browse/DEV-3382)

The following are ALL required for the PR to be merged (in ascending LOE):
- [ ] Link to this PR in JIRA ticket
`N/A` Tagged Design, Testing, and Code Reviewers in `#us-ux-frontend` Slack Channel in the thread under the Post from Github for their SA
`N/A` Scheduled demo including Design/Testing/Front-end `if applicable`
`N/A` Provided instructions for testing in JIRA (for benefit of testing) and PR (for benefit of code reviewer) `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` Design review complete `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged `if applicable`
- [ ] Code review complete
