### PR TITLE
[DEV-3483] Resotring existing selectedNAICS component

### DIFF
--- a/src/js/components/search/filters/naics/SelectedNAICS.jsx
+++ b/src/js/components/search/filters/naics/SelectedNAICS.jsx
@@ -10,22 +10,27 @@ import * as OtherFiltersFormatter from 'helpers/otherFiltersFormatter';
 import ShownValue from 'components/search/filters/otherFilters/ShownValue';
 
 const propTypes = {
-    selectedNAICS: PropTypes.array,
+    selectedNAICS: PropTypes.object,
     removeNAICS: PropTypes.func
 };
 
 export default class SelectedNAICS extends React.Component {
     render() {
+        const shownNAICS = [];
+        this.props.selectedNAICS.entrySeq().forEach((entry) => {
+            const naics = entry[1].naics;
+            const description = entry[1].naics_description;
+            const value = (<ShownValue
+                label={OtherFiltersFormatter.formatValue(naics, description)}
+                key={naics}
+                removeValue={this.props.removeNAICS.bind(null, entry[1])} />);
+            shownNAICS.push(value);
+        });
         return (
             <div
                 className="selected-filters"
                 role="status">
-                {this.props.selectedNAICS.map((node) => (
-                    <ShownValue
-                        key={node.value}
-                        label={OtherFiltersFormatter.formatValue(node.value, node.label)}
-                        removeValue={() => this.props.removeNAICS(node)} />)
-                )}
+                {shownNAICS}
             </div>
         );
     }


### PR DESCRIPTION
**High level description:**
Broke the old/existing selectedNaics filter component. Reverting those changes.

Restoring this change: https://github.com/fedspendingtransparency/usaspending-website/pull/1541/files?file-filters%5B%5D=.jsx&hide-deleted-files=true#diff-38fd6a4622d1491a90a800975a23de9f

The following are ALL required for the PR to be merged:
Reviewer(s):
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
