### PR TITLE
[bug-dev-3900] fixes styles in IE for download button on AS2.0 Page

### DIFF
--- a/src/_scss/layouts/tabbedSearch/header/_downloadButton.scss
+++ b/src/_scss/layouts/tabbedSearch/header/_downloadButton.scss
@@ -1,7 +1,8 @@
 .download-wrap {
     display: none;
     @include media($tablet-screen) {
-        display: block;
+        display: flex;
+        flex: 1 1 0%;
     }
 
     position: relative;
@@ -11,18 +12,17 @@
         @include button-unstyled;
         padding: rem(8) rem(20);
         cursor: pointer;
-
+        
         @include display(flex);
         @include justify-content(center);
         @include align-items(center);
         position: relative;
-
         border: none;
         background-color: $color-primary;
-
-
+        
+        
         @include transition(opacity 0.2s ease-in-out);
-
+        
         .label {
             @include flex(1 1 auto);
             text-align: center;
@@ -32,17 +32,18 @@
             line-height: rem(18);
             font-weight: $font-semibold;
         }
-
+        
         &:hover, &:active {
             opacity: 1;
             background-color: $color-primary-darker;
         }
-
+        
         &[disabled], &.disabled {
             cursor: default;
             opacity: 0.4;
             border: 1px solid $color-white;
             background-color: transparent;
         }
+        margin-left: auto;
     }
 }


### PR DESCRIPTION
**High level description:**
Adds more flex box to fix IE flexbog bug ❓ 

![image](https://user-images.githubusercontent.com/12897813/69450231-b2eebf80-0d2a-11ea-90db-3fd33fe8112a.png)


**JIRA Ticket:**
[DEV-3900](https://federal-spending-transparency.atlassian.net/browse/DEV-3900)

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
- [ ] Should this be a hotfix? @jonhill13 @ebdabbs 