### PR TITLE
[DEV-3836] Bug in IE when using TAS section of Advanced Search

### DIFF
--- a/src/js/components/search/filters/programSource/ProgramSourceSection.jsx
+++ b/src/js/components/search/filters/programSource/ProgramSourceSection.jsx
@@ -91,7 +91,8 @@ export default class ProgramSourceSection extends React.Component {
         });
     }
 
-    applyFilter() {
+    applyFilter(e) {
+        e.preventDefault();
         const components = this.state.components;
         if (this.state.activeTab === 'federal') {
             const identifier = `${components.aid}-${components.main}`;

--- a/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
+++ b/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
@@ -319,7 +319,8 @@ export class TopFilterBarContainer extends React.Component {
         if (props.federalAccounts && props.federalAccounts.count() > 0) {
             // federal account components have been selected
             selected = true;
-            const [...identifiers] = props.federalAccounts.keys();
+            // not working in IE
+            const [...identifiers] = props.federalAccounts.key();
             filter.values = identifiers;
         }
 
@@ -340,7 +341,8 @@ export class TopFilterBarContainer extends React.Component {
         if (props.treasuryAccounts && props.treasuryAccounts.count() > 0) {
             // treasury account components have been selected
             selected = true;
-            const [...identifiers] = props.treasuryAccounts.keys();
+            // not working in IE
+            const [...identifiers] = props.treasuryAccounts.key();
             filter.values = identifiers;
         }
 

--- a/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
+++ b/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
@@ -319,8 +319,7 @@ export class TopFilterBarContainer extends React.Component {
         if (props.federalAccounts && props.federalAccounts.count() > 0) {
             // federal account components have been selected
             selected = true;
-            // not working in IE
-            const [...identifiers] = props.federalAccounts.key();
+            const identifiers = Object.keys(props.federalAccounts.toObject());
             filter.values = identifiers;
         }
 
@@ -341,8 +340,7 @@ export class TopFilterBarContainer extends React.Component {
         if (props.treasuryAccounts && props.treasuryAccounts.count() > 0) {
             // treasury account components have been selected
             selected = true;
-            // not working in IE
-            const [...identifiers] = props.treasuryAccounts.key();
+            const identifiers = Object.keys(props.treasuryAccounts.toObject());
             filter.values = identifiers;
         }
 


### PR DESCRIPTION
**High level description:**
Uncaught exception was being thrown in console, resulting in page reload and redirect back to home page:

`value is not an iterable...` or something to that effect.

**Technical details:**
Identified the root cause as the method call `.keys()` on an immutable map. Appears that IE 11 is not supported by immutablejs? Not sure, but that appears to be the case at least with the `.keys` method.

**JIRA Ticket:**
[DEV-3836](https://federal-spending-transparency.atlassian.net/browse/DEV-3836)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
