### PR TITLE
[DEV-3478] add cfda column to assistance transaction tables

### DIFF
--- a/src/js/components/award/table/TransactionsTable.jsx
+++ b/src/js/components/award/table/TransactionsTable.jsx
@@ -110,7 +110,7 @@ export default class TransactionsTable extends React.Component {
             const isLast = i === tableMapping.table._order.length - 1;
 
             const displayName = tableMapping.table[column];
-            let columnWidth = Math.max(measureTableHeader(displayName),
+            let columnWidth = Math.max(measureTableHeader(displayName) - 40,
                 tableMapping.columnWidths[column]);
             if (isLast) {
                 // make it fill out the remainder of the width necessary

--- a/src/js/components/award/table/TransactionsTable.jsx
+++ b/src/js/components/award/table/TransactionsTable.jsx
@@ -25,7 +25,7 @@ const rowHeight = 40;
 // setting the table height to a partial row prevents double bottom borders and also clearly
 // indicates when there's more data
 const tableHeight = 10.5 * rowHeight;
-
+const columnWidthOffset = 40;
 const propTypes = {
     transactions: PropTypes.array,
     tableInstance: PropTypes.string,
@@ -110,7 +110,7 @@ export default class TransactionsTable extends React.Component {
             const isLast = i === tableMapping.table._order.length - 1;
 
             const displayName = tableMapping.table[column];
-            let columnWidth = Math.max(measureTableHeader(displayName) - 40,
+            let columnWidth = Math.max(measureTableHeader(displayName) - columnWidthOffset,
                 tableMapping.columnWidths[column]);
             if (isLast) {
                 // make it fill out the remainder of the width necessary

--- a/src/js/components/award/table/cells/TransactionTableHeaderCell.jsx
+++ b/src/js/components/award/table/cells/TransactionTableHeaderCell.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import * as Icons from 'components/sharedComponents/icons/Icons';
 
 import tableMapping from 'dataMapping/contracts/transactionTable';
-import assistanceTableMapping from 'dataMapping/financialAssistance/financialAssistanceTransactionTable.js';
+import assistanceTableMapping from 'dataMapping/financialAssistance/financialAssistanceTransactionTable';
 
 const propTypes = {
     label: PropTypes.string,

--- a/src/js/components/award/table/cells/TransactionTableHeaderCell.jsx
+++ b/src/js/components/award/table/cells/TransactionTableHeaderCell.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import * as Icons from 'components/sharedComponents/icons/Icons';
 
 import tableMapping from 'dataMapping/contracts/transactionTable';
+import assistanceTableMapping from 'dataMapping/financialAssistance/financialAssistanceTransactionTable.js';
 
 const propTypes = {
     label: PropTypes.string,
@@ -30,7 +31,8 @@ export default class TransactionTableHeaderCell extends React.Component {
 
     clickedHeader() {
         // check if this is the field that is currently being used to sort
-        const apiFieldName = tableMapping.table._mapping[this.props.column];
+        const apiFieldName = tableMapping.table._mapping[this.props.column] == null ?
+            assistanceTableMapping.table._mapping[this.props.column] : tableMapping.table._mapping[this.props.column];
         if (apiFieldName === this.props.order.field) {
             // it's the same field, just toggle the direction
             let direction = 'asc';
@@ -57,7 +59,8 @@ export default class TransactionTableHeaderCell extends React.Component {
         e.stopPropagation();
 
         const direction = e.currentTarget.value;
-        const apiFieldName = tableMapping.table._mapping[this.props.column];
+        const apiFieldName = tableMapping.table._mapping[this.props.column] == null ?
+            assistanceTableMapping.table._mapping[this.props.column] : tableMapping.table._mapping[this.props.column];
         this.props.setTransactionSort({
             direction,
             field: apiFieldName
@@ -73,7 +76,8 @@ export default class TransactionTableHeaderCell extends React.Component {
 
     render() {
         // highlight the active arrows
-        const apiFieldName = tableMapping.table._mapping[this.props.column];
+        const apiFieldName = tableMapping.table._mapping[this.props.column] == null ?
+            assistanceTableMapping.table._mapping[this.props.column] : tableMapping.table._mapping[this.props.column];
         let activeAsc = '';
         let activeDesc = '';
         if (apiFieldName === this.props.order.field) {

--- a/src/js/containers/award/table/TransactionsTableContainer.jsx
+++ b/src/js/containers/award/table/TransactionsTableContainer.jsx
@@ -15,6 +15,7 @@ import * as awardActions from 'redux/actions/award/awardActions';
 
 import BaseContractTransaction from 'models/v2/awards/transactions/BaseContractTransaction';
 import BaseLoanTransaction from 'models/v2/awards/transactions/BaseLoanTransaction';
+import BaseAssistanceTransaction from 'models/v2/awards/transactions/BaseAssistanceTransaction';
 import TransactionsTable from 'components/award/table/TransactionsTable';
 
 const propTypes = {
@@ -106,8 +107,16 @@ export class TransactionsTableContainer extends React.Component {
     }
 
     parseTransactions(data, reset) {
-        const baseTransaction = this.props.category === 'loan' ?
-            BaseLoanTransaction : BaseContractTransaction;
+        let baseTransaction = BaseContractTransaction;
+        if (this.props.category === 'loan') {
+            baseTransaction = BaseLoanTransaction;
+        }
+        else if (this.props.category === 'contract' || this.props.category === 'idv') {
+            baseTransaction = BaseContractTransaction;
+        }
+        else {
+            baseTransaction = BaseAssistanceTransaction;
+        }
         const transactions = data.results.map((item) => {
             const transaction = Object.create(baseTransaction);
             transaction.populate(item);

--- a/src/js/dataMapping/financialAssistance/financialAssistanceTransactionTable.js
+++ b/src/js/dataMapping/financialAssistance/financialAssistanceTransactionTable.js
@@ -6,13 +6,15 @@
 const tableSearchFields = {
     columnWidths: {
         modificationNumber: 0,
+        cfdaNumber: 0,
         actionDate: 0,
         federalActionObligation: 0,
-        actionTypeDescription: 380,
+        actionTypeDescription: 0,
         description: 380
     },
     defaultSortDirection: {
         modificationNumber: 'desc',
+        cfdaNumber: 'desc',
         actionDate: 'desc',
         federalActionObligation: 'desc',
         action_type: 'asc',
@@ -21,6 +23,7 @@ const tableSearchFields = {
     table: {
         _order: [
             'modificationNumber',
+            'cfdaNumber',
             'actionDate',
             'federalActionObligation',
             'actionTypeDescription',
@@ -28,12 +31,14 @@ const tableSearchFields = {
         ],
         _mapping: {
             modificationNumber: 'modification_number',
+            cfdaNumber: 'cfda_number',
             actionDate: 'action_date',
             federalActionObligation: 'federal_action_obligation',
             actionTypeDescription: 'action_type',
             description: 'description'
         },
         modificationNumber: 'Modification Number',
+        cfdaNumber: 'CFDA Number',
         actionDate: 'Action Date',
         federalActionObligation: 'Amount',
         actionTypeDescription: 'Action Type',

--- a/src/js/models/v2/awards/transactions/BaseAssistanceTransaction.js
+++ b/src/js/models/v2/awards/transactions/BaseAssistanceTransaction.js
@@ -18,7 +18,8 @@ BaseAssistanceTransaction.populate = function populate(data) {
         actionType: data.action_type,
         actionTypeDescription: (data.action_type && actionTypes[data.action_type.toUpperCase()]),
         modificationNumber: data.modification_number,
-        description: data.description
+        description: data.description,
+        cfda_number: data.cfda_number
     };
     this.populateCore(coreData);
 

--- a/src/js/models/v2/awards/transactions/CoreTransaction.js
+++ b/src/js/models/v2/awards/transactions/CoreTransaction.js
@@ -19,6 +19,7 @@ const CoreTransaction = {
         this._actionTypeDescription = data.actionTypeDescription || '';
         this.modificationNumber = data.modificationNumber || '';
         this.description = data.description || '';
+        this.cfdaNumber = data.cfda_number || '';
     },
     get actionDate() {
         if (this._actionDate) {

--- a/tests/models/awards/transactions/BaseTransactions-test.js
+++ b/tests/models/awards/transactions/BaseTransactions-test.js
@@ -13,7 +13,8 @@ const mockContractTransaction = {
 const mockAssistanceTransaction = {
     federal_action_obligation: '1230.4',
     original_loan_subsidy_cost: '1230.4',
-    action_type: 'a'
+    action_type: 'a',
+    cfda_number: '12.345'
 };
 
 const mockLoanTransaction = {
@@ -48,6 +49,9 @@ describe('Base Transactions', () => {
         });
         it('should convert the action type', () => {
             expect(assistanceTransaction._actionTypeDescription).toEqual('New');
+        });
+        it('should contain the cfda number', () => {
+            expect(assistanceTransaction.cfdaNumber).toEqual('12.345');
         });
     });
     describe('BaseLoanTransaction', () => {

--- a/tests/models/awards/transactions/CoreTransaction-test.js
+++ b/tests/models/awards/transactions/CoreTransaction-test.js
@@ -7,7 +7,8 @@ import CoreTransaction from "models/v2/awards/transactions/CoreTransaction";
 const transactionData = {
     actionDate: '1999-12-31',
     actionType: 'a',
-    actionTypeDescription: 'New'
+    actionTypeDescription: 'New',
+    cfda_number: '12.345'
 };
 
 const transaction = Object.create(CoreTransaction);
@@ -20,5 +21,8 @@ describe('CoreTransactions', () => {
     });
     it('should format the action type description', () => {
         expect(transaction.actionTypeDescription).toEqual('A: New');
+    });
+    it('should contain the cfda number', () => {
+        expect(transaction.cfdaNumber).toEqual('12.345');
     });
 });


### PR DESCRIPTION
**High level description:**

- Adds row containing CFDA Number to the transactions table on the award summary pages
- Tightens up horizontal spacing in transactions table

**Technical details:**
- Added CFDA number to CoreTransaction and BaseAssistanceTransaction
- Switches between assistance and contract (and loan) tables in TransactionTableContainer
- Switches between contract table mapping and assistance table mapping in TransactionTableHeaderCell when the contract table mapping returns null. 

**JIRA Ticket:**
[DEV-3478](https://federal-spending-transparency.atlassian.net/browse/DEV-3478)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [X] Verified cross-browser compatibility
- [X] Verified mobile/tablet/desktop/monitor responsiveness
- [X] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [ ] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [X] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [X] Design review complete
- [x] [API #2340](https://github.com/fedspendingtransparency/usaspending-api/pull/2340) merged concurrently
- [x] Code review complete
