### PR TITLE
[DEV-3967] Award page links use new generated_internal_id

### DIFF
--- a/src/js/components/awardv2/idv/referencedAwards/ReferencedAwardsTable.jsx
+++ b/src/js/components/awardv2/idv/referencedAwards/ReferencedAwardsTable.jsx
@@ -60,7 +60,7 @@ export default class ReferencedAwardsTable extends React.Component {
                     {columns.map((col) => {
                         let data = row[col.name];
                         if (col.name === 'piid') {
-                            data = (<a href={`/#/award/${row.id}`}>{row[col.name]}</a>);
+                            data = (<a href={`/#/award/${row.internalId}`}>{row[col.name]}</a>);
                         }
                         if (col.name === 'awardingAgency' && row.awardingAgencyId) {
                             data = (<a href={`/#/agency/${row.awardingAgencyId}`}>{row[col.name]}</a>);

--- a/src/js/components/awardv2/table/FederalAccountTable.jsx
+++ b/src/js/components/awardv2/table/FederalAccountTable.jsx
@@ -81,7 +81,7 @@ export default class FedAccountTable extends React.Component {
         const isLast = columnIndex === this.tableMapping.table._order.length - 1;
         let link;
         if (column === 'id') {
-            link = item.awardId ? `#/award/${item.awardId}` : null;
+            link = item.generatedId ? `#/award/${item.generatedId}` : null;
         }
         if (column === 'agency') {
             link = item.fundingAgencyId ? `#/agency/${item.fundingAgencyId}` : null;

--- a/src/js/components/keyword/table/ResultsTable.jsx
+++ b/src/js/components/keyword/table/ResultsTable.jsx
@@ -83,7 +83,7 @@ export default class ResultsTable extends React.Component {
 
         if (column.columnName === 'Award ID') {
             cellClass = ResultsTableLinkCell;
-            props.id = parseInt(this.props.results[rowIndex].internal_id, 10);
+            props.id = this.props.results[rowIndex].generated_internal_id;
             props.column = 'award';
         }
 


### PR DESCRIPTION
**High level description:**
Updating links to use the new human readable id.

**Technical details:**
Mostly updating the `parseApiCallResponse` methods to replace relevant result-storage-objects with the `generated_internal_id` value.

**JIRA Ticket:**
[DEV-3967](https://federal-spending-transparency.atlassian.net/browse/DEV-3967)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
