### PR TITLE
[DEV-3942] Setting FY Dropdown via URL (part 2 - State Page) (Contains Pt. 1)

### DIFF
--- a/scripts/buildSitemap.js
+++ b/scripts/buildSitemap.js
@@ -40,6 +40,9 @@ const createSitemapEntry = (xml, pageData, pageInfo) => {
             if (page.name === 'award') {
                 return `${str}<url><loc>${clientRoute}/${encodeURI(page.value)}</loc><changefreq>${updatedFrequency}</changefreq><priority>${priority}</priority></url>`;
             }
+            else if (page.name === 'recipient' || page.name === 'state') {
+                return `${str}<url><loc>${clientRoute}/${page.value}/latest</loc><changefreq>${updatedFrequency}</changefreq><priority>${priority}</priority></url>`;
+            }
             return `${str}<url><loc>${clientRoute}/${page.value}</loc><changefreq>${updatedFrequency}</changefreq><priority>${priority}</priority></url>`;
         }, xml);
 };

--- a/src/_scss/pages/recipient/recipientPage.scss
+++ b/src/_scss/pages/recipient/recipientPage.scss
@@ -14,6 +14,7 @@
 		@include fullSectionWrap(($global-mrg * 2), ($global-mrg * 2));
 		padding:  0;
 		@import "./_positioning";
+		@import "../../components/pageLoading";
 		@import "./_contentWrap";
 		@import "elements/_divider";
 		@import "./_overview";

--- a/src/_scss/pages/state/statePage.scss
+++ b/src/_scss/pages/state/statePage.scss
@@ -14,7 +14,7 @@
         @import "./_positioning";
         @import "./_contentWrap";
         @import "elements/_divider";
-
+        @import "../../components/pageLoading";
         @import "./_sidebar";
 
         @import "./footer/footer";

--- a/src/js/components/recipient/RecipientContent.jsx
+++ b/src/js/components/recipient/RecipientContent.jsx
@@ -214,7 +214,7 @@ export default class RecipientContent extends React.Component {
                         jumpToSection={this.jumpToSection}
                         stickyHeaderHeight={StickyHeader.stickyHeaderHeight}
                         fyPicker
-                        currentFy={this.props.recipient.fy}
+                        selectedFy={this.props.recipient.fy}
                         pickedYear={this.props.pickedFy} />
                 </div>
                 <div className="recipient-content">

--- a/src/js/components/recipient/RecipientPage.jsx
+++ b/src/js/components/recipient/RecipientPage.jsx
@@ -13,6 +13,7 @@ import Header from 'components/sharedComponents/header/Header';
 import StickyHeader from 'components/sharedComponents/stickyHeader/StickyHeader';
 import Error from 'components/sharedComponents/Error';
 import Footer from 'components/sharedComponents/Footer';
+import { LoadingWrapper } from "components/sharedComponents/Loading";
 
 import RecipientModalContainer from 'containers/recipient/modal/RecipientModalContainer';
 import RecipientContent from './RecipientContent';
@@ -56,14 +57,7 @@ export default class RecipientPage extends React.Component {
                 showModal={this.showModal}
                 {...this.props} />
         );
-        if (this.props.loading) {
-            content = (
-                <Error
-                    title="Loading..."
-                    message="" />
-            );
-        }
-        else if (this.props.error) {
+        if (this.props.error) {
             content = (<Error
                 title="Invalid Recipient"
                 message="The recipient ID provided is invalid. Please check the ID and try again." />);
@@ -83,11 +77,13 @@ export default class RecipientPage extends React.Component {
                 <main
                     id="main-content"
                     className="main-content">
-                    {content}
-                    <RecipientModalContainer
-                        mounted={this.state.showModal}
-                        hideModal={this.hideModal}
-                        recipient={this.props.recipient} />
+                    <LoadingWrapper isLoading={this.props.loading}>
+                        {content}
+                        <RecipientModalContainer
+                            mounted={this.state.showModal}
+                            hideModal={this.hideModal}
+                            recipient={this.props.recipient} />    
+                    </LoadingWrapper>
                 </main>
                 <Footer />
             </div>

--- a/src/js/components/recipient/RecipientPage.jsx
+++ b/src/js/components/recipient/RecipientPage.jsx
@@ -82,7 +82,7 @@ export default class RecipientPage extends React.Component {
                         <RecipientModalContainer
                             mounted={this.state.showModal}
                             hideModal={this.hideModal}
-                            recipient={this.props.recipient} />    
+                            recipient={this.props.recipient} />
                     </LoadingWrapper>
                 </main>
                 <Footer />

--- a/src/js/components/recipientLanding/table/RecipientLinkCell.jsx
+++ b/src/js/components/recipientLanding/table/RecipientLinkCell.jsx
@@ -26,7 +26,7 @@ export default class RecipientLinkCell extends React.Component {
         return (
             <td className="recipient-list__body-cell">
                 <span className={labelType}>{this.props.type}</span>
-                <a href={`#/recipient/${this.props.id}`}>
+                <a href={`#/recipient/${this.props.id}/latest`}>
                     {this.props.name}
                 </a>
             </td>

--- a/src/js/components/sharedComponents/sidebar/Sidebar.jsx
+++ b/src/js/components/sharedComponents/sidebar/Sidebar.jsx
@@ -17,7 +17,7 @@ const propTypes = {
     jumpToSection: PropTypes.func,
     stickyHeaderHeight: PropTypes.number,
     fyPicker: PropTypes.bool,
-    currentFy: PropTypes.string,
+    selectedFy: PropTypes.string,
     pickedYear: PropTypes.func
 };
 
@@ -137,7 +137,7 @@ export default class Sidebar extends React.Component {
         if (this.props.fyPicker) {
             fyPicker = (
                 <FYPicker
-                    fy={this.props.currentFy}
+                    selectedFy={this.props.selectedFy}
                     pickedYear={this.props.pickedYear} />
             );
         }

--- a/src/js/components/state/RecipientFYPicker.jsx
+++ b/src/js/components/state/RecipientFYPicker.jsx
@@ -5,25 +5,14 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as FiscalYearHelper from 'helpers/fiscalYearHelper';
+import { getDropdownLabelsByApiValue } from 'dataMapping/recipients/fiscalYearDropdown';
 
 import { Calendar, AngleDown } from 'components/sharedComponents/icons/Icons';
 
 const propTypes = {
-    fy: PropTypes.string,
+    selectedFy: PropTypes.string,
     pickedYear: PropTypes.func
 };
-
-const fyOptions = [
-    {
-        name: 'latest',
-        label: 'Trailing 12 Months'
-    },
-    {
-        name: 'all',
-        label: 'All Fiscal Years'
-    }
-];
 
 export default class FYPicker extends React.Component {
     constructor(props) {
@@ -36,6 +25,7 @@ export default class FYPicker extends React.Component {
         this.toggleList = this.toggleList.bind(this);
         this.clickedYear = this.clickedYear.bind(this);
         this.closeMenu = this.closeMenu.bind(this);
+        this.sortDropdownOptions = this.sortDropdownOptions.bind(this);
     }
 
     componentWillUnmount() {
@@ -79,53 +69,25 @@ export default class FYPicker extends React.Component {
         });
     }
 
+    sortDropdownOptions(key1, key2) {
+        if (key1 === 'latest') return -1;
+        else if (key2 === 'latest') return 1;
+        else if (key1 === 'all') return -1;
+        else if (key2 === 'all') return 1;
+        else if (key1 > key2) return -1;
+        else if (key2 > key1) return 1;
+        return 0;
+    }
+
     render() {
-        const fy = [];
-        const currentFY = FiscalYearHelper.currentFiscalYear();
-        const earliestFY = FiscalYearHelper.earliestFiscalYear;
-        for (let year = currentFY; year >= earliestFY; year--) {
-            const item = (
-                <li
-                    key={year}
-                    className="fy-picker__list-item">
-                    <button
-                        className="fy-picker__item"
-                        value={year}
-                        onClick={this.clickedYear}>
-                        FY {year}
-                    </button>
-                </li>
-            );
-
-            fy.push(item);
-        }
-
-        const otherFyOptions = fyOptions.map((option) => (
-            <li
-                key={option.name}
-                className="fy-picker__list-item">
-                <button
-                    className="fy-picker__item"
-                    value={option.name}
-                    onClick={this.clickedYear}>
-                    {option.label}
-                </button>
-            </li>
-        ));
-
+        const dropdownValuesByApiValue = getDropdownLabelsByApiValue();
         let visibleClass = 'fy-picker__list_hidden';
         if (this.state.expanded) {
             visibleClass = '';
         }
 
-        let currentSelection = `FY ${this.props.fy}`;
-        const otherSelection = fyOptions.find((option) =>
-            option.name === this.props.fy
-        );
-        if (otherSelection) {
-            currentSelection = otherSelection.label;
-        }
-
+        const selectedApiValue = Object.keys(dropdownValuesByApiValue)
+            .find((option) => option === this.props.selectedFy);
         return (
             <div
                 className="fy-picker"
@@ -141,23 +103,27 @@ export default class FYPicker extends React.Component {
                             className="fy-picker__button"
                             onClick={this.toggleList}>
                             <div className="fy-picker__button-text">
-                                {currentSelection}
+                                {dropdownValuesByApiValue[selectedApiValue]}
                             </div>
                             <div className="fy-picker__button-icon">
                                 <AngleDown alt="Toggle menu" />
                             </div>
                         </button>
                         <ul className={`fy-picker__list ${visibleClass}`}>
-                            {otherFyOptions}
-                            <li
-                                className="fy-picker__list-item">
-                                <button
-                                    disabled
-                                    className="fy-picker__item fy-picker__item_disabled">
-                                    &mdash;
-                                </button>
-                            </li>
-                            {fy}
+                            {Object.keys(dropdownValuesByApiValue)
+                                .sort(this.sortDropdownOptions)
+                                .map((apiValue) => (
+                                    <li
+                                        key={apiValue}
+                                        className="fy-picker__list-item">
+                                        <button
+                                            className="fy-picker__item"
+                                            value={apiValue}
+                                            onClick={this.clickedYear}>
+                                            {dropdownValuesByApiValue[apiValue]}
+                                        </button>
+                                    </li>
+                                ))}
                         </ul>
                     </div>
                 </div>

--- a/src/js/components/state/StateContent.jsx
+++ b/src/js/components/state/StateContent.jsx
@@ -216,7 +216,7 @@ export default class StateContent extends React.Component {
                         jumpToSection={this.jumpToSection}
                         stickyHeaderHeight={StickyHeader.stickyHeaderHeight}
                         fyPicker
-                        currentFy={this.props.stateProfile.fy}
+                        selectedFy={this.props.stateProfile.fy}
                         pickedYear={this.props.pickedFy} />
                 </div>
                 <div className="state-content">

--- a/src/js/components/state/StatePage.jsx
+++ b/src/js/components/state/StatePage.jsx
@@ -14,6 +14,7 @@ import Header from 'components/sharedComponents/header/Header';
 import StickyHeader from 'components/sharedComponents/stickyHeader/StickyHeader';
 import Error from 'components/sharedComponents/Error';
 import Footer from 'components/sharedComponents/Footer';
+import { LoadingWrapper } from "components/sharedComponents/Loading";
 
 import StateContent from './StateContent';
 
@@ -28,14 +29,7 @@ const propTypes = {
 export default class StatePage extends React.Component {
     render() {
         let content = <StateContent {...this.props} />;
-        if (this.props.loading) {
-            content = (
-                <Error
-                    title="Loading..."
-                    message="" />
-            );
-        }
-        else if (this.props.error) {
+        if (this.props.error) {
             content = (
                 <Error
                     title="Invalid State"
@@ -57,7 +51,9 @@ export default class StatePage extends React.Component {
                 <main
                     id="main-content"
                     className="main-content">
-                    {content}
+                    <LoadingWrapper isLoading={this.props.loading}>
+                        {content}
+                    </LoadingWrapper>
                 </main>
                 <Footer />
             </div>

--- a/src/js/containers/recipient/RecipientContainer.jsx
+++ b/src/js/containers/recipient/RecipientContainer.jsx
@@ -13,7 +13,7 @@ import BaseRecipientOverview from 'models/v2/recipient/BaseRecipientOverview';
 import * as recipientActions from 'redux/actions/recipient/recipientActions';
 import * as RecipientHelper from 'helpers/recipientHelper';
 import Router from 'containers/router/Router';
-
+import { LoadingWrapper } from "components/sharedComponents/Loading";
 
 import RecipientPage from 'components/recipient/RecipientPage';
 

--- a/src/js/containers/recipient/RecipientContainer.jsx
+++ b/src/js/containers/recipient/RecipientContainer.jsx
@@ -12,6 +12,8 @@ import { isCancel } from 'axios';
 import BaseRecipientOverview from 'models/v2/recipient/BaseRecipientOverview';
 import * as recipientActions from 'redux/actions/recipient/recipientActions';
 import * as RecipientHelper from 'helpers/recipientHelper';
+import Router from 'containers/router/Router';
+
 
 import RecipientPage from 'components/recipient/RecipientPage';
 
@@ -20,7 +22,7 @@ require('pages/recipient/recipientPage.scss');
 const propTypes = {
     setRecipientOverview: PropTypes.func,
     setRecipientFiscalYear: PropTypes.func,
-    params: PropTypes.object,
+    params: PropTypes.shape({ recipientId: PropTypes.string, fy: PropTypes.string }),
     recipient: PropTypes.object
 };
 
@@ -34,16 +36,18 @@ export class RecipientContainer extends React.Component {
         };
 
         this.request = null;
+        this.updateSelectedFy = this.updateSelectedFy.bind(this);
     }
 
     componentDidMount() {
+        this.props.setRecipientFiscalYear(this.props.params.fy);
         this.loadRecipientOverview(this.props.params.recipientId, this.props.recipient.fy);
     }
 
     componentDidUpdate(prevProps) {
         if (this.props.params.recipientId !== prevProps.params.recipientId) {
             // Reset the FY
-            this.props.setRecipientFiscalYear('latest');
+            this.props.setRecipientFiscalYear(this.props.params.fy);
             this.loadRecipientOverview(this.props.params.recipientId, 'latest');
         }
         if (this.props.recipient.fy !== prevProps.recipient.fy) {
@@ -90,6 +94,11 @@ export class RecipientContainer extends React.Component {
         this.props.setRecipientOverview(recipientOverview);
     }
 
+    updateSelectedFy(fy) {
+        Router.history.push(`/recipient/${this.props.recipient.id}/${fy}`);
+        this.props.setRecipientFiscalYear(fy);
+    }
+
     render() {
         return (
             <RecipientPage
@@ -97,7 +106,7 @@ export class RecipientContainer extends React.Component {
                 error={this.state.error}
                 id={this.props.recipient.id}
                 recipient={this.props.recipient}
-                pickedFy={this.props.setRecipientFiscalYear} />
+                pickedFy={this.updateSelectedFy} />
         );
     }
 }

--- a/src/js/containers/recipient/RecipientContainer.jsx
+++ b/src/js/containers/recipient/RecipientContainer.jsx
@@ -40,6 +40,9 @@ export class RecipientContainer extends React.Component {
     }
 
     componentDidMount() {
+        if (!Object.keys(this.props.params).includes('fy')) {
+            Router.history.replace(`/recipient/${this.props.params.recipientId}/latest`);
+        }
         this.props.setRecipientFiscalYear(this.props.params.fy);
         this.loadRecipientOverview(this.props.params.recipientId, this.props.recipient.fy);
     }
@@ -49,6 +52,10 @@ export class RecipientContainer extends React.Component {
             // Reset the FY
             this.props.setRecipientFiscalYear(this.props.params.fy);
             this.loadRecipientOverview(this.props.params.recipientId, 'latest');
+        }
+        if (!prevProps.params.fy && this.props.params.fy) {
+            // we just redirected the user to the new url which includes the fy selection
+            this.props.setRecipientFiscalYear(this.props.params.fy);
         }
         if (this.props.recipient.fy !== prevProps.recipient.fy) {
             this.loadRecipientOverview(this.props.params.recipientId, this.props.recipient.fy);

--- a/src/js/containers/recipient/RecipientContainer.jsx
+++ b/src/js/containers/recipient/RecipientContainer.jsx
@@ -13,7 +13,6 @@ import BaseRecipientOverview from 'models/v2/recipient/BaseRecipientOverview';
 import * as recipientActions from 'redux/actions/recipient/recipientActions';
 import * as RecipientHelper from 'helpers/recipientHelper';
 import Router from 'containers/router/Router';
-import { LoadingWrapper } from "components/sharedComponents/Loading";
 
 import RecipientPage from 'components/recipient/RecipientPage';
 

--- a/src/js/containers/router/RouterRoutes.js
+++ b/src/js/containers/router/RouterRoutes.js
@@ -234,6 +234,16 @@ const routes = {
             }
         },
         {
+            path: '/state/:stateId/:fy',
+            parent: '/state',
+            addToSitemap: false,
+            component: (cb) => {
+                require.ensure([], (require) => {
+                    cb(require('containers/state/StateContainer').default);
+                });
+            }
+        },
+        {
             path: '/recipient',
             parent: '/recipient',
             addToSitemap: true,

--- a/src/js/containers/router/RouterRoutes.js
+++ b/src/js/containers/router/RouterRoutes.js
@@ -252,6 +252,16 @@ const routes = {
                     cb(require('containers/recipient/RecipientContainer').default);
                 });
             }
+        },
+        {
+            path: '/recipient/:recipientId/:fy',
+            parent: '/recipient',
+            addToSitemap: false,
+            component: (cb) => {
+                require.ensure([], (require) => {
+                    cb(require('containers/recipient/RecipientContainer').default);
+                });
+            }
         }
     ],
     notFound: {

--- a/src/js/containers/state/StateContainer.jsx
+++ b/src/js/containers/state/StateContainer.jsx
@@ -15,7 +15,6 @@ import * as stateActions from 'redux/actions/state/stateActions';
 import { stateCenterFromFips } from 'helpers/mapHelper';
 import Router from 'containers/router/Router';
 
-
 import StatePage from 'components/state/StatePage';
 
 require('pages/state/statePage.scss');
@@ -45,7 +44,6 @@ export class StateContainer extends React.Component {
         if (!Object.keys(this.props.params).includes('fy')) {
             Router.history.replace(`/state/${this.props.params.stateId}/latest`);
         }
-        console.log("didMount");
         this.props.setStateFiscalYear('latest');
         this.loadStateOverview(this.props.params.stateId, this.props.stateProfile.fy);
         this.setStateCenter(this.props.params.stateId);

--- a/src/js/containers/state/StateContainer.jsx
+++ b/src/js/containers/state/StateContainer.jsx
@@ -13,13 +13,15 @@ import BaseStateProfile from 'models/v2/state/BaseStateProfile';
 import * as StateHelper from 'helpers/stateHelper';
 import * as stateActions from 'redux/actions/state/stateActions';
 import { stateCenterFromFips } from 'helpers/mapHelper';
+import Router from 'containers/router/Router';
+
 
 import StatePage from 'components/state/StatePage';
 
 require('pages/state/statePage.scss');
 
 const propTypes = {
-    params: PropTypes.object,
+    params: PropTypes.shape({ stateId: PropTypes.string, fy: PropTypes.string }),
     stateProfile: PropTypes.object,
     setStateOverview: PropTypes.func,
     setStateFiscalYear: PropTypes.func,
@@ -36,9 +38,15 @@ export class StateContainer extends React.Component {
         };
 
         this.request = null;
+        this.onClickFy = this.onClickFy.bind(this);
     }
 
     componentDidMount() {
+        if (!Object.keys(this.props.params).includes('fy')) {
+            Router.history.replace(`/state/${this.props.params.stateId}/latest`);
+        }
+        console.log("didMount");
+        this.props.setStateFiscalYear('latest');
         this.loadStateOverview(this.props.params.stateId, this.props.stateProfile.fy);
         this.setStateCenter(this.props.params.stateId);
     }
@@ -51,9 +59,18 @@ export class StateContainer extends React.Component {
             // Update the map center
             this.setStateCenter(this.props.params.stateId);
         }
+        if (!prevProps.params.fy && this.props.params.fy) {
+            // we just redirected the user to the new url which includes the fy selection
+            this.props.setStateFiscalYear(this.props.params.fy);
+        }
         if (this.props.stateProfile.fy !== prevProps.stateProfile.fy) {
             this.loadStateOverview(this.props.params.stateId, this.props.stateProfile.fy);
         }
+    }
+
+    onClickFy(fy) {
+        Router.history.push(`/state/${this.props.params.stateId}/${fy}`);
+        this.props.setStateFiscalYear(fy);
     }
 
     setStateCenter(id) {
@@ -106,7 +123,7 @@ export class StateContainer extends React.Component {
                 error={this.state.error}
                 id={this.props.stateProfile.id}
                 stateProfile={this.props.stateProfile}
-                pickedFy={this.props.setStateFiscalYear} />
+                pickedFy={this.onClickFy} />
         );
     }
 }

--- a/src/js/dataMapping/recipients/fiscalYearDropdown.js
+++ b/src/js/dataMapping/recipients/fiscalYearDropdown.js
@@ -8,23 +8,35 @@ import { currentFiscalYear, earliestFiscalYear } from "helpers/fiscalYearHelper"
 
 const earliestFY = moment(`10-01-${earliestFiscalYear}`);
 const currentFY = moment(`10-01-${currentFiscalYear()}`);
+const dropdownLabels = ['Trailing 12 Months', 'All Fiscal Years'];
 
 // eslint-disable-next-line import/prefer-default-export
-export const dropdownOptions = () => {
-    const options = ['Trailing 12 Months', 'All Fiscal Years'];
+export const getDropdownLabelsByApiValue = () => {
     const yearsSinceEarliestFY = currentFY.diff(earliestFY, 'y');
 
     for (let i = 0; i < yearsSinceEarliestFY; i++) {
         const nextFY = earliestFiscalYear + i;
-        options.push(`FY ${nextFY}`);
+        dropdownLabels.push(`FY ${nextFY}`);
     }
 
-    return options;
-};
+    return dropdownLabels
+        .reduce((acc, label) => {
+            if (label === 'Trailing 12 Months') {
+                return {
+                    ...acc,
+                    latest: label
+                };
+            }
+            else if (label === 'All Fiscal Years') {
+                return {
+                    ...acc,
+                    all: label
+                };
+            }
 
-export const urlSelections = dropdownOptions()
-    .map((option) => option
-        .split(" ")
-        .map((word) => word.toLowerCase())
-        .join("_")
-    );
+            return {
+                ...acc,
+                [label.split(" ")[1]]: label
+            };
+        }, {});
+};

--- a/src/js/dataMapping/recipients/fiscalYearDropdown.js
+++ b/src/js/dataMapping/recipients/fiscalYearDropdown.js
@@ -1,0 +1,30 @@
+/**
+ * fiscalYearDropdown.js
+ * Created by Maxwell Kendall 01/21/2020
+ */
+
+import moment from 'moment';
+import { currentFiscalYear, earliestFiscalYear } from "helpers/fiscalYearHelper";
+
+const earliestFY = moment(`10-01-${earliestFiscalYear}`);
+const currentFY = moment(`10-01-${currentFiscalYear()}`);
+
+// eslint-disable-next-line import/prefer-default-export
+export const dropdownOptions = () => {
+    const options = ['Trailing 12 Months', 'All Fiscal Years'];
+    const yearsSinceEarliestFY = currentFY.diff(earliestFY, 'y');
+
+    for (let i = 0; i < yearsSinceEarliestFY; i++) {
+        const nextFY = earliestFiscalYear + i;
+        options.push(`FY ${nextFY}`);
+    }
+
+    return options;
+};
+
+export const urlSelections = dropdownOptions()
+    .map((option) => option
+        .split(" ")
+        .map((word) => word.toLowerCase())
+        .join("_")
+    );

--- a/tests/containers/recipient/RecipientContainer-test.jsx
+++ b/tests/containers/recipient/RecipientContainer-test.jsx
@@ -6,19 +6,20 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 
+import { RecipientContainer } from 'containers/recipient/RecipientContainer';
+import BaseRecipientOverview from 'models/v2/recipient/BaseRecipientOverview';
+import { mockActions, mockRedux } from './mockData';
+import { mockRecipientOverview } from '../../models/recipient/mockRecipientApi';
+
 // mock the state helper
 jest.mock('helpers/recipientHelper', () => require('./mockRecipientHelper'));
 
-import { RecipientContainer } from 'containers/recipient/RecipientContainer';
-import { mockActions, mockRedux } from './mockData';
-import BaseRecipientOverview from 'models/v2/recipient/BaseRecipientOverview';
-import { mockRecipientOverview } from '../../models/recipient/mockRecipientApi';
 
 // mock the child component by replacing it with a function that returns a null element
 jest.mock('components/recipient/RecipientPage', () => jest.fn(() => null));
 
 describe('RecipientContainer', () => {
-    it('should make an API call for the selected recipient on mount', async () => {
+    it('on mount: should make an API call for the selected recipient & set fiscal year based on url params', async () => {
         const container = mount(<RecipientContainer
             {...mockRedux}
             {...mockActions} />);
@@ -30,6 +31,7 @@ describe('RecipientContainer', () => {
         await container.instance().request.promise;
 
         expect(loadRecipientOverview).toHaveBeenCalledTimes(1);
+        expect(mockActions.setRecipientFiscalYear).toHaveBeenCalledWith(mockRedux.params.fy);
         expect(loadRecipientOverview).toHaveBeenCalledWith('0123456-ABC-P', 'latest');
     });
     it('should make an API call when the id changes', async () => {

--- a/tests/containers/recipient/mockData.js
+++ b/tests/containers/recipient/mockData.js
@@ -9,7 +9,8 @@ export const mockActions = {
 
 export const mockRedux = {
     params: {
-        recipientId: '0123456-ABC-P'
+        recipientId: '0123456-ABC-P',
+        fy: 'latest'
     },
     recipient: initialState
 };

--- a/tests/containers/state/StateContainer-test.jsx
+++ b/tests/containers/state/StateContainer-test.jsx
@@ -6,12 +6,12 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 
-// mock the state helper
-jest.mock('helpers/stateHelper', () => require('./mockStateHelper'));
-
 import { StateContainer } from 'containers/state/StateContainer';
 import { mockActions, mockRedux, mockStateOverview } from './mockData';
 import BaseStateProfile from 'models/v2/state/BaseStateProfile';
+
+// mock the state helper
+jest.mock('helpers/stateHelper', () => require('./mockStateHelper'));
 
 // mock the child component by replacing it with a function that returns a null element
 jest.mock('components/state/StatePage', () => jest.fn(() => null));
@@ -29,6 +29,7 @@ describe('StateContainer', () => {
         await container.instance().request.promise;
 
         expect(loadStateOverview).toHaveBeenCalledTimes(1);
+        expect(mockActions.setStateFiscalYear).toHaveBeenCalledWith('latest');
         expect(loadStateOverview).toHaveBeenCalledWith('01', 'latest');
     });
     it('should update the center coordinates for the selected state on mount', async () => {

--- a/tests/containers/state/mockData.js
+++ b/tests/containers/state/mockData.js
@@ -12,7 +12,8 @@ stateProfile.populate({});
 
 export const mockRedux = {
     params: {
-        stateId: '01'
+        stateId: '01',
+        fy: 'latest'
     },
     stateProfile: {
         id: '',


### PR DESCRIPTION
**High level description:**
FY Selector is updated via url param.

**Technical details:**
- Adds to didMount the call to look for the url param; onClick handler in FY Selector now updates both redux and url.
- Reuses Award Page Loading indicator that has icon and dynamic dots (...)
- Updates sitemap script to append `/latest` to state and recipient sitemap pages

**JIRA Ticket:**
[DEV-3942](https://federal-spending-transparency.atlassian.net/browse/DEV-3942)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
