### PR TITLE
[DEV-4329] Download Account Page now Accepts Array / Checkboxes for submissionTypes

### DIFF
--- a/src/_scss/pages/bulkDownload/form/_downloadButtons.scss
+++ b/src/_scss/pages/bulkDownload/form/_downloadButtons.scss
@@ -1,4 +1,5 @@
-.radio {
+.radio,
+.checkbox {
     padding-top: rem(15);
     &:first-child {
         padding-top: 0;
@@ -7,7 +8,8 @@
     input {
         margin-right: rem(5);
     }
-    .radio-label {
+    .radio-label,
+    .checkbox-label {
         color: #4A4A4A;
         font-size: rem(18);
         line-height: rem(23);

--- a/src/_scss/pages/bulkDownload/form/downloadForm.scss
+++ b/src/_scss/pages/bulkDownload/form/downloadForm.scss
@@ -112,7 +112,7 @@
         }
         @import "agencyPicker";
         @import "federalPicker";
-        @import "radioButtons";
+        @import "downloadButtons";
         @import "dateRange";
         @import "locationFilter";
     }

--- a/src/js/components/bulkDownload/accounts/AccountDataContent.jsx
+++ b/src/js/components/bulkDownload/accounts/AccountDataContent.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { isEqual } from 'lodash';
 import kGlobalConstants from 'GlobalConstants';
 
 import { accountDownloadOptions } from 'dataMapping/bulkDownload/bulkDownloadOptions';
@@ -45,7 +46,7 @@ export default class AccountDataContent extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (prevProps.accounts !== this.props.accounts) {
+        if (!isEqual(prevProps.accounts, this.props.accounts)) {
             this.validateForm(this.props.accounts);
         }
     }
@@ -68,7 +69,7 @@ export default class AccountDataContent extends React.Component {
         const validForm = (
             (accounts.budgetFunction.code !== '')
             && (accounts.agency.id !== '')
-            && (accounts.submissionType !== '')
+            && (accounts.submissionTypes.length !== 0)
             && (accounts.fy !== '')
             && (accounts.quarter !== '')
         );
@@ -113,9 +114,9 @@ export default class AccountDataContent extends React.Component {
                             valid={accounts.accountLevel !== ''} />
                         <SubmissionTypeFilter
                             submissionTypes={accountDownloadOptions.submissionTypes}
-                            currentSubmissionType={accounts.submissionType}
+                            currentSubmissionTypes={accounts.submissionTypes}
                             updateFilter={this.props.updateFilter}
-                            valid={accounts.submissionType !== ''} />
+                            valid={accounts.submissionTypes.length !== 0} />
                         <FiscalYearFilter
                             currentFy={accounts.fy}
                             currentQuarter={accounts.quarter}

--- a/src/js/components/bulkDownload/accounts/UserSelections.jsx
+++ b/src/js/components/bulkDownload/accounts/UserSelections.jsx
@@ -88,13 +88,18 @@ export default class UserSelections extends React.Component {
     }
 
     generateSubmissionTypeString() {
-        if (this.props.accounts.submissionType) {
-            const options = accountDownloadOptions.submissionTypes;
-            const selectedOption = options.find((option) =>
-                option.name === this.props.accounts.submissionType
-            );
+        if (this.props.accounts.submissionTypes.length > 0) {
             return (
-                <div className="selection__content">{selectedOption.label}</div>
+                <div className="selection__content">
+                    {accountDownloadOptions.submissionTypes
+                        .filter((option) => this.props.accounts.submissionTypes.includes(option.name))
+                        .reduce((acc, option, i, array) => {
+                            // don't append comma
+                            if (i === 0 && array.length === 1) return `${option.label}`;
+                            if (i === array.length - 1) return `${acc}${option.label}`;
+                            return `${acc}${option.label}, `;
+                        }, '')}
+                </div>
             );
         }
         return (

--- a/src/js/components/bulkDownload/accounts/filters/SubmissionTypeFilter.jsx
+++ b/src/js/components/bulkDownload/accounts/filters/SubmissionTypeFilter.jsx
@@ -9,7 +9,7 @@ import { CheckCircle, ExclamationCircle } from 'components/sharedComponents/icon
 
 const propTypes = {
     submissionTypes: PropTypes.array,
-    currentSubmissionType: PropTypes.string,
+    currentSubmissionTypes: PropTypes.array,
     updateFilter: PropTypes.func,
     valid: PropTypes.bool
 };
@@ -23,7 +23,7 @@ export default class SubmissionTypeFilter extends React.Component {
 
     onChange(e) {
         const target = e.target;
-        this.props.updateFilter('submissionType', target.value);
+        this.props.updateFilter('submissionTypes', target.value);
     }
 
     render() {
@@ -43,16 +43,16 @@ export default class SubmissionTypeFilter extends React.Component {
 
         const submissionTypes = this.props.submissionTypes.map((type) => (
             <div
-                className="radio"
+                className="checkbox"
                 key={type.name}>
                 <input
-                    type="radio"
+                    type="checkbox"
                     value={type.name}
                     name="submission-type"
-                    checked={this.props.currentSubmissionType === type.name}
+                    checked={this.props.currentSubmissionTypes.includes(type.name)}
                     onChange={this.onChange} />
                 <label
-                    className="radio-label"
+                    className="checkbox-label"
                     htmlFor="submission-type">
                     {type.label}
                 </label>

--- a/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
+++ b/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
@@ -142,17 +142,16 @@ export class BulkDownloadPageContainer extends React.Component {
         );
 
         // Get the submission type object
-        const submissionTypes = accountDownloadOptions.submissionTypes;
-        const submissionType = submissionTypes.find((type) =>
-            type.name === formState.submissionType
-        );
+        const submissionTypes = accountDownloadOptions.submissionTypes
+            .filter((type) => formState.submissionTypes.includes(type.name))
+            .map((type) => type.apiName);
 
         const params = {
             account_level: accountLevel.apiName,
             filters: {
                 budget_function: formState.budgetFunction.code,
                 agency: formState.agency.id,
-                submission_type: submissionType.apiName,
+                submission_types: submissionTypes,
                 fy: formState.fy,
                 quarter: formState.quarter
             },

--- a/src/js/redux/reducers/bulkDownload/bulkDownloadReducer.js
+++ b/src/js/redux/reducers/bulkDownload/bulkDownloadReducer.js
@@ -67,7 +67,7 @@ export const initialState = {
             id: '',
             name: 'Select a Federal Account'
         },
-        submissionType: 'accountBalances',
+        submissionTypes: ['accountBalances'],
         fy: `${initialQuarters.year}`,
         quarter: `${Math.max(...initialQuarters.quarters)}`,
         fileFormat: 'csv'
@@ -101,12 +101,31 @@ const bulkDownloadReducer = (state = initialState, action) => {
             });
         }
         case 'UPDATE_DOWNLOAD_FILTER': {
-            const dataType = Object.assign({}, state[action.dataType], {
-                [action.name]: action.value
-            });
-
+            const { dataType, name, value } = action;
+            if (name === 'submissionTypes') {
+                // toggle; checkbox is unchecked
+                if (state[dataType][name].includes(value)) {
+                    return {
+                        ...state,
+                        [dataType]: {
+                            ...state[dataType],
+                            [name]: state[dataType][name].filter((submissionType) => submissionType !== value)
+                        }
+                    };
+                }
+                // insert; checkbox is checked, persist existing values and add new value
+                return {
+                    ...state,
+                    [dataType]: {
+                        ...state[dataType],
+                        [name]: [...state[dataType][name], value]
+                    }
+                };
+            }
             return Object.assign({}, state, {
-                [action.dataType]: dataType
+                [dataType]: Object.assign({}, state[dataType], {
+                    [name]: value
+                })
             });
         }
         case 'UPDATE_AWARD_DATE_RANGE': {

--- a/tests/containers/bulkDownload/BulkDownloadPageContainer-test.jsx
+++ b/tests/containers/bulkDownload/BulkDownloadPageContainer-test.jsx
@@ -245,7 +245,7 @@ describe('BulkDownloadPageContainer', () => {
                     budget_subfunction: '123',
                     agency: '123',
                     federal_account: '212',
-                    submission_type: 'account_balances',
+                    submission_types: ['account_balances'],
                     fy: '1989',
                     quarter: '1'
                 },

--- a/tests/containers/bulkDownload/mockData.js
+++ b/tests/containers/bulkDownload/mockData.js
@@ -144,7 +144,7 @@ export const mockRedux = {
             },
             fy: '1989',
             quarter: '1',
-            submissionType: 'accountBalances',
+            submissionTypes: ['accountBalances'],
             fileFormat: 'csv'
         },
         download: {

--- a/tests/redux/reducers/bulkDownload/bulkDownloadReducer-test.js
+++ b/tests/redux/reducers/bulkDownload/bulkDownloadReducer-test.js
@@ -24,6 +24,21 @@ describe('bulkDownloadReducer', () => {
             const state = bulkDownloadReducer(undefined, action);
             expect(state.awards.fileFormat).toEqual('mockFormat');
         });
+        it('should update the submissionTypes array', () => {
+            const action = {
+                type: 'UPDATE_DOWNLOAD_FILTER',
+                dataType: 'accounts',
+                name: 'submissionTypes',
+                value: 'accountBreakdown'
+            };
+
+            let state = bulkDownloadReducer(initialState, action);
+            // inserting new...
+            expect(state.accounts.submissionTypes).toEqual(['accountBalances', 'accountBreakdown']);
+            // toggle when value is already present in the array
+            state = bulkDownloadReducer(initialState, { ...action, value: 'accountBalances'});
+            expect(state.accounts.submissionTypes).toEqual([]);
+        });
     });
 
     describe('UPDATE_CHECKBOX', () => {


### PR DESCRIPTION
**High level description:**
Allows user to select mutliple values for file type. These used to be radio buttons, they are now checkboxes as seen below:

![image](https://user-images.githubusercontent.com/12897813/74060358-cb7c8680-49b7-11ea-8aa9-03a97555b3de.png)

**Technical details:**

A few places required updates:

fdcf402 Reducer now storing an array in redux, was previously storing a single string value
a4de17b Container now making service call w/ an array of values for this property
e44a761 Validation Logic (component level): invalid state of form is now when the length of the array is 0; previously this logic checked for an empty string resulting in a falsey value.
9c1d0a1 Displaying current selections: To display user selections at the bottom of the form, we now are expecting an array of strings rather than just a single string.
4fab5d9 changing class names to reflect shared styles between radio/checkboxes
cf4855e Updated tests to reflect new data structure; also added new test to ensure that properties are removed from array on `unCheck` as well as added `onCheck`

**JIRA Ticket:**
[DEV-4329](https://federal-spending-transparency.atlassian.net/browse/DEV-4329)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
- [x] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
