### PR TITLE
Ops-908 Remove Jquery by Removing USWDS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1725,7 +1725,8 @@
         "abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "dev": true
         },
         "accepts": {
             "version": "1.3.7",
@@ -1914,12 +1915,14 @@
         "aproba": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+            "dev": true
         },
         "are-we-there-yet": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
             "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+            "dev": true,
             "requires": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -1973,7 +1976,8 @@
         "array-find-index": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+            "dev": true
         },
         "array-flatten": {
             "version": "1.1.1",
@@ -2123,7 +2127,8 @@
         "async-foreach": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-            "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
+            "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+            "dev": true
         },
         "async-limiter": {
             "version": "1.0.1",
@@ -2610,6 +2615,7 @@
             "version": "0.0.9",
             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+            "dev": true,
             "requires": {
                 "inherits": "~2.0.0"
             }
@@ -2696,19 +2702,6 @@
             "requires": {
                 "base64-js": "0.0.2",
                 "to-utf8": "0.0.1"
-            }
-        },
-        "bourbon": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/bourbon/-/bourbon-4.3.4.tgz",
-            "integrity": "sha1-TaOAAp6SwMj5dkx3lFGhNLEefMM="
-        },
-        "bourbon-neat": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/bourbon-neat/-/bourbon-neat-1.9.1.tgz",
-            "integrity": "sha512-W4gjJx1j+KPNF8Bg/3ecaTHPMC7IJ2pFKmYEZanWtzFk9MpM9kn+f14iXypIj8htHMRmzVByhzFhVWwuDKSTYg==",
-            "requires": {
-                "node-sass": "^4.1.1"
             }
         },
         "bowser": {
@@ -3083,12 +3076,14 @@
         "camelcase": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+            "dev": true
         },
         "camelcase-keys": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+            "dev": true,
             "requires": {
                 "camelcase": "^2.0.0",
                 "map-obj": "^1.0.0"
@@ -3288,11 +3283,6 @@
                 }
             }
         },
-        "classlist-polyfill": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
-            "integrity": "sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4="
-        },
         "classnames": {
             "version": "2.2.6",
             "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
@@ -3352,6 +3342,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+            "dev": true,
             "requires": {
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1",
@@ -3402,7 +3393,8 @@
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
         },
         "collection-visit": {
             "version": "1.0.0",
@@ -3582,7 +3574,8 @@
         "console-control-strings": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+            "dev": true
         },
         "constants-browserify": {
             "version": "1.0.0",
@@ -3756,24 +3749,6 @@
                 "ripemd160": "^2.0.0",
                 "safe-buffer": "^5.0.1",
                 "sha.js": "^2.4.8"
-            }
-        },
-        "cross-spawn": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.2.3.tgz",
-            "integrity": "sha1-+sViAt/T0N2GF3jy2iA79DS7ghw=",
-            "requires": {
-                "cross-spawn-async": "^2.2.2",
-                "spawn-sync": "^1.0.15"
-            }
-        },
-        "cross-spawn-async": {
-            "version": "2.2.5",
-            "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
-            "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
-            "requires": {
-                "lru-cache": "^4.0.0",
-                "which": "^1.2.8"
             }
         },
         "crypto-browserify": {
@@ -4666,6 +4641,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+            "dev": true,
             "requires": {
                 "array-find-index": "^1.0.1"
             }
@@ -4825,7 +4801,8 @@
         "decamelize": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
         },
         "decode-uri-component": {
             "version": "0.2.0",
@@ -4952,7 +4929,8 @@
         "delegates": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+            "dev": true
         },
         "depd": {
             "version": "1.1.2",
@@ -6503,6 +6481,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+            "dev": true,
             "requires": {
                 "path-exists": "^2.0.0",
                 "pinkie-promise": "^2.0.0"
@@ -7153,6 +7132,7 @@
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
             "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -7193,6 +7173,7 @@
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+            "dev": true,
             "requires": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -7208,6 +7189,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
             "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+            "dev": true,
             "requires": {
                 "globule": "^1.0.0"
             }
@@ -7239,12 +7221,14 @@
         "get-caller-file": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+            "dev": true
         },
         "get-stdin": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+            "dev": true
         },
         "get-stream": {
             "version": "4.1.0",
@@ -7379,6 +7363,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
             "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+            "dev": true,
             "requires": {
                 "glob": "~7.1.1",
                 "lodash": "~4.17.10",
@@ -7518,7 +7503,8 @@
         "has-unicode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+            "dev": true
         },
         "has-value": {
             "version": "1.0.0",
@@ -8008,12 +7994,14 @@
         "in-publish": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-            "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
+            "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
+            "dev": true
         },
         "indent-string": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
             "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+            "dev": true,
             "requires": {
                 "repeating": "^2.0.0"
             }
@@ -8167,7 +8155,8 @@
         "invert-kv": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
         },
         "ip": {
             "version": "1.1.5",
@@ -8332,6 +8321,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+            "dev": true,
             "requires": {
                 "number-is-nan": "^1.0.0"
             }
@@ -8340,6 +8330,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "dev": true,
             "requires": {
                 "number-is-nan": "^1.0.0"
             }
@@ -8494,7 +8485,8 @@
         "is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
         },
         "is-windows": {
             "version": "1.0.2",
@@ -9843,11 +9835,6 @@
                 }
             }
         },
-        "jquery": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
-            "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
-        },
         "js-base64": {
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
@@ -10065,6 +10052,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "dev": true,
             "requires": {
                 "invert-kv": "^1.0.0"
             }
@@ -10094,6 +10082,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "parse-json": "^2.2.0",
@@ -10269,6 +10258,7 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+            "dev": true,
             "requires": {
                 "currently-unhandled": "^0.4.1",
                 "signal-exit": "^3.0.0"
@@ -10284,6 +10274,7 @@
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
             "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+            "dev": true,
             "requires": {
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
@@ -10346,7 +10337,8 @@
         "map-obj": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+            "dev": true
         },
         "map-visit": {
             "version": "1.0.0",
@@ -10502,6 +10494,7 @@
             "version": "3.7.0",
             "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+            "dev": true,
             "requires": {
                 "camelcase-keys": "^2.0.0",
                 "decamelize": "^1.1.2",
@@ -10943,6 +10936,7 @@
             "version": "3.8.0",
             "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
             "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+            "dev": true,
             "requires": {
                 "fstream": "^1.0.0",
                 "glob": "^7.0.3",
@@ -10961,7 +10955,8 @@
                 "semver": {
                     "version": "5.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                    "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+                    "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+                    "dev": true
                 }
             }
         },
@@ -11048,6 +11043,7 @@
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.0.tgz",
             "integrity": "sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==",
+            "dev": true,
             "requires": {
                 "async-foreach": "^0.1.3",
                 "chalk": "^1.1.1",
@@ -11072,6 +11068,7 @@
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
                     "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+                    "dev": true,
                     "requires": {
                         "lru-cache": "^4.0.1",
                         "which": "^1.2.9"
@@ -11119,6 +11116,7 @@
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+            "dev": true,
             "requires": {
                 "abbrev": "1"
             }
@@ -11159,11 +11157,6 @@
                 "sort-keys": "^1.0.0"
             }
         },
-        "normalize.css": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-3.0.3.tgz",
-            "integrity": "sha1-rMACYuI1osqpE2Oi5eO/pPitBcY="
-        },
         "npm-run-path": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -11176,6 +11169,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+            "dev": true,
             "requires": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -11200,7 +11194,8 @@
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
         },
         "nwsapi": {
             "version": "2.2.0",
@@ -11534,24 +11529,22 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "dev": true,
             "requires": {
                 "lcid": "^1.0.0"
             }
         },
-        "os-shim": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-            "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc="
-        },
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
         },
         "osenv": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+            "dev": true,
             "requires": {
                 "os-homedir": "^1.0.0",
                 "os-tmpdir": "^1.0.0"
@@ -11677,6 +11670,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "dev": true,
             "requires": {
                 "error-ex": "^1.2.0"
             }
@@ -11723,6 +11717,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+            "dev": true,
             "requires": {
                 "pinkie-promise": "^2.0.0"
             }
@@ -11767,6 +11762,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "pify": "^2.0.0",
@@ -11803,17 +11799,20 @@
         "pify": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true
         },
         "pinkie": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
         },
         "pinkie-promise": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
             "requires": {
                 "pinkie": "^2.0.0"
             }
@@ -11927,11 +11926,6 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/point-geometry/-/point-geometry-0.0.0.tgz",
             "integrity": "sha1-b8vK16gDtkGCR91uScKFPFhNr/c="
-        },
-        "politespace": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/politespace/-/politespace-0.1.4.tgz",
-            "integrity": "sha1-pVWcGBu27leZCzrouK07TbfS8Ro="
         },
         "portfinder": {
             "version": "1.0.25",
@@ -13118,27 +13112,6 @@
                 }
             }
         },
-        "prismjs": {
-            "version": "1.17.1",
-            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-            "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
-            "requires": {
-                "clipboard": "^2.0.0"
-            },
-            "dependencies": {
-                "clipboard": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
-                    "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
-                    "optional": true,
-                    "requires": {
-                        "good-listener": "^1.2.2",
-                        "select": "^1.1.2",
-                        "tiny-emitter": "^2.0.0"
-                    }
-                }
-            }
-        },
         "private": {
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -13229,7 +13202,8 @@
         "pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "dev": true
         },
         "psl": {
             "version": "1.4.0",
@@ -13844,6 +13818,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+            "dev": true,
             "requires": {
                 "load-json-file": "^1.0.0",
                 "normalize-package-data": "^2.3.2",
@@ -13854,6 +13829,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+            "dev": true,
             "requires": {
                 "find-up": "^1.0.0",
                 "read-pkg": "^1.0.0"
@@ -13896,6 +13872,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
             "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+            "dev": true,
             "requires": {
                 "indent-string": "^2.1.0",
                 "strip-indent": "^1.0.1"
@@ -14113,6 +14090,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+            "dev": true,
             "requires": {
                 "is-finite": "^1.0.0"
             }
@@ -14174,12 +14152,14 @@
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
         },
         "require-main-filename": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "dev": true
         },
         "require-uncached": {
             "version": "1.0.3",
@@ -14423,6 +14403,7 @@
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
             "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+            "dev": true,
             "requires": {
                 "glob": "^7.0.0",
                 "lodash": "^4.0.0",
@@ -14479,6 +14460,7 @@
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
             "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+            "dev": true,
             "requires": {
                 "js-base64": "^2.1.8",
                 "source-map": "^0.4.2"
@@ -14488,6 +14470,7 @@
                     "version": "0.4.4",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                    "dev": true,
                     "requires": {
                         "amdefine": ">=0.0.4"
                     }
@@ -14641,7 +14624,8 @@
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
         },
         "set-value": {
             "version": "2.0.1",
@@ -15050,15 +15034,6 @@
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
             "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
         },
-        "spawn-sync": {
-            "version": "1.0.15",
-            "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-            "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-            "requires": {
-                "concat-stream": "^1.4.7",
-                "os-shim": "^0.1.2"
-            }
-        },
         "spdx-correct": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -15293,6 +15268,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
             "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
+            "dev": true,
             "requires": {
                 "readable-stream": "^2.0.1"
             }
@@ -15378,6 +15354,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "dev": true,
             "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -15438,6 +15415,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "dev": true,
             "requires": {
                 "is-utf8": "^0.2.0"
             }
@@ -15456,6 +15434,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
             "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+            "dev": true,
             "requires": {
                 "get-stdin": "^4.0.1"
             }
@@ -15812,6 +15791,7 @@
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
             "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+            "dev": true,
             "requires": {
                 "block-stream": "*",
                 "fstream": "^1.0.12",
@@ -16181,7 +16161,8 @@
         "trim-newlines": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-            "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+            "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+            "dev": true
         },
         "trim-right": {
             "version": "1.0.1",
@@ -16193,6 +16174,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
             "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
+            "dev": true,
             "requires": {
                 "glob": "^7.1.2"
             }
@@ -16543,21 +16525,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
-        },
-        "uswds": {
-            "version": "0.13.3",
-            "resolved": "https://registry.npmjs.org/uswds/-/uswds-0.13.3.tgz",
-            "integrity": "sha1-cwtYAjqiIhL95sY6XutN0U36bho=",
-            "requires": {
-                "bourbon": "^4.2.6",
-                "bourbon-neat": "^1.7.3",
-                "classlist-polyfill": "^1.0.3",
-                "cross-spawn": "^2.1.5",
-                "jquery": "^2.2.0",
-                "normalize.css": "^3.0.3",
-                "politespace": "0.1.4",
-                "prismjs": "^1.5.1"
-            }
         },
         "util": {
             "version": "0.11.1",
@@ -17457,7 +17424,8 @@
         "which-module": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-            "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+            "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+            "dev": true
         },
         "whoots-js": {
             "version": "2.1.0",
@@ -17468,6 +17436,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
             "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+            "dev": true,
             "requires": {
                 "string-width": "^1.0.2 || 2"
             }
@@ -17496,6 +17465,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true,
             "requires": {
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1"
@@ -17561,17 +17531,20 @@
         "y18n": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+            "dev": true
         },
         "yallist": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+            "dev": true
         },
         "yargs": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
             "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+            "dev": true,
             "requires": {
                 "camelcase": "^3.0.0",
                 "cliui": "^3.2.0",
@@ -17591,7 +17564,8 @@
                 "camelcase": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+                    "dev": true
                 }
             }
         },
@@ -17599,6 +17573,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
             "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+            "dev": true,
             "requires": {
                 "camelcase": "^3.0.0"
             },
@@ -17606,7 +17581,8 @@
                 "camelcase": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+                    "dev": true
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
         "regenerator-runtime": "^0.13.2",
         "svg4everybody": "^2.0.3",
         "tinycolor2": "^1.3.0",
-        "uswds": "^0.13.1",
         "xmldoc": "^0.4.0"
     }
 }


### PR DESCRIPTION
**Do Not Merge**

- [x] @plooksm tested in sandbox.

- [x] I do not think this is the correct solution.

**High level description:**

Removes the USWDS NPM package.

**Technical details:**

* removes USWDS npm package
* There is a jQuery bundle in out static S3 bucket that our app references.  I initially did not know where this jQuery was coming from but looking at the bundles in the bucket I thought it was coming from bootstrap. On further investigation, there were four references to jQuery in our package lock. Three of them were from the jQuery package and one was from the USWDS dependencies.  I initially upgraded the USWDS package from 0.13.1 to 1.6 which removed jQuery altogether. After consulting the front-end team, we thought we were not using USWDS anywhere. This PR removes the USWDS dependency. I took a quick look locally and in sandbox and did not notice any changes.

**JIRA Ticket:**
[Ops-908](https://federal-spending-transparency.atlassian.net/browse/Ops-908)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
- [x] Code review complete
