### PR TITLE
[DEV-3789] Adding fn to BaseAwardAmounts model

### DIFF
--- a/src/js/components/award/idv/amounts/AggregatedAwardAmounts.jsx
+++ b/src/js/components/award/idv/amounts/AggregatedAwardAmounts.jsx
@@ -73,7 +73,7 @@ export default class AggregatedAwardAmounts extends React.Component {
                     </div>
                 </div>
                 <JumpToSectionButton linkText="View award orders table" onClick={this.jumpToReferencedAwardsTable} icon="table" />
-                <AwardAmountsTable awardAmountType="idv_agg" awardData={awardAmounts} spendingScenario={spendingScenario} />
+                <AwardAmountsTable awardAmountType="idv_aggregated" awardData={awardAmounts} spendingScenario={spendingScenario} />
             </div>
         );
     }

--- a/src/js/components/award/idv/amounts/AggregatedAwardAmounts.jsx
+++ b/src/js/components/award/idv/amounts/AggregatedAwardAmounts.jsx
@@ -73,7 +73,7 @@ export default class AggregatedAwardAmounts extends React.Component {
                     </div>
                 </div>
                 <JumpToSectionButton linkText="View award orders table" onClick={this.jumpToReferencedAwardsTable} icon="table" />
-                <AwardAmountsTable awardType="idv" awardData={awardAmounts} spendingScenario={spendingScenario} />
+                <AwardAmountsTable awardAmountType="idv_agg" awardData={awardAmounts} spendingScenario={spendingScenario} />
             </div>
         );
     }

--- a/src/js/components/award/idv/amounts/AwardAmounts.jsx
+++ b/src/js/components/award/idv/amounts/AwardAmounts.jsx
@@ -49,8 +49,8 @@ export default class AwardAmounts extends React.Component {
             }
         ];
 
-        const awards = Object.create(BaseAwardAmounts)
-        awards.populate(this.props.overview)
+        const awards = Object.create(BaseAwardAmounts);
+        awards.populate(this.props.overview);
         awards.getNonCombinedIdvAmounts(this.props.overview);
         const content = this.state.active === 'awards' ? (
             <IdvAwardAmountsSectionContainer

--- a/src/js/components/award/idv/amounts/AwardAmounts.jsx
+++ b/src/js/components/award/idv/amounts/AwardAmounts.jsx
@@ -50,16 +50,14 @@ export default class AwardAmounts extends React.Component {
         ];
 
         const awards = Object.create(BaseAwardAmounts);
-        awards.populate(this.props.overview);
-        awards.getNonCombinedIdvAmounts(this.props.overview);
+        awards.populate(this.props.overview, 'idv');
         const content = this.state.active === 'awards' ? (
             <IdvAwardAmountsSectionContainer
                 jumpToSection={this.props.jumpToSection} />
         ) : (
             <AwardAmountsTable
                 awardData={awards}
-                // hacky way to avoid the "Combined" label prepended to award amounts ☠
-                awardType="contract"
+                awardAmountType="idv"
                 spendingScenario={determineSpendingScenarioByAwardType("idv", awards)} />
         );
         const tabsClassName = 'idv-award-amounts-tabs';

--- a/src/js/components/award/idv/amounts/AwardAmounts.jsx
+++ b/src/js/components/award/idv/amounts/AwardAmounts.jsx
@@ -7,10 +7,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { TooltipWrapper } from 'data-transparency-ui';
 
+import { determineSpendingScenarioByAwardType } from 'helpers/awardAmountHelper';
+import BaseAwardAmounts from 'models/v2/awardsV2/BaseAwardAmounts';
 import IdvAwardAmountsSectionContainer from 'containers/award/idv/IdvAwardAmountsSectionContainer';
 import ResultsTableTabs from 'components/search/table/ResultsTableTabs';
 import ResultsTablePicker from 'components/search/table/ResultsTablePicker';
-import IDVAmounts from './IDVAmounts';
+import AwardAmountsTable from 'components/award/shared/awardAmountsSection/AwardAmountsTable';
 import { awardAmountsInfo } from '../../shared/InfoTooltipContent';
 
 const propTypes = {
@@ -47,13 +49,18 @@ export default class AwardAmounts extends React.Component {
             }
         ];
 
-        const awards = this.props.overview;
+        const awards = Object.create(BaseAwardAmounts)
+        awards.populate(this.props.overview)
+        awards.getNonCombinedIdvAmounts(this.props.overview);
         const content = this.state.active === 'awards' ? (
             <IdvAwardAmountsSectionContainer
                 jumpToSection={this.props.jumpToSection} />
         ) : (
-            <IDVAmounts
-                awards={awards} />
+            <AwardAmountsTable
+                awardData={awards}
+                // hacky way to avoid the "Combined" label prepended to award amounts ☠
+                awardType="contract"
+                spendingScenario={determineSpendingScenarioByAwardType("idv", awards)} />
         );
         const tabsClassName = 'idv-award-amounts-tabs';
         return (

--- a/src/js/components/award/shared/awardAmountsSection/AwardAmountsSection.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/AwardAmountsSection.jsx
@@ -34,7 +34,7 @@ const AwardAmountsSection = ({
                         spendingScenario={spendingScenario} />
                     <AwardAmountsTable
                         awardData={awardOverview}
-                        awardType={awardType}
+                        awardAmountType={awardType}
                         spendingScenario={spendingScenario} />
                 </div>
             </div>

--- a/src/js/components/award/shared/awardAmountsSection/AwardAmountsTable.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/AwardAmountsTable.jsx
@@ -47,14 +47,14 @@ const AwardAmountsTable = ({
         switch (scenario) {
             case ('normal'):
                 return null;
-            case ('exceedsCurrent'):
+            case ('exceedsBigger'):
                 return (
                     <div className="award-amounts__data-content">
                         <div><span className="award-amounts__data-icon award-amounts__data-icon_overspending" />{type === 'idv' ? 'Exceeds Combined Current Award Amounts' : 'Exceeds Current Award Amount'}</div>
                         <span>{awardAmounts.overspendingFormatted}</span>
                     </div>
                 );
-            case ('exceedsPotential'):
+            case ('exceedsBiggest'):
                 return (
                     <div className="award-amounts__data-content">
                         <div><span className="award-amounts__data-icon award-amounts__data-icon_extreme-overspending" />{type === 'idv' ? 'Exceeds Combined Potential Award Amounts' : 'Exceeds Potential Award Amount'}</div>

--- a/src/js/components/award/shared/awardAmountsSection/AwardAmountsTable.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/AwardAmountsTable.jsx
@@ -8,18 +8,18 @@ import {
     awardTableClassMap
 } from "dataMapping/awards/awardAmountsSection";
 
-import { AWARD_TYPE_PROPS } from "../../../../propTypes";
+import { AWARD_AMOUNT_TYPE_PROPS } from "../../../../propTypes";
 
 const propTypes = {
     children: PropTypes.node,
-    awardType: AWARD_TYPE_PROPS,
+    awardAmountType: AWARD_AMOUNT_TYPE_PROPS,
     awardData: PropTypes.shape({}),
     spendingScenario: PropTypes.string
 };
 
-const getSpendingCategoriesByAwardType = (awardType) => {
-    if (Object.keys(formattedSpendingCategoriesByAwardType).includes(awardType)) {
-        return formattedSpendingCategoriesByAwardType[awardType];
+const getSpendingCategoriesByAwardType = (awardAmountType) => {
+    if (Object.keys(formattedSpendingCategoriesByAwardType).includes(awardAmountType)) {
+        return formattedSpendingCategoriesByAwardType[awardAmountType];
     }
     return formattedSpendingCategoriesByAwardType.asst;
 };
@@ -33,7 +33,7 @@ const getTableTitleByAwardTypeByCategory = (type) => {
 
 const AwardAmountsTable = ({
     awardData,
-    awardType,
+    awardAmountType,
     spendingScenario
 }) => {
     /*
@@ -43,7 +43,7 @@ const AwardAmountsTable = ({
      * so we're relying on the parent in this case because we cant deduce the spending scenario
      **/
 
-    const getOverSpendingRow = (awardAmounts = awardData, scenario = spendingScenario, type = awardType) => {
+    const getOverSpendingRow = (awardAmounts = awardData, scenario = spendingScenario, type = awardAmountType) => {
         switch (scenario) {
             case ('normal'):
                 return null;
@@ -69,11 +69,11 @@ const AwardAmountsTable = ({
     // Returns: { titleInTable: AwardCategoryAmount }
     const buildAmountMapByCategoryTitle = (accumulator, category) => ({
         ...accumulator,
-        [getTableTitleByAwardTypeByCategory(awardType)[category]]: awardData[category]
+        [getTableTitleByAwardTypeByCategory(awardAmountType)[category]]: awardData[category]
     });
 
-    // build a map using the relevant keys for the awardType
-    const amountMapByCategoryTitle = getSpendingCategoriesByAwardType(awardType)
+    // build a map using the relevant keys for the awardAmountType
+    const amountMapByCategoryTitle = getSpendingCategoriesByAwardType(awardAmountType)
         .reduce((acc, category) => buildAmountMapByCategoryTitle(acc, category), {});
 
     const overspendingRow = getOverSpendingRow(awardData, spendingScenario);

--- a/src/js/containers/award/idv/IdvAwardAmountsSectionContainer.jsx
+++ b/src/js/containers/award/idv/IdvAwardAmountsSectionContainer.jsx
@@ -86,7 +86,7 @@ export class IdvAmountsContainer extends React.Component {
 
     parseAward(data) {
         const awardAmounts = Object.create(BaseAwardAmounts);
-        awardAmounts.populate(data, 'idv');
+        awardAmounts.populate(data, 'idv_agg');
         this.setState({
             awardAmounts,
             error: false,

--- a/src/js/containers/award/idv/IdvAwardAmountsSectionContainer.jsx
+++ b/src/js/containers/award/idv/IdvAwardAmountsSectionContainer.jsx
@@ -86,7 +86,7 @@ export class IdvAmountsContainer extends React.Component {
 
     parseAward(data) {
         const awardAmounts = Object.create(BaseAwardAmounts);
-        awardAmounts.populate(data, 'idv_agg');
+        awardAmounts.populate(data, 'idv_aggregated');
         this.setState({
             awardAmounts,
             error: false,

--- a/src/js/dataMapping/awards/awardAmountsSection.js
+++ b/src/js/dataMapping/awards/awardAmountsSection.js
@@ -9,12 +9,14 @@
 export const spendingCategoriesByAwardType = {
     loan: ['_subsidy', '_faceValue'],
     contract: ['_totalObligation', '_baseExercisedOptions', '_baseAndAllOptions'],
-    idv: ['_totalObligation', '_baseExercisedOptions', '_baseAndAllOptions']
+    idv: ['_totalObligation', '_baseExercisedOptions', '_baseAndAllOptions'],
+    idv_agg: ['_totalObligation', '_baseExercisedOptions', '_baseAndAllOptions']
 };
 
 export const formattedSpendingCategoriesByAwardType = {
     contract: ['totalObligationFormatted', 'baseExercisedOptionsFormatted', 'baseAndAllOptionsFormatted'],
     idv: ['totalObligationFormatted', 'baseExercisedOptionsFormatted', 'baseAndAllOptionsFormatted'],
+    idv_agg: ['totalObligationFormatted', 'baseExercisedOptionsFormatted', 'baseAndAllOptionsFormatted'],
     asst: ['totalObligationFormatted', 'nonFederalFundingFormatted', 'totalFundingFormatted'],
     loan: ['subsidyFormatted', 'faceValueFormatted']
 };
@@ -38,12 +40,17 @@ export const tableTitlesBySpendingCategoryAndAwardType = {
         nonFederalFundingFormatted: 'Non-Federal Funding',
         totalObligationFormatted: 'Obligated Amount'
     },
-    idv: {
+    idv_agg: {
         baseExercisedOptionsFormatted: 'Combined Current Amounts',
         baseAndAllOptionsFormatted: 'Combined Potential Amounts',
         totalObligationFormatted: 'Combined Obligated Amounts'
     },
     contract: {
+        baseExercisedOptionsFormatted: 'Current Amount',
+        baseAndAllOptionsFormatted: 'Potential Amount',
+        totalObligationFormatted: 'Obligated Amount'
+    },
+    idv: {
         baseExercisedOptionsFormatted: 'Current Amount',
         baseAndAllOptionsFormatted: 'Potential Amount',
         totalObligationFormatted: 'Obligated Amount'

--- a/src/js/dataMapping/awards/awardAmountsSection.js
+++ b/src/js/dataMapping/awards/awardAmountsSection.js
@@ -10,13 +10,13 @@ export const spendingCategoriesByAwardType = {
     loan: ['_subsidy', '_faceValue'],
     contract: ['_totalObligation', '_baseExercisedOptions', '_baseAndAllOptions'],
     idv: ['_totalObligation', '_baseExercisedOptions', '_baseAndAllOptions'],
-    idv_agg: ['_totalObligation', '_baseExercisedOptions', '_baseAndAllOptions']
+    idv_aggregated: ['_totalObligation', '_baseExercisedOptions', '_baseAndAllOptions']
 };
 
 export const formattedSpendingCategoriesByAwardType = {
     contract: ['totalObligationFormatted', 'baseExercisedOptionsFormatted', 'baseAndAllOptionsFormatted'],
     idv: ['totalObligationFormatted', 'baseExercisedOptionsFormatted', 'baseAndAllOptionsFormatted'],
-    idv_agg: ['totalObligationFormatted', 'baseExercisedOptionsFormatted', 'baseAndAllOptionsFormatted'],
+    idv_aggregated: ['totalObligationFormatted', 'baseExercisedOptionsFormatted', 'baseAndAllOptionsFormatted'],
     asst: ['totalObligationFormatted', 'nonFederalFundingFormatted', 'totalFundingFormatted'],
     loan: ['subsidyFormatted', 'faceValueFormatted']
 };
@@ -40,7 +40,7 @@ export const tableTitlesBySpendingCategoryAndAwardType = {
         nonFederalFundingFormatted: 'Non-Federal Funding',
         totalObligationFormatted: 'Obligated Amount'
     },
-    idv_agg: {
+    idv_aggregated: {
         baseExercisedOptionsFormatted: 'Combined Current Amounts',
         baseAndAllOptionsFormatted: 'Combined Potential Amounts',
         totalObligationFormatted: 'Combined Obligated Amounts'

--- a/src/js/helpers/awardAmountHelper.js
+++ b/src/js/helpers/awardAmountHelper.js
@@ -45,7 +45,7 @@ export const determineSpendingScenarioAsstAwards = (awardAmountObj) => {
     if (_totalObligation < 0 || _nonFederalFunding < 0 || _totalFunding < 0) {
         return 'insufficientData';
     }
-    else if (_totalObligation === 0 && _nonFederalFunding === 0 && _totalObligation === 0) {
+    else if (_totalObligation === 0 && _nonFederalFunding === 0 && _totalFunding === 0) {
         return 'insufficientData';
     }
     // if total funding is sum of obligation and non federal funding, return normal

--- a/src/js/models/v2/awardsV2/BaseAwardAmounts.js
+++ b/src/js/models/v2/awardsV2/BaseAwardAmounts.js
@@ -12,7 +12,7 @@ const BaseAwardAmounts = {
             ? encodeURI(`${data.generated_unique_award_id}`)
             : '';
     },
-    populateIdv(data) {
+    populateAggIdv(data) {
         this.childIDVCount = data.child_idv_count || 0;
         this.childAwardCount = data.child_award_count || 0;
         this.grandchildAwardCount = data.grandchild_award_count || 0;
@@ -25,6 +25,11 @@ const BaseAwardAmounts = {
         this._baseExercisedOptions = parseFloat(
             data.child_award_base_exercised_options_val + data.grandchild_award_base_exercised_options_val
         ) || 0;
+    },
+    populateIdv(data) {
+        this._totalObligation = data._totalObligation;
+        this._baseExercisedOptions = data._baseExercisedOptions;
+        this._baseAndAllOptions = data._baseAndAllOptions;
     },
     populateLoan(data) {
         this._subsidy = data._subsidy;
@@ -40,15 +45,18 @@ const BaseAwardAmounts = {
         this._baseExercisedOptions = data._baseExercisedOptions;
         this._baseAndAllOptions = data._baseAndAllOptions;
     },
-    populate(data, awardType) {
+    populate(data, awardAmountType) {
         this.populateBase(data);
-        if (awardType === 'idv') {
+        if (awardAmountType === 'idv_agg') {
+            this.populateAggIdv(data);
+        }
+        else if (awardAmountType === 'idv') {
             this.populateIdv(data);
         }
-        else if (awardType === 'contract') {
+        else if (awardAmountType === 'contract') {
             this.populateContract(data);
         }
-        else if (awardType === 'loan') {
+        else if (awardAmountType === 'loan') {
             this.populateLoan(data);
         }
         else {
@@ -152,20 +160,6 @@ const BaseAwardAmounts = {
     get subsidyFormatted() {
         return MoneyFormatter.formatMoneyWithPrecision(this._subsidy, 2);
     }
-};
-
-BaseAwardAmounts.getNonCombinedIdvAmounts = function getNonCombinedIdvAmounts(data) {
-    /*
-        * Award amounts for idv's are special...
-        * This fn is used to get the award amounts for the idv itself.
-        * populateIdv handles the more ordinary and complex case:
-        * when we want the aggregated amounts across all child and grand child awards.
-        * This guy is designed to be invoked after populate to overwrite the award-amount
-        * integer values from the summed/combined amount to the non-combined amount. 👍
-    */
-    this._totalObligation = data._totalObligation;
-    this._baseExercisedOptions = data._baseExercisedOptions;
-    this._baseAndAllOptions = data._baseAndAllOptions;
 };
 
 export default BaseAwardAmounts;

--- a/src/js/models/v2/awardsV2/BaseAwardAmounts.js
+++ b/src/js/models/v2/awardsV2/BaseAwardAmounts.js
@@ -160,7 +160,7 @@ BaseAwardAmounts.getNonCombinedIdvAmounts = function getNonCombinedIdvAmounts(da
         * This fn is used to get the award amounts for the idv itself.
         * The above handles the more ordinary and complex case:
         * when we want the aggregated amounts across all child and grand child awards.
-        * This guy is composed w/ populate (after populate) to overwrite the award-amount 
+        * This guy is composed w/ populate (after populate) to overwrite the award-amount
         * integer values from the summed/combined amount, the the non-combined amount. 👍
     */
     this._totalObligation = data._totalObligation;

--- a/src/js/models/v2/awardsV2/BaseAwardAmounts.js
+++ b/src/js/models/v2/awardsV2/BaseAwardAmounts.js
@@ -47,7 +47,7 @@ const BaseAwardAmounts = {
     },
     populate(data, awardAmountType) {
         this.populateBase(data);
-        if (awardAmountType === 'idv_agg') {
+        if (awardAmountType === 'idv_aggregated') {
             this.populateAggIdv(data);
         }
         else if (awardAmountType === 'idv') {

--- a/src/js/models/v2/awardsV2/BaseAwardAmounts.js
+++ b/src/js/models/v2/awardsV2/BaseAwardAmounts.js
@@ -154,4 +154,18 @@ const BaseAwardAmounts = {
     }
 };
 
+BaseAwardAmounts.getNonCombinedIdvAmounts = function getNonCombinedIdvAmounts(data) {
+    /*
+        * Award amounts for idv's are special...
+        * This fn is used to get the award amounts for the idv itself.
+        * The above handles the more ordinary and complex case:
+        * when we want the aggregated amounts across all child and grand child awards.
+        * This guy is composed w/ populate (after populate) to overwrite the award-amount 
+        * integer values from the summed/combined amount, the the non-combined amount. 👍
+    */
+    this._totalObligation = data._totalObligation;
+    this._baseExercisedOptions = data._baseExercisedOptions;
+    this._baseAndAllOptions = data._baseAndAllOptions;
+};
+
 export default BaseAwardAmounts;

--- a/src/js/models/v2/awardsV2/BaseAwardAmounts.js
+++ b/src/js/models/v2/awardsV2/BaseAwardAmounts.js
@@ -158,10 +158,10 @@ BaseAwardAmounts.getNonCombinedIdvAmounts = function getNonCombinedIdvAmounts(da
     /*
         * Award amounts for idv's are special...
         * This fn is used to get the award amounts for the idv itself.
-        * The above handles the more ordinary and complex case:
+        * populateIdv handles the more ordinary and complex case:
         * when we want the aggregated amounts across all child and grand child awards.
-        * This guy is composed w/ populate (after populate) to overwrite the award-amount
-        * integer values from the summed/combined amount, the the non-combined amount. 👍
+        * This guy is designed to be invoked after populate to overwrite the award-amount
+        * integer values from the summed/combined amount to the non-combined amount. 👍
     */
     this._totalObligation = data._totalObligation;
     this._baseExercisedOptions = data._baseExercisedOptions;

--- a/src/js/propTypes/index.js
+++ b/src/js/propTypes/index.js
@@ -32,7 +32,7 @@ export const AWARD_TYPE_PROPS = PropTypes.oneOf([
 ]);
 
 export const AWARD_AMOUNT_TYPE_PROPS = PropTypes.oneOf([
-    'idv', 'contract', 'grant', 'loan', 'direct payment', 'insurance', 'other', 'idv_agg'
+    'idv', 'contract', 'grant', 'loan', 'direct payment', 'insurance', 'other', 'idv_aggregated'
 ]);
 
 export const TOOLTIP_PROPS = PropTypes.shape({

--- a/src/js/propTypes/index.js
+++ b/src/js/propTypes/index.js
@@ -31,6 +31,10 @@ export const AWARD_TYPE_PROPS = PropTypes.oneOf([
     'idv', 'contract', 'grant', 'loan', 'direct payment', 'insurance', 'other'
 ]);
 
+export const AWARD_AMOUNT_TYPE_PROPS = PropTypes.oneOf([
+    'idv', 'contract', 'grant', 'loan', 'direct payment', 'insurance', 'other', 'idv_agg'
+]);
+
 export const TOOLTIP_PROPS = PropTypes.shape({
     isControlled: PropTypes.bool,
     isVisible: PropTypes.bool,

--- a/tests/models/awardsV2/BaseAwardAmounts-test.js
+++ b/tests/models/awardsV2/BaseAwardAmounts-test.js
@@ -37,9 +37,18 @@ const extremeOverspending = {
     grandchild_award_total_obligation: 5000000
 };
 
+const awardAmountsNonCombined = Object.create(BaseAwardAmounts);
+const nonCombinedSpendingIdv = {
+    base_exercised_options: 0.0,
+    base_and_all_options: 0.0,
+    total_obligation: 0.0
+};
+
 awardAmountsNeg.populate(negativeObligation, "idv");
 awardAmountsOverspent.populate(overspending, "idv");
 awardAmountsExtremeOverspent.populate(extremeOverspending, "idv");
+awardAmountsNonCombined.populate(overspending, "idv");
+awardAmountsNonCombined.getNonCombinedIdvAmounts(nonCombinedSpendingIdv);
 
 describe('BaseAwardAmounts', () => {
     describe('IDV Award Type', () => {
@@ -84,6 +93,14 @@ describe('BaseAwardAmounts', () => {
         });
         it('should format the amount overspent with units', () => {
             expect(awardAmountsOverspent.overspendingAbbreviated).toEqual('$2.5 M');
+        });
+        it('should successfully return spending data for the IDV itself (non-combined)', () => {
+            expect(awardAmountsNonCombined.baseExercisedOptionsFormatted).toEqual('$0.00');
+            expect(awardAmountsNonCombined.totalObligationFormatted).toEqual('$0.00');
+            expect(awardAmountsNonCombined.baseAndAllOptionsFormatted).toEqual('$0.00');
+            expect(awardAmountsNonCombined.overspendingFormatted).toEqual('$0.00');
+            expect(awardAmountsNonCombined.extremeOverspendingFormatted).toEqual('$0.00');
+
         });
     });
     /*

--- a/tests/models/awardsV2/BaseAwardAmounts-test.js
+++ b/tests/models/awardsV2/BaseAwardAmounts-test.js
@@ -9,7 +9,7 @@ import BaseFinancialAssistance from '../../../src/js/models/v2/awardsV2/BaseFina
 import { mockAwardAmounts, mockContract, mockGrant, mockLoan } from './mockAwardApi';
 
 const awardAmounts = Object.create(BaseAwardAmounts);
-awardAmounts.populate(mockAwardAmounts, "idv");
+awardAmounts.populate(mockAwardAmounts, "idv_agg");
 
 const awardAmountsNeg = Object.create(BaseAwardAmounts);
 const negativeObligation = {
@@ -37,21 +37,36 @@ const extremeOverspending = {
     grandchild_award_total_obligation: 5000000
 };
 
-const awardAmountsNonCombined = Object.create(BaseAwardAmounts);
-const nonCombinedSpendingIdv = {
-    base_exercised_options: 0.0,
-    base_and_all_options: 0.0,
-    total_obligation: 0.0
+const nonAggregateIdvNormal = Object.create(BaseAwardAmounts);
+const nonAggregateIdvOverspent = Object.create(BaseAwardAmounts);
+const nonAggregateIdvExtremeOverspent = Object.create(BaseAwardAmounts);
+const normalIdv = {
+    _baseExercisedOptions: 0.0,
+    _baseAndAllOptions: 0.0,
+    _totalObligation: 0.0
+};
+const overspentIdv = {
+    _baseExercisedOptions: 10.0,
+    _baseAndAllOptions: 0.0,
+    _totalObligation: 0.0
+
+};
+const extremeOverspentIdv = {
+    _baseExercisedOptions: 0.0,
+    _baseAndAllOptions: 10.0,
+    _totalObligation: 0.0
 };
 
-awardAmountsNeg.populate(negativeObligation, "idv");
-awardAmountsOverspent.populate(overspending, "idv");
-awardAmountsExtremeOverspent.populate(extremeOverspending, "idv");
-awardAmountsNonCombined.populate(overspending, "idv");
-awardAmountsNonCombined.getNonCombinedIdvAmounts(nonCombinedSpendingIdv);
+awardAmountsNeg.populate(negativeObligation, "idv_agg");
+awardAmountsOverspent.populate(overspending, "idv_agg");
+awardAmountsExtremeOverspent.populate(extremeOverspending, "idv_agg");
+
+nonAggregateIdvNormal.populate(normalIdv, 'idv');
+nonAggregateIdvOverspent.populate(overspentIdv, 'idv');
+nonAggregateIdvExtremeOverspent.populate(extremeOverspentIdv, 'idv');
 
 describe('BaseAwardAmounts', () => {
-    describe('IDV Award Type', () => {
+    describe('IDV Award Type -- Aggregate Amounts', () => {
         it('should have an empty string as a unique generated id if the field is null or undefined', () => {
             expect(awardAmounts.generatedId).toEqual('');
         });
@@ -94,13 +109,28 @@ describe('BaseAwardAmounts', () => {
         it('should format the amount overspent with units', () => {
             expect(awardAmountsOverspent.overspendingAbbreviated).toEqual('$2.5 M');
         });
+    });
+    describe('IDVs - Non Aggregated Award Amounts', () => {
         it('should successfully return spending data for the IDV itself (non-combined)', () => {
-            expect(awardAmountsNonCombined.baseExercisedOptionsFormatted).toEqual('$0.00');
-            expect(awardAmountsNonCombined.totalObligationFormatted).toEqual('$0.00');
-            expect(awardAmountsNonCombined.baseAndAllOptionsFormatted).toEqual('$0.00');
-            expect(awardAmountsNonCombined.overspendingFormatted).toEqual('$0.00');
-            expect(awardAmountsNonCombined.extremeOverspendingFormatted).toEqual('$0.00');
-
+            expect(nonAggregateIdvNormal.baseExercisedOptionsFormatted).toEqual('$0.00');
+            expect(nonAggregateIdvNormal.totalObligationFormatted).toEqual('$0.00');
+            expect(nonAggregateIdvNormal.baseAndAllOptionsFormatted).toEqual('$0.00');
+            expect(nonAggregateIdvNormal.overspendingFormatted).toEqual('$0.00');
+            expect(nonAggregateIdvNormal.extremeOverspendingFormatted).toEqual('$0.00');
+        });
+        it('should handle overspending', () => {
+            expect(nonAggregateIdvOverspent.baseExercisedOptionsFormatted).toEqual('$10.00');
+            expect(nonAggregateIdvOverspent.totalObligationFormatted).toEqual('$0.00');
+            expect(nonAggregateIdvOverspent.baseAndAllOptionsFormatted).toEqual('$0.00');
+            expect(nonAggregateIdvOverspent.overspendingFormatted).toEqual('-$10.00');
+            expect(nonAggregateIdvOverspent.extremeOverspendingFormatted).toEqual('$0.00');
+        });
+        it('should handle extremeOverspending', () => {
+            expect(nonAggregateIdvExtremeOverspent.baseExercisedOptionsFormatted).toEqual('$0.00');
+            expect(nonAggregateIdvExtremeOverspent.totalObligationFormatted).toEqual('$0.00');
+            expect(nonAggregateIdvExtremeOverspent.baseAndAllOptionsFormatted).toEqual('$10.00');
+            expect(nonAggregateIdvExtremeOverspent.overspendingFormatted).toEqual('$0.00');
+            expect(nonAggregateIdvExtremeOverspent.extremeOverspendingFormatted).toEqual('-$10.00');
         });
     });
     /*

--- a/tests/models/awardsV2/BaseAwardAmounts-test.js
+++ b/tests/models/awardsV2/BaseAwardAmounts-test.js
@@ -9,7 +9,7 @@ import BaseFinancialAssistance from '../../../src/js/models/v2/awardsV2/BaseFina
 import { mockAwardAmounts, mockContract, mockGrant, mockLoan } from './mockAwardApi';
 
 const awardAmounts = Object.create(BaseAwardAmounts);
-awardAmounts.populate(mockAwardAmounts, "idv_agg");
+awardAmounts.populate(mockAwardAmounts, "idv_aggregated");
 
 const awardAmountsNeg = Object.create(BaseAwardAmounts);
 const negativeObligation = {
@@ -57,9 +57,9 @@ const extremeOverspentIdv = {
     _totalObligation: 0.0
 };
 
-awardAmountsNeg.populate(negativeObligation, "idv_agg");
-awardAmountsOverspent.populate(overspending, "idv_agg");
-awardAmountsExtremeOverspent.populate(extremeOverspending, "idv_agg");
+awardAmountsNeg.populate(negativeObligation, "idv_aggregated");
+awardAmountsOverspent.populate(overspending, "idv_aggregated");
+awardAmountsExtremeOverspent.populate(extremeOverspending, "idv_aggregated");
 
 nonAggregateIdvNormal.populate(normalIdv, 'idv');
 nonAggregateIdvOverspent.populate(overspentIdv, 'idv');


### PR DESCRIPTION
**High level description:**
IDV Awards have two sets of data related to spending:

(a) Aggregated spending across all child and grand child awards
(b) Spending that is directly associated with the IDV and not its children

This complexity is currently not reflected in our models. This manifests itself on the IDV Award Page, in the Award Amounts Section, on the "This IDV" tab.

The problem is we're only showing our aggregated spending on the IDV, and not for the IDV itself.

**Technical details:**
Updates BaseAwardAmounts Model:

- Currently, model for IDV gets obligated, current, and potential award amounts from child/grand child awards
- Now, we do the same thing but have a new method to override the _obligated/current/potential amounts from the aggregated amount, to the amounts for the IDV itself

**JIRA Ticket:**
[DEV-3789](https://federal-spending-transparency.atlassian.net/browse/DEV-3789)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA 
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
