### PR TITLE
Warm Fix Dev-1976 provide state for foreign contracts

### DIFF
--- a/src/js/dataMapping/awards/awardOverview.js
+++ b/src/js/dataMapping/awards/awardOverview.js
@@ -33,7 +33,7 @@ export const AddresskeysByAwardType = {
     nonFinancialAssistanceForeign: [
         'streetAddress1',
         '_address2',
-        'recipientRegionalAddress',
+        'recipientRegionalAddressContractsAndIDV',
         'countryName'
     ],
     redactedDueToPIIDomestic: ['recipientRegionalAddress', 'recipientCongressionalDistrict', 'countryName'],

--- a/src/js/models/v2/CoreLocation.js
+++ b/src/js/models/v2/CoreLocation.js
@@ -85,10 +85,10 @@ const CoreLocation = {
             const zip = this._zip || '--';
             return `${city}, ${state} ${zip}`;
         }
-        const province = this._province || '';
+        const fState = this._state || '';
         const fZip = this._zip || '';
         // if province or foreign zip exist show comma
-        if (province || fZip) return `${city}, ${state} ${fZip}`;
+        if (fState || fZip) return `${city}, ${state} ${fZip}`;
         // if neither province or foreign zip exist do not show comma;
         return city;
     },

--- a/src/js/models/v2/CoreLocation.js
+++ b/src/js/models/v2/CoreLocation.js
@@ -76,6 +76,22 @@ const CoreLocation = {
         // if neither province or foreign zip exist do not show comma;
         return city;
     },
+    get recipientRegionalAddressContractsAndIDV() {
+        const city = this._city || '--';
+        const state = this._stateCode || '--';
+        if (this._countryCode === 'USA'
+            || this._countryCode === 'UNITED STATES'
+            || this._country === 'UNITED STATES') {
+            const zip = this._zip || '--';
+            return `${city}, ${state} ${zip}`;
+        }
+        const province = this._province || '';
+        const fZip = this._zip || '';
+        // if province or foreign zip exist show comma
+        if (province || fZip) return `${city}, ${state} ${fZip}`;
+        // if neither province or foreign zip exist do not show comma;
+        return city;
+    },
     get countyAndState() {
         const county = this._county ? `${this._county} County` : '--';
         const stateCode = this._stateCode ? `${this._stateCode} ` : '--';

--- a/tests/models/CoreLocation-test.js
+++ b/tests/models/CoreLocation-test.js
@@ -102,6 +102,16 @@ describe('Core Location getter functions', () => {
             expect(partialLocation.regionalAddress).toEqual('Pawnee, IN 12345');
         });
     });
+    describe('Recipient Regional Address Contracts & IDV', () => {
+        it('should use state code property when foreign', () => {
+            const newForeignLocationData = { ...foreignLocation };
+            newForeignLocationData.stateCode = 'CA';
+            const newForeignLocation = Object.create(CoreLocation);
+            newForeignLocation.populateCore(newForeignLocationData);
+            const includesStateCode = newForeignLocation.recipientRegionalAddressContractsAndIDV.includes('CA');
+            expect(includesStateCode).toEqual(true);
+        });
+    });
     describe('Congressional District', () => {
         it('should format the congressional district', () => {
             expect(location.congressionalDistrict).toEqual('IN-04');


### PR DESCRIPTION
**High level description:**

Uses state property for contract and idvs for foreign recipients when showing the recipient address in the overview section on the award page.

**Technical details:**

Technical details for the knowledge of other developers.

**JIRA Ticket:**
[DEV-1976](https://federal-spending-transparency.atlassian.net/browse/DEV-1976)

Reviewer(s):
- [ ] Code review complete
