### PR TITLE
[DEV-3942 && DEV-3194] Refactors componentDidUpdate to handle update to fy url param and updates links

### DIFF
--- a/src/js/components/recipient/modal/table/RecipientModalTable.jsx
+++ b/src/js/components/recipient/modal/table/RecipientModalTable.jsx
@@ -25,7 +25,7 @@ export default class RecipientModalTable extends React.Component {
                 className="recipients-list__body-row"
                 key={child.duns}>
                 <td className="recipients-list__body-cell">
-                    <a href={`/#/recipient/${child.id}`} onClick={this.props.hideModal}>{child.name}</a>
+                    <a href={`/#/recipient/${child.id}/latest`} onClick={this.props.hideModal}>{child.name}</a>
                 </td>
                 <td className="recipients-list__body-cell">
                     {child.duns}

--- a/src/js/containers/recipient/RecipientContainer.jsx
+++ b/src/js/containers/recipient/RecipientContainer.jsx
@@ -47,13 +47,15 @@ export class RecipientContainer extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
+        if (!Object.keys(this.props.params).includes('fy')) {
+            Router.history.replace(`/recipient/${this.props.params.recipientId}/latest`);
+        }
         if (this.props.params.recipientId !== prevProps.params.recipientId) {
             // Reset the FY
             this.props.setRecipientFiscalYear(this.props.params.fy);
             this.loadRecipientOverview(this.props.params.recipientId, 'latest');
         }
-        if (!prevProps.params.fy && this.props.params.fy) {
-            // we just redirected the user to the new url which includes the fy selection
+        if (prevProps.params.fy !== this.props.params.fy) {
             this.props.setRecipientFiscalYear(this.props.params.fy);
         }
         if (this.props.recipient.fy !== prevProps.recipient.fy) {

--- a/src/js/containers/state/StateContainer.jsx
+++ b/src/js/containers/state/StateContainer.jsx
@@ -58,8 +58,10 @@ export class StateContainer extends React.Component {
             // Update the map center
             this.setStateCenter(this.props.params.stateId);
         }
-        if (!prevProps.params.fy && this.props.params.fy) {
-            // we just redirected the user to the new url which includes the fy selection
+        if (
+            (!prevProps.params.fy && this.props.params.fy) ||
+            (prevProps.params.fy !== this.props.params.fy)) {
+            // we just redirected the user or to the new url which includes the fy selection
             this.props.setStateFiscalYear(this.props.params.fy);
         }
         if (this.props.stateProfile.fy !== prevProps.stateProfile.fy) {

--- a/src/js/dataMapping/awards/additionalDetailsContract.js
+++ b/src/js/dataMapping/awards/additionalDetailsContract.js
@@ -102,7 +102,7 @@ const additionalDetailsContracts = (awardData) => {
             Recipient: {
                 type: 'link',
                 data: {
-                    path: recipient.internalId ? `/#/recipient/${recipient.internalId}` : null,
+                    path: recipient.internalId ? `/#/recipient/${recipient.internalId}/latest` : null,
                     title: recipient._name
                 }
             },
@@ -111,7 +111,7 @@ const additionalDetailsContracts = (awardData) => {
                 type: 'link',
                 data: {
                     path: recipient.parentInternalId ?
-                        `/#/recipient/${recipient.parentInternalId}` : null,
+                        `/#/recipient/${recipient.parentInternalId}/latest` : null,
                     title: recipient.parentName
                 }
             },

--- a/src/js/dataMapping/awards/additionalDetailsFinancialAssistance.js
+++ b/src/js/dataMapping/awards/additionalDetailsFinancialAssistance.js
@@ -75,7 +75,7 @@ const additionalDetailsFinancialAssistance = (awardData) => {
             Recipient: {
                 type: 'link',
                 data: {
-                    path: recipient.internalId ? `/#/recipient/${recipient.internalId}` : null,
+                    path: recipient.internalId ? `/#/recipient/${recipient.internalId}/latest` : null,
                     title: recipient._name
                 }
             },
@@ -84,7 +84,7 @@ const additionalDetailsFinancialAssistance = (awardData) => {
                 type: 'link',
                 data: {
                     path: recipient.parentInternalId ?
-                        `/#/recipient/${recipient.parentInternalId}` : null,
+                        `/#/recipient/${recipient.parentInternalId}/latest` : null,
                     title: recipient.parentName
                 }
             },

--- a/src/js/dataMapping/awards/additionalDetailsIdv.js
+++ b/src/js/dataMapping/awards/additionalDetailsIdv.js
@@ -66,7 +66,7 @@ const additionalDetails = (awardData) => {
             Recipient: {
                 type: 'link',
                 data: {
-                    path: recipient.internalId ? `/#/recipient/${recipient.internalId}` : null,
+                    path: recipient.internalId ? `/#/recipient/${recipient.internalId}/latest` : null,
                     title: recipient._name
                 }
             },
@@ -74,7 +74,7 @@ const additionalDetails = (awardData) => {
             'Parent Recipient': {
                 type: 'link',
                 data: {
-                    path: recipient.parentInternalId ? `/#/recipient/${recipient.parentInternalId}` : null,
+                    path: recipient.parentInternalId ? `/#/recipient/${recipient.parentInternalId}/latest` : null,
                     title: recipient.parentName
                 }
             },

--- a/tests/containers/recipient/RecipientContainer-test.jsx
+++ b/tests/containers/recipient/RecipientContainer-test.jsx
@@ -79,6 +79,29 @@ describe('RecipientContainer', () => {
 
         expect(loadRecipientOverview).toHaveBeenLastCalledWith('876543-ABC-R', 'latest');
     });
+    it('should handle changes in the new fy url param', () => {
+        // Use 'all' for the initial FY
+        jest.clearAllMocks();
+        const container = mount(<RecipientContainer
+            {...mockRedux}
+            {...mockActions} />);
+
+        container.setProps({
+            params: {
+                recipientId: '876543-ABC-R'
+            }
+        });
+
+        expect(mockActions.setRecipientFiscalYear).toHaveBeenCalledWith('latest');
+
+        container.setProps({
+            params: {
+                fy: '2009'
+            }
+        });
+
+        expect(mockActions.setRecipientFiscalYear).toHaveBeenCalledWith('2009');
+    });
     it('should make an API call when the fiscal year changes', async () => {
         const container = mount(<RecipientContainer
             {...mockRedux}

--- a/tests/containers/state/StateContainer-test.jsx
+++ b/tests/containers/state/StateContainer-test.jsx
@@ -85,7 +85,7 @@ describe('StateContainer', () => {
         expect(setStateCenter).toHaveBeenCalledTimes(1);
         expect(setStateCenter).toHaveBeenCalledWith('02');
     });
-    it('should reset the fiscal year when the state id changes', async () => {
+    it('should reset the fiscal year when the state id changes or the fy param changes', async () => {
         // Use 'all' for the initial FY
         const stateProfile = Object.assign({}, mockRedux.stateProfile, {
             fy: 'all'
@@ -109,8 +109,10 @@ describe('StateContainer', () => {
         });
 
         await container.instance().request.promise;
-
         expect(loadStateOverview).toHaveBeenLastCalledWith('02', 'latest');
+
+        container.setProps({ params: { stateId: '02', fy: '2008' } });
+        expect(mockActions.setStateFiscalYear).toHaveBeenLastCalledWith('2008');
     });
     it('should make an API call when the fiscal year changes', async () => {
         const container = mount(<StateContainer


### PR DESCRIPTION


**High level description:**
- State Page (DEV-3942): Updating the url manually, specifically the fy url param (state/stateId/fyparam --> state/01/latest|2019|etc/
- Recipient Page: Updating child recipient links

**Technical details:**
947793a - State Page: Adds logic to componentDidUpdate to handle this case when only the fy url param is updated
b810b19 - Recipient Page: Updates links

**JIRA Ticket:**
[DEV-3942](https://federal-spending-transparency.atlassian.net/browse/DEV-3942)
[DEV-3194](https://federal-spending-transparency.atlassian.net/browse/DEV-3194)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
