### PR TITLE
[DEV-3935] Prevent linking to agencies without agency pages

### DIFF
--- a/src/js/components/award/shared/overview/AwardingAgency.jsx
+++ b/src/js/components/award/shared/overview/AwardingAgency.jsx
@@ -14,7 +14,7 @@ const propTypes = {
 
 const AwardingAgency = ({ awardingAgency }) => {
     let innerComponent = awardingAgency.formattedToptier;
-    if (awardingAgency.hasAgencyPage) {
+    if (awardingAgency.hasAgencyPage && awardingAgency.id) {
         innerComponent = (
             <a href={`/#/agency/${awardingAgency.id}`}>
                 {innerComponent}

--- a/src/js/components/award/shared/overview/AwardingAgency.jsx
+++ b/src/js/components/award/shared/overview/AwardingAgency.jsx
@@ -12,16 +12,24 @@ const propTypes = {
     awardingAgency: PropTypes.object
 };
 
-const AwardingAgency = ({ awardingAgency }) => (
-    <AwardSection className="award-overview__left-section__awarding award-overview-column first award-overview-column__spacing">
-        <h6 className="award-overview-title">Awarding Agency</h6>
-        <h5 className="award-overview__left-section__agency-name">
+const AwardingAgency = ({ awardingAgency }) => {
+    let innerComponent = awardingAgency.formattedToptier;
+    if (awardingAgency.hasAgencyPage) {
+        innerComponent = (
             <a href={`/#/agency/${awardingAgency.id}`}>
-                {awardingAgency.formattedToptier}
+                {innerComponent}
             </a>
-        </h5>
-    </AwardSection>
-);
+        );
+    }
+    return (
+        <AwardSection className="award-overview__left-section__awarding award-overview-column first award-overview-column__spacing">
+            <h6 className="award-overview-title">Awarding Agency</h6>
+            <h5 className="award-overview__left-section__agency-name">
+                {innerComponent}
+            </h5>
+        </AwardSection>
+    );
+};
 
 AwardingAgency.propTypes = propTypes;
 export default AwardingAgency;

--- a/src/js/dataMapping/awards/additionalDetailsContract.js
+++ b/src/js/dataMapping/awards/additionalDetailsContract.js
@@ -17,7 +17,7 @@ const additionalDetailsContracts = (awardData) => {
             'Awarding Agency': {
                 type: 'link',
                 data: {
-                    path: awardingAgency.id ? `/#/agency/${awardingAgency.id}` : null,
+                    path: (awardingAgency.id && awardingAgency.hasAgencyPage) ? `/#/agency/${awardingAgency.id}` : null,
                     title: awardingAgency.formattedToptier
                 }
             },
@@ -38,7 +38,7 @@ const additionalDetailsContracts = (awardData) => {
             'Funding Agency': {
                 type: 'link',
                 data: {
-                    path: fundingAgency.id ? `/#/agency/${fundingAgency.id}` : null,
+                    path: (fundingAgency.id && fundingAgency.hasAgencyPage) ? `/#/agency/${fundingAgency.id}` : null,
                     title: fundingAgency.formattedToptier
                 }
             },

--- a/src/js/dataMapping/awards/additionalDetailsFinancialAssistance.js
+++ b/src/js/dataMapping/awards/additionalDetailsFinancialAssistance.js
@@ -17,7 +17,7 @@ const additionalDetailsFinancialAssistance = (awardData) => {
             'Awarding Agency': {
                 type: 'link',
                 data: {
-                    path: awardingAgency.id ? `/#/agency/${awardingAgency.id}` : null,
+                    path: (awardingAgency.id && awardingAgency.hasAgencyPage) ? `/#/agency/${awardingAgency.id}` : null,
                     title: awardingAgency.formattedToptier
                 }
             },
@@ -38,7 +38,7 @@ const additionalDetailsFinancialAssistance = (awardData) => {
             'Funding Agency': {
                 type: 'link',
                 data: {
-                    path: fundingAgency.id ? `/#/agency/${fundingAgency.id}` : null,
+                    path: (fundingAgency.id && fundingAgency.hasAgencyPage) ? `/#/agency/${fundingAgency.id}` : null,
                     title: fundingAgency.formattedToptier
                 }
             },

--- a/src/js/dataMapping/awards/additionalDetailsIdv.js
+++ b/src/js/dataMapping/awards/additionalDetailsIdv.js
@@ -14,7 +14,7 @@ const additionalDetails = (awardData) => {
             'Awarding Agency': {
                 type: 'link',
                 data: {
-                    path: awardData.awardingAgency.id ? `/#/agency/${awardData.awardingAgency.id}` : null,
+                    path: (awardData.awardingAgency.id && awardData.awardingAgency.hasAgencyPage) ? `/#/agency/${awardData.awardingAgency.id}` : null,
                     title: awardData.awardingAgency.formattedToptier
                 }
             },
@@ -23,7 +23,7 @@ const additionalDetails = (awardData) => {
             'Funding Agency': {
                 type: 'link',
                 data: {
-                    path: awardData.fundingAgency.id ? `/#/agency/${awardData.fundingAgency.id}` : null,
+                    path: (awardData.fundingAgency.id && awardData.fundingAgency.hasAgencyPage) ? `/#/agency/${awardData.fundingAgency.id}` : null,
                     title: awardData.fundingAgency.formattedToptier
                 }
             },

--- a/src/js/models/v2/awardsV2/BaseContract.js
+++ b/src/js/models/v2/awardsV2/BaseContract.js
@@ -74,6 +74,7 @@ BaseContract.populate = function populate(data) {
     if (data.awarding_agency) {
         const awardingAgencyData = {
             id: data.awarding_agency.id,
+            hasAgencyPage: data.awarding_agency.has_agency_page,
             toptierName: data.awarding_agency.toptier_agency.name,
             toptierAbbr: data.awarding_agency.toptier_agency.abbreviation || '',
             subtierName: data.awarding_agency.subtier_agency.name,
@@ -91,6 +92,7 @@ BaseContract.populate = function populate(data) {
     if (data.funding_agency) {
         const fundingAgencyData = {
             id: data.funding_agency.id,
+            hasAgencyPage: data.funding_agency.has_agency_page,
             toptierName: data.funding_agency.toptier_agency.name,
             toptierAbbr: data.funding_agency.toptier_agency.abbreviation || '',
             subtierName: data.funding_agency.subtier_agency.name,

--- a/src/js/models/v2/awardsV2/BaseFinancialAssistance.js
+++ b/src/js/models/v2/awardsV2/BaseFinancialAssistance.js
@@ -89,6 +89,7 @@ BaseFinancialAssistance.populate = function populate(data) {
     if (data.awarding_agency) {
         const awardingAgencyData = {
             id: data.awarding_agency.id,
+            hasAgencyPage: data.awarding_agency.has_agency_page,
             toptierName: data.awarding_agency.toptier_agency.name,
             toptierAbbr: data.awarding_agency.toptier_agency.abbreviation || '',
             subtierName: data.awarding_agency.subtier_agency.name,
@@ -106,6 +107,7 @@ BaseFinancialAssistance.populate = function populate(data) {
     if (data.funding_agency) {
         const fundingAgencyData = {
             id: data.funding_agency.id,
+            hasAgencyPage: data.funding_agency.has_agency_page,
             toptierName: data.funding_agency.toptier_agency.name,
             toptierAbbr: data.funding_agency.toptier_agency.abbreviation || '',
             subtierName: data.funding_agency.subtier_agency.name,

--- a/src/js/models/v2/awardsV2/BaseIdv.js
+++ b/src/js/models/v2/awardsV2/BaseIdv.js
@@ -84,6 +84,7 @@ BaseIdv.populate = function populate(data) {
     if (data.funding_agency) {
         const fundingAgencyData = {
             id: data.funding_agency.id,
+            hasAgencyPage: data.funding_agency.has_agency_page,
             toptierName: data.funding_agency.toptier_agency.name,
             toptierAbbr: data.funding_agency.toptier_agency.abbreviation || '',
             subtierName: data.funding_agency.subtier_agency.name,
@@ -98,6 +99,7 @@ BaseIdv.populate = function populate(data) {
     if (data.awarding_agency) {
         const awardingAgencyData = {
             id: data.awarding_agency.id,
+            hasAgencyPage: data.awarding_agency.has_agency_page,
             toptierName: data.awarding_agency.toptier_agency.name,
             toptierAbbr: data.awarding_agency.toptier_agency.abbreviation || '',
             subtierName: data.awarding_agency.subtier_agency.name,

--- a/src/js/models/v2/awardsV2/CoreAwardAgency.js
+++ b/src/js/models/v2/awardsV2/CoreAwardAgency.js
@@ -7,6 +7,7 @@ const CoreAwardAgency = {
     toptierName: '--',
     populateCore(data) {
         this.id = data.id || '';
+        this.hasAgencyPage = data.hasAgencyPage || false;
         this.toptierName = data.toptierName || '--';
         this.toptierAbbr = data.toptierAbbr || '';
         this.toptierId = data.toptierId || '';

--- a/tests/containers/award/shared/AwardingAgencyContainer-test.jsx
+++ b/tests/containers/award/shared/AwardingAgencyContainer-test.jsx
@@ -1,0 +1,21 @@
+/**
+ * AwardingAgencyContainer-test.js
+ * Created by Kirk Barden 2/27/20
+ **/
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import AwardingAgency from '../../../../src/js/components/award/shared/overview/AwardingAgency';
+
+describe('AwardingAgency', () => {
+    it('Should wrap agency name in a link', () => {
+        const awardingAgency = { id: 1, hasAgencyPage: true, formattedToptier: "Agency Name" };
+        const wrapper = shallow(<AwardingAgency awardingAgency={awardingAgency} />);
+        expect(wrapper.find('a').exists()).toBeTruthy();
+    });
+    it('Should not wrap agency name in a link', () => {
+        const awardingAgency = { id: 1, hasAgencyPage: false, formattedToptier: "Agency Name" };
+        const wrapper = shallow(<AwardingAgency awardingAgency={awardingAgency} />);
+        expect(wrapper.find('a').exists()).toBeFalsy();
+    });
+});

--- a/tests/models/awardsV2/CoreAwardAgency-test.js
+++ b/tests/models/awardsV2/CoreAwardAgency-test.js
@@ -9,6 +9,7 @@ import { mockLoan } from './mockAwardApi';
 const agency = Object.create(CoreAwardAgency);
 const agencyData = {
     id: 123,
+    hasAgencyPage: mockLoan.awarding_agency.has_agency_page,
     toptierName: mockLoan.awarding_agency.toptier_agency.name,
     toptierAbbr: mockLoan.awarding_agency.toptier_agency.abbreviation,
     subtierName: mockLoan.awarding_agency.subtier_agency.name,
@@ -19,6 +20,9 @@ agency.populateCore(agencyData);
 describe('CoreAwardAgency', () => {
     it('should have an id field', () => {
         expect(agency.id).toEqual(123);
+    });
+    it('should have an agency page field', () => {
+        expect(agency.hasAgencyPage).toEqual(true);
     });
     it('should format toptier, subtier, and office names', () => {
         expect(agency.toptierName).toEqual('Department of Defense');
@@ -42,6 +46,6 @@ describe('CoreAwardAgency', () => {
         expect(emptyAgency.toptierName).toEqual('--');
     });
     it('should format the name and abbreviation when both are provided', () => {
-       expect(agency.formattedToptier).toEqual('Department of Defense (DOD)');
+        expect(agency.formattedToptier).toEqual('Department of Defense (DOD)');
     });
 });

--- a/tests/models/awardsV2/mockAwardApi.js
+++ b/tests/models/awardsV2/mockAwardApi.js
@@ -13,6 +13,7 @@ export const mockContract = {
     base_exercised_options: 234242,
     awarding_agency: {
         id: '234',
+        has_agency_page: true,
         toptier_agency: {
             name: 'Department of Defense',
             abbreviation: 'DOD'
@@ -156,6 +157,7 @@ export const mockLoan = {
     total_subaward_amount: 32423342,
     awarding_agency: {
         id: '323',
+        has_agency_page: true,
         toptier_agency: {
             name: 'Department of Defense',
             abbreviation: 'DOD'
@@ -237,6 +239,7 @@ export const mockIdv = {
     description: 'ewraijwrw',
     date_signed: '2005-02-18',
     awarding_agency: {
+        has_agency_page: true,
         toptier_agency: {
             name: 'Department of Defense',
             abbreviation: 'DOD'


### PR DESCRIPTION
**High level description:**

Today, when an award is viewed that was awarded by an agency that has no agency page in USAspending, users are taken to a 404 page when they click on the agency link. This pull request aims to rectify that.

**JIRA Ticket:**
[DEV-3935](https://federal-spending-transparency.atlassian.net/browse/DEV-3935)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions
- [x] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts/contracts/v2/awards/award_id.md) updated

Reviewer(s):
- [ ] [API #2320](https://github.com/fedspendingtransparency/usaspending-api/pull/2320) merged concurrently
- [x] Code review complete
