### PR TITLE
[DEV-4100] Adding Conditional Back & Resetting Redux Award Namespace on unMount

### DIFF
--- a/src/js/components/award/contract/ContractContent.jsx
+++ b/src/js/components/award/contract/ContractContent.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import { glossaryLinks } from 'dataMapping/search/awardType';
 import BaseAwardAmounts from 'models/v2/awardsV2/BaseAwardAmounts';
 import AwardHistory from 'containers/award/shared/AwardHistorySectionContainer';
+import { awardTypesWithSubawards } from 'dataMapping/awards/awardHistorySection';
 
 import AdditionalInfo from '../shared/additionalInfo/AdditionalInfo';
 import AwardOverviewLeftSection from '../shared/overview/AwardOverviewLeftSection';
@@ -63,7 +64,7 @@ const ContractContent = ({
     };
 
     useEffect(() => {
-        if (isSubAwardIdClicked) {
+        if (isSubAwardIdClicked && awardTypesWithSubawards.includes(overview.category)) {
             jumpToSubAwardHistoryTable();
             subAwardIdClicked(false);
         }

--- a/src/js/components/award/financialAssistance/FinancialAssistanceContent.jsx
+++ b/src/js/components/award/financialAssistance/FinancialAssistanceContent.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import { glossaryLinks } from 'dataMapping/search/awardType';
 import BaseAwardAmounts from 'models/v2/awardsV2/BaseAwardAmounts';
 import AwardHistory from 'containers/award/shared/AwardHistorySectionContainer';
+import { awardTypesWithSubawards } from 'dataMapping/awards/awardHistorySection';
 
 import AwardAmountsSection from '../shared/awardAmountsSection/AwardAmountsSection';
 import AdditionalInfo from '../shared/additionalInfo/AdditionalInfo';
@@ -60,7 +61,7 @@ const FinancialAssistanceContent = ({
     };
 
     useEffect(() => {
-        if (isSubAwardIdClicked) {
+        if (isSubAwardIdClicked && awardTypesWithSubawards.includes(overview.category)) {
             jumpToSubAwardHistoryTable();
             subAwardIdClicked(false);
         }

--- a/src/js/containers/award/AwardContainer.jsx
+++ b/src/js/containers/award/AwardContainer.jsx
@@ -11,7 +11,7 @@ import { isCancel } from 'axios';
 import Award from 'components/award/Award';
 
 import * as SearchHelper from 'helpers/searchHelper';
-import { setAward } from 'redux/actions/award/awardActions';
+import { setAward, resetAward } from 'redux/actions/award/awardActions';
 import {
     setDownloadCollapsed,
     setDownloadPending,
@@ -34,6 +34,7 @@ require('pages/award/awardPage.scss');
 const propTypes = {
     subAwardIdClicked: PropTypes.func,
     setAward: PropTypes.func,
+    resetAward: PropTypes.func,
     handleDownloadRequest: PropTypes.func,
     setDownloadCollapsed: PropTypes.func,
     setDownloadPending: PropTypes.func,
@@ -74,6 +75,7 @@ export class AwardContainer extends React.Component {
         if (this.awardRequest) {
             this.awardRequest.cancel();
         }
+        this.props.resetAward();
     }
 
     getSelectedAward(id) {
@@ -209,6 +211,7 @@ export default connect(
         setDownloadPending,
         setDownloadCollapsed,
         setAward,
-        subAwardIdClicked
+        subAwardIdClicked,
+        resetAward
     }, dispatch)
 )(AwardContainer);

--- a/src/js/dataMapping/awards/awardHistorySection.js
+++ b/src/js/dataMapping/awards/awardHistorySection.js
@@ -24,4 +24,4 @@ export const tabs = (awardType) => [
     }
 ];
 
-export const awardTypesWithSubawards = ['grant', 'contract', 'loan'];
+export const awardTypesWithSubawards = ['grant', 'contract'];

--- a/src/js/dataMapping/awards/awardHistorySection.js
+++ b/src/js/dataMapping/awards/awardHistorySection.js
@@ -24,4 +24,4 @@ export const tabs = (awardType) => [
     }
 ];
 
-export const awardTypesWithSubawards = ['grant', 'contract'];
+export const awardTypesWithSubawards = ['grant', 'contract', 'loan'];

--- a/tests/containers/award/AwardContainer-test.jsx
+++ b/tests/containers/award/AwardContainer-test.jsx
@@ -25,6 +25,13 @@ const getAwardContainer = (params = mockParams) => shallow(<AwardContainer
     {...mockActions} />);
 
 describe('awardContainer', () => {
+    it('should reset redux.award on unMount', async () => {
+        const container = getAwardContainer();
+
+        await container.instance().componentWillUnmount();
+
+        expect(mockActions.resetAward).toHaveBeenCalled();
+    });
     it('should make an API call for the selected award on mount', async () => {
         const container = getAwardContainer();
 


### PR DESCRIPTION
**High level description:**
Ensuring that only awards w/ subaward tab scroll on subaward id click.

**Technical details:**
- Adds check to useEffect for award category to be either contract/grant
- Resets award redux state on unMount to prevent false positive on second condition above in useEffect

**JIRA Ticket:**
[DEV-4100](https://federal-spending-transparency.atlassian.net/browse/DEV-4100)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A`  Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
