### PR TITLE
[DEV-4013] Fixes Award Summary Tooltips in Internet Explorer

### DIFF
--- a/src/_scss/components/tooltips/_index.scss
+++ b/src/_scss/components/tooltips/_index.scss
@@ -1,8 +1,10 @@
 .tooltip-wrapper {
     div:first-of-type {
-        width:100%;
+        display: flex;
+    }
+    &.award-amounts-tt__wrapper div:first-of-type {
+        width: 100%;
         height: 100%;
-        display: flex; 
     }
     &.award-section-tt div:first-of-type {
         flex-direction: column;

--- a/src/js/components/awardv2/shared/awardAmountsSection/Tooltips.jsx
+++ b/src/js/components/awardv2/shared/awardAmountsSection/Tooltips.jsx
@@ -316,6 +316,14 @@ export const getTooltipPropsByAwardTypeAndSpendingCategory = (type, category, da
             }
         }
     };
-    if (Object.keys(map).includes(type)) return map[type][category];
-    return map.asst[category];
+    if (Object.keys(map).includes(type)) {
+        return {
+            className: 'award-amounts-tt__wrapper',
+            ...map[type][category]
+        };
+    }
+    return {
+        className: 'award-amounts-tt__wrapper',
+        ...map.asst[category]
+    };
 };


### PR DESCRIPTION
**High level description:**
Style bug in Award Summary 2.0 tooltips w/ integration of component library tooltips. Only existed in Internet Explorer.

**Technical details:**
A 100% width and height was applied to the `first-of-type` divs under the tooltip-wrapper parent div.

This was only necessary for the tooltips inside the award amounts chart.

- Added a new class to these tooltips
- Scoped 100% width & height for first div to this new class

**JIRA Ticket:**
[DEV-4013](https://federal-spending-transparency.atlassian.net/browse/DEV-4013)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete