### PR TITLE
Dev-3094 Dates Section Labels Empty Strings for Unknown Award Type

### DIFF
--- a/src/js/components/awardv2/shared/overview/AwardDates.jsx
+++ b/src/js/components/awardv2/shared/overview/AwardDates.jsx
@@ -113,11 +113,22 @@ export default class AwardDates extends React.Component {
         return { startDate, endDate };
     }
 
+    titles() {
+        const { awardType } = this.props;
+        if (!awardType) return ['', '', ''];
+        return [
+            titles[awardType][0],
+            titles[awardType][1],
+            titles[awardType][2]
+        ];
+    }
+
     render() {
-        const { dates, awardType } = this.props;
+        const { dates } = this.props;
         const { startDate, endDate } = this.datesByAwardType();
         const { timeline, remainingText, remainingLabel } = this.timelineInfo(startDate, endDate);
         const tooltipInfo = this.tooltipInfo();
+        const datesTitles = this.titles();
 
         return (
             <AwardSection type="column">
@@ -139,7 +150,7 @@ export default class AwardDates extends React.Component {
                     {timeline}
                     <div className="award-dates__row">
                         <div className="award-dates__label">
-                            {titles[awardType][0]}
+                            {datesTitles[0]}
                         </div>
                         <div className="award-dates__date">
                             {dates.startDateLong || 'not provided'}
@@ -147,17 +158,17 @@ export default class AwardDates extends React.Component {
                     </div>
                     <div className="award-dates__row">
                         <div className="award-dates__label">
-                            {titles[awardType][1]}
+                            {datesTitles[1]}
                         </div>
                         <div className="award-dates__date">
                             {dates.endDateLong || 'not provided'}
                         </div>
                     </div>
                     {
-                        titles[awardType][2] &&
+                        datesTitles[2] &&
                         <div className="award-dates__row">
                             <div className="award-dates__label">
-                                {titles[awardType][2]}
+                                {datesTitles[2]}
                             </div>
                             <div className="award-dates__date">
                                 {dates.potentialEndDateLong || 'not provided'}


### PR DESCRIPTION
**High level description:**

Updates the dates section to display no labels when we do not know the award type.

**Technical details:**

Updates the dates section to display no labels when we do not know the award type.

**JIRA Ticket:**
[DEV-3094](https://federal-spending-transparency.atlassian.net/browse/DEV-3094)

**Testing**

1. Navigate to this url `http://localhost:3000/#/award/ASST_NON_PA26H084068-08S_8630`.
2. Verify the page is not broken and the no titles are displayed for the dates section.

The following are ALL required for the PR to be merged (in ascending LOE):
- [x] Link to this PR in JIRA ticket
- [x] Tagged Design, Testing, and Code Reviewers in `#us-ux-frontend` Slack Channel in the thread under the Post from Github for their SA
- [ ] Scheduled demo including Design/Testing/Front-end `if applicable`
- [x] Provided instructions for testing in JIRA (for benefit of testing) and PR (for benefit of code reviewer) `if applicable`
- [x] Verified cross-browser compatibility
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [ ] Design review complete `if applicable`
- [N/A] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged `if applicable`
- [ ] Code review complete
