### PR TITLE
[DEV-3483] removes bug introduced by unit test pr that changed one line of code

### DIFF
--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -99,7 +99,7 @@ export const mergeChildren = (parentFromSearch, existingParent) => {
             .children
             .filter((node) => {
                 const childFromSearch = getNodeFromTree(parentFromSearch.children, node.value);
-                if (node.isPlaceHolder && node.count === childFromSearch?.children.length) {
+                if (node.isPlaceHolder && childFromSearch && childFromSearch.count === childFromSearch?.children.length) {
                     return false;
                 }
                 return true;

--- a/tests/helpers/checkboxTreeHelper-test.js
+++ b/tests/helpers/checkboxTreeHelper-test.js
@@ -49,21 +49,21 @@ describe('checkboxTree Helpers', () => {
             expect(visibleNodes.length).toEqual(1);
             expect(visibleNodes[0].naics_description).toEqual('Soybean Farming');
         });
-        it('removes placeholder children / grandchildren for nodes with all children / grandchildren', () => {
+        it('removes placeholder grandchildren for nodes with all grandchildren', () => {
             const existingNodes = mockData.placeholderNodes;
             const searchResult = addSearchResultsToTree(existingNodes, [mockData.reallyBigTree[0]]);
-            const grandChildrenFromSearch = searchResult
-                .find((node) => node.value === '11')
-                .children[0].children;
             const childrenFromSearch = searchResult
                 .find((node) => node.value === '11')
                 .children;
+
+            // 1111's children
+            const grandChildrenFromSearch = childrenFromSearch
+                .find((node) => node.value === '1111')
+                .children;
             const grandChildrenWithPlaceholder = grandChildrenFromSearch
                 .filter((node) => node.isPlaceHolder);
-            const childrenWithPlaceholder = childrenFromSearch
-                .filter((node) => node.isPlaceHolder);
+
             expect(grandChildrenWithPlaceholder.length).toEqual(0);
-            expect(childrenWithPlaceholder.length).toEqual(0);
         });
         it('keeps placeholder children/grandchildren for nodes without all children', () => {
             const existingNodes = mockData.treeWithPlaceholdersAndRealData;


### PR DESCRIPTION
**High level description:**
In a unit test only pr, that changed a single line of code, there was a bug where a conditional was evaluating to true when the relevant variables had values of `undefined`. The only reason this slipped under the radar is because we are using the `?` chain operator to traverse an undefined object.

**Technical details:**

Adds truthy/falsy evaluations to conditional for relevant variables.

**JIRA Ticket:**
[DEV-3483](https://federal-spending-transparency.atlassian.net/browse/DEV-3483)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
