### PR TITLE
Dev-3815 Federal Account Table Button is First

### DIFF
--- a/src/js/components/awardv2/shared/federalAccounts/FederalAccountsViz.jsx
+++ b/src/js/components/awardv2/shared/federalAccounts/FederalAccountsViz.jsx
@@ -93,17 +93,17 @@ export default class FederalAccountsViz extends React.Component {
                 <div className="federal-accounts-results">
                     <div className="view-buttons">
                         <ViewTypeButton
-                            value="tree"
-                            label="Treemap"
-                            icon="th-large"
-                            changeView={this.props.changeView}
-                            active={isTreeView} />
-                        <ViewTypeButton
                             value="table"
                             label="Table"
                             icon="table"
                             changeView={this.props.changeView}
                             active={!isTreeView} />
+                        <ViewTypeButton
+                            value="tree"
+                            label="Treemap"
+                            icon="th-large"
+                            changeView={this.props.changeView}
+                            active={isTreeView} />
                     </div>
                     {!isTreeView && <FederalAccountsTable {...this.props} />}
                     <div


### PR DESCRIPTION
**High level description:**

Moves the federal account table button to the left of the tree-map button.

**Technical details:**

N/A

**JIRA Ticket:**
[DEV-3815](https://federal-spending-transparency.atlassian.net/browse/DEV-3815)

**Mockup:**
https://bahdigital.invisionapp.com/share/9EIABE5KQ24#/screens/296011639

The following are ALL required for the PR to be merged (in ascending LOE):
- [x] Link to this PR in JIRA ticket
- [x] Tagged Design, Testing, and Code Reviewers in `#us-ux-frontend` Slack Channel in the thread under the Post from Github for their SA
- [ ] Scheduled demo including Design/Testing/Front-end `if applicable`
- [N/A] Provided instructions for testing in JIRA (for benefit of testing) and PR (for benefit of code reviewer) `if applicable`
- [N/A] Verified cross-browser compatibility
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [ ] Design review complete `if applicable`
- [N/A] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged `if applicable`
- [ ] Code review complete
