### PR TITLE
[data-transparency-ui] migrating to semver for data-transparency-ui dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4764,8 +4764,8 @@
             }
         },
         "data-transparency-ui": {
-            "version": "github:fedspendingtransparency/data-transparency-ui#9d7e905c0eed442a068c65f5f0f3870876719174",
-            "from": "github:fedspendingtransparency/data-transparency-ui#master",
+            "version": "github:fedspendingtransparency/data-transparency-ui#402022054ec84c30a87df05dc00a4e9cdd07d475",
+            "from": "github:fedspendingtransparency/data-transparency-ui#v0.1.0",
             "requires": {
                 "@fortawesome/fontawesome-svg-core": "^1.2.25",
                 "@fortawesome/free-solid-svg-icons": "^5.11.2",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "d3-interpolate": "^1.1.4",
         "d3-scale": "^1.0.4",
         "d3-time": "^1.0.11",
-        "data-transparency-ui": "github:fedspendingtransparency/data-transparency-ui#master",
+        "data-transparency-ui": "github:fedspendingtransparency/data-transparency-ui#v0.1.0",
         "file-loader": "^3.0.1",
         "fixed-data-table": "0.6.3",
         "history": "^4.6.1",


### PR DESCRIPTION
Corresponding documentation [here](https://github.com/fedspendingtransparency/data-transparency-ui/pull/20)

- [x] local test
- [x] sandbox test

