### PR TITLE
[DEV-4373] Lowering value of z-index for sankey

### DIFF
--- a/src/_scss/pages/agency/v2/index.scss
+++ b/src/_scss/pages/agency/v2/index.scss
@@ -67,7 +67,7 @@ $verticalOffsetCollapsedSankey: 141;
         width: 100%;
         background: #fff;
         box-shadow: 0 0 5px 5px rgba(0,0,0,0.15);
-        z-index: 10;
+        z-index: 8;
         @include flex-direction(column);
         &.expanded-sankey {
             height: rem(200);

--- a/src/_scss/pages/bulkDownload/form/_fyPicker.scss
+++ b/src/_scss/pages/bulkDownload/form/_fyPicker.scss
@@ -43,6 +43,7 @@
 
                     .fy-picker__button-icon {
                         @include flex(0 0 rem(20));
+                        color: $color-gray;
                         svg {
                             width: rem(12);
                             height: rem(12);


### PR DESCRIPTION

**High level description:**
Z Index of sankey was higher than that of the tooltip, so it was hidden in internet explorer.

**Technical details:**
Lowered index of sankey z-index.

**JIRA Ticket:**
[DEV-4373](https://federal-spending-transparency.atlassian.net/browse/DEV-4373)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
