### PR TITLE
[DEV-4430] Warmfix all foreign countries selection for custom award download

### DIFF
--- a/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
+++ b/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
@@ -120,7 +120,12 @@ export class BulkDownloadPageContainer extends React.Component {
             const locationType = awardDownloadOptions.locationTypes.find((type) => (
                 type.name === formState.locationType
             ));
-            params.filters[locationType.apiName] = [locations];
+            // Since "FOREIGN" is not a country the scope filter is used instead
+            if (formState.location.country.code === 'FOREIGN') {
+                params.filters[locationType.apiScopeName] = "foreign";
+            } else {
+                params.filters[locationType.apiName] = [locations];
+            }
         }
 
         this.requestDownload(params, 'awards');

--- a/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
+++ b/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
@@ -85,12 +85,14 @@ export const awardDownloadOptions = {
         {
             name: 'recipient_location',
             label: 'Recipient Location',
-            apiName: 'recipient_locations'
+            apiName: 'recipient_locations',
+            apiScopeName: 'recipient_scope'
         },
         {
             name: 'place_of_performance',
             label: 'Place of Performance',
-            apiName: 'place_of_performance_locations'
+            apiName: 'place_of_performance_locations',
+            apiScopeName: 'place_of_performance_scope'
         }
     ],
     fileFormats: [

--- a/tests/containers/bulkDownload/BulkDownloadPageContainer-test.jsx
+++ b/tests/containers/bulkDownload/BulkDownloadPageContainer-test.jsx
@@ -65,7 +65,7 @@ describe('BulkDownloadPageContainer', () => {
 
             expect(requestDownload).toHaveBeenCalledWith(expectedParams, 'awards');
         });
-        it('should not include the recipient location state filter for foreign locations', () => {
+        it('should include the recipient scope filter for foreign locations', () => {
             const awards = Object.assign({}, mockRedux.bulkDownload.awards, {
                 location: {
                     country: {
@@ -96,11 +96,7 @@ describe('BulkDownloadPageContainer', () => {
                     agency: '123',
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
-                    recipient_locations: [
-                        {
-                            country: 'FOREIGN'
-                        }
-                    ],
+                    recipient_scope: 'foreign',
                     date_range: {
                         end_date: '11-01-2017',
                         start_date: '11-01-2016'
@@ -260,7 +256,55 @@ describe('BulkDownloadPageContainer', () => {
 
             expect(requestDownload).toHaveBeenCalledWith(expectedParams, 'awards');
         });
+        it('should include the place of performance scope filter for foreign locations', () => {
+            const awards = Object.assign({}, mockRedux.bulkDownload.awards, {
+                location: {
+                    country: {
+                        code: 'FOREIGN',
+                        name: 'All Foreign Countries'
+                    },
+                    state: {
+                        code: '',
+                        name: ''
+                    }
+                },
+                locationType: 'place_of_performance'
+            });
+            const bulkDownload = Object.assign({}, mockRedux.bulkDownload, {
+                awards
+            });
+            const updatedRedux = Object.assign({}, mockRedux, {
+                bulkDownload
+            });
 
+            const container = shallow(<BulkDownloadPageContainer
+                {...updatedRedux}
+                {...mockActions} />);
+
+            const expectedParams = {
+                columns: [],
+                file_format: 'csv',
+                filters: {
+                    agency: '123',
+                    prime_award_types: ["02", "03", "04", "05", "07", "08"],
+                    sub_award_types: ['procurement'],
+                    place_of_performance_scope: 'foreign',
+                    date_range: {
+                        end_date: '11-01-2017',
+                        start_date: '11-01-2016'
+                    },
+                    date_type: 'action_date',
+                    sub_agency: 'Mock Sub-Agency'
+                }
+            };
+
+            const requestDownload = jest.fn();
+            container.instance().requestDownload = requestDownload;
+
+            container.instance().startAwardDownload();
+
+            expect(requestDownload).toHaveBeenCalledWith(expectedParams, 'awards');
+        });
 
     });
     describe('startAccountDownload', () => {


### PR DESCRIPTION
**High level description:**

Fix the ability to select all foreign countries as a location selected on the Custom Award Download page.

**Technical details:**

While testing DEV-4430 it was noticed that this functionality was already broken due to how the location filter handles the value of `FOREIGN`. To fix this the scope filter is used when a user selects all foreign countries.

**JIRA Ticket:**
[DEV-4430](https://federal-spending-transparency.atlassian.net/browse/DEV-4430)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [X] Linked to this PR in JIRA ticket
- [N/A] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [X] Verified cross-browser compatibility
- [X] Verified mobile/tablet/desktop/monitor responsiveness
- [X] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [X] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [X] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [X] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [X] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [X] [API #2348](https://github.com/fedspendingtransparency/usaspending-api/pull/2348) merged concurrently `if applicable`
- [ ] Code review complete
