### PR TITLE
Warmfix Remove padding top cfda

### DIFF
--- a/src/_scss/pages/awardV2/awardFinancialAssistance.scss
+++ b/src/_scss/pages/awardV2/awardFinancialAssistance.scss
@@ -6,6 +6,7 @@
         .award__col__content {
             .award-expandable-section__primary {
                 h4 {
+                    margin-top: 0;
                     margin-bottom: 0;
                 }
                 h5 {


### PR DESCRIPTION
**High level description:**

Remove padding top from CFDA section header to keep space between sections and content consistent.