### PR TITLE
[DEV-4036] adding robots.txt back to webpack copy plugin

### DIFF
--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -104,6 +104,11 @@ module.exports = {
                 from: '*.xml',
                 to: path.resolve(__dirname, "../public"),
                 context: path.resolve(__dirname, '../')
+            },
+            {
+                from: 'robots.txt',
+                to: path.resolve(__dirname, "../public"),
+                context: path.resolve(__dirname, '../')
             }
         ])
     ]


### PR DESCRIPTION
Accidentally removed code that copies the robot.txt file into the public/ folder.