### PR TITLE
[DEV-3743] refactoring spendingScenario logic to show N/A Chart in all scenarios 

### DIFF
--- a/src/js/helpers/awardAmountHelper.js
+++ b/src/js/helpers/awardAmountHelper.js
@@ -42,7 +42,10 @@ export const getAscendingSpendingCategoriesByAwardType = (awardType, awardAmount
 export const determineSpendingScenarioAsstAwards = (awardAmountObj) => {
     const { _totalObligation, _nonFederalFunding, _totalFunding } = awardAmountObj;
     // if any of the values are negative, return insufficient data
-    if (_totalObligation < 0 || _nonFederalFunding < 0 || _totalObligation < 0) {
+    if (_totalObligation < 0 || _nonFederalFunding < 0 || _totalFunding < 0) {
+        return 'insufficientData';
+    }
+    else if (_totalObligation === 0 && _nonFederalFunding === 0 && _totalObligation === 0) {
         return 'insufficientData';
     }
     // if total funding is sum of obligation and non federal funding, return normal
@@ -59,10 +62,14 @@ export const determineSpendingScenarioAsstAwards = (awardAmountObj) => {
 // includes logic for idvs, contracts, loan award types
 export const determineSpendingScenario = (small = 0, bigger = 0, biggest = null) => {
     const allCategoriesAreInPlay = (small && bigger && biggest);
+
     if (small === 0 && bigger === 0 && biggest === 0) {
-        return null;
+        return 'insufficientData';
     }
-    if (allCategoriesAreInPlay && small >= 0) {
+    else if (small < 0 || bigger < 0 || biggest < 0) {
+        return 'insufficientData';
+    }
+    else if (allCategoriesAreInPlay) {
         if (small <= bigger && bigger <= biggest) {
             return 'normal';
         }
@@ -74,11 +81,8 @@ export const determineSpendingScenario = (small = 0, bigger = 0, biggest = null)
         }
     }
     else if (small >= 0) {
-        if (small <= bigger) {
+        if (small <= bigger && bigger > 0) {
             return 'normal';
-        }
-        else if (bigger < small) {
-            return 'exceedsBigger';
         }
     }
 


### PR DESCRIPTION
**High level description:**
ASST awards did not have as robust logic as IDVs/Contracts. Adding more robust logic to ensure insufficientData is returned when charting is not currently suitable.

**Technical details:**
Cases added:
- When all spending categories are zero, return insufficient data
- If any single spending category is negative, return insufficient data

- Removing exceedsBigger case from line 86 of `determineSpendingScenario` b/c loans don't
actually handle exceedsBigger at this time and the logic will only bring us to line 86 if we're dealing with a loan where !allCategoriesAreInPlay

- Lots of tests are added to ensure the expected behavior

**JIRA Ticket:**
[DEV-3743](https://federal-spending-transparency.atlassian.net/browse/DEV-3743)

The following are ALL required for the PR to be merged (in ascending LOE):
- [x] Link to this PR in JIRA ticket
- [x] Tagged Design, Testing, and Code Reviewers in `#us-ux-frontend` Slack Channel in the thread under the Post from Github for their SA
`N/A` Scheduled demo including Design/Testing/Front-end `if applicable`
- [x] Provided instructions for testing in JIRA (for benefit of testing) and PR (for benefit of code reviewer) `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` Design review complete `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged `if applicable`
- [x] Code review complete
