### PR TITLE
[DEV-1976] Adds spacing to items within the Award Overview Section, w/ IE polish

### DIFF
--- a/src/_scss/pages/awardV2/visualizations/overview/overview.scss
+++ b/src/_scss/pages/awardV2/visualizations/overview/overview.scss
@@ -22,6 +22,9 @@
             }
           }
         }
+        .award-overview-column__spacing {
+          padding: 0 rem(15);
+        }
         // header
         .award-viz__heading {
             @include display(flex);
@@ -38,7 +41,6 @@
         // body
         .award-overview__body {
             @include flex(1 1 auto);
-            padding: 0 rem(10);
             @include media($medium-screen) {
                 @include flex(0 0 25%);
             }

--- a/src/_scss/pages/awardV2/visualizations/overview/overview.scss
+++ b/src/_scss/pages/awardV2/visualizations/overview/overview.scss
@@ -15,7 +15,8 @@
           @include flex(0 0 auto);
           width: 100%;
           @include media($tablet-screen) {
-              @include flex(1 0 45%);
+              // IE offset for padding in .award-overview-column__spacing not :face-palm:
+              @include flex(0 0 47%);
           }
           &.first {
             padding-bottom: rem(30);
@@ -25,7 +26,11 @@
           }
         }
         .award-overview-column__spacing {
-          padding: 0 rem(15);
+          @include media($tablet-screen) {
+            &:nth-child(odd) {
+              padding-right: rem(15);
+            }
+          }
         }
         // header
         .award-viz__heading {

--- a/src/_scss/pages/awardV2/visualizations/overview/overview.scss
+++ b/src/_scss/pages/awardV2/visualizations/overview/overview.scss
@@ -11,7 +11,9 @@
     }
     .award__col {
         .award-overview-column {
-          @include flex(0 0 100%);
+          // flex 100% not working in IE
+          @include flex(0 0 auto);
+          width: 100%;
           @include media($tablet-screen) {
               @include flex(1 0 45%);
           }

--- a/src/_scss/pages/awardV2/visualizations/overview/overview.scss
+++ b/src/_scss/pages/awardV2/visualizations/overview/overview.scss
@@ -13,7 +13,7 @@
         .award-overview-column {
           @include flex(0 0 100%);
           @include media($tablet-screen) {
-              @include flex(0 0 50%);
+              @include flex(1 0 45%);
           }
           &.first {
             padding-bottom: rem(30);
@@ -37,6 +37,7 @@
         .award-overview-title {
             font-size: rem(16);
             margin-top: 0;
+            align-items: center;
         }
         // body
         .award-overview__body {

--- a/src/js/components/awardv2/financialAssistance/CFDAOverview.jsx
+++ b/src/js/components/awardv2/financialAssistance/CFDAOverview.jsx
@@ -11,7 +11,7 @@ const propTypes = {
 const CFDAOverview = ({
     cfdaPropgram
 }) => (
-    <div className="award-overview__right-section__cfda award-overview-column first">
+    <div className="award-overview__right-section__cfda award-overview-column first award-overview-column__spacing">
         <h6 className="award-overview-title">
             CFDA Program / Assistance Listing
             <TooltipWrapper

--- a/src/js/components/awardv2/shared/overview/AwardDates.jsx
+++ b/src/js/components/awardv2/shared/overview/AwardDates.jsx
@@ -108,7 +108,7 @@ export default class AwardDates extends React.Component {
         const datesTitles = this.titles();
 
         return (
-            <div className="award-dates award-overview-column">
+            <div className="award-dates award-overview-column award-overview-column__spacing">
                 <div className="award-dates__heading">
                     <h6 className="award-overview-title award-dates__title">
                         Dates

--- a/src/js/components/awardv2/shared/overview/AwardingAgency.jsx
+++ b/src/js/components/awardv2/shared/overview/AwardingAgency.jsx
@@ -13,7 +13,7 @@ const propTypes = {
 };
 
 const AwardingAgency = ({ awardingAgency }) => (
-    <AwardSection className="award-overview__left-section__awarding award-overview-column first">
+    <AwardSection className="award-overview__left-section__awarding award-overview-column first award-overview-column__spacing">
         <h6 className="award-overview-title">Awarding Agency</h6>
         <h5 className="award-overview__left-section__agency-name">
             <a href={`/#/agency/${awardingAgency.id}`}>

--- a/src/js/components/awardv2/shared/overview/Recipient.jsx
+++ b/src/js/components/awardv2/shared/overview/Recipient.jsx
@@ -87,7 +87,7 @@ const Recipient = ({
     };
 
     return (
-        <AwardSection className="award-overview__left-section__recipient award-overview-column">
+        <AwardSection className="award-overview__left-section__recipient award-overview-column award-overview-column__spacing">
             <h6 className="award-overview-title">Recipient</h6>
             {recipientComponent()}
             <RecipientAddress

--- a/src/js/components/awardv2/shared/overview/RelatedAwards.jsx
+++ b/src/js/components/awardv2/shared/overview/RelatedAwards.jsx
@@ -145,7 +145,7 @@ export default class RelatedAwards extends React.Component {
         }
 
         return (
-            <div className="award-viz related-awards award-overview-column first">
+            <div className="award-viz related-awards award-overview-column award-overview-column__spacing first">
                 <h6 className="award-overview-title related-awards__title">
                     Related Awards
                     <TooltipWrapper className="award-section-tt" icon="info" left tooltipComponent={tooltipInfo} />


### PR DESCRIPTION
**High level description:**
Restores first iteration of PR #1419 w/ some added Internet Explorer polish to the new styles.

**Technical details:**
Adds `flex(1, 0 45%)` rather than ...50% for IE problems w/ calculating available width.

**JIRA Ticket:**
[DEV-1976](https://federal-spending-transparency.atlassian.net/browse/DEV-1976)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A`All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A`API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`

Reviewer(s):
`N/A`Design review complete `if applicable`
`N/A`[API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
