### PR TITLE
[DEV-4121] Change url to file_url for download response

### DIFF
--- a/src/js/containers/award/AwardContainer.jsx
+++ b/src/js/containers/award/AwardContainer.jsx
@@ -168,7 +168,7 @@ export class AwardContainer extends React.Component {
 
         try {
             const { data } = await this.downloadRequest.promise;
-            this.props.setDownloadExpectedUrl(data.url);
+            this.props.setDownloadExpectedUrl(data.file_url);
             this.props.setDownloadExpectedFile(data.file_name);
             // disable download button
             this.props.setDownloadPending(true);

--- a/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
+++ b/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
@@ -193,7 +193,7 @@ export class BulkDownloadPageContainer extends React.Component {
 
         this.request.promise
             .then((res) => {
-                this.props.setDownloadExpectedUrl(res.data.url);
+                this.props.setDownloadExpectedUrl(res.data.file_url);
                 this.props.setDownloadExpectedFile(res.data.file_name);
                 this.props.setDownloadPending(true);
             })

--- a/src/js/containers/bulkDownload/modal/BulkDownloadBottomBarContainer.jsx
+++ b/src/js/containers/bulkDownload/modal/BulkDownloadBottomBarContainer.jsx
@@ -111,7 +111,7 @@ export class BulkDownloadBottomBarContainer extends React.Component {
     parseStatus(data) {
         if (data.status === 'finished') {
             // download is ready
-            this.downloadFile(data.url);
+            this.downloadFile(data.file_url);
             return;
         }
         else if (data.status === 'failed') {

--- a/src/js/containers/keyword/KeywordContainer.jsx
+++ b/src/js/containers/keyword/KeywordContainer.jsx
@@ -97,7 +97,7 @@ export class KeywordContainer extends React.Component {
 
         this.downloadRequest.promise
             .then((res) => {
-                this.props.setDownloadExpectedUrl(res.data.url);
+                this.props.setDownloadExpectedUrl(res.data.file_url);
                 this.props.setDownloadExpectedFile(res.data.file_name);
                 this.props.setDownloadPending(true);
             })

--- a/src/js/containers/search/modals/fullDownload/DownloadBottomBarContainer.jsx
+++ b/src/js/containers/search/modals/fullDownload/DownloadBottomBarContainer.jsx
@@ -211,12 +211,12 @@ export class DownloadBottomBarContainer extends React.Component {
         });
     }
 
-    downloadFile(file_url) {
+    downloadFile(fileUrl) {
         // stop monitoring for window close events
         window.removeEventListener('beforeunload', this.windowWillClose);
 
         // start the download
-        window.open(file_url, '_self');
+        window.open(fileUrl, '_self');
 
         // update redux
         this.props.resetDownload();

--- a/src/js/containers/search/modals/fullDownload/DownloadBottomBarContainer.jsx
+++ b/src/js/containers/search/modals/fullDownload/DownloadBottomBarContainer.jsx
@@ -112,7 +112,7 @@ export class DownloadBottomBarContainer extends React.Component {
         this.request.promise
             .then((res) => {
                 this.props.setDownloadExpectedFile(res.data.file_name);
-                this.props.setDownloadExpectedUrl(res.data.url);
+                this.props.setDownloadExpectedUrl(res.data.file_url);
                 this.checkStatus();
             })
             .catch((err) => {
@@ -171,7 +171,7 @@ export class DownloadBottomBarContainer extends React.Component {
     parseStatus(data) {
         if (data.status === 'finished') {
             // download is ready
-            this.downloadFile(data.url);
+            this.downloadFile(data.file_url);
             return;
         }
         else if (data.status === 'failed') {
@@ -211,12 +211,12 @@ export class DownloadBottomBarContainer extends React.Component {
         });
     }
 
-    downloadFile(url) {
+    downloadFile(file_url) {
         // stop monitoring for window close events
         window.removeEventListener('beforeunload', this.windowWillClose);
 
         // start the download
-        window.open(url, '_self');
+        window.open(file_url, '_self');
 
         // update redux
         this.props.resetDownload();

--- a/src/js/redux/actions/bulkDownload/bulkDownloadActions.js
+++ b/src/js/redux/actions/bulkDownload/bulkDownloadActions.js
@@ -59,7 +59,7 @@ export const resetDownload = () => ({
 });
 
 export const handleDownloadRequest = (res) => (dispatch) => {
-    dispatch(setDownloadExpectedUrl(res.url));
+    dispatch(setDownloadExpectedUrl(res.file_url));
     dispatch(setDownloadExpectedFile(res.file_name));
     dispatch(setDownloadPending(true));
 };

--- a/tests/containers/bulkDownload/mockData.js
+++ b/tests/containers/bulkDownload/mockData.js
@@ -168,14 +168,10 @@ export const mockStatusResponse = {
 };
 
 export const mockAwardDownloadResponse = {
-    status: 'ready',
-    total_rows: 1000,
     file_name: 'mock_file.zip',
-    total_size: 1000,
-    total_columns: 200,
-    message: null,
-    url: 'mockurl/mock_file.zip',
-    seconds_elapsed: '0.5001'
+    file_url: 'mockurl/mock_file.zip',
+    status_url: 'download/status?file_name=mock_file.zip',
+    download_request: {download_details: 'for award'}
 };
 
 export const mockArchiveResponse = {

--- a/tests/containers/bulkDownload/modal/BulkDownloadBottomBarContainer-test.jsx
+++ b/tests/containers/bulkDownload/modal/BulkDownloadBottomBarContainer-test.jsx
@@ -102,7 +102,7 @@ describe('BulkDownloadBottomBarContainer', () => {
         it('should download the file if the status is finished', () => {
             const response = Object.assign({}, mockStatusResponse, {
                 status: 'finished',
-                url: 'http://www.google.com'
+                file_url: 'http://www.google.com'
             });
             const container = shallow(<BulkDownloadBottomBarContainer
                 {...mockRedux}

--- a/tests/containers/search/modals/fullDownload/DownloadBottomBarContainer-test.jsx
+++ b/tests/containers/search/modals/fullDownload/DownloadBottomBarContainer-test.jsx
@@ -111,7 +111,7 @@ describe('DownloadBottomBarContainer', () => {
         it('should download the file if the status is finished', () => {
             const response = Object.assign({}, mockResponse, {
                 status: 'finished',
-                url: 'http://www.google.com'
+                file_url: 'http://www.google.com'
             });
             const container = shallow(<DownloadBottomBarContainer
                 {...mockRedux}

--- a/tests/containers/search/modals/fullDownload/mockFullDownload.js
+++ b/tests/containers/search/modals/fullDownload/mockFullDownload.js
@@ -25,7 +25,7 @@ export const mockResponse = {
     total_rows: 55555,
     file_name: "transaction_123.csv",
     status: "running",
-    url: "https://s3.amazonaws.com/award_123.zip",
+    file_url: "https://s3.amazonaws.com/award_123.zip",
     message: "Your file failed because the database crashed.",
     seconds_elapsed: 50
 };

--- a/tests/models/awardsV2/mockAwardApi.js
+++ b/tests/models/awardsV2/mockAwardApi.js
@@ -463,33 +463,24 @@ export const mockAwardFundingMetaData = {
 };
 
 export const mockFileDownloadResponseIdv = {
-    total_size: 35.055,
     file_name: `idv.zip`,
-    total_rows: 652,
-    total_columns: 27,
-    url: `S3/path_to/bucket/012_account_balances_20180613140845.zip`,
-    status: `finished`,
-    seconds_elapsed: `10.061132`
+    file_url: `S3/path_to/bucket/012_account_balances_20180613140845.zip`,
+    status_url: `download/status?file_name=idv.zip`,
+    download_request: {download_details: `for idv`}
 };
 
 export const mockFileDownloadResponseContract = {
-    total_size: 35.055,
     file_name: `contract.zip`,
-    total_rows: 652,
-    total_columns: 27,
-    url: `S3/path_to/bucket/012_account_balances_20180613140845.zip`,
-    status: `finished`,
-    seconds_elapsed: `10.061132`
+    file_url: `S3/path_to/bucket/012_account_balances_20180613140845.zip`,
+    status_url: `download/status?file_name=contract.zip`,
+    download_request: {download_details: `for contract`}
 };
 
 export const mockFileDownloadResponseAssistance = {
-    total_size: 35.055,
     file_name: `assistance.zip`,
-    total_rows: 652,
-    total_columns: 27,
-    url: `S3/path_to/bucket/012_account_balances_20180613140845.zip`,
-    status: `finished`,
-    seconds_elapsed: `10.061132`
+    file_url: `S3/path_to/bucket/012_account_balances_20180613140845.zip`,
+    status_url: `download/status?file_name=assistance.zip`,
+    download_request: {download_details: `for assistance`}
 };
 
 export const mockAwardFederalAccounts = {


### PR DESCRIPTION
**High level description:**

The response for the different download endpoints was updated and as a result, some fields were added and others had their names changed. This PR is to make the necessary changes to work with the new download endpoint responses.

**Technical details:**

All changes are to change `url` to `file_url` since there is now a `file_url` and a `status_url` on the `/api/v2/download/<type>/` endpoints.

Sample Old Response:
```{
    "status": "ready",
    "url": "https://files-nonprod.usaspending.gov/generated_downloads/dev/IDV_UNKNOWN_2020-01-10_H18M46S31395245.zip",
    "message": null,
    "file_name": "IDV_UNKNOWN_2020-01-10_H18M46S31395245.zip",
    "total_size": null,
    "total_columns": null,
    "total_rows": null,
    "seconds_elapsed": null
}
```

Sample New Response:
```
{
    "status_url": "http://localhost:8000/api/v2/download/status?file_name=IDV_UNKNOWN_2020-01-10_H17M40S19533231.zip",
    "file_name": "IDV_UNKNOWN_2020-01-10_H17M40S19533231.zip",
    "file_url": "/Users/sethstoudenmier/Documents/DATA_Act/projects/usaspending-api/csv_downloads/IDV_UNKNOWN_2020-01-10_H17M40S19533231.zip",
    "download_request": {
        "account_level": "treasury_account",
        "columns": [],
        "download_types": [
            "idv_federal_account_funding",
            "idv_orders",
            "idv_transaction_history"
        ],
        "file_format": "csv",
        "filters": {
            "award_type_codes": [
                "IDV_B_A",
                "B",
                "A",
                "D",
                "IDV_E",
                "IDV_A",
                "IDV_B_C",
                "IDV_B_B",
                "IDV_B",
                "IDV_C",
                "IDV_D",
                "C"
            ],
            "idv_award_id": 41813500
        },
        "include_data_dictionary": true,
        "include_file_description": {
            "destination": "readme.txt",
            "source": "/Users/sethstoudenmier/Documents/DATA_Act/projects/usaspending-api/usaspending_api/data/idv_download_readme.txt"
        },
        "is_for_idv": true,
        "limit": 500000,
        "piid": null,
        "request_type": "idv"
    }
}
```

**JIRA Ticket:**
[DEV-4121](https://federal-spending-transparency.atlassian.net/browse/DEV-4121)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [X] Linked to this PR in JIRA ticket
- [X] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable` (N/A)
- [X] Verified cross-browser compatibility (N/A)
- [X] Verified mobile/tablet/desktop/monitor responsiveness (N/A)
- [X] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [X] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [X] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [X] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`

Reviewer(s):
- [X] Design review complete `if applicable` (N/A)
- [X] [API #2211](https://github.com/fedspendingtransparency/usaspending-api/pull/2211) merged concurrently `if applicable`
- [x] Code review complete
