### PR TITLE
Remove redundant aria-describedby

### DIFF
--- a/src/js/components/sharedComponents/IBTable/components/TableBody.jsx
+++ b/src/js/components/sharedComponents/IBTable/components/TableBody.jsx
@@ -367,7 +367,6 @@ export default class TableBody extends React.PureComponent {
                         role="gridcell"
                         aria-colindex={columnIndex + 1}
                         aria-rowindex={rowIndex + 1}
-                        aria-describedby={`${this.props.tableId}-header-${columnIndex}`}
                         data-ibt-table-element="cell"
                         data-ibt-table-owner={this.props.tableId}
                         data-ibt-col-index={columnIndex}


### PR DESCRIPTION
**High level description:**

This was causing the table header to be read twice by the screen reader when in table cells.

**Technical details:**

Screen readers can read the header cell without the need for an `aria-describedby` attribute. The additional`aria-describedby` causes the header cell to be read a second time by screen readers. Below are screenshots showing Mac OS X's VoiceOver screen reader behavior before and after this change.

Before:
![image](https://user-images.githubusercontent.com/945062/73573594-b8126e00-4441-11ea-8c52-4b4b114a6b62.png)


After:
![image](https://user-images.githubusercontent.com/945062/73573541-91543780-4441-11ea-97a4-b46b135abc3d.png)


**JIRA Ticket:**
N/A

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- `N/A` Linked to this PR in JIRA ticket
- `N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- `N/A` Verified cross-browser compatibility
- `N/A` Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- `N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- `N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- `N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- `N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
