### PR TITLE
[DEV-3932] Adjust download agency list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ usa_spending.sh
 # sitemaps
 /robots.txt
 /*.xml
+
+# direnv
+.envrc

--- a/src/js/containers/bulkDownload/accounts/AccountDataContainer.jsx
+++ b/src/js/containers/bulkDownload/accounts/AccountDataContainer.jsx
@@ -60,6 +60,7 @@ export class AccountDataContainer extends React.Component {
 
         // perform the API request
         this.agencyListRequest = BulkDownloadHelper.requestAgenciesList({
+            type: "account_agencies",
             agency: 0
         });
 

--- a/src/js/containers/bulkDownload/archive/AwardDataArchiveContainer.jsx
+++ b/src/js/containers/bulkDownload/archive/AwardDataArchiveContainer.jsx
@@ -79,6 +79,7 @@ export default class AwardDataArchiveContainer extends React.Component {
 
         // perform the API request
         this.agencyListRequest = BulkDownloadHelper.requestAgenciesList({
+            type: "award_agencies",
             agency: 0
         });
 

--- a/src/js/containers/bulkDownload/awards/AwardDataContainer.jsx
+++ b/src/js/containers/bulkDownload/awards/AwardDataContainer.jsx
@@ -65,6 +65,7 @@ export class AwardDataContainer extends React.Component {
 
         // perform the API request
         this.agencyListRequest = BulkDownloadHelper.requestAgenciesList({
+            type: "award_agencies",
             agency: 0
         });
 
@@ -97,6 +98,7 @@ export class AwardDataContainer extends React.Component {
 
             // perform the API request
             this.agencyListRequest = BulkDownloadHelper.requestAgenciesList({
+                type: "award_agencies",
                 agency: parseInt(id, 10)
             });
 

--- a/tests/containers/bulkDownload/mockBulkDownloadHelper.js
+++ b/tests/containers/bulkDownload/mockBulkDownloadHelper.js
@@ -8,8 +8,7 @@ export const requestAgenciesList = () => ({
             resolve({
                 data: {
                     agencies: mockAgencies,
-                    sub_agencies: [],
-                    federal_accounts: []
+                    sub_agencies: []
                 }
             });
         });


### PR DESCRIPTION
**High level description:**

Minor tweak to provide new parameter for `list_agencies` endpoint and to remove an unused response array.

**JIRA Ticket:**

[DEV-3932](https://federal-spending-transparency.atlassian.net/browse/DEV-3932)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] I mean, PO demos, but I don't think we'll need any special demo time
- [x] Browser agnostic change
- [x] Responsiveness agnostic change
- [x] Accessibility unaffected
- [x] Minor change for code that didn't have tests.
- [x] Minor change that should be future invincible
- [x] [API contract](https://github.com/fedspendingtransparency/usaspending-api/blob/6bce5b21496bfc6d5ef5df141d2d9482eabbc951/usaspending_api/api_contracts/contracts/v2/bulk_download/list_agencies.md) updated
- [x] No need to bring the Component Library into this

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [ ] [API #2308](https://github.com/fedspendingtransparency/usaspending-api/pull/2308) merged concurrently
- [x] Code review complete
