### PR TITLE
[warmfix-award-amounts-asst-tooltips] fixes non-federal funding tooltip

### DIFF
--- a/src/js/components/awardv2/shared/awardAmountsSection/Tooltips.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/Tooltips.jsx
@@ -101,7 +101,7 @@ export const NonFederalFundingTooltip = ({ total }) => (
         <h4 className="tooltip__title">Non-Federal Funding</h4>
         <h5 className="tooltip__amount--loans">{total}</h5>
         <div className="tooltip__text">
-            <p>This is the total amount of the award funded by non-federal source(s).</p>
+            <p>This is the amount funded by any non-federal source(s).</p>
         </div>
     </div>
 );


### PR DESCRIPTION
Changes verbiage to nonFederalFunding tooltip