### PR TITLE
[FTR/DEV-3608] adding link to prime award id in SubAward Advanced Search

### DIFF
--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -103,7 +103,7 @@ export default class ResultsTable extends React.Component {
             }
             else {
                 // primeAwardId null case
-                props.value = 'N/A';
+                props.value = '- -';
             }
         }
 

--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { isAwardAggregate } from 'helpers/awardSummaryHelper';
 import { awardTableColumnTypes } from 'dataMapping/search/awardTableColumnTypes';
 
 import IBTable from 'components/sharedComponents/IBTable/IBTable';
@@ -96,6 +97,9 @@ export default class ResultsTable extends React.Component {
                 cellClass = ResultsTableLinkCell;
                 props.id = primeAwardId;
                 props.column = 'award';
+                props.value = isAwardAggregate(primeAwardId)
+                    ? primeAwardId
+                    : props.value;
             }
             else {
                 // primeAwardId null case

--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -90,6 +90,18 @@ export default class ResultsTable extends React.Component {
             props.id = this.props.results[rowIndex].prime_award_recipient_id;
             props.column = 'recipient';
         }
+        else if (column.columnName === 'Prime Award ID') {
+            const primeAwardId = this.props.results[rowIndex].prime_award_generated_internal_id;
+            if (primeAwardId) {
+                cellClass = ResultsTableLinkCell;
+                props.id = primeAwardId;
+                props.column = 'award';
+            }
+            else {
+                // primeAwardId null case
+                props.value = 'N/A';
+            }
+        }
 
         return React.createElement(
             cellClass,


### PR DESCRIPTION
**High level description:**
Adds link to go to the Parent or Prime Award Id page from advanced search.

**Technical details:**
`bodyCellRender` in `ResultsTable` component looks for column, handles case where id is truthy -- providing a link -- and falsy, providing a `N/A`

**JIRA Ticket:**
[DEV-3608](https://federal-spending-transparency.atlassian.net/browse/DEV-3608)
& [DEV-3490](https://federal-spending-transparency.atlassian.net/browse/DEV-3490)

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
