### PR TITLE
Dev-3814 Contract Related Awards Section

### DIFF
--- a/src/js/components/awardv2/AwardV2.jsx
+++ b/src/js/components/awardv2/AwardV2.jsx
@@ -105,6 +105,7 @@ export default class Award extends React.Component {
                     <ContractContent
                         awardId={awardId}
                         overview={overview}
+                        counts={{ subawardCount: overview.subawardCount }}
                         jumpToSection={this.jumpToSection} />
                 );
             }

--- a/src/js/components/awardv2/contract/ContractContent.jsx
+++ b/src/js/components/awardv2/contract/ContractContent.jsx
@@ -23,10 +23,16 @@ import AwardDescription from "../shared/description/AwardDescription";
 const propTypes = {
     awardId: PropTypes.string,
     overview: PropTypes.object,
-    jumpToSection: PropTypes.func
+    jumpToSection: PropTypes.func,
+    counts: PropTypes.object
 };
 
-const ContractContent = ({ awardId, overview, jumpToSection }) => {
+const ContractContent = ({
+    awardId,
+    overview,
+    jumpToSection,
+    counts
+}) => {
     const [activeTab, setActiveTab] = useState('transaction');
     const glossarySlug = glossaryLinks[overview.type];
     const glossaryLink = glossarySlug
@@ -46,6 +52,11 @@ const ContractContent = ({ awardId, overview, jumpToSection }) => {
         jumpToSection("award-history");
     };
 
+    const jumpToSubAwardHistoryTable = () => {
+        setActiveTab('subaward');
+        jumpToSection("award-history");
+    };
+
     return (
         <AwardPageWrapper
             glossaryLink={glossaryLink}
@@ -60,6 +71,9 @@ const ContractContent = ({ awardId, overview, jumpToSection }) => {
                     category="contract"
                     recipient={overview.recipient} />
                 <RelatedAwards
+                    jumpToSubAwardHistoryTable={jumpToSubAwardHistoryTable}
+                    jumpToSection={jumpToSection}
+                    counts={counts}
                     overview={overview} />
                 <AwardDates
                     awardType={overview.category}

--- a/src/js/components/awardv2/shared/overview/RelatedAwards.jsx
+++ b/src/js/components/awardv2/shared/overview/RelatedAwards.jsx
@@ -15,6 +15,7 @@ const propTypes = {
     overview: PropTypes.object,
     jumpToSection: PropTypes.func,
     setRelatedAwardsTab: PropTypes.func,
+    jumpToSubAwardHistoryTable: PropTypes.func,
     counts: PropTypes.object
 };
 
@@ -42,31 +43,51 @@ export default class RelatedAwards extends React.Component {
         this.props.setRelatedAwardsTab('grandchild_awards');
         this.props.jumpToSection('referenced-awards');
     }
+    jumpToAwardHistoryTableSubAwardsTab = () => {
+        this.props.jumpToSubAwardHistoryTable('subaward');
+        this.props.jumpToSection('award-history');
+    }
 
     referencedAwardCounts() {
-        const { counts } = this.props;
+        const { counts, overview } = this.props;
         if (!counts) return null;
-        const childData = [
-            {
-                count: formatNumber(counts.child_awards),
-                name: 'Child Award',
-                funcName: 'ChildAwards',
-                glossary: 'contract'
-            },
-            {
-                count: formatNumber(counts.child_idvs),
-                name: 'Child IDV',
-                funcName: 'ChildIDVs',
-                glossary: 'IDV'
-            },
-            {
-                count: formatNumber(counts.grandchild_awards),
-                name: 'Grandchild Award',
-                funcName: 'GrandchildAwards',
-                glossary: 'award'
-            }
-        ];
-
+        let childData = [];
+        if (overview.category === 'idv') {
+            childData = [
+                {
+                    count: formatNumber(counts.child_awards),
+                    name: 'Child Award',
+                    funcName: 'jumpToReferencedAwardsTableChildAwardsTab',
+                    glossary: 'contract',
+                    postText: counts.child_awards === 1 ? 'Order' : 'Orders'
+                },
+                {
+                    count: formatNumber(counts.child_idvs),
+                    name: 'Child IDV',
+                    funcName: 'jumpToReferencedAwardsTableChildIDVsTab',
+                    glossary: 'IDV',
+                    postText: counts.child_idvs === 1 ? 'Order' : 'Orders'
+                },
+                {
+                    count: formatNumber(counts.grandchild_awards),
+                    name: 'Grandchild Award',
+                    funcName: 'jumpToReferencedAwardsTableGrandchildAwardsTab',
+                    glossary: 'award',
+                    postText: counts.grandchild_awards === 1 ? 'Order' : 'Orders'
+                }
+            ];
+        }
+        else {
+            childData = [
+                {
+                    count: formatNumber(counts.subawardCount),
+                    name: 'Sub-Awards',
+                    funcName: 'jumpToAwardHistoryTableSubAwardsTab',
+                    glossary: 'contract',
+                    postText: ''
+                }
+            ];
+        }
         return (
             <div className="related-awards__label related-awards__label_count">
                 <div className="related-awards__counts">
@@ -74,7 +95,7 @@ export default class RelatedAwards extends React.Component {
                         <button
                             key={`${data.glossary}count`}
                             className="award-viz__button"
-                            onClick={this[`jumpToReferencedAwardsTable${data.funcName}Tab`]}>
+                            onClick={this[`${data.funcName}`]}>
                             {data.count}
                         </button>
                     ))}
@@ -82,7 +103,7 @@ export default class RelatedAwards extends React.Component {
                 <div className="related-awards__description">
                     {map(childData, (data) => (
                         <div key={`${data.glossary}text`} className="related-awards__text">
-                            {data.name} {data.count === 1 ? 'Order' : 'Orders'}
+                            {data.name} {data.postText}
                         </div>
                     ))}
                 </div>


### PR DESCRIPTION
**High level description:**

Adds the related awards section to the contracts v2 page.

**Technical details:**

* add counts from contract subawards to related awards section

* add subawards section for contracts

* dd another jumptosection for subawards tab in history table

* update post text

**JIRA Ticket:**
[DEV-3814](https://federal-spending-transparency.atlassian.net/browse/DEV-3814)

**Mockup:**
https://bahdigital.invisionapp.com/share/9EIABE5KQ24#/screens/296011639

The following are ALL required for the PR to be merged (in ascending LOE):
- [x] Link to this PR in JIRA ticket
- [x] Tagged Design, Testing, and Code Reviewers in `#us-ux-frontend` Slack Channel in the thread under the Post from Github for their SA
- [ ] Scheduled demo including Design/Testing/Front-end `if applicable`
- [N/A] Provided instructions for testing in JIRA (for benefit of testing) and PR (for benefit of code reviewer) `if applicable`
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [ ] Design review complete `if applicable`
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged `if applicable`
- [ ] Code review complete
