### PR TITLE
[DEV-4100] removes unnecessary conditional from subaward scroll fn

### DIFF
--- a/src/js/components/award/financialAssistance/FinancialAssistanceContent.jsx
+++ b/src/js/components/award/financialAssistance/FinancialAssistanceContent.jsx
@@ -60,7 +60,7 @@ const FinancialAssistanceContent = ({
     };
 
     useEffect(() => {
-        if (isSubAwardIdClicked && overview.type === '05') {
+        if (isSubAwardIdClicked) {
             jumpToSubAwardHistoryTable();
             subAwardIdClicked(false);
         }

--- a/tests/containers/state/StateContainer-test.jsx
+++ b/tests/containers/state/StateContainer-test.jsx
@@ -5,13 +5,12 @@
 
 import React from 'react';
 import { shallow, mount } from 'enzyme';
+import { StateContainer } from 'containers/state/StateContainer';
+import BaseStateProfile from 'models/v2/state/BaseStateProfile';
+import { mockActions, mockRedux, mockStateOverview } from './mockData';
 
 // mock the state helper
 jest.mock('helpers/stateHelper', () => require('./mockStateHelper'));
-
-import { StateContainer } from 'containers/state/StateContainer';
-import { mockActions, mockRedux, mockStateOverview } from './mockData';
-import BaseStateProfile from 'models/v2/state/BaseStateProfile';
 
 // mock the child component by replacing it with a function that returns a null element
 jest.mock('components/state/StatePage', () => jest.fn(() => null));

--- a/tests/containers/state/mockData.js
+++ b/tests/containers/state/mockData.js
@@ -12,7 +12,8 @@ stateProfile.populate({});
 
 export const mockRedux = {
     params: {
-        stateId: '01'
+        stateId: '01',
+        fy: 'latest'
     },
     stateProfile: {
         id: '',


### PR DESCRIPTION
**High level description:**
All awards w/ subaward tab, when clicked on subaward link from advanced search, should go to prime award page and scroll to subaward

**Technical details:**
Removes conditional that checks award type, this is unecessary as the boolean prop from redux will only be true if the sub-award link was clicked; this link will not appear for awards that dont have a subaward tab

**JIRA Ticket:**
[DEV-4100](https://federal-spending-transparency.atlassian.net/browse/DEV-4100)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
