### PR TITLE
[DEV-3839] Contract/IDV Award page details tweaks

### DIFF
--- a/src/js/components/award/shared/overview/RelatedAwards.jsx
+++ b/src/js/components/award/shared/overview/RelatedAwards.jsx
@@ -132,7 +132,7 @@ export default class RelatedAwards extends React.Component {
     render() {
         const { overview } = this.props;
         const tooltipInfo = this.tooltipInfo();
-        const awardTitle = overview.category === 'idv' ? 'Parent Award' : 'Parent IDV';
+        const awardTitle = 'Parent Award';
         let parentLink = 'N/A';
         if (overview.parentAwardDetails.piid && overview.parentAwardDetails.awardId) {
             parentLink = (

--- a/src/js/dataMapping/awards/additionalDetailsContract.js
+++ b/src/js/dataMapping/awards/additionalDetailsContract.js
@@ -58,7 +58,7 @@ const additionalDetailsContracts = (awardData) => {
             }
         },
         parentAwardDetails: {
-            'Parent IDV PIID': {
+            'Parent Award ID': {
                 type: 'link',
                 data: {
                     path: parentAwardDetails.awardId ? `/#/award/${parentAwardDetails.awardId}` : null,
@@ -69,12 +69,12 @@ const additionalDetailsContracts = (awardData) => {
             'Parent IDV Agency Name': {
                 type: 'link',
                 data: {
-                    // path: parentAwardDetails.agencyId ?
-                    //     `/#/agency/${parentAwardDetails.agencyId}` : null,
-                    path: null,
+                    path: parentAwardDetails.agencyId ?
+                        `/#/agency/${parentAwardDetails.agencyId}` : null,
                     title: parentAwardDetails.agencyName
                 }
             },
+            'Parent IDV Sub-Agency Name': parentAwardDetails.subAgencyName,
             'Multiple Or Single Parent Award IDV': parentAwardDetails.multipleOrSingle || ''
         },
         placeOfPerformance: {

--- a/src/js/dataMapping/awards/additionalDetailsIdv.js
+++ b/src/js/dataMapping/awards/additionalDetailsIdv.js
@@ -42,14 +42,12 @@ const additionalDetails = (awardData) => {
             'Parent IDV Agency Name': {
                 type: 'link',
                 data: {
-                    // TODO - when backend updates the API response
-                    // uncomment this link
-                    // path: parentAwardDetails.agencyId ?
-                    //     `/#/agency/${parentAwardDetails.agencyId}` : null,
-                    path: null,
+                    path: parentAwardDetails.agencyId ?
+                        `/#/agency/${parentAwardDetails.agencyId}` : null,
                     title: parentAwardDetails.agencyName
                 }
             },
+            'Parent IDV Sub-Agency Name': parentAwardDetails.subAgencyName,
             'Multiple Or Single Parent Award IDV': parentAwardDetails.multipleOrSingle || ''
         },
         periodOfPerformance: {

--- a/src/js/models/v2/awardsV2/BaseParentAwardDetails.js
+++ b/src/js/models/v2/awardsV2/BaseParentAwardDetails.js
@@ -12,6 +12,8 @@ const parentAwardDetails = {
         this.idcType = data.type_of_idc_description || '';
         this.agencyId = data.agency_id || '';
         this.agencyName = data.agency_name || '';
+        this.subAgencyId = data.sub_agency_id || '';
+        this.subAgencyName = data.sub_agency_name || '';
         this.multipleOrSingle = data.multiple_or_single_aw_desc || '';
         this.piid = data.piid || '';
     }

--- a/tests/models/awardsV2/BaseParentAwardDetails-test.js
+++ b/tests/models/awardsV2/BaseParentAwardDetails-test.js
@@ -16,6 +16,8 @@ describe('parentAwardDetails', () => {
         expect(result.idcType).toEqual(mockData.type_of_idc_description);
         expect(result.agencyId).toEqual(mockData.agency_id);
         expect(result.agencyName).toEqual(mockData.agency_name);
+        expect(result.subAgencyId).toEqual(mockData.sub_agency_id);
+        expect(result.subAgencyName).toEqual(mockData.sub_agency_name);
         expect(result.multipleOrSingle).toEqual(mockData.multiple_or_single_aw_desc);
         expect(result.piid).toEqual(mockData.piid);
     });

--- a/tests/models/awardsV2/mockAwardApi.js
+++ b/tests/models/awardsV2/mockAwardApi.js
@@ -123,6 +123,8 @@ export const mockContract = {
     parent_award: {
         agency_id: '123',
         agency_name: 'Department of Justice',
+        sub_agency_id: '1000',
+        sub_agency_name: 'Department of Justice',
         award_id: 5738,
         generated_unique_award_id: '45',
         idv_type_description: 'test',
@@ -276,8 +278,10 @@ export const mockIdv = {
         award_id: 5738,
         idv_type_description: 'test',
         type_of_idc_description: 'r3w',
-        agency_id: '123',
-        agency_name: 'test',
+        agency_id: 90,
+        agency_name: 'toptier test',
+        sub_agency_id: '123',
+        sub_agency_name: 'test',
         multiple_or_single_aw_desc: 'something',
         piid: '345'
     },


### PR DESCRIPTION
**High level description:**

Makes minor changes to the Contract and IDV Awards pages.

**Technical details:**
Changes:
- Change `Parent IDV` to `Parent Award` in Related Awards section
- Change `Parent IDV PIID` to `Parent Award ID` in Parent Award Details section
- Change `Parent IDV Agency Name` to pull from the toptier agency, not the subtier, also links to agency profile page
- Add `Parent IDV Sub-Agency Name`, which uses the subtier agency previously under `Parent IDV Agency Name` 

**JIRA Ticket:**
[DEV-3839](https://federal-spending-transparency.atlassian.net/browse/DEV-3839)

**Mockup:**
https://bahdigital.invisionapp.com/share/3KIABNW4PGR#/screens/296008376

The following are ALL required for the PR to be merged:

Author:
- [X] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #2325](https://github.com/fedspendingtransparency/usaspending-api/pull/2325) merged concurrently `if applicable`
- [x] Code review complete
