### PR TITLE
[DEV-3194] Setting FY Dropdown via URL (part 1 - Recipient Page)

### DIFF
--- a/src/js/components/recipient/RecipientContent.jsx
+++ b/src/js/components/recipient/RecipientContent.jsx
@@ -214,7 +214,7 @@ export default class RecipientContent extends React.Component {
                         jumpToSection={this.jumpToSection}
                         stickyHeaderHeight={StickyHeader.stickyHeaderHeight}
                         fyPicker
-                        currentFy={this.props.recipient.fy}
+                        selectedFy={this.props.recipient.fy}
                         pickedYear={this.props.pickedFy} />
                 </div>
                 <div className="recipient-content">

--- a/src/js/components/recipientLanding/table/RecipientLinkCell.jsx
+++ b/src/js/components/recipientLanding/table/RecipientLinkCell.jsx
@@ -26,7 +26,7 @@ export default class RecipientLinkCell extends React.Component {
         return (
             <td className="recipient-list__body-cell">
                 <span className={labelType}>{this.props.type}</span>
-                <a href={`#/recipient/${this.props.id}`}>
+                <a href={`#/recipient/${this.props.id}/latest`}>
                     {this.props.name}
                 </a>
             </td>

--- a/src/js/components/sharedComponents/sidebar/Sidebar.jsx
+++ b/src/js/components/sharedComponents/sidebar/Sidebar.jsx
@@ -17,7 +17,7 @@ const propTypes = {
     jumpToSection: PropTypes.func,
     stickyHeaderHeight: PropTypes.number,
     fyPicker: PropTypes.bool,
-    currentFy: PropTypes.string,
+    selectedFy: PropTypes.string,
     pickedYear: PropTypes.func
 };
 
@@ -137,7 +137,7 @@ export default class Sidebar extends React.Component {
         if (this.props.fyPicker) {
             fyPicker = (
                 <FYPicker
-                    fy={this.props.currentFy}
+                    selectedFy={this.props.selectedFy}
                     pickedYear={this.props.pickedYear} />
             );
         }

--- a/src/js/components/state/RecipientFYPicker.jsx
+++ b/src/js/components/state/RecipientFYPicker.jsx
@@ -5,25 +5,14 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as FiscalYearHelper from 'helpers/fiscalYearHelper';
+import { getDropdownLabelsByApiValue } from 'dataMapping/recipients/fiscalYearDropdown';
 
 import { Calendar, AngleDown } from 'components/sharedComponents/icons/Icons';
 
 const propTypes = {
-    fy: PropTypes.string,
+    selectedFy: PropTypes.string,
     pickedYear: PropTypes.func
 };
-
-const fyOptions = [
-    {
-        name: 'latest',
-        label: 'Trailing 12 Months'
-    },
-    {
-        name: 'all',
-        label: 'All Fiscal Years'
-    }
-];
 
 export default class FYPicker extends React.Component {
     constructor(props) {
@@ -36,6 +25,7 @@ export default class FYPicker extends React.Component {
         this.toggleList = this.toggleList.bind(this);
         this.clickedYear = this.clickedYear.bind(this);
         this.closeMenu = this.closeMenu.bind(this);
+        this.sortDropdownOptions = this.sortDropdownOptions.bind(this);
     }
 
     componentWillUnmount() {
@@ -79,53 +69,25 @@ export default class FYPicker extends React.Component {
         });
     }
 
+    sortDropdownOptions(key1, key2) {
+        if (key1 === 'latest') return -1;
+        else if (key2 === 'latest') return 1;
+        else if (key1 === 'all') return -1;
+        else if (key2 === 'all') return 1;
+        else if (key1 > key2) return -1;
+        else if (key2 > key1) return 1;
+        return 0;
+    }
+
     render() {
-        const fy = [];
-        const currentFY = FiscalYearHelper.currentFiscalYear();
-        const earliestFY = FiscalYearHelper.earliestFiscalYear;
-        for (let year = currentFY; year >= earliestFY; year--) {
-            const item = (
-                <li
-                    key={year}
-                    className="fy-picker__list-item">
-                    <button
-                        className="fy-picker__item"
-                        value={year}
-                        onClick={this.clickedYear}>
-                        FY {year}
-                    </button>
-                </li>
-            );
-
-            fy.push(item);
-        }
-
-        const otherFyOptions = fyOptions.map((option) => (
-            <li
-                key={option.name}
-                className="fy-picker__list-item">
-                <button
-                    className="fy-picker__item"
-                    value={option.name}
-                    onClick={this.clickedYear}>
-                    {option.label}
-                </button>
-            </li>
-        ));
-
+        const dropdownValuesByApiValue = getDropdownLabelsByApiValue();
         let visibleClass = 'fy-picker__list_hidden';
         if (this.state.expanded) {
             visibleClass = '';
         }
 
-        let currentSelection = `FY ${this.props.fy}`;
-        const otherSelection = fyOptions.find((option) =>
-            option.name === this.props.fy
-        );
-        if (otherSelection) {
-            currentSelection = otherSelection.label;
-        }
-
+        const selectedApiValue = Object.keys(dropdownValuesByApiValue)
+            .find((option) => option === this.props.selectedFy);
         return (
             <div
                 className="fy-picker"
@@ -141,23 +103,27 @@ export default class FYPicker extends React.Component {
                             className="fy-picker__button"
                             onClick={this.toggleList}>
                             <div className="fy-picker__button-text">
-                                {currentSelection}
+                                {dropdownValuesByApiValue[selectedApiValue]}
                             </div>
                             <div className="fy-picker__button-icon">
                                 <AngleDown alt="Toggle menu" />
                             </div>
                         </button>
                         <ul className={`fy-picker__list ${visibleClass}`}>
-                            {otherFyOptions}
-                            <li
-                                className="fy-picker__list-item">
-                                <button
-                                    disabled
-                                    className="fy-picker__item fy-picker__item_disabled">
-                                    &mdash;
-                                </button>
-                            </li>
-                            {fy}
+                            {Object.keys(dropdownValuesByApiValue)
+                                .sort(this.sortDropdownOptions)
+                                .map((apiValue) => (
+                                    <li
+                                        key={apiValue}
+                                        className="fy-picker__list-item">
+                                        <button
+                                            className="fy-picker__item"
+                                            value={apiValue}
+                                            onClick={this.clickedYear}>
+                                            {dropdownValuesByApiValue[apiValue]}
+                                        </button>
+                                    </li>
+                                ))}
                         </ul>
                     </div>
                 </div>

--- a/src/js/containers/recipient/RecipientContainer.jsx
+++ b/src/js/containers/recipient/RecipientContainer.jsx
@@ -12,6 +12,8 @@ import { isCancel } from 'axios';
 import BaseRecipientOverview from 'models/v2/recipient/BaseRecipientOverview';
 import * as recipientActions from 'redux/actions/recipient/recipientActions';
 import * as RecipientHelper from 'helpers/recipientHelper';
+import Router from 'containers/router/Router';
+
 
 import RecipientPage from 'components/recipient/RecipientPage';
 
@@ -20,7 +22,7 @@ require('pages/recipient/recipientPage.scss');
 const propTypes = {
     setRecipientOverview: PropTypes.func,
     setRecipientFiscalYear: PropTypes.func,
-    params: PropTypes.object,
+    params: PropTypes.shape({ recipientId: PropTypes.string, fy: PropTypes.string }),
     recipient: PropTypes.object
 };
 
@@ -34,16 +36,18 @@ export class RecipientContainer extends React.Component {
         };
 
         this.request = null;
+        this.updateSelectedFy = this.updateSelectedFy.bind(this);
     }
 
     componentDidMount() {
+        this.props.setRecipientFiscalYear(this.props.params.fy);
         this.loadRecipientOverview(this.props.params.recipientId, this.props.recipient.fy);
     }
 
     componentDidUpdate(prevProps) {
         if (this.props.params.recipientId !== prevProps.params.recipientId) {
             // Reset the FY
-            this.props.setRecipientFiscalYear('latest');
+            this.props.setRecipientFiscalYear(this.props.params.fy);
             this.loadRecipientOverview(this.props.params.recipientId, 'latest');
         }
         if (this.props.recipient.fy !== prevProps.recipient.fy) {
@@ -90,6 +94,11 @@ export class RecipientContainer extends React.Component {
         this.props.setRecipientOverview(recipientOverview);
     }
 
+    updateSelectedFy(fy) {
+        Router.history.push(`/recipient/${this.props.recipient.id}/${fy}`);
+        this.props.setRecipientFiscalYear(fy);
+    }
+
     render() {
         return (
             <RecipientPage
@@ -97,7 +106,7 @@ export class RecipientContainer extends React.Component {
                 error={this.state.error}
                 id={this.props.recipient.id}
                 recipient={this.props.recipient}
-                pickedFy={this.props.setRecipientFiscalYear} />
+                pickedFy={this.updateSelectedFy} />
         );
     }
 }

--- a/src/js/containers/recipient/RecipientContainer.jsx
+++ b/src/js/containers/recipient/RecipientContainer.jsx
@@ -40,6 +40,9 @@ export class RecipientContainer extends React.Component {
     }
 
     componentDidMount() {
+        if (!Object.keys(this.props.params).includes('fy')) {
+            Router.history.replace(`/recipient/${this.props.params.recipientId}/latest`);
+        }
         this.props.setRecipientFiscalYear(this.props.params.fy);
         this.loadRecipientOverview(this.props.params.recipientId, this.props.recipient.fy);
     }
@@ -49,6 +52,10 @@ export class RecipientContainer extends React.Component {
             // Reset the FY
             this.props.setRecipientFiscalYear(this.props.params.fy);
             this.loadRecipientOverview(this.props.params.recipientId, 'latest');
+        }
+        if (!prevProps.params.fy && this.props.params.fy) {
+            // we just redirected the user to the new url which includes the fy selection
+            this.props.setRecipientFiscalYear(this.props.params.fy);
         }
         if (this.props.recipient.fy !== prevProps.recipient.fy) {
             this.loadRecipientOverview(this.props.params.recipientId, this.props.recipient.fy);

--- a/src/js/containers/router/RouterRoutes.js
+++ b/src/js/containers/router/RouterRoutes.js
@@ -252,6 +252,16 @@ const routes = {
                     cb(require('containers/recipient/RecipientContainer').default);
                 });
             }
+        },
+        {
+            path: '/recipient/:recipientId/:fy',
+            parent: '/recipient',
+            addToSitemap: false,
+            component: (cb) => {
+                require.ensure([], (require) => {
+                    cb(require('containers/recipient/RecipientContainer').default);
+                });
+            }
         }
     ],
     notFound: {

--- a/src/js/dataMapping/recipients/fiscalYearDropdown.js
+++ b/src/js/dataMapping/recipients/fiscalYearDropdown.js
@@ -8,23 +8,35 @@ import { currentFiscalYear, earliestFiscalYear } from "helpers/fiscalYearHelper"
 
 const earliestFY = moment(`10-01-${earliestFiscalYear}`);
 const currentFY = moment(`10-01-${currentFiscalYear()}`);
+const dropdownLabels = ['Trailing 12 Months', 'All Fiscal Years'];
 
 // eslint-disable-next-line import/prefer-default-export
-export const dropdownOptions = () => {
-    const options = ['Trailing 12 Months', 'All Fiscal Years'];
+export const getDropdownLabelsByApiValue = () => {
     const yearsSinceEarliestFY = currentFY.diff(earliestFY, 'y');
 
     for (let i = 0; i < yearsSinceEarliestFY; i++) {
         const nextFY = earliestFiscalYear + i;
-        options.push(`FY ${nextFY}`);
+        dropdownLabels.push(`FY ${nextFY}`);
     }
 
-    return options;
-};
+    return dropdownLabels
+        .reduce((acc, label) => {
+            if (label === 'Trailing 12 Months') {
+                return {
+                    ...acc,
+                    latest: label
+                };
+            }
+            else if (label === 'All Fiscal Years') {
+                return {
+                    ...acc,
+                    all: label
+                };
+            }
 
-export const urlSelections = dropdownOptions()
-    .map((option) => option
-        .split(" ")
-        .map((word) => word.toLowerCase())
-        .join("_")
-    );
+            return {
+                ...acc,
+                [label.split(" ")[1]]: label
+            };
+        }, {});
+};

--- a/src/js/dataMapping/recipients/fiscalYearDropdown.js
+++ b/src/js/dataMapping/recipients/fiscalYearDropdown.js
@@ -1,0 +1,30 @@
+/**
+ * fiscalYearDropdown.js
+ * Created by Maxwell Kendall 01/21/2020
+ */
+
+import moment from 'moment';
+import { currentFiscalYear, earliestFiscalYear } from "helpers/fiscalYearHelper";
+
+const earliestFY = moment(`10-01-${earliestFiscalYear}`);
+const currentFY = moment(`10-01-${currentFiscalYear()}`);
+
+// eslint-disable-next-line import/prefer-default-export
+export const dropdownOptions = () => {
+    const options = ['Trailing 12 Months', 'All Fiscal Years'];
+    const yearsSinceEarliestFY = currentFY.diff(earliestFY, 'y');
+
+    for (let i = 0; i < yearsSinceEarliestFY; i++) {
+        const nextFY = earliestFiscalYear + i;
+        options.push(`FY ${nextFY}`);
+    }
+
+    return options;
+};
+
+export const urlSelections = dropdownOptions()
+    .map((option) => option
+        .split(" ")
+        .map((word) => word.toLowerCase())
+        .join("_")
+    );

--- a/tests/containers/recipient/RecipientContainer-test.jsx
+++ b/tests/containers/recipient/RecipientContainer-test.jsx
@@ -6,19 +6,20 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 
+import { RecipientContainer } from 'containers/recipient/RecipientContainer';
+import BaseRecipientOverview from 'models/v2/recipient/BaseRecipientOverview';
+import { mockActions, mockRedux } from './mockData';
+import { mockRecipientOverview } from '../../models/recipient/mockRecipientApi';
+
 // mock the state helper
 jest.mock('helpers/recipientHelper', () => require('./mockRecipientHelper'));
 
-import { RecipientContainer } from 'containers/recipient/RecipientContainer';
-import { mockActions, mockRedux } from './mockData';
-import BaseRecipientOverview from 'models/v2/recipient/BaseRecipientOverview';
-import { mockRecipientOverview } from '../../models/recipient/mockRecipientApi';
 
 // mock the child component by replacing it with a function that returns a null element
 jest.mock('components/recipient/RecipientPage', () => jest.fn(() => null));
 
 describe('RecipientContainer', () => {
-    it('should make an API call for the selected recipient on mount', async () => {
+    it('on mount: should make an API call for the selected recipient & set fiscal year based on url params', async () => {
         const container = mount(<RecipientContainer
             {...mockRedux}
             {...mockActions} />);
@@ -30,6 +31,7 @@ describe('RecipientContainer', () => {
         await container.instance().request.promise;
 
         expect(loadRecipientOverview).toHaveBeenCalledTimes(1);
+        expect(mockActions.setRecipientFiscalYear).toHaveBeenCalledWith(mockRedux.params.fy);
         expect(loadRecipientOverview).toHaveBeenCalledWith('0123456-ABC-P', 'latest');
     });
     it('should make an API call when the id changes', async () => {

--- a/tests/containers/recipient/mockData.js
+++ b/tests/containers/recipient/mockData.js
@@ -9,7 +9,8 @@ export const mockActions = {
 
 export const mockRedux = {
     params: {
-        recipientId: '0123456-ABC-P'
+        recipientId: '0123456-ABC-P',
+        fy: 'latest'
     },
     recipient: initialState
 };


### PR DESCRIPTION
**High level description:**
Sets the FY Dropdown selection based on URL

**Technical details:**
Adds new route to include `:fy` param and redirects users to new url if need be

**JIRA Ticket:**
[DEV-3194](https://federal-spending-transparency.atlassian.net/browse/DEV-3194)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
