### PR TITLE
Warmfix DEV-4211 glossary share button order

### DIFF
--- a/src/js/components/glossary/definition/GlossaryDefinition.jsx
+++ b/src/js/components/glossary/definition/GlossaryDefinition.jsx
@@ -42,6 +42,7 @@ const pickerOptions = [
     { component: <GlossaryDropdownOption icon={faRedditSquare} title="Reddit" />, name: 'reddit' }
 ];
 
+
 export default class GlossaryDefinition extends React.Component {
     constructor(props) {
         super(props);
@@ -128,7 +129,8 @@ export default class GlossaryDefinition extends React.Component {
                     options={options}
                     dropdownDirection="left"
                     backgroundColor="#215493"
-                    selectedOption="twitter">
+                    selectedOption="copy"
+                    sortFn = {(a,b,select) => 1}>
                     <FontAwesomeIcon className="glossary-share-icon" icon="share-alt" color="#e2e2e2" size="lg" />
                 </Picker>
                 <span className={`copy-confirmation ${this.state.showCopiedConfirmation ? '' : 'hide'}`}><FontAwesomeIcon icon="check-circle" color="#3A8250" /> Copied</span>

--- a/src/js/components/glossary/definition/GlossaryDefinition.jsx
+++ b/src/js/components/glossary/definition/GlossaryDefinition.jsx
@@ -130,7 +130,7 @@ export default class GlossaryDefinition extends React.Component {
                     dropdownDirection="left"
                     backgroundColor="#215493"
                     selectedOption="copy"
-                    sortFn={(a, b) => 1}>
+                    sortFn={() => 1}>
                     <FontAwesomeIcon className="glossary-share-icon" icon="share-alt" color="#e2e2e2" size="lg" />
                 </Picker>
                 <span className={`copy-confirmation ${this.state.showCopiedConfirmation ? '' : 'hide'}`}><FontAwesomeIcon icon="check-circle" color="#3A8250" /> Copied</span>

--- a/src/js/components/glossary/definition/GlossaryDefinition.jsx
+++ b/src/js/components/glossary/definition/GlossaryDefinition.jsx
@@ -130,7 +130,7 @@ export default class GlossaryDefinition extends React.Component {
                     dropdownDirection="left"
                     backgroundColor="#215493"
                     selectedOption="copy"
-                    sortFn = {(a,b,select) => 1}>
+                    sortFn={(a, b) => 1}>
                     <FontAwesomeIcon className="glossary-share-icon" icon="share-alt" color="#e2e2e2" size="lg" />
                 </Picker>
                 <span className={`copy-confirmation ${this.state.showCopiedConfirmation ? '' : 'hide'}`}><FontAwesomeIcon icon="check-circle" color="#3A8250" /> Copied</span>


### PR DESCRIPTION
Fixed glossary share button order

**High level description:**

Fixed the order of the glossary share button.

**JIRA Ticket:**
[DEV-4211](https://federal-spending-transparency.atlassian.net/browse/DEV-4211)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [x] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [x] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
