### PR TITLE
[DEV-4036] Fixes XML Syntax for indexed sitemap

### DIFF
--- a/scripts/buildSitemap.js
+++ b/scripts/buildSitemap.js
@@ -7,9 +7,11 @@ const pages = require('./pages');
 const siteUrl = 'https://www.usaspending.gov';
 const xmlStart = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
-
+const indexedSitemapXmlStart = `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
 const sitemapsWritten = [];
 const xmlEnd = `</urlset>`;
+const indexedSitemapXmlEnd = `</sitemapindex>`;
 const forbiddenChars = ['&', "'", '"', '<', '>'];
 
 /**
@@ -51,6 +53,16 @@ const createRobots = () => {
         () => console.log("robots.txt successfully created!")
     );
 };
+
+const createIndexedSitemap = (xmlRoutes) => {
+    fs.writeFile(
+        path.resolve(__dirname, `../sitemap.xml`),
+        `${indexedSitemapXmlStart}${xmlRoutes}${indexedSitemapXmlEnd}`,
+        () => console.log(`Sitemap sitemap.xml successfully created!`)
+    );
+
+    sitemapsWritten.push('sitemap');
+}
 
 const createSitemap = (xmlRoutes, siteMapName = 'sitemap') => {
     fs.writeFile(
@@ -149,13 +161,11 @@ const buildIndividualSitemaps = () => {
 
 const buildIndexedSitemap = (individualSiteMaps) => {
     const xml = individualSiteMaps
-        .reduce((acc, pageName) => {
-            return (
-                `${acc}<sitemap><loc>${siteUrl}/${pageName}.xml</loc></sitemap>`
-            );
-        }, '');
+        .reduce((acc, pageName) => (
+            `${acc}<sitemap><loc>${siteUrl}/${pageName}.xml</loc></sitemap>`
+        ), '');
 
-    createSitemap(xml);
+    createIndexedSitemap(xml);
 };
 
 buildIndividualSitemaps()


### PR DESCRIPTION
**High level description:**
We are using the wrong parent tag for our indexed sitemap. 

**Technical details:**

[This documentation](https://support.google.com/webmasters/answer/75712?hl=en&ref_topic=4581190) shows the correct syntax for an indexed sitemap. Previously, we were using the same syntax as non-indexed sitemaps.

`indexedSiteMap`: sitemap.xml

Correct Parent tag:   <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
Current Parent tag is `urlset` which is the same as the other sitemaps which are not indexed.

**JIRA Ticket:**
[DEV-4036](https://federal-spending-transparency.atlassian.net/browse/DEV-4036)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
