### PR TITLE
[DEV-3483] Adding more Unit Tests for the NAICS Search Tree

### DIFF
--- a/src/js/containers/search/filters/naics/NAICSContainer.jsx
+++ b/src/js/containers/search/filters/naics/NAICSContainer.jsx
@@ -298,7 +298,7 @@ export class NAICSContainer extends React.Component {
         this.props.setChecked([...new Set([...removeParentPlaceholders, ...newValues])]);
     }
 
-    autoCheckSearchedResultDescendents = (checked, expanded) => {
+    autoCheckSearchedResultDescendants = (checked, expanded) => {
         const { nodes } = this.props;
         const placeholderNodes = checked
             .filter((node) => node.includes('children_of_'))
@@ -357,7 +357,7 @@ export class NAICSContainer extends React.Component {
             if (isSearch) {
                 const visibleNaicsValues = expandAllNodes(data.results, 'naics');
                 this.props.setSearchedNaics(data.results);
-                this.autoCheckSearchedResultDescendents(checked, visibleNaicsValues);
+                this.autoCheckSearchedResultDescendants(checked, visibleNaicsValues);
                 this.props.setExpanded(visibleNaicsValues, 'SET_SEARCHED_EXPANDED');
             }
             else {

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -1,7 +1,38 @@
 /**
   * checkboxTreeHelper.js
   * Created by Jonathan Hill 10/01/2019
-  **/
+**/
+
+
+const getChildren = (node) => {
+    if (!node.children && node.naics.length <= 4) {
+        return {
+            children: [{
+                isPlaceHolder: true,
+                label: 'Placeholder Child',
+                value: `children_of_${node.naics}`
+            }]
+        };
+    }
+    else if (node.children) {
+        return {
+            children: node.children.map((child) => ({
+                ...child,
+                label: child.naics_description,
+                value: child.naics,
+                ...getChildren(child)
+            }))
+        };
+    }
+    return {};
+};
+
+export const cleanNaicsData = (nodes) => nodes.map((node) => ({
+    ...node,
+    label: node.naics_description,
+    value: node.naics,
+    ...getChildren(node)
+}));
 
 export const sortNodes = (a, b) => {
     if (a.isPlaceHolder) return 1;

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -31,15 +31,15 @@ export const getNodeFromTree = (tree, nodeKey, treePropForKey = 'value') => {
     if (nodeKey.length === 4) {
         return tree
             .find((node) => node[treePropForKey] === parentKey)
-            .children
+            ?.children
             .find((node) => node[treePropForKey] === nodeKey);
     }
     if (nodeKey.length === 6) {
         return tree
             .find((node) => node[treePropForKey] === parentKey)
-            .children
+            ?.children
             .find((node) => node[treePropForKey] === ancestorKey)
-            .children
+            ?.children
             .find((node) => node[treePropForKey] === nodeKey);
     }
     return null;
@@ -64,7 +64,16 @@ export const mergeChildren = (parentFromSearch, existingParent) => {
     // 1. hide node not in search
     // 2. add placeholders if not there
     if (existingParent.children && parentFromSearch.children) {
-        const existingChildArray = existingParent.children.map((node) => ({ ...node, className: 'hide' }));
+        const existingChildArray = existingParent
+            .children
+            .filter((node) => {
+                const childFromSearch = getNodeFromTree(parentFromSearch.children, node.value);
+                if (node.isPlaceHolder && node.count === childFromSearch?.children.length) {
+                    return false;
+                }
+                return true;
+            })
+            .map((node) => ({ ...node, className: 'hide' }));
 
         const nodes = parentFromSearch.children
             .reduce((acc, searchChild) => {

--- a/src/js/redux/actions/search/naicsActions.js
+++ b/src/js/redux/actions/search/naicsActions.js
@@ -3,35 +3,7 @@
   * Created by Jonathan Hill 12/30/19
   **/
 
-const getChildren = (node) => {
-    if (!node.children && node.naics.length <= 4) {
-        return {
-            children: [{
-                isPlaceHolder: true,
-                label: 'Placeholder Child',
-                value: `children_of_${node.naics}`
-            }]
-        };
-    }
-    else if (node.children) {
-        return {
-            children: node.children.map((child) => ({
-                ...child,
-                label: child.naics_description,
-                value: child.naics,
-                ...getChildren(child)
-            }))
-        };
-    }
-    return {};
-};
-
-const cleanNaicsData = (nodes) => nodes.map((node) => ({
-    ...node,
-    label: node.naics_description,
-    value: node.naics,
-    ...getChildren(node)
-}));
+import { cleanNaicsData } from "helpers/checkboxTreeHelper";
 
 export const setNaics = (key, nodes) => ({
     type: 'SET_NAICS',

--- a/tests/containers/search/filters/naics/NAICSContainer-test.jsx
+++ b/tests/containers/search/filters/naics/NAICSContainer-test.jsx
@@ -68,7 +68,7 @@ describe('NAICS Search Filter Container', () => {
         });
     });
     describe('autoCheckImmediateChildrenAfterDynamicExpand fn', () => {
-        it('auto checks unchecked descendents of selected parent', async () => {
+        it('auto checks unchecked descendants of selected parent', async () => {
             const setChecked = jest.fn();
             const container = shallow(<NAICSContainer
                 {...defaultProps}
@@ -77,19 +77,19 @@ describe('NAICS Search Filter Container', () => {
                 
             await container.instance().autoCheckImmediateChildrenAfterDynamicExpand(treeWithPlaceholdersAndRealData[0]);
 
-            // removing the placeholder selection for 11 and adding all the descendents grandchildren (placeholders) to checked. In this test case, we only have one immediate child of 11. Non-placeholder children should not be auto checked.
-            expect(setChecked).toHaveBeenCalledWith(["children_of_1111"]);
+            // removing the placeholder selection for 11 and adding all the descendants grandchildren (placeholders) to checked. In this test case, we only have one immediate child of 11. Non-placeholder children should not be auto checked.
+            expect(setChecked).toHaveBeenCalledWith(["children_of_1111", "children_of_1112"]);
         });
     });
-    describe('autoCheckSearchedResultDescendents fn', () => {
-        it('auto checks unchecked descendents of selected parent', async () => {
+    describe('autoCheckSearchedResultDescendants fn', () => {
+        it('auto checks unchecked descendants of selected parent', async () => {
             const addChecked = jest.fn();
             const container = shallow(<NAICSContainer
                 {...defaultProps}
                 nodes={searchResults}
                 addChecked={addChecked} />);
             const expanded = ["11", "1111", "111110", "144444"];
-            await container.instance().autoCheckSearchedResultDescendents(["children_of_11"], expanded);
+            await container.instance().autoCheckSearchedResultDescendants(["children_of_11"], expanded);
 
             expect(addChecked).toHaveBeenCalledWith("111110");
             expect(addChecked).not.toHaveBeenCalledWith("144444");

--- a/tests/containers/search/filters/naics/mockNaics_v2.js
+++ b/tests/containers/search/filters/naics/mockNaics_v2.js
@@ -104,6 +104,12 @@ export const treeWithPlaceholdersAndRealData = [
                         count: 0
                     }
                 ]
+            },
+            {
+                value: "children_of_1112",
+                naics: "children_of_1112",
+                isPlaceHolder: true,
+                count: 0
             }
         ]
     }

--- a/tests/containers/search/filters/naics/mockNaics_v2.js
+++ b/tests/containers/search/filters/naics/mockNaics_v2.js
@@ -447,7 +447,7 @@ export const reallyBigTree = [
         count: 29,
         children: []
     }
-]
+];
 
 export const defaultProps = {
     expanded: [],

--- a/tests/helpers/checkboxTreeHelper-test.js
+++ b/tests/helpers/checkboxTreeHelper-test.js
@@ -4,11 +4,9 @@ import {
     getImmediateAncestorNaicsCode,
     getNodeFromTree,
     expandAllNodes,
-    showAllTreeItems
+    showAllTreeItems,
+    cleanNaicsData
 } from 'helpers/checkboxTreeHelper';
-import {
-    setNaics
-} from 'redux/actions/search/naicsActions';
 
 import * as mockData from '../containers/search/filters/naics/mockNaics_v2';
 
@@ -123,6 +121,38 @@ describe('checkboxTree Helpers', () => {
             const lengthWithoutPlaceholderNodes = mockData.reallyBigTree[0].children.length;
             const nodeWithPlaceHolderChildren = getNodeFromTree(result, '11', 'naics');
             expect(nodeWithPlaceHolderChildren.children.length).toEqual(lengthWithoutPlaceholderNodes);
+        });
+    });
+    describe('cleanNaicsData', () => {
+        it('object property mapping: (A) naics_description --> label & (B) naics --> value', () => {
+            const [mock] = [{ naics: '11', naics_description: 'test1' }];
+            const [cleanData] = cleanNaicsData([mock]);
+            expect(cleanData.label).toEqual(mock.naics_description);
+            expect(cleanData.value).toEqual(mock.naics);
+            expect(cleanData.children[0].isPlaceHolder).toEqual(true);
+        });
+        it('recursively cleans child objects objects', () => {
+            const [mock] = [
+                {
+                    naics: '11',
+                    naics_description: 'test1',
+                    children: [{
+                        naics: '1111',
+                        naics_description: 'test2',
+                        children: [{
+                            naics: '111110',
+                            naics_description: 'test3'
+                        }]
+                    }]
+                }
+            ];
+            const [cleanData] = cleanNaicsData([mock]);
+            expect(cleanData.label).toEqual(mock.naics_description);
+            expect(cleanData.value).toEqual(mock.naics);
+            expect(cleanData.children[0].value).toEqual(cleanData.children[0].naics);
+            expect(cleanData.children[0].label).toEqual(cleanData.children[0].naics_description);
+            expect(cleanData.children[0].children[0].value).toEqual(cleanData.children[0].children[0].naics);
+            expect(cleanData.children[0].children[0].label).toEqual(cleanData.children[0].children[0].naics_description);
         });
     });
 });

--- a/tests/helpers/checkboxTreeHelper-test.js
+++ b/tests/helpers/checkboxTreeHelper-test.js
@@ -23,7 +23,7 @@ const mockSearchResults = [{
 }];
 
 describe('checkboxTree Helpers', () => {
-    describe('mergeChildren & addSearchResultsToTree', () => {
+    describe('addSearchResultsToTree & mergeChildren & ', () => {
         it('does NOT overwrite existing grand-children', () => {
             const existingNodes = mockData.treeWithPlaceholdersAndRealData;
             const [newChildren] = addSearchResultsToTree(existingNodes, mockSearchResults);
@@ -31,6 +31,36 @@ describe('checkboxTree Helpers', () => {
             const existingGrandChildren = existingNodes[0].children[0].children;
             expect(grandChildrenWithSearch.length).toEqual(existingGrandChildren.length + 1);
         });
+        it('adds a the hide class to nodes not in search results', () => {
+            const existingNodes = mockData.reallyBigTree;
+            const searchResult = addSearchResultsToTree(existingNodes, mockData.searchResults);
+            const existingGrandChildren = existingNodes[0].children[0].children;
+            const grandChildrenWithSearch = searchResult
+                .find((node) => node.value === '11')
+                .children[0].children;
+            // not overwriting existing children
+            expect(grandChildrenWithSearch.length).toEqual(existingGrandChildren.length);
+            // adding class to all nodes not in search result
+            const hiddenNodes = grandChildrenWithSearch.filter((node) => node.className === 'hide');
+            const visibleNodes = grandChildrenWithSearch.filter((node) => node.className === '');
+            expect(hiddenNodes.length).toEqual(7);
+            expect(visibleNodes.length).toEqual(1);
+            expect(visibleNodes[0].naics_description).toEqual('Soybean Farming');
+        });
+        // it('removes placeholder children for nodes with all children', () => {
+        //     const existingNodes = mockData.treeWithPlaceholdersAndRealData;
+        //     const [newChildren] = addSearchResultsToTree(existingNodes, mockSearchResults);
+        //     const grandChildrenWithSearch = newChildren.children[0].children;
+        //     const existingGrandChildren = existingNodes[0].children[0].children;
+        //     expect(grandChildrenWithSearch.length).toEqual(existingGrandChildren.length + 1);
+        // });
+        // it('adds placeholder children for nodes without all children', () => {
+        //     const existingNodes = mockData.treeWithPlaceholdersAndRealData;
+        //     const [newChildren] = addSearchResultsToTree(existingNodes, mockSearchResults);
+        //     const grandChildrenWithSearch = newChildren.children[0].children;
+        //     const existingGrandChildren = existingNodes[0].children[0].children;
+        //     expect(grandChildrenWithSearch.length).toEqual(existingGrandChildren.length + 1);
+        // });
     });
     describe('expandAllNodes', () => {
         it('returns an array containing all values from tree', () => {

--- a/tests/helpers/checkboxTreeHelper-test.js
+++ b/tests/helpers/checkboxTreeHelper-test.js
@@ -6,6 +6,10 @@ import {
     expandAllNodes,
     showAllTreeItems
 } from 'helpers/checkboxTreeHelper';
+import {
+    setNaics
+} from 'redux/actions/search/naicsActions';
+
 import * as mockData from '../containers/search/filters/naics/mockNaics_v2';
 
 // overwriting this because it makes life easier
@@ -47,20 +51,37 @@ describe('checkboxTree Helpers', () => {
             expect(visibleNodes.length).toEqual(1);
             expect(visibleNodes[0].naics_description).toEqual('Soybean Farming');
         });
-        // it('removes placeholder children for nodes with all children', () => {
-        //     const existingNodes = mockData.treeWithPlaceholdersAndRealData;
-        //     const [newChildren] = addSearchResultsToTree(existingNodes, mockSearchResults);
-        //     const grandChildrenWithSearch = newChildren.children[0].children;
-        //     const existingGrandChildren = existingNodes[0].children[0].children;
-        //     expect(grandChildrenWithSearch.length).toEqual(existingGrandChildren.length + 1);
-        // });
-        // it('adds placeholder children for nodes without all children', () => {
-        //     const existingNodes = mockData.treeWithPlaceholdersAndRealData;
-        //     const [newChildren] = addSearchResultsToTree(existingNodes, mockSearchResults);
-        //     const grandChildrenWithSearch = newChildren.children[0].children;
-        //     const existingGrandChildren = existingNodes[0].children[0].children;
-        //     expect(grandChildrenWithSearch.length).toEqual(existingGrandChildren.length + 1);
-        // });
+        it('removes placeholder children / grandchildren for nodes with all children / grandchildren', () => {
+            const existingNodes = mockData.placeholderNodes;
+            const searchResult = addSearchResultsToTree(existingNodes, [mockData.reallyBigTree[0]]);
+            const grandChildrenFromSearch = searchResult
+                .find((node) => node.value === '11')
+                .children[0].children;
+            const childrenFromSearch = searchResult
+                .find((node) => node.value === '11')
+                .children;
+            const grandChildrenWithPlaceholder = grandChildrenFromSearch
+                .filter((node) => node.isPlaceHolder);
+            const childrenWithPlaceholder = childrenFromSearch
+                .filter((node) => node.isPlaceHolder);
+            expect(grandChildrenWithPlaceholder.length).toEqual(0);
+            expect(childrenWithPlaceholder.length).toEqual(0);
+        });
+        it('keeps placeholder children/grandchildren for nodes without all children', () => {
+            const existingNodes = mockData.treeWithPlaceholdersAndRealData;
+            const [searchResults] = addSearchResultsToTree(existingNodes, mockSearchResults);
+            const childFromSearch = searchResults.children[0];
+            const childPlaceHolderExists = searchResults
+                .children
+                .some((child) => child.isPlaceHolder);
+
+            const grandPlaceHolderExists = childFromSearch
+                .children
+                .some((grand) => grand.isPlaceHolder);
+            expect(grandPlaceHolderExists).toEqual(true);
+            expect(childPlaceHolderExists).toEqual(true);
+
+        });
     });
     describe('expandAllNodes', () => {
         it('returns an array containing all values from tree', () => {


### PR DESCRIPTION
**High level description:**
Adding some more unit tests for different scenarios in the NAICS Search Tree.

**Technical details:**
- `cleanNaicsData` which maps the api object to the shape necessary for the checkbox tree component
- `addSearchResultsToTree` which does three things

1. removes / adds placeholder children when necessary
2. doesn't overwrite existing children
3. add's hide class to non-search result nodes

**JIRA Ticket:**
[DEV-3483](https://federal-spending-transparency.atlassian.net/browse/DEV-3483)

The following are ALL required for the PR to be merged:

Reviewer(s):
- [x] Code review complete
