### PR TITLE
[DEV-4516] spending explorer dropdown 2017 not clickable

### DIFF
--- a/src/_scss/pages/explorer/detail/sidebar/_fyPicker.scss
+++ b/src/_scss/pages/explorer/detail/sidebar/_fyPicker.scss
@@ -60,6 +60,7 @@
         right: 0;
         border: 1px solid #464B53;
         background-color: #272F38;
+        z-index: 12;
 
         &.fy-picker__list_hidden {
             display: none;


### PR DESCRIPTION
**High level description:**
2017 not click able in spending explorer fy drop down

**Technical details:**
z index is lower than the button underneath it

**JIRA Ticket:**
[DEV-4516](https://federal-spending-transparency.atlassian.net/browse/DEV-4516)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Tested in sandbox
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
