### PR TITLE
[DEV-4373 & DEV-4369] Agency Profile Page V2, iteration 1 (Scaffolding + Navigation)

### DIFF
--- a/src/_scss/pages/agency/v2/index.scss
+++ b/src/_scss/pages/agency/v2/index.scss
@@ -1,7 +1,3 @@
-$fg-column: 78px;             // Column Width
-$fg-gutter: 5px;             // Gutter Width
-$fg-max-columns: 12;          // Total Columns For Main Container
-
 .usa-da-agency-page-v2 {
     @import "all";
     @import "layouts/default/default";
@@ -22,30 +18,36 @@ $fg-max-columns: 12;          // Total Columns For Main Container
     .footer-container {
         width: 100%;
     }
-
-    .main-content .sidebar,
-    .main-content .body {
-        max-width: rem(1600);
+    
+    .sankey {
+        width: flex-grid(12);
+        background: #fff;
+        box-shadow: 0 0 5px 5px rgba(0,0,0,0.15);
+        h2 {
+            padding: 0px;
+            margin: 0px;
+        }
     }
 
+    .usda__flex-row {
+        display: flex;
+        flex-wrap: wrap;
+        width: 100%;
+        .usda__flex-col {
+            @include flex(1 1 auto);
+        }
+    }
+    
     .main-content {
         display: flex;
-        width: flex-grid(12);
+        width: 100%;
         flex-grow: 1;
         flex-wrap: wrap;
+        max-width: rem(1600);
         ul {
             padding: 0;
             li {
                 list-style: none;
-            }
-        }
-        .sankey {
-            width: flex-grid(12);
-            background: #fff;
-            box-shadow: 0 0 5px 5px rgba(0,0,0,0.15);
-            h2 {
-                padding: 0px;
-                margin: 0px;
             }
         }
         .sidebar {
@@ -53,8 +55,8 @@ $fg-max-columns: 12;          // Total Columns For Main Container
             @media(min-width: $tablet-screen) {
                 display: flex;
                 flex-direction: column;
-                width: flex-grid(2);
-                margin: flex-gutter() / 2;
+                width: 20%;
+                margin: 2.5%;
             }
             .agency-v2-sidebar-reference {
                 display: none;
@@ -113,12 +115,11 @@ $fg-max-columns: 12;          // Total Columns For Main Container
             }
         }
         .body {
-            margin: flex-gutter() / 2 0;
             display: flex;
-            width: flex-grid(10);
             flex-direction: column;
+            width: 70%;
+            margin: 2.5% 2.5% 0 0;
             @media(min-width: $tablet-screen) {
-                width: flex-grid(10);
             }
             .body__section {
                 height: 250px;

--- a/src/_scss/pages/agency/v2/index.scss
+++ b/src/_scss/pages/agency/v2/index.scss
@@ -66,7 +66,7 @@ $fg-max-columns: 12;          // Total Columns For Main Container
             .agency-v2-sidebar-content {
                 &.float-sidebar {
                     position: fixed;
-                    top: rem(126);
+                    top: rem(86);
                 }
             
                 background-color: $color-white;
@@ -113,7 +113,7 @@ $fg-max-columns: 12;          // Total Columns For Main Container
             }
         }
         .body {
-            // margin: flex-gutter();
+            margin: flex-gutter() / 2 0;
             display: flex;
             width: flex-grid(10);
             flex-direction: column;

--- a/src/_scss/pages/agency/v2/index.scss
+++ b/src/_scss/pages/agency/v2/index.scss
@@ -1,4 +1,8 @@
-.usa-da-agency-page {
+$fg-column: 78px;             // Column Width
+$fg-gutter: 5px;             // Gutter Width
+$fg-max-columns: 12;          // Total Columns For Main Container
+
+.usa-da-agency-page-v2 {
     @import "all";
     @import "layouts/default/default";
     @import "layouts/default/stickyHeader/header";
@@ -8,8 +12,8 @@
     justify-content: flex-start;
     align-items: center;
     flex-direction: column;
-    width: 100%;
     min-height: 100vh;
+    width: 100%;
 
     .site-header,
     .sticky-header,
@@ -19,8 +23,111 @@
         width: 100%;
     }
 
+    .main-content .sidebar,
+    .main-content .body {
+        max-width: rem(1600);
+    }
+
     .main-content {
+        display: flex;
+        width: flex-grid(12);
         flex-grow: 1;
+        flex-wrap: wrap;
+        ul {
+            padding: 0;
+            li {
+                list-style: none;
+            }
+        }
+        .sankey {
+            width: flex-grid(12);
+            background: #fff;
+            box-shadow: 0 0 5px 5px rgba(0,0,0,0.15);
+            h2 {
+                padding: 0px;
+                margin: 0px;
+            }
+        }
+        .sidebar {
+            display: none;
+            @media(min-width: $tablet-screen) {
+                display: flex;
+                flex-direction: column;
+                width: flex-grid(2);
+                margin: flex-gutter() / 2;
+            }
+            .agency-v2-sidebar-reference {
+                display: none;
+            
+                &.float-sidebar {
+                    display: block;
+                }
+            }
+            .agency-v2-sidebar-content {
+                &.float-sidebar {
+                    position: fixed;
+                    top: rem(126);
+                }
+            
+                background-color: $color-white;
+                box-shadow: $container-shadow;
+                color: $color-base;
+                border-top: 1px solid $color-gray-border;
+                border-right: 1px solid $color-gray-border;
+                border-bottom: 1px solid $color-gray-border;
+            
+                @import 'pages/state/_fyPicker';
+            
+                ul {
+                    @include unstyled-list;
+                    padding: rem(15) rem(30) rem(30);
+            
+                    li {
+                        margin-bottom: rem(24);
+            
+                        &:last-child {
+                            margin-bottom: rem(0);
+                        }
+                    }
+            
+                    a.sidebar-link {
+                        color: $color-base;
+                        font-size: rem(19);
+                        line-height: rem(20);
+                        padding-bottom: rem(5);
+            
+                        text-decoration: none;
+                        border-bottom: 5px solid transparent;
+                        @include transition(all 0.15s ease-in-out);
+            
+                        &:hover {
+                            border-bottom: 5px solid $color-primary;
+                        }
+            
+                        &.active {
+                            font-weight: $font-bold;
+                            border-bottom: 5px solid $color-primary;
+                        }
+                    }
+                }
+            }
+        }
+        .body {
+            // margin: flex-gutter();
+            display: flex;
+            width: flex-grid(10);
+            flex-direction: column;
+            @media(min-width: $tablet-screen) {
+                width: flex-grid(10);
+            }
+            .body__section {
+                height: 250px;
+                border: 1px solid red;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+            }
+        }
     }
 
     $color-gray-border: #D8D8D8;

--- a/src/_scss/pages/agency/v2/index.scss
+++ b/src/_scss/pages/agency/v2/index.scss
@@ -125,7 +125,6 @@
                 width: 70%;
             }
             .body__section {
-                height: 250px;
                 display: flex;
                 flex-wrap: wrap;
                 margin-bottom: $global-mrg;
@@ -159,6 +158,7 @@
                     flex-direction: column;
                     @extend %coming-soon-idv;
                     padding-bottom: 0;
+                    height: 730px;
                 }
 
                 .agency-v2-tt {

--- a/src/_scss/pages/agency/v2/index.scss
+++ b/src/_scss/pages/agency/v2/index.scss
@@ -23,6 +23,7 @@
         width: flex-grid(12);
         background: #fff;
         box-shadow: 0 0 5px 5px rgba(0,0,0,0.15);
+        z-index: 10;
         h2 {
             padding: 0px;
             margin: 0px;
@@ -56,7 +57,7 @@
                 display: flex;
                 flex-direction: column;
                 width: 20%;
-                margin: 2.5%;
+                margin: 2.5% 2.5% 2.5% 0;
             }
             .agency-v2-sidebar-reference {
                 display: none;
@@ -116,17 +117,63 @@
         }
         .body {
             display: flex;
+            width: 100%;
             flex-direction: column;
-            width: 70%;
-            margin: 2.5% 2.5% 0 0;
+            padding: 2.5% 2.5% 0 2.5%;
+            background: white;
             @media(min-width: $tablet-screen) {
+                width: 70%;
             }
             .body__section {
                 height: 250px;
-                border: 1px solid red;
                 display: flex;
-                justify-content: center;
-                align-items: center;
+                flex-wrap: wrap;
+                margin-bottom: $global-mrg;
+                .body__header {
+                    width: 100%;
+                    height: rem(30);
+                    display: flex;
+                    align-items: center;
+                    justify-content: flex-start;
+                    .body__header-icon {
+                        margin-right: $global-mrg;
+                    }
+                    h3 {
+                        @include display(flex);
+                        margin: 0;
+                        line-height: $base-line-height;
+                        font-size: rem(18);
+                        font-weight: $font-semibold;
+                    }
+                }
+                hr {
+                    width: 100%;
+                    height: 2px;
+                    background: #555555;
+                    border: none;
+                    margin-bottom: rem(35);
+                }
+                .coming-soon-section {
+                    width: 100%;
+                    display: flex;
+                    flex-direction: column;
+                    @extend %coming-soon-idv;
+                    padding-bottom: 0;
+                }
+
+                .agency-v2-tt {
+                    display: flex;
+                    justify-content: center;
+                    flex-direction: column;
+                    .tooltip__title {
+                        width: 100%;
+                        margin-bottom: $global-mrg / 2;
+                        text-align: center;
+                    }
+                    .tooltip__text {
+                        padding: rem(0) rem(23);
+                    }
+                }
             }
         }
     }

--- a/src/_scss/pages/agency/v2/index.scss
+++ b/src/_scss/pages/agency/v2/index.scss
@@ -135,7 +135,7 @@
                     align-items: center;
                     justify-content: flex-start;
                     .body__header-icon {
-                        margin-right: $global-mrg;
+                        margin-right: $global-mrg / 2;
                     }
                     h3 {
                         @include display(flex);
@@ -151,6 +151,7 @@
                     background: #555555;
                     border: none;
                     margin-bottom: rem(35);
+                    margin-top: 0;
                 }
                 .coming-soon-section {
                     width: 100%;

--- a/src/_scss/pages/agency/v2/index.scss
+++ b/src/_scss/pages/agency/v2/index.scss
@@ -1,0 +1,28 @@
+.usa-da-agency-page {
+    @import "all";
+    @import "layouts/default/default";
+    @import "layouts/default/stickyHeader/header";
+    @import "components/pageLoading";
+
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    flex-direction: column;
+    width: 100%;
+    min-height: 100vh;
+
+    .site-header,
+    .sticky-header,
+    .page__loading,
+    .main-content,
+    .footer-container {
+        width: 100%;
+    }
+
+    .main-content {
+        flex-grow: 1;
+    }
+
+    $color-gray-border: #D8D8D8;
+    $color-blue-background: #F5FBFC;
+}

--- a/src/_scss/pages/award/_comingSoon.scss
+++ b/src/_scss/pages/award/_comingSoon.scss
@@ -1,5 +1,4 @@
 .coming-soon__section {
     @extend %coming-soon-idv;
     height: 100%;
-    
 }

--- a/src/_scss/pages/glossary/glossaryPage.scss
+++ b/src/_scss/pages/glossary/glossaryPage.scss
@@ -1,42 +1,41 @@
 .usa-da-glossary-animations {
     @import "all";
     @import "./_animations";
-}
 
-.usa-da-glossary-wrapper {
-    @import "all";
-    position: fixed;
-    right: 0;
-    top: 0;
+    .usa-da-glossary-wrapper {
+        position: fixed;
+        right: 0;
+        top: 0;
 
-    width: 310px;
-    height: 100%;
-
-    z-index: $z-guide;
-
-    box-shadow: -3px 0px 4px rgba(0, 0, 0, 0.2);
-
-    .glossary-sidebar {
-        background-color: $color-primary-darker;
-        color: $color-white;
-        font-size: 14px;
-
-        width: 100%;
+        width: 310px;
         height: 100%;
 
-        @import "./_scrollbar";
+        z-index: $z-guide;
 
-        @import "./_header";
-        @import "./_searchList";
-        @import "./_definition";
-        @import "./_noResults";
+        box-shadow: -3px 0px 4px rgba(0, 0, 0, 0.2);
 
-        .glossary-loading-content {
-            padding: 20px;
-        }
+        .glossary-sidebar {
+            background-color: $color-primary-darker;
+            color: $color-white;
+            font-size: 14px;
 
-        .loading {
-            opacity: 0.2;
+            width: 100%;
+            height: 100%;
+
+            @import "./_scrollbar";
+
+            @import "./_header";
+            @import "./_searchList";
+            @import "./_definition";
+            @import "./_noResults";
+
+            .glossary-loading-content {
+                padding: 20px;
+            }
+
+            .loading {
+                opacity: 0.2;
+            }
         }
     }
 }

--- a/src/js/GlobalConstants.js
+++ b/src/js/GlobalConstants.js
@@ -17,5 +17,5 @@ const globalConstants = {
     MAPBOX_TOKEN: process.env.MAPBOX_TOKEN
 };
 
-export default globalConstants;
+module.exports = globalConstants;
 

--- a/src/js/components/sharedComponents/sidebar/Sidebar.jsx
+++ b/src/js/components/sharedComponents/sidebar/Sidebar.jsx
@@ -125,7 +125,6 @@ export default class Sidebar extends React.Component {
     }
 
     highlightCurrentSection() {
-        console.log("HighlightCurrentSection fired", this.props.active);
         const windowTop = window.pageYOffset || document.documentElement.scrollTop;
         const windowBottom = windowTop + this.state.window.height;
 

--- a/src/js/containers/agency/AgencyContainer.jsx
+++ b/src/js/containers/agency/AgencyContainer.jsx
@@ -138,11 +138,6 @@ export class AgencyContainer extends React.Component {
     }
 }
 
-export default connect(
-    (state) => ({
-        agency: state.agency
-    }),
-    (dispatch) => bindActionCreators(agencyActions, dispatch)
-)(AgencyContainer);
+export default connect((state) => ({ agency: state.agency }), (dispatch) => bindActionCreators(agencyActions, dispatch))(AgencyContainer);
 
 AgencyContainer.propTypes = propTypes;

--- a/src/js/containers/agency/AgencyContainerV2.jsx
+++ b/src/js/containers/agency/AgencyContainerV2.jsx
@@ -3,21 +3,41 @@
  * Created by Maxwell Kendall 01/31/2020
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { startCase, snakeCase, find } from "lodash";
 
 import { agencyPageMetaTags } from 'helpers/metaTagHelper';
-
-import { setAgencyOverview, resetAgency } from "../../redux/actions/agency/agencyActions";
+import { scrollToY } from 'helpers/scrollToHelper';
 
 import MetaTags from 'components/sharedComponents/metaTags/MetaTags';
 import Header from 'components/sharedComponents/header/Header';
-import StickyHeader from 'components/sharedComponents/stickyHeader/StickyHeader';
+import StickyHeader, { stickyHeaderHeight } from 'components/sharedComponents/stickyHeader/StickyHeader';
 import Footer from 'components/sharedComponents/Footer';
 import { LoadingWrapper } from 'components/sharedComponents/Loading';
 
+import { setAgencyOverview, resetAgency } from "../../redux/actions/agency/agencyActions";
+import Sidebar from '../../components/sharedComponents/sidebar/Sidebar';
+
 require('pages/agency/v2/index.scss');
+
+const ComingSoonSection = ({ title }) => <div>{`${title}: Coming Soon`}</div>;
+
+const componentByAgencySection = {
+    overview: <ComingSoonSection title="Overview" />,
+    account_spending: <ComingSoonSection title="Account Spending" />,
+    award_spending: <ComingSoonSection title="Award Spending" />,
+    'sub-agency_spending': <ComingSoonSection title="Sub-Agency Spending" />,
+    award_recipients: <ComingSoonSection title="Award Recipients" />,
+    'top_5:_award_dimensions': <ComingSoonSection title="Top 5: Award Dimensions" />
+};
+
+const sections = Object.keys(componentByAgencySection)
+    .map((section) => ({
+        section,
+        label: startCase(section)
+    }));
 
 const AgencyProfileV2 = ({
     agencyOverview,
@@ -25,20 +45,70 @@ const AgencyProfileV2 = ({
     resetAgency,
     setAgencyOverview
 }) => {
+    const [activeSection, setActiveSection] = useState(sections[0].section);
+
+    const jumpToSection = (section = '') => {
+        // we've been provided a section to jump to
+        // check if it's a valid section
+        const matchedSection = find(sections, {
+            section
+        });
+
+        if (!matchedSection) {
+            // no matching section
+            return;
+        }
+
+        // scroll to the correct section
+        const sectionDom = document.querySelector(`#${snakeCase(section)}`);
+
+        if (!sectionDom) {
+            return;
+        }
+
+        const sectionTop = sectionDom.offsetTop - 145;
+        scrollToY(sectionTop, 700);
+        setActiveSection(matchedSection.section);
+    };
+
     return (
-        <div className="usa-da-agency-page">
+        <div className="usa-da-agency-page-v2">
             <MetaTags {...agencyPageMetaTags} />
             <Header />
             <StickyHeader>
                 <div className="sticky-header__title">
                     <h1 tabIndex={-1} id="main-focus">
-                        Agency Profile
+                        Agency Profile v2
                     </h1>
+                    <div className="fy-picker">
+                        FY Picker
+                    </div>
                 </div>
             </StickyHeader>
             <LoadingWrapper>
                 <main id="main-content" className="main-content">
-                    YOOOO
+                    <div className="sankey">
+                        <h2>Agency Spending Snapshot</h2>
+                        <span>Overview</span>
+                        <div className="sankey__viz coming-soon">
+                            Coming Soon
+                        </div>
+                    </div>
+                    <div className="sidebar">
+                        <Sidebar
+                            stickyHeaderHeight={stickyHeaderHeight}
+                            sections={sections}
+                            active={activeSection}
+                            jumpToSection={jumpToSection}
+                            pageName="agency-v2" />
+                    </div>
+                    <div className="body">
+                        {sections.map((section) => (
+                            <section id={snakeCase(section.section)} className={`body__section ${snakeCase(section.section)}`}>
+                                {componentByAgencySection[section.section]}
+                            </section>
+                        ))}
+                    </div>
                 </main>
             </LoadingWrapper>
             <Footer />

--- a/src/js/containers/agency/AgencyContainerV2.jsx
+++ b/src/js/containers/agency/AgencyContainerV2.jsx
@@ -85,16 +85,16 @@ const AgencyProfileV2 = ({
                     </div>
                 </div>
             </StickyHeader>
+            <div className="sankey">
+                <h2>Agency Spending Snapshot</h2>
+                <span>Overview</span>
+                <div className="sankey__viz coming-soon">
+                    Coming Soon
+                </div>
+            </div>
             <LoadingWrapper>
-                <main id="main-content" className="main-content">
-                    <div className="sankey">
-                        <h2>Agency Spending Snapshot</h2>
-                        <span>Overview</span>
-                        <div className="sankey__viz coming-soon">
-                            Coming Soon
-                        </div>
-                    </div>
-                    <div className="sidebar">
+                <main id="main-content" className="main-content usda__flex-row">
+                    <div className="sidebar usda__flex-col">
                         <Sidebar
                             stickyHeaderHeight={stickyHeaderHeight}
                             sections={sections}
@@ -102,7 +102,7 @@ const AgencyProfileV2 = ({
                             jumpToSection={jumpToSection}
                             pageName="agency-v2" />
                     </div>
-                    <div className="body">
+                    <div className="body usda__flex-col">
                         {sections.map((section) => (
                             <section id={snakeCase(section.section)} className={`body__section ${snakeCase(section.section)}`}>
                                 {componentByAgencySection[section.section]}

--- a/src/js/containers/agency/AgencyContainerV2.jsx
+++ b/src/js/containers/agency/AgencyContainerV2.jsx
@@ -1,0 +1,62 @@
+/**
+ * AgencyPage.jsx
+ * Created by Maxwell Kendall 01/31/2020
+ */
+
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import { agencyPageMetaTags } from 'helpers/metaTagHelper';
+
+import { setAgencyOverview, resetAgency } from "../../redux/actions/agency/agencyActions";
+
+import MetaTags from 'components/sharedComponents/metaTags/MetaTags';
+import Header from 'components/sharedComponents/header/Header';
+import StickyHeader from 'components/sharedComponents/stickyHeader/StickyHeader';
+import Footer from 'components/sharedComponents/Footer';
+import { LoadingWrapper } from 'components/sharedComponents/Loading';
+
+require('pages/agency/agencyPage.scss');
+
+const AgencyProfileV2 = ({
+    agencyOverview,
+    agencyId,
+    resetAgency,
+    setAgencyOverview
+}) => {
+    return (
+        <div className="usa-da-agency-page">
+            <MetaTags {...agencyPageMetaTags} />
+            <Header />
+            <StickyHeader>
+                <div className="sticky-header__title">
+                    <h1 tabIndex={-1} id="main-focus">
+                        Agency Profile
+                    </h1>
+                </div>
+            </StickyHeader>
+            <LoadingWrapper>
+                <main id="main-content" className="main-content">
+                    {agencyOverview.name}
+                </main>
+            </LoadingWrapper>
+            <Footer />
+        </div>
+    );
+};
+
+const mapStateToProps = (state) => ({
+    agencyOverview: state.agency.overview,
+    agencyId: state.agency.id
+});
+
+const mapDispatchToProps = (dispatch) => ({
+    resetAgency: () => dispatch(resetAgency()),
+    setAgencyOverview: (agency) => dispatch(setAgencyOverview(agency))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(AgencyProfileV2);
+
+// export default AgencyProfileV2;
+

--- a/src/js/containers/agency/AgencyContainerV2.jsx
+++ b/src/js/containers/agency/AgencyContainerV2.jsx
@@ -17,7 +17,7 @@ import StickyHeader from 'components/sharedComponents/stickyHeader/StickyHeader'
 import Footer from 'components/sharedComponents/Footer';
 import { LoadingWrapper } from 'components/sharedComponents/Loading';
 
-require('pages/agency/agencyPage.scss');
+require('pages/agency/v2/index.scss');
 
 const AgencyProfileV2 = ({
     agencyOverview,
@@ -38,7 +38,7 @@ const AgencyProfileV2 = ({
             </StickyHeader>
             <LoadingWrapper>
                 <main id="main-content" className="main-content">
-                    {agencyOverview.name}
+                    YOOOO
                 </main>
             </LoadingWrapper>
             <Footer />

--- a/src/js/containers/agency/AgencyContainerV2.jsx
+++ b/src/js/containers/agency/AgencyContainerV2.jsx
@@ -5,7 +5,6 @@
 
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { startCase, snakeCase, find } from "lodash";
 import { TooltipWrapper } from 'data-transparency-ui';
@@ -31,8 +30,9 @@ const TooltipComponent = () => (
     </div>
 );
 
+// eslint-disable-next-line react/prop-types
 const ComingSoonSection = ({ section, icon = "chart-area" }) => (
-    <section id={snakeCase(section)} className={`body__section ${snakeCase(section)}`}>
+    <section id={`agency-v2-${snakeCase(section)}`} className={`body__section ${snakeCase(section)}`}>
         <div className="body__header">
             <div className="body__header-icon">
                 <FontAwesomeIcon size="lg" icon={icon} />
@@ -52,9 +52,9 @@ const componentByAgencySection = {
     overview: <ComingSoonSection section="overview" />,
     account_spending: <ComingSoonSection section="account_spending" />,
     award_spending: <ComingSoonSection section="award_spending" />,
-    'sub-agency_spending': <ComingSoonSection section="sub-agency_spending" />,
+    sub_agency_spending: <ComingSoonSection section="sub-agency_spending" />,
     award_recipients: <ComingSoonSection section="award_recipients" />,
-    'top_5:_award_dimensions': <ComingSoonSection section="top_5:_award_dimensions" />
+    top_5_award_dimensions: <ComingSoonSection section="top_5_award_dimensions" />
 };
 
 const sections = Object.keys(componentByAgencySection)
@@ -77,14 +77,13 @@ const AgencyProfileV2 = ({
         const matchedSection = find(sections, {
             section
         });
-
         if (!matchedSection) {
             // no matching section
             return;
         }
 
         // scroll to the correct section
-        const sectionDom = document.querySelector(`#${snakeCase(section)}`);
+        const sectionDom = document.querySelector(`#agency-v2-${snakeCase(section)}`);
 
         if (!sectionDom) {
             return;
@@ -121,9 +120,10 @@ const AgencyProfileV2 = ({
                     <div className="sidebar usda__flex-col">
                         <Sidebar
                             stickyHeaderHeight={stickyHeaderHeight}
-                            sections={sections}
+                            sections={sections.map((section) => ({ section: snakeCase(section.section), label: section.label }))}
                             active={activeSection}
                             jumpToSection={jumpToSection}
+                            detectActiveSection={setActiveSection}
                             pageName="agency-v2" />
                     </div>
                     <div className="body usda__flex-col">

--- a/src/js/containers/agency/AgencyContainerV2.jsx
+++ b/src/js/containers/agency/AgencyContainerV2.jsx
@@ -12,6 +12,7 @@ import { TooltipWrapper } from 'data-transparency-ui';
 import { agencyPageMetaTags } from 'helpers/metaTagHelper';
 import { scrollToY } from 'helpers/scrollToHelper';
 
+
 import MetaTags from 'components/sharedComponents/metaTags/MetaTags';
 import Header from 'components/sharedComponents/header/Header';
 import StickyHeader, { stickyHeaderHeight } from 'components/sharedComponents/stickyHeader/StickyHeader';
@@ -84,12 +85,13 @@ const AgencyProfileV2 = ({
 
         // scroll to the correct section
         const sectionDom = document.querySelector(`#agency-v2-${snakeCase(section)}`);
-
+        console.log("section Dom", sectionDom.offsetTop);
+  
         if (!sectionDom) {
             return;
         }
-
-        const sectionTop = sectionDom.offsetTop - 145;
+        // minus 60 to offset .body__header height and hr margin bottom!
+        const sectionTop = sectionDom.offsetTop - 60;
         scrollToY(sectionTop, 700);
         setActiveSection(matchedSection.section);
     };

--- a/src/js/containers/agency/AgencyContainerV2.jsx
+++ b/src/js/containers/agency/AgencyContainerV2.jsx
@@ -6,7 +6,9 @@
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { startCase, snakeCase, find } from "lodash";
+import { TooltipWrapper } from 'data-transparency-ui';
 
 import { agencyPageMetaTags } from 'helpers/metaTagHelper';
 import { scrollToY } from 'helpers/scrollToHelper';
@@ -22,15 +24,37 @@ import Sidebar from '../../components/sharedComponents/sidebar/Sidebar';
 
 require('pages/agency/v2/index.scss');
 
-const ComingSoonSection = ({ title }) => <div>{`${title}: Coming Soon`}</div>;
+const TooltipComponent = () => (
+    <div className="agency-v2-tt">
+        <h4 className="tooltip__title">Coming Soon</h4>
+        <p className="tooltip__text">The tooltip content for this section is currently under review.</p>
+    </div>
+);
+
+const ComingSoonSection = ({ section, icon = "chart-area" }) => (
+    <section id={snakeCase(section)} className={`body__section ${snakeCase(section)}`}>
+        <div className="body__header">
+            <div className="body__header-icon">
+                <FontAwesomeIcon size="lg" icon={icon} />
+            </div>
+            <h3>{startCase(section)}</h3>
+            <TooltipWrapper className="agency-v2-tt" icon="info" tooltipComponent={<TooltipComponent />} />
+        </div>
+        <hr />
+        <div className="coming-soon-section">
+            <h4>Coming Soon</h4>
+            <p>This feature is currently under development.</p>
+        </div>
+    </section>
+);
 
 const componentByAgencySection = {
-    overview: <ComingSoonSection title="Overview" />,
-    account_spending: <ComingSoonSection title="Account Spending" />,
-    award_spending: <ComingSoonSection title="Award Spending" />,
-    'sub-agency_spending': <ComingSoonSection title="Sub-Agency Spending" />,
-    award_recipients: <ComingSoonSection title="Award Recipients" />,
-    'top_5:_award_dimensions': <ComingSoonSection title="Top 5: Award Dimensions" />
+    overview: <ComingSoonSection section="overview" />,
+    account_spending: <ComingSoonSection section="account_spending" />,
+    award_spending: <ComingSoonSection section="award_spending" />,
+    'sub-agency_spending': <ComingSoonSection section="sub-agency_spending" />,
+    award_recipients: <ComingSoonSection section="award_recipients" />,
+    'top_5:_award_dimensions': <ComingSoonSection section="top_5:_award_dimensions" />
 };
 
 const sections = Object.keys(componentByAgencySection)
@@ -104,9 +128,7 @@ const AgencyProfileV2 = ({
                     </div>
                     <div className="body usda__flex-col">
                         {sections.map((section) => (
-                            <section id={snakeCase(section.section)} className={`body__section ${snakeCase(section.section)}`}>
-                                {componentByAgencySection[section.section]}
-                            </section>
+                            componentByAgencySection[section.section]
                         ))}
                     </div>
                 </main>

--- a/src/js/containers/agency/AgencyContainerV2.jsx
+++ b/src/js/containers/agency/AgencyContainerV2.jsx
@@ -64,7 +64,7 @@ const sections = Object.keys(componentByAgencySection)
         label: startCase(section)
     }));
 
-const AgencyProfileV2 = ({
+export const AgencyProfileV2 = ({
     agencyOverview,
     agencyId,
     resetAgency,

--- a/src/js/containers/agency/AgencyContainerV2.jsx
+++ b/src/js/containers/agency/AgencyContainerV2.jsx
@@ -3,6 +3,9 @@
  * Created by Maxwell Kendall 01/31/2020
  */
 
+/* eslint-disable no-unused-vars */
+/* eslint-disable react/prop-types */
+
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -11,7 +14,6 @@ import { TooltipWrapper } from 'data-transparency-ui';
 
 import { agencyPageMetaTags } from 'helpers/metaTagHelper';
 import { scrollToY } from 'helpers/scrollToHelper';
-
 
 import MetaTags from 'components/sharedComponents/metaTags/MetaTags';
 import Header from 'components/sharedComponents/header/Header';
@@ -67,8 +69,8 @@ const sections = Object.keys(componentByAgencySection)
 export const AgencyProfileV2 = ({
     agencyOverview,
     agencyId,
-    resetAgency,
-    setAgencyOverview
+    clearAgency,
+    setOverview
 }) => {
     const [activeSection, setActiveSection] = useState(sections[0].section);
 
@@ -146,11 +148,8 @@ const mapStateToProps = (state) => ({
 });
 
 const mapDispatchToProps = (dispatch) => ({
-    resetAgency: () => dispatch(resetAgency()),
-    setAgencyOverview: (agency) => dispatch(setAgencyOverview(agency))
+    clearAgency: () => dispatch(resetAgency()),
+    setOverview: (agency) => dispatch(setAgencyOverview(agency))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(AgencyProfileV2);
-
-// export default AgencyProfileV2;
-

--- a/src/js/containers/router/RouterRoutes.js
+++ b/src/js/containers/router/RouterRoutes.js
@@ -8,7 +8,7 @@
 // changes that Redux causes
 /* eslint-disable global-require */
 
-const kGlobalConstants = require("../../GlobalConstants").default;
+const kGlobalConstants = require("../../GlobalConstants");
 
 const routes = {
     routes: [

--- a/src/js/containers/router/RouterRoutes.js
+++ b/src/js/containers/router/RouterRoutes.js
@@ -7,6 +7,9 @@
 // defining the routes outside of the component because React Router cannot handle state/prop
 // changes that Redux causes
 /* eslint-disable global-require */
+
+const kGlobalConstants = require("../../GlobalConstants").default;
+
 const routes = {
     routes: [
         {
@@ -282,6 +285,21 @@ const routes = {
         }
     }
 };
+
+if (kGlobalConstants.DEV) {
+    routes.routes.push(
+        {
+            path: '/agency_v2/:agencyId',
+            parent: '/agency',
+            addToSitemap: false,
+            component: (cb) => {
+                require.ensure([], (require) => {
+                    cb(require('containers/agency/AgencyContainerV2').default);
+                });
+            }
+        }
+    );
+}
 
 module.exports = routes;
 

--- a/tests/containers/agency/v2/AgencyContainerV2-test.jsx
+++ b/tests/containers/agency/v2/AgencyContainerV2-test.jsx
@@ -1,0 +1,16 @@
+/**
+ * AgencyContainer-test.jsx
+ * Created by Kevin Li 6/15/17
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { AgencyProfileV2 } from 'containers/agency/AgencyContainerV2';
+
+describe('AgencyContainer', () => {
+    it('should make an API call for the selected agency on mount', () => {
+        const component = shallow(<AgencyProfileV2 />);
+        expect(component.exists()).toBe(true);
+    });
+});


### PR DESCRIPTION
# DNM
just merge the other one which contains this one; opening this to make review a bit less overwhelming

**High level description:**
Lays out CSS / Scaffolding of Page.

**Technical details:**
Reuses logic for 
(A) detecting active section of page per the scroll position
(B) Jumping to Page
(C) Tooltips
(D) Coming Soon Styles

Seeking feedback for areas to improve reducing duplicate styles!

**JIRA Ticket:**
[DEV-4373](https://federal-spending-transparency.atlassian.net/browse/DEV-4373)
[DEV-4369](https://federal-spending-transparency.atlassian.net/browse/DEV-4369)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
