### PR TITLE
[DEV-3484] Submit NAICS Search and Load from Hash URL

### DIFF
--- a/src/js/components/search/topFilterBar/filterGroups/NAICSFilterGroup.jsx
+++ b/src/js/components/search/topFilterBar/filterGroups/NAICSFilterGroup.jsx
@@ -36,23 +36,24 @@ export default class NAICSFilterGroup extends React.Component {
     }
 
     generateTags() {
-        const tags = [];
-
-        // check to see if an naics code is provided
-        const naics = this.props.filter.values;
-
-        naics.forEach((value) => {
-            const tag = {
-                value: `${value.identifier}`,
-                title: `${value.naics} | ${value.naics_description}`,
-                isSpecial: false,
-                removeFilter: this.removeFilter
-            };
-
-            tags.push(tag);
-        });
-
-        return tags;
+        return this.props.filter.values
+            .map((naics) => {
+                if (naics.isV2) {
+                    return {
+                        value: `${naics.identifier}`,
+                        title: `${naics.naics} - ${naics.naics_description} (${naics.count})`,
+                        isSpecial: false,
+                        // doesn't appear to be being used...
+                        removeFilter: () => this.removeFilter
+                    };
+                }
+                return {
+                    value: `${naics.identifier}`,
+                    title: `${naics.naics} | ${naics.naics_description}`,
+                    isSpecial: false,
+                    removeFilter: this.removeFilter
+                };
+            });
     }
 
     render() {

--- a/src/js/containers/search/SearchContainer.jsx
+++ b/src/js/containers/search/SearchContainer.jsx
@@ -35,7 +35,6 @@ import {
     sendFieldCombinations
 } from './helpers/searchAnalytics';
 
-
 require('pages/search/searchPage.scss');
 
 const propTypes = {
@@ -307,7 +306,7 @@ export class SearchContainer extends React.Component {
         }
 
         this.request = SearchHelper.generateUrlHash({
-            filters,
+            filters: SearchHelper.removeNaicsCountsFromFilters(filters),
             version: filterStoreVersion
         });
 

--- a/src/js/containers/search/SearchContainer.jsx
+++ b/src/js/containers/search/SearchContainer.jsx
@@ -235,7 +235,6 @@ export class SearchContainer extends React.Component {
             }
         });
 
-
         // apply the filters to both the staged and applied stores
         this.props.restoreHashedFilters(reduxValues);
 

--- a/src/js/containers/search/filters/naics/NAICSContainer.jsx
+++ b/src/js/containers/search/filters/naics/NAICSContainer.jsx
@@ -146,7 +146,6 @@ export class NAICSContainer extends React.Component {
 
                     return fetchAllNodesAndCheckTheirChildren(checkedParentAndChildrenNodesFromHash)
                         .then((newChecked) => {
-                            console.log("resolved");
                             this.updateCountOfSelectedTopTierNaicsCodes(newChecked);
                             this.props.restoreHashedFilters({
                                 ...this.props.filters,

--- a/src/js/containers/search/filters/naics/NAICSContainer.jsx
+++ b/src/js/containers/search/filters/naics/NAICSContainer.jsx
@@ -279,7 +279,6 @@ export class NAICSContainer extends React.Component {
         const parentNode = getNodeFromTree(this.props.nodes, parentKey);
         const ancestorNode = getNodeFromTree(this.props.nodes, ancestorKey);
         const currentNode = getNodeFromTree(this.props.nodes, key);
-        console.log("current Node", currentNode, checkedCode);
         const { count } = currentNode;
 
         const uncheckedCodeToBeRemoved = unchecked

--- a/src/js/containers/search/filters/naics/NAICSContainer.jsx
+++ b/src/js/containers/search/filters/naics/NAICSContainer.jsx
@@ -71,7 +71,7 @@ export class NAICSContainer extends React.Component {
     componentDidMount() {
         const { checkedFromHash, uncheckedFromHash } = this.props;
         // always get da nodes first.
-        this.fetchNAICS()
+        return this.fetchNAICS()
             .then(() => {
                 // lets load a stateful tree from the url, fun. timez.
                 if (checkedFromHash.length > 0) {
@@ -117,11 +117,11 @@ export class NAICSContainer extends React.Component {
                             })
                             .catch((e) => {
                                 console.log("Error on fetching NAICS Data from hash url", e);
-                                reject();
+                                reject(e);
                             }), Promise.resolve('first'));
                     });
 
-                    fetchAllNodesAndCheckTheirChildren(checkedParentAndChildrenNodesFromHash)
+                    return fetchAllNodesAndCheckTheirChildren(checkedParentAndChildrenNodesFromHash)
                         .then((newChecked) => {
                             this.updateCountOfSelectedTopTierNaicsCodes(newChecked);
                             this.props.restoreHashedFilters({
@@ -134,6 +134,11 @@ export class NAICSContainer extends React.Component {
                             });
                         });
                 }
+                // don't fetch anything more, no hash to load tree from; return a resolved promise for consistent return.
+                return Promise.resolve();
+            })
+            .catch((e) => {
+                console.log("Error on componentDidMount: ", e);
             });
     }
 

--- a/src/js/containers/search/filters/naics/NAICSContainer.jsx
+++ b/src/js/containers/search/filters/naics/NAICSContainer.jsx
@@ -139,7 +139,6 @@ export class NAICSContainer extends React.Component {
                                 return this.fetchNAICS(checked);
                             })
                             .catch((e) => {
-                                debugger;
                                 console.log("Error on fetching NAICS Data from hash url", e);
                                 reject(e);
                             }), Promise.resolve('first'));

--- a/src/js/containers/search/filters/naics/NAICSContainer.jsx
+++ b/src/js/containers/search/filters/naics/NAICSContainer.jsx
@@ -77,7 +77,14 @@ export class NAICSContainer extends React.Component {
                 if (checkedFromHash.length > 0) {
                     // first, expand da nodes.
                     const checkedParentAndChildrenNodesFromHash = checkedFromHash
-                        .filter((checked) => checked.length < 6)
+                        .filter((checked) => {
+                            const parentKey = getHighestAncestorNaicsCode(checked);
+                            const ancestorKey = getImmediateAncestorNaicsCode(checked);
+                            if (checkedFromHash.includes(parentKey) || checkedFromHash.includes(ancestorKey)) {
+                                return false;
+                            }
+                            return true;
+                        })
                         .sort((a, b) => {
                             if (a.length > b.length) return 1;
                             if (b.length > a.length) return -1;
@@ -89,29 +96,40 @@ export class NAICSContainer extends React.Component {
                             .then(() => {
                                 if (i === arr.length - 1) {
                                     const newChecked = [];
+                                    const param = checked.length === 6 ? getImmediateAncestorNaicsCode(checked) : checked;
                                     // last thing to fetch
-                                    return this.fetchNAICS(checked)
+                                    return this.fetchNAICS(param)
                                         .then(() => {
                                             iterable.forEach((code) => {
                                                 const node = getNodeFromTree(this.props.nodes, code);
-                                                node.children
-                                                    .forEach((child) => {
-                                                        if (child.value.length === 4) {
-                                                            child.children.forEach((grand) => {
-                                                                // add the grand-children.
-                                                                if (!uncheckedFromHash.includes(removePlaceholderString(grand.value))) {
-                                                                    newChecked.push(grand.value);
-                                                                }
-                                                            });
-                                                        }
-                                                        // or we're already looking at the grandchildren
-                                                        else if (!uncheckedFromHash.includes(removePlaceholderString(child.value))) {
-                                                            newChecked.push(child.value);
-                                                        }
-                                                    });
+                                                if (code.length === 6) {
+                                                    if (!uncheckedFromHash.includes(code)) {
+                                                        newChecked.push(code);
+                                                    }
+                                                }
+                                                else {
+                                                    node.children
+                                                        .forEach((child) => {
+                                                            if (child.value.length === 4) {
+                                                                child.children.forEach((grand) => {
+                                                                    // add the grand-children.
+                                                                    if (!uncheckedFromHash.includes(removePlaceholderString(grand.value))) {
+                                                                        newChecked.push(grand.value);
+                                                                    }
+                                                                });
+                                                            }
+                                                            // or we're already looking at the grandchildren
+                                                            else if (!uncheckedFromHash.includes(removePlaceholderString(child.value))) {
+                                                                newChecked.push(child.value);
+                                                            }
+                                                        });
+                                                }
                                             });
                                             resolve(newChecked);
                                         });
+                                }
+                                if (checked.length === 6) {
+                                    return this.fetchNAICS(getImmediateAncestorNaicsCode(checked));
                                 }
                                 return this.fetchNAICS(checked);
                             })
@@ -261,6 +279,7 @@ export class NAICSContainer extends React.Component {
         const parentNode = getNodeFromTree(this.props.nodes, parentKey);
         const ancestorNode = getNodeFromTree(this.props.nodes, ancestorKey);
         const currentNode = getNodeFromTree(this.props.nodes, key);
+        console.log("current Node", currentNode, checkedCode);
         const { count } = currentNode;
 
         const uncheckedCodeToBeRemoved = unchecked

--- a/src/js/containers/search/filters/naics/NAICSContainer.jsx
+++ b/src/js/containers/search/filters/naics/NAICSContainer.jsx
@@ -84,44 +84,41 @@ export class NAICSContainer extends React.Component {
                             return 0;
                         });
 
-                    
                     const fetchAllNodesAndCheckTheirChildren = (iterable) => new Promise((resolve, reject) => {
-                        iterable.reduce((prevPromise, checked, i, arr) => {
-                            return prevPromise
-                                .then(() => {
-                                    if (i === arr.length - 1) {
-                                        const newChecked = [];
-                                        // last thing to fetch
-                                        return this.fetchNAICS(checked)
-                                            .then(() => {
-                                                iterable.forEach((code) => {
-                                                    const node = getNodeFromTree(this.props.nodes, code);
-                                                    node.children
-                                                        .forEach((child) => {
-                                                            if (child.value.length === 4) {
-                                                                child.children.forEach((grand) => {
-                                                                    // add the grand-children.
-                                                                    if (!uncheckedFromHash.includes(removePlaceholderString(grand.value))) {
-                                                                        newChecked.push(grand.value);
-                                                                    }
-                                                                });
-                                                            }
-                                                            // or we're already looking at the grandchildren
-                                                            else if (!uncheckedFromHash.includes(removePlaceholderString(child.value))) {
-                                                                newChecked.push(child.value);
-                                                            }
-                                                        });
-                                                });
-                                                resolve(newChecked);
+                        iterable.reduce((prevPromise, checked, i, arr) => prevPromise
+                            .then(() => {
+                                if (i === arr.length - 1) {
+                                    const newChecked = [];
+                                    // last thing to fetch
+                                    return this.fetchNAICS(checked)
+                                        .then(() => {
+                                            iterable.forEach((code) => {
+                                                const node = getNodeFromTree(this.props.nodes, code);
+                                                node.children
+                                                    .forEach((child) => {
+                                                        if (child.value.length === 4) {
+                                                            child.children.forEach((grand) => {
+                                                                // add the grand-children.
+                                                                if (!uncheckedFromHash.includes(removePlaceholderString(grand.value))) {
+                                                                    newChecked.push(grand.value);
+                                                                }
+                                                            });
+                                                        }
+                                                        // or we're already looking at the grandchildren
+                                                        else if (!uncheckedFromHash.includes(removePlaceholderString(child.value))) {
+                                                            newChecked.push(child.value);
+                                                        }
+                                                    });
                                             });
-                                    }
-                                    return this.fetchNAICS(checked);
-                                })
-                                .catch((e) => {
-                                    console.log("Error on fetching NAICS Data from hash url", e);
-                                    reject();
-                                });
-                        }, Promise.resolve('first'));
+                                            resolve(newChecked);
+                                        });
+                                }
+                                return this.fetchNAICS(checked);
+                            })
+                            .catch((e) => {
+                                console.log("Error on fetching NAICS Data from hash url", e);
+                                reject();
+                            }), Promise.resolve('first'));
                     });
 
                     fetchAllNodesAndCheckTheirChildren(checkedParentAndChildrenNodesFromHash)
@@ -486,7 +483,7 @@ export class NAICSContainer extends React.Component {
                 if (checked.includes(`children_of_${param}`)) {
                     this.autoCheckImmediateChildrenAfterDynamicExpand(results[0], param);
                 }
-                
+
                 this.setState({
                     isLoading: false,
                     isError: false,

--- a/src/js/containers/search/filters/naics/NAICSContainer.jsx
+++ b/src/js/containers/search/filters/naics/NAICSContainer.jsx
@@ -649,8 +649,8 @@ export default connect(
         searchExpanded: state.naics.searchExpanded.toJS(),
         checked: state.naics.checked.toJS(),
         unchecked: state.naics.unchecked.toJS(),
-        checkedFromHash: state.appliedFilters.filters.naics_codes.included,
-        uncheckedFromHash: state.appliedFilters.filters.naics_codes.excluded,
+        checkedFromHash: state.appliedFilters.filters.naics_codes.require,
+        uncheckedFromHash: state.appliedFilters.filters.naics_codes.exclude,
         filters: state.appliedFilters.filters
     }),
     (dispatch) => ({

--- a/src/js/containers/search/filters/naics/NAICSContainer.jsx
+++ b/src/js/containers/search/filters/naics/NAICSContainer.jsx
@@ -80,9 +80,12 @@ export class NAICSContainer extends React.Component {
                         .filter((checked) => {
                             const parentKey = getHighestAncestorNaicsCode(checked);
                             const ancestorKey = getImmediateAncestorNaicsCode(checked);
-                            if (checkedFromHash.includes(parentKey) || checkedFromHash.includes(ancestorKey)) {
-                                return false;
-                            }
+                            const ancestorIsChecked = (
+                                checkedFromHash.includes(parentKey) ||
+                                checkedFromHash.includes(ancestorKey)
+                            );
+                            if (checked.length === 6 && ancestorIsChecked) return false;
+                            if (checked.length === 4 && checkedFromHash.includes(parentKey)) return false;
                             return true;
                         })
                         .sort((a, b) => {
@@ -92,6 +95,7 @@ export class NAICSContainer extends React.Component {
                         });
 
                     const fetchAllNodesAndCheckTheirChildren = (iterable) => new Promise((resolve, reject) => {
+                        console.log('iterable', iterable);
                         iterable.reduce((prevPromise, checked, i, arr) => prevPromise
                             .then(() => {
                                 if (i === arr.length - 1) {
@@ -126,6 +130,7 @@ export class NAICSContainer extends React.Component {
                                                 }
                                             });
                                             resolve(newChecked);
+                                            return Promise.resolve();
                                         });
                                 }
                                 if (checked.length === 6) {
@@ -134,6 +139,7 @@ export class NAICSContainer extends React.Component {
                                 return this.fetchNAICS(checked);
                             })
                             .catch((e) => {
+                                debugger;
                                 console.log("Error on fetching NAICS Data from hash url", e);
                                 reject(e);
                             }), Promise.resolve('first'));
@@ -141,6 +147,7 @@ export class NAICSContainer extends React.Component {
 
                     return fetchAllNodesAndCheckTheirChildren(checkedParentAndChildrenNodesFromHash)
                         .then((newChecked) => {
+                            console.log("resolved");
                             this.updateCountOfSelectedTopTierNaicsCodes(newChecked);
                             this.props.restoreHashedFilters({
                                 ...this.props.filters,

--- a/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
+++ b/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
@@ -629,12 +629,12 @@ export class TopFilterBarContainer extends React.Component {
             return filter;
         }
 
-        else if (props.naics_v2.included.length > 0) {
+        else if (props.naics_codes.included.length > 0) {
             return {
                 code: 'selectedNAICS',
                 isV2: true,
                 name: 'NAICS',
-                values: props.naics_v2.counts.map((naics) => ({
+                values: props.naics_codes.counts.map((naics) => ({
                     ...naics,
                     identifier: naics.value,
                     naics_description: `${naics.naics_description} (${naics.count})`

--- a/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
+++ b/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
@@ -629,7 +629,7 @@ export class TopFilterBarContainer extends React.Component {
             return filter;
         }
 
-        else if (props.naics_codes.included.length > 0) {
+        else if (props.naics_codes.require.length > 0) {
             return {
                 code: 'selectedNAICS',
                 isV2: true,

--- a/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
+++ b/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
@@ -629,6 +629,19 @@ export class TopFilterBarContainer extends React.Component {
             return filter;
         }
 
+        else if (props.naics_v2.included.length > 0) {
+            return {
+                code: 'selectedNAICS',
+                isV2: true,
+                name: 'NAICS',
+                values: props.naics_v2.counts.map((naics) => ({
+                    ...naics,
+                    identifier: naics.value,
+                    naics_description: `${naics.naics_description} (${naics.count})`
+                }))
+            };
+        }
+
         return null;
     }
 

--- a/src/js/dataMapping/search/awardsOperationKeys.js
+++ b/src/js/dataMapping/search/awardsOperationKeys.js
@@ -19,6 +19,7 @@ export const rootKeys = {
     awardID: 'award_ids',
     cfda: 'program_numbers',
     naics: 'naics_codes',
+    naics_v2: 'naics_codes',
     psc: 'psc_codes',
     contractPricing: 'contract_pricing_type_codes',
     setAsideType: 'set_aside_type_codes',

--- a/src/js/helpers/apiRequest.js
+++ b/src/js/helpers/apiRequest.js
@@ -11,7 +11,7 @@ export const apiRequest = (axiosParams = {}) => {
     const defaultHeaders = { 'X-Requested-With': 'USASpendingFrontend' };
     const cancelToken = CancelToken.source();
     const defaultParams = {
-        baseURL: kGlobalConstants.API,
+        baseURL: axiosParams.isMocked ? 'http://localhost:5000/api/' : kGlobalConstants.API,
         cancelToken: cancelToken.token
     };
 

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -114,7 +114,7 @@ export const mergeChildren = (parentFromSearch, existingParent) => {
             .children
             .filter((node) => {
                 const childFromSearch = getNodeFromTree(parentFromSearch.children, node.value);
-                if (node.isPlaceHolder && childFromSearch && childFromSearch.count === childFromSearch?.children.length) {
+                if (node.isPlaceHolder && childFromSearch && childFromSearch.count === childFromSearch?.children?.length) {
                     return false;
                 }
                 return true;

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -72,7 +72,7 @@ export const getNodeFromTree = (tree, nodeKey, treePropForKey = 'value') => {
             ?.children
             .find((node) => node[treePropForKey] === nodeKey);
     }
-    return null;
+    return { count: null };
 };
 
 export const removePlaceholderString = (str) => {

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -214,8 +214,16 @@ export const addSearchResultsToTree = (tree, searchResults) => {
 
 export const showAllTreeItems = (tree, key = '', newNodes = []) => tree
     .map((node) => {
+        const parentKey = getHighestAncestorNaicsCode(key);
+        const [data] = newNodes;
+        const shouldAddNewChildToParent = (
+            key &&
+            data &&
+            node.value === parentKey &&
+            // no child exists
+            !node.children.some((child) => child.value === key)
+        );
         if (node.value === key) {
-            const [data] = newNodes;
             return {
                 ...data,
                 children: data.children.map((child) => {
@@ -254,6 +262,17 @@ export const showAllTreeItems = (tree, key = '', newNodes = []) => tree
                 }).sort(sortNodes)
             };
         }
+        else if (shouldAddNewChildToParent) {
+            return {
+                ...node,
+                className: '',
+                children: [
+                    // leave the placeholder!
+                    ...node.children,
+                    data
+                ]
+            };
+        }
         return {
             ...node,
             className: '',
@@ -267,7 +286,7 @@ export const showAllTreeItems = (tree, key = '', newNodes = []) => tree
                             };
                         }
                         return {
-                            ...newNodes[0]
+                            ...data
                         };
                     }
                     if (child.children && child.children.some((grand) => grand.className === 'hide')) {

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -3,7 +3,6 @@
   * Created by Jonathan Hill 10/01/2019
 **/
 
-
 const getChildren = (node) => {
     if (!node.children && node.naics.length <= 4) {
         return {
@@ -76,6 +75,22 @@ export const getNodeFromTree = (tree, nodeKey, treePropForKey = 'value') => {
     return null;
 };
 
+export const removePlaceholderString = (str) => {
+    if (str.includes('children_of_')) return str.split('children_of_')[1];
+    return str;
+};
+
+export const getCountOfAllCheckedDescendants = (nodes, ancestorKey, checkedNodes) => checkedNodes
+    .map((checked) => removePlaceholderString(checked))
+    .filter((checkedNode) => checkedNode.includes(ancestorKey))
+    .reduce((ancestorCount, checkedAncestor) => {
+        const nodeCount = getNodeFromTree(nodes, checkedAncestor).count;
+        if (nodeCount === 0) {
+            return ancestorCount + 1;
+        }
+        return ancestorCount + nodeCount;
+    }, 0);
+
 export const expandAllNodes = (nodes, propForNode = 'value') => {
     const getValue = (acc, node) => {
         acc.push(node[propForNode]);
@@ -99,7 +114,7 @@ export const mergeChildren = (parentFromSearch, existingParent) => {
             .children
             .filter((node) => {
                 const childFromSearch = getNodeFromTree(parentFromSearch.children, node.value);
-                if (node.isPlaceHolder && node.count === childFromSearch?.children.length) {
+                if (node.isPlaceHolder && childFromSearch && childFromSearch.count === childFromSearch?.children.length) {
                     return false;
                 }
                 return true;

--- a/src/js/helpers/downloadHelper.js
+++ b/src/js/helpers/downloadHelper.js
@@ -17,6 +17,7 @@ export const requestDownloadStatus = (params) => apiRequest({
 });
 
 export const requestDownloadCount = (params) => apiRequest({
+    isMocked: true,
     url: 'v2/download/count/',
     method: 'post',
     data: params

--- a/src/js/helpers/searchHelper.js
+++ b/src/js/helpers/searchHelper.js
@@ -77,6 +77,7 @@ export const performSpendingByGeographySearch = (params) => apiRequest({
 
 // Spending By Award Tab Count Endpoint
 export const performSpendingByAwardTabCountSearch = (params) => apiRequest({
+    isMocked: true,
     url: 'v2/search/spending_by_award_count/',
     method: 'post',
     data: params
@@ -84,6 +85,7 @@ export const performSpendingByAwardTabCountSearch = (params) => apiRequest({
 
 // Spending By Award Table Endpoint
 export const performSpendingByAwardSearch = (params) => apiRequest({
+    isMocked: true,
     url: 'v2/search/spending_by_award/',
     method: 'post',
     data: params
@@ -96,12 +98,14 @@ export const performSubawardSearch = (data) => apiRequest({
 });
 
 export const generateUrlHash = (data) => apiRequest({
+    isMocked: true,
     url: 'v1/references/filter/',
     method: 'post',
     data
 });
 
 export const restoreUrlHash = (data) => apiRequest({
+    isMocked: true,
     url: 'v1/references/hash/',
     method: 'post',
     data

--- a/src/js/helpers/searchHelper.js
+++ b/src/js/helpers/searchHelper.js
@@ -110,3 +110,11 @@ export const restoreUrlHash = (data) => apiRequest({
 export const fetchLastUpdate = () => apiRequest({
     url: 'v2/awards/last_updated/'
 });
+
+export const removeNaicsCountsFromFilters = (reduxFilters) => ({
+    ...reduxFilters,
+    naics_codes: {
+        included: reduxFilters.naics_codes.included,
+        excluded: reduxFilters.naics_codes.excluded
+    }
+});

--- a/src/js/helpers/searchHelper.js
+++ b/src/js/helpers/searchHelper.js
@@ -118,7 +118,7 @@ export const fetchLastUpdate = () => apiRequest({
 export const removeNaicsCountsFromFilters = (reduxFilters) => ({
     ...reduxFilters,
     naics_codes: {
-        included: reduxFilters.naics_codes.included,
-        excluded: reduxFilters.naics_codes.excluded
+        require: reduxFilters.naics_codes.require,
+        exclude: reduxFilters.naics_codes.exclude
     }
 });

--- a/src/js/helpers/sidebarHelper.js
+++ b/src/js/helpers/sidebarHelper.js
@@ -60,7 +60,7 @@ export const filterHasSelections = (reduxFilters, filter) => {
             }
             return false;
         case 'North American Industry Classification System (NAICS)':
-            return (reduxFilters.naics_codes.included.length > 0);
+            return (reduxFilters.naics_codes.require.length > 0);
         case 'Product/Service Code (PSC)':
             if (reduxFilters.selectedPSC.toArray().length > 0) {
                 return true;

--- a/src/js/helpers/sidebarHelper.js
+++ b/src/js/helpers/sidebarHelper.js
@@ -59,6 +59,8 @@ export const filterHasSelections = (reduxFilters, filter) => {
                 return true;
             }
             return false;
+        case 'North American Industry Classification System (NAICS)':
+            return (reduxFilters.naics_codes.included.length > 0);
         case 'Product/Service Code (PSC)':
             if (reduxFilters.selectedPSC.toArray().length > 0) {
                 return true;

--- a/src/js/models/search/SearchAwardsOperation.js
+++ b/src/js/models/search/SearchAwardsOperation.js
@@ -38,7 +38,7 @@ class SearchAwardsOperation {
 
         this.selectedCFDA = [];
         this.selectedNAICS = [];
-        this.naics_v2 = { included: [], excluded: [] };
+        this.naics_codes = { included: [], excluded: [] };
         this.selectedPSC = [];
 
         this.pricingType = [];
@@ -79,7 +79,7 @@ class SearchAwardsOperation {
 
         this.selectedCFDA = state.selectedCFDA.toArray();
         this.selectedNAICS = state.selectedNAICS.toArray();
-        this.naics_v2 = { included: state.naics_v2.included, excluded: state.naics_v2.excluded };
+        this.naics_codes = { included: state.naics_codes.included, excluded: state.naics_codes.excluded };
         this.selectedPSC = state.selectedPSC.toArray();
 
         this.pricingType = state.pricingType.toArray();
@@ -274,9 +274,8 @@ class SearchAwardsOperation {
         }
 
         // NAICS v2
-        if (this.naics_v2.included.length > 0) {
-            console.log("this", this.naics_v2);
-            filters[rootKeys.naics_v2] = this.naics_v2;
+        if (this.naics_codes.included.length > 0) {
+            filters[rootKeys.naics_v2] = this.naics_codes;
         }
 
         // Add PSC

--- a/src/js/models/search/SearchAwardsOperation.js
+++ b/src/js/models/search/SearchAwardsOperation.js
@@ -38,6 +38,7 @@ class SearchAwardsOperation {
 
         this.selectedCFDA = [];
         this.selectedNAICS = [];
+        this.naics_v2 = { checked: [], unchecked: [] };
         this.selectedPSC = [];
 
         this.pricingType = [];
@@ -78,6 +79,7 @@ class SearchAwardsOperation {
 
         this.selectedCFDA = state.selectedCFDA.toArray();
         this.selectedNAICS = state.selectedNAICS.toArray();
+        this.naics_v2 = { checked: state.naics_v2.checked, unchecked: state.naics_v2.unchecked };
         this.selectedPSC = state.selectedPSC.toArray();
 
         this.pricingType = state.pricingType.toArray();
@@ -269,6 +271,11 @@ class SearchAwardsOperation {
         // Add NAICS
         if (this.selectedNAICS.length > 0) {
             filters[rootKeys.naics] = this.selectedNAICS.map((naics) => naics.naics);
+        }
+
+        // NAICS v2
+        if (this.naics_v2.checked.length > 0) {
+            filters[rootKeys.naics_v2] = this.naics_v2;
         }
 
         // Add PSC

--- a/src/js/models/search/SearchAwardsOperation.js
+++ b/src/js/models/search/SearchAwardsOperation.js
@@ -38,7 +38,7 @@ class SearchAwardsOperation {
 
         this.selectedCFDA = [];
         this.selectedNAICS = [];
-        this.naics_codes = { included: [], excluded: [] };
+        this.naics_codes = { require: [], exclude: [] };
         this.selectedPSC = [];
 
         this.pricingType = [];
@@ -79,7 +79,7 @@ class SearchAwardsOperation {
 
         this.selectedCFDA = state.selectedCFDA.toArray();
         this.selectedNAICS = state.selectedNAICS.toArray();
-        this.naics_codes = { included: state.naics_codes.included, excluded: state.naics_codes.excluded };
+        this.naics_codes = { require: state.naics_codes.require, exclude: state.naics_codes.exclude };
         this.selectedPSC = state.selectedPSC.toArray();
 
         this.pricingType = state.pricingType.toArray();
@@ -274,7 +274,7 @@ class SearchAwardsOperation {
         }
 
         // NAICS v2
-        if (this.naics_codes.included.length > 0) {
+        if (this.naics_codes.require.length > 0) {
             filters[rootKeys.naics_v2] = this.naics_codes;
         }
 

--- a/src/js/models/search/SearchAwardsOperation.js
+++ b/src/js/models/search/SearchAwardsOperation.js
@@ -38,7 +38,7 @@ class SearchAwardsOperation {
 
         this.selectedCFDA = [];
         this.selectedNAICS = [];
-        this.naics_v2 = { checked: [], unchecked: [] };
+        this.naics_v2 = { included: [], excluded: [] };
         this.selectedPSC = [];
 
         this.pricingType = [];
@@ -79,7 +79,7 @@ class SearchAwardsOperation {
 
         this.selectedCFDA = state.selectedCFDA.toArray();
         this.selectedNAICS = state.selectedNAICS.toArray();
-        this.naics_v2 = { checked: state.naics_v2.checked, unchecked: state.naics_v2.unchecked };
+        this.naics_v2 = { included: state.naics_v2.included, excluded: state.naics_v2.excluded };
         this.selectedPSC = state.selectedPSC.toArray();
 
         this.pricingType = state.pricingType.toArray();
@@ -274,7 +274,8 @@ class SearchAwardsOperation {
         }
 
         // NAICS v2
-        if (this.naics_v2.checked.length > 0) {
+        if (this.naics_v2.included.length > 0) {
+            console.log("this", this.naics_v2);
             filters[rootKeys.naics_v2] = this.naics_v2;
         }
 

--- a/src/js/redux/actions/search/searchFilterActions.js
+++ b/src/js/redux/actions/search/searchFilterActions.js
@@ -133,15 +133,20 @@ export const updateSelectedCFDA = (state) => ({
 });
 
 // NAICS Filter
-export const updateNaics = (naics) => ({
-    type: 'UPDATE_NAICS',
-    naics: naics.map((code) => {
-        if (code.includes('children_of_')) {
-            return code.split('children_of_')[1];
-        }
-        return code;
-    })
+export const updateNaicsV2 = (checked, unchecked, counts) => ({
+    type: 'UPDATE_NAICS_V2',
+    payload: {
+        unchecked,
+        checked: checked.map((code) => {
+            if (code.includes('children_of_')) {
+                return code.split('children_of_')[1];
+            }
+            return code;
+        }),
+        counts
+    }
 });
+
 export const updateSelectedNAICS = (state) => ({
     type: 'UPDATE_SELECTED_NAICS',
     naics: state.naics

--- a/src/js/redux/actions/search/searchFilterActions.js
+++ b/src/js/redux/actions/search/searchFilterActions.js
@@ -135,11 +135,11 @@ export const updateSelectedCFDA = (state) => ({
 });
 
 // NAICS Filter
-export const updateNaicsV2 = (included, excluded, counts) => ({
+export const updateNaicsV2 = (require, exclude, counts) => ({
     type: 'UPDATE_NAICS_V2',
     payload: {
-        excluded,
-        included: included.map((code) => removePlaceholderString(code)),
+        exclude,
+        require: require.map((code) => removePlaceholderString(code)),
         counts
     }
 });

--- a/src/js/redux/actions/search/searchFilterActions.js
+++ b/src/js/redux/actions/search/searchFilterActions.js
@@ -3,6 +3,8 @@
   * Created by Kevin Li 11/1/16
   **/
 
+import { removePlaceholderString } from "helpers/checkboxTreeHelper";
+
 // Keyword Filter
 export const updateTextSearchInput = (textInput) => ({
     type: 'UPDATE_TEXT_SEARCH',
@@ -133,16 +135,11 @@ export const updateSelectedCFDA = (state) => ({
 });
 
 // NAICS Filter
-export const updateNaicsV2 = (checked, unchecked, counts) => ({
+export const updateNaicsV2 = (included, excluded, counts) => ({
     type: 'UPDATE_NAICS_V2',
     payload: {
-        unchecked,
-        checked: checked.map((code) => {
-            if (code.includes('children_of_')) {
-                return code.split('children_of_')[1];
-            }
-            return code;
-        }),
+        excluded,
+        included: included.map((code) => removePlaceholderString(code)),
         counts
     }
 });

--- a/src/js/redux/reducers/search/filters/OtherFilterFunctions.js
+++ b/src/js/redux/reducers/search/filters/OtherFilterFunctions.js
@@ -2,8 +2,6 @@
  * Created by Emily Gullo 07/18/2017
  */
 
-import { List } from 'immutable';
-
 export const updateSelectedCFDA = (state, value) => {
     let updatedSet = state;
 
@@ -21,13 +19,6 @@ export const updateSelectedCFDA = (state, value) => {
 
     return updatedSet;
 };
-/**
- * updateNaics v2
- * - sets naics property in redux
- * @param {*[]} checked - new naics checked array
- * @returns {object} - new state object
- */
-export const updateNaics = (checked) => new List(checked);
 
 export const updateSelectedNAICS = (state, value) => {
     let updatedSet = state;

--- a/src/js/redux/reducers/search/searchFiltersReducer.js
+++ b/src/js/redux/reducers/search/searchFiltersReducer.js
@@ -35,6 +35,7 @@ export const requiredTypes = {
     awardAmounts: OrderedMap,
     selectedCFDA: OrderedMap,
     selectedNAICS: OrderedMap,
+    naics_codes: { included: [], excluded: [], counts: [] },
     selectedPSC: OrderedMap,
     pricingType: Set,
     setAside: Set,
@@ -62,7 +63,7 @@ export const initialState = {
     awardAmounts: new OrderedMap(),
     selectedCFDA: new OrderedMap(),
     selectedNAICS: new OrderedMap(),
-    naics_v2: { included: [], excluded: [], counts: [] },
+    naics_codes: { included: [], excluded: [], counts: [] },
     selectedPSC: new OrderedMap(),
     pricingType: new Set(),
     setAside: new Set(),
@@ -222,7 +223,7 @@ const searchFiltersReducer = (state = initialState, action) => {
         // NAICS_V2 Filter
         case 'UPDATE_NAICS_V2': {
             return Object.assign({}, state, {
-                naics_v2: action.payload
+                naics_codes: action.payload
             });
         }
 

--- a/src/js/redux/reducers/search/searchFiltersReducer.js
+++ b/src/js/redux/reducers/search/searchFiltersReducer.js
@@ -19,7 +19,15 @@ import * as ProgramSourceFilterFunctions from './filters/programSourceFilterFunc
 // frontend will reject inbound hashed search filter sets with different versions because the
 // data structures may have changed
 
-export const filterStoreVersion = '2019-07-26';
+// export const filterStoreVersion = '2019-07-26';
+export const filterStoreVersion = '2017-11-21';
+
+function NaicsCodes(data = { included: [], excluded: [], counts: [] }) {
+    console.log("HEY GUYZ DATA", data);
+    this.included = data.included;
+    this.excluded = data.excluded;
+    this.counts = data.counts || [];
+}
 
 export const requiredTypes = {
     keyword: OrderedMap,
@@ -35,7 +43,7 @@ export const requiredTypes = {
     awardAmounts: OrderedMap,
     selectedCFDA: OrderedMap,
     selectedNAICS: OrderedMap,
-    naics_codes: { included: [], excluded: [], counts: [] },
+    naics_codes: NaicsCodes,
     selectedPSC: OrderedMap,
     pricingType: Set,
     setAside: Set,
@@ -63,7 +71,7 @@ export const initialState = {
     awardAmounts: new OrderedMap(),
     selectedCFDA: new OrderedMap(),
     selectedNAICS: new OrderedMap(),
-    naics_codes: { included: [], excluded: [], counts: [] },
+    naics_codes: new NaicsCodes(),
     selectedPSC: new OrderedMap(),
     pricingType: new Set(),
     setAside: new Set(),

--- a/src/js/redux/reducers/search/searchFiltersReducer.js
+++ b/src/js/redux/reducers/search/searchFiltersReducer.js
@@ -22,8 +22,7 @@ import * as ProgramSourceFilterFunctions from './filters/programSourceFilterFunc
 // export const filterStoreVersion = '2019-07-26';
 export const filterStoreVersion = '2017-11-21';
 
-function NaicsCodes(data = { included: [], excluded: [], counts: [] }) {
-    console.log("HEY GUYZ DATA", data);
+export function NaicsCodes(data = { included: [], excluded: [], counts: [] }) {
     this.included = data.included;
     this.excluded = data.excluded;
     this.counts = data.counts || [];

--- a/src/js/redux/reducers/search/searchFiltersReducer.js
+++ b/src/js/redux/reducers/search/searchFiltersReducer.js
@@ -62,6 +62,7 @@ export const initialState = {
     awardAmounts: new OrderedMap(),
     selectedCFDA: new OrderedMap(),
     selectedNAICS: new OrderedMap(),
+    naics_v2: { checked: [], excluded: [] },
     selectedPSC: new OrderedMap(),
     pricingType: new Set(),
     setAside: new Set(),
@@ -210,18 +211,21 @@ const searchFiltersReducer = (state = initialState, action) => {
             });
         }
 
-        // NAICS Filter (v2)
-        case 'UPDATE_NAICS': {
-            return Object.assign({}, state, {
-                naics: OtherFilterFunctions.updateNaics(action.naics)
-            });
-        }
-
         // NAICS Filter
         case 'UPDATE_SELECTED_NAICS': {
             return Object.assign({}, state, {
                 selectedNAICS: OtherFilterFunctions.updateSelectedNAICS(
                     state.selectedNAICS, action.naics)
+            });
+        }
+
+        // NAICS_V2 Filter
+        case 'UPDATE_NAICS_V2': {
+            return Object.assign({}, state, {
+                naics_v2: {
+                    ...state.naics_v2,
+                    ...action.payload
+                }
             });
         }
 

--- a/src/js/redux/reducers/search/searchFiltersReducer.js
+++ b/src/js/redux/reducers/search/searchFiltersReducer.js
@@ -22,9 +22,9 @@ import * as ProgramSourceFilterFunctions from './filters/programSourceFilterFunc
 // export const filterStoreVersion = '2019-07-26';
 export const filterStoreVersion = '2017-11-21';
 
-export function NaicsCodes(data = { included: [], excluded: [], counts: [] }) {
-    this.included = data.included;
-    this.excluded = data.excluded;
+export function NaicsCodes(data = { require: [], exclude: [], counts: [] }) {
+    this.require = data.require;
+    this.exclude = data.exclude;
     this.counts = data.counts || [];
 }
 

--- a/src/js/redux/reducers/search/searchFiltersReducer.js
+++ b/src/js/redux/reducers/search/searchFiltersReducer.js
@@ -62,7 +62,7 @@ export const initialState = {
     awardAmounts: new OrderedMap(),
     selectedCFDA: new OrderedMap(),
     selectedNAICS: new OrderedMap(),
-    naics_v2: { checked: [], excluded: [] },
+    naics_v2: { included: [], excluded: [], counts: [] },
     selectedPSC: new OrderedMap(),
     pricingType: new Set(),
     setAside: new Set(),
@@ -222,10 +222,7 @@ const searchFiltersReducer = (state = initialState, action) => {
         // NAICS_V2 Filter
         case 'UPDATE_NAICS_V2': {
             return Object.assign({}, state, {
-                naics_v2: {
-                    ...state.naics_v2,
-                    ...action.payload
-                }
+                naics_v2: action.payload
             });
         }
 

--- a/tests/containers/search/filters/naics/NAICSContainer-test.jsx
+++ b/tests/containers/search/filters/naics/NAICSContainer-test.jsx
@@ -137,7 +137,7 @@ describe('NAICS Search Filter Container', () => {
         it('decrements count of stagedFilter one of many children/grandchildren is unchecked', async () => {
             const container = shallow(<NAICSContainer {...defaultProps} nodes={reallyBigTree} />);
             await container.setState({ stagedNaicsFilters: [{ value: '11', count: '8', label: 'test' }] });
-            
+
             const uncheckedNode = { value: '111110', count: 1, label: 'test' };
             await container.instance().onUncheck([], uncheckedNode);
 
@@ -154,11 +154,43 @@ describe('NAICS Search Filter Container', () => {
                 setUnchecked={setUnchecked}
                 checked={["children_of_11"]}
                 nodes={reallyBigTree} />);
-           
+
             const uncheckedNode = { value: '111110', count: 1, label: 'test' };
             await container.instance().onUncheck(["children_of_11"], uncheckedNode);
 
             expect(setUnchecked).toHaveBeenCalledWith([uncheckedNode.value]);
+        });
+    });
+    describe('removeFromUnchecked', async () => {
+        it('removes items from unchecked array when all immediate children are checked', () => {
+            // ie, 1111 is unchecked, then all grand children underneath are checked.
+            const allGrandchildren = reallyBigTree[0].children[0].children
+                .map((grand) => grand.value);
+            const lastGrandChild = allGrandchildren[allGrandchildren.length - 1];
+            const container = shallow(<NAICSContainer
+                {...defaultProps}
+                checked={allGrandchildren.splice(0, allGrandchildren.length - 1)}
+                unchecked={["1111"]}
+                nodes={reallyBigTree} />);
+
+            const result = container.instance().removeFromUnchecked(lastGrandChild);
+
+            expect(result).toEqual("1111");
+        });
+        it('does NOT remove from unchecked array when less than all immediate children are checked', () => {
+            // ie, 1111 is unchecked, then all but one grandchild underneath is checked.
+            const allGrandchildren = reallyBigTree[0].children[0].children
+                .map((grand) => grand.value);
+            const lastGrandChild = allGrandchildren[allGrandchildren.length - 1];
+            const container = shallow(<NAICSContainer
+                {...defaultProps}
+                checked={allGrandchildren.splice(0, allGrandchildren.length - 2)}
+                unchecked={["1111"]}
+                nodes={reallyBigTree} />);
+
+            const result = container.instance().removeFromUnchecked(lastGrandChild);
+
+            expect(result).toEqual(null);
         });
     });
 });

--- a/tests/containers/search/filters/naics/NAICSContainer-test.jsx
+++ b/tests/containers/search/filters/naics/NAICSContainer-test.jsx
@@ -143,5 +143,22 @@ describe('NAICS Search Filter Container', () => {
 
             expect(container.instance().state.stagedNaicsFilters[0].count).toEqual(7);
         });
+        it('updates the unchecked array when ancestor is checked and descendant is unchecked', async () => {
+            // currently, this only happens in search.
+            // This is because...
+            // In the expand/collapse view, when you check a parent and expand to its children
+            // the checkbox tree removes the parent from checked, and adds all the immediate children of the expanded node
+            const setUnchecked = jest.fn();
+            const container = shallow(<NAICSContainer
+                {...defaultProps}
+                setUnchecked={setUnchecked}
+                checked={["children_of_11"]}
+                nodes={reallyBigTree} />);
+           
+            const uncheckedNode = { value: '111110', count: 1, label: 'test' };
+            await container.instance().onUncheck(["children_of_11"], uncheckedNode);
+
+            expect(setUnchecked).toHaveBeenCalledWith([uncheckedNode.value]);
+        });
     });
 });

--- a/tests/containers/search/filters/naics/NAICSContainer-test.jsx
+++ b/tests/containers/search/filters/naics/NAICSContainer-test.jsx
@@ -17,7 +17,17 @@ jest.mock('helpers/naicsHelper', () => require('./mockNAICSHelper'));
 
 describe('NAICS Search Filter Container', () => {
     describe('Loading a stateful tree from url hash', () => {
-        it('fetches the children of the checked nodes from the hash and adds their grand children to checked array', async () => {
+        it('fetches the ancestor when a grandchild is in checked w/o any ancestor', async () => {
+            const fetchNAICS = jest.fn(() => Promise.resolve());
+            const container = shallow(<NAICSContainer
+                {...defaultProps}
+                nodes={reallyBigTree}
+                checkedFromHash={["111110"]} />);
+            container.instance().fetchNAICS = fetchNAICS;
+            await container.instance().componentDidMount();
+            expect(fetchNAICS).toHaveBeenCalledWith('1111');
+        });
+        it('fetches the children of the checked nodes from the hash and adds their grand children to checked array', () => {
             const fetchNaics = jest.fn(() => Promise.resolve());
             const updateCountOfSelectedTopTierNaicsCodes = jest.fn();
             const container = shallow(<NAICSContainer
@@ -25,12 +35,14 @@ describe('NAICS Search Filter Container', () => {
                 checkedFromHash={["11"]} />);
             container.instance().fetchNAICS = fetchNaics;
             container.instance().updateCountOfSelectedTopTierNaicsCodes = updateCountOfSelectedTopTierNaicsCodes;
-            await container.instance().componentDidMount();
-            // once for regular mount, once for the checked node.
-            expect(fetchNaics).toHaveBeenCalledTimes(2);
-            // second time it was called, it was called with the checked node from the hash
-            expect(fetchNaics).toHaveBeenLastCalledWith('11');
-            expect(updateCountOfSelectedTopTierNaicsCodes).toHaveBeenCalledWith(['children_of_11']);
+            container.instance().componentDidMount()
+                .then(() => {
+                    // once for regular mount, once for the checked node.
+                    expect(fetchNaics).toHaveBeenCalledTimes(2);
+                    // second time it was called, it was called with the checked node from the hash
+                    expect(fetchNaics).toHaveBeenLastCalledWith('11');
+                    expect(updateCountOfSelectedTopTierNaicsCodes).toHaveBeenCalledWith(['children_of_11']);
+                });
         });
         it('does not add nodes to checked which are in the unchecked array', async () => {
             const updateCountOfSelectedTopTierNaicsCodes = jest.fn();

--- a/tests/containers/search/filters/naics/mockNaics_v2.js
+++ b/tests/containers/search/filters/naics/mockNaics_v2.js
@@ -475,8 +475,8 @@ export const defaultProps = {
     checkedFromHash: [],
     filters: {
         naics_codes: {
-            included: [],
-            excluded: []
+            require: [],
+            exclude: []
         }
     }
 };

--- a/tests/containers/search/filters/naics/mockNaics_v2.js
+++ b/tests/containers/search/filters/naics/mockNaics_v2.js
@@ -469,5 +469,14 @@ export const defaultProps = {
     setSearchedNaics: () => {},
     addChecked: () => {},
     showNaicsTree: () => {},
-    setUnchecked: () => {}
+    setUnchecked: () => {},
+    restoreHashedFilters: () => {},
+    uncheckedFromHash: [],
+    checkedFromHash: [],
+    filters: {
+        naics_codes: {
+            included: [],
+            excluded: []
+        }
+    }
 };

--- a/tests/containers/search/filters/naics/mockNaics_v2.js
+++ b/tests/containers/search/filters/naics/mockNaics_v2.js
@@ -461,7 +461,7 @@ export const defaultProps = {
     unchecked: [],
     nodes: placeholderNodes,
     searchExpanded: [],
-    updateNaics: () => {},
+    stageNaics: () => {},
     setNaics: () => {},
     setExpanded: () => {},
     setChecked: () => {},

--- a/tests/containers/search/mockSearchHashes.js
+++ b/tests/containers/search/mockSearchHashes.js
@@ -26,6 +26,7 @@ export const mockFilters = {
             selectedRecipientLocations: {},
             awardAmounts: {},
             timePeriodEnd: null,
+            naics_codes: { included: [], excluded: [], counts: [] },
             selectedCFDA: {},
             selectedNAICS: {},
             selectedPSC: {},

--- a/tests/containers/search/mockSearchHashes.js
+++ b/tests/containers/search/mockSearchHashes.js
@@ -26,7 +26,7 @@ export const mockFilters = {
             selectedRecipientLocations: {},
             awardAmounts: {},
             timePeriodEnd: null,
-            naics_codes: { included: [], excluded: [], counts: [] },
+            naics_codes: { require: [], exclude: [], counts: [] },
             selectedCFDA: {},
             selectedNAICS: {},
             selectedPSC: {},

--- a/tests/helpers/checkboxTreeHelper-test.js
+++ b/tests/helpers/checkboxTreeHelper-test.js
@@ -78,7 +78,6 @@ describe('checkboxTree Helpers', () => {
                 .some((grand) => grand.isPlaceHolder);
             expect(grandPlaceHolderExists).toEqual(true);
             expect(childPlaceHolderExists).toEqual(true);
-
         });
     });
     describe('expandAllNodes', () => {
@@ -121,6 +120,21 @@ describe('checkboxTree Helpers', () => {
             const lengthWithoutPlaceholderNodes = mockData.reallyBigTree[0].children.length;
             const nodeWithPlaceHolderChildren = getNodeFromTree(result, '11', 'naics');
             expect(nodeWithPlaceHolderChildren.children.length).toEqual(lengthWithoutPlaceholderNodes);
+        });
+        it('adds new children as a sibling to the loading placeholder if we have a new node to add', () => {
+            // Should be node 1111
+            const newNode = mockData.reallyBigTree[0].children[0];
+
+            const result = showAllTreeItems(mockData.placeholderNodes, '1111', [newNode]);
+            const node = getNodeFromTree(result, '11');
+
+            // node has the placeholder child
+            expect(node.children.some((child) => child.isPlaceHolder)).toEqual(true);
+            const childrenWithNoPlaceHolder = node.children
+                .find((child) => child.value === '1111');
+
+            // node also has the new child
+            expect(childrenWithNoPlaceHolder.value).toEqual('1111');
         });
     });
     describe('cleanNaicsData', () => {

--- a/tests/helpers/checkboxTreeHelper-test.js
+++ b/tests/helpers/checkboxTreeHelper-test.js
@@ -49,21 +49,21 @@ describe('checkboxTree Helpers', () => {
             expect(visibleNodes.length).toEqual(1);
             expect(visibleNodes[0].naics_description).toEqual('Soybean Farming');
         });
-        it('removes placeholder children / grandchildren for nodes with all children / grandchildren', () => {
+        it('removes placeholder grandchildren for nodes with all grandchildren', () => {
             const existingNodes = mockData.placeholderNodes;
             const searchResult = addSearchResultsToTree(existingNodes, [mockData.reallyBigTree[0]]);
-            const grandChildrenFromSearch = searchResult
-                .find((node) => node.value === '11')
-                .children[0].children;
             const childrenFromSearch = searchResult
                 .find((node) => node.value === '11')
                 .children;
+
+            // 1111's children
+            const grandChildrenFromSearch = childrenFromSearch
+                .find((node) => node.value === '1111')
+                .children;
             const grandChildrenWithPlaceholder = grandChildrenFromSearch
                 .filter((node) => node.isPlaceHolder);
-            const childrenWithPlaceholder = childrenFromSearch
-                .filter((node) => node.isPlaceHolder);
+
             expect(grandChildrenWithPlaceholder.length).toEqual(0);
-            expect(childrenWithPlaceholder.length).toEqual(0);
         });
         it('keeps placeholder children/grandchildren for nodes without all children', () => {
             const existingNodes = mockData.treeWithPlaceholdersAndRealData;

--- a/tests/testResources/defaultReduxFilters.js
+++ b/tests/testResources/defaultReduxFilters.js
@@ -5,6 +5,8 @@
 
 import { Set, OrderedMap } from 'immutable';
 
+import { NaicsCodes } from '../../src/js/redux/reducers/search/searchFiltersReducer';
+
 import * as FiscalYearHelper from '../../src/js/helpers/fiscalYearHelper';
 
 export const defaultFilters = {
@@ -24,6 +26,7 @@ export const defaultFilters = {
     selectedAwardingAgencies: new OrderedMap(),
     selectedRecipients: new OrderedMap(),
     recipientDomesticForeign: 'all',
+    naics_codes: new NaicsCodes(),
     recipientType: new Set(),
     selectedRecipientLocations: new OrderedMap(),
     selectedAwardIDs: new OrderedMap(),


### PR DESCRIPTION
# DNM Til API is Ready

**Local Instructions**
Depends on the mock API on this branch in the api repo: `mock-server-improvements`.

To spin up the server, navigate to the `api-contracts` directory, execute `npm i && npm run mock`.

**High level description:**
Provides ability to (a) build a request object with `included` and `excluded` naics codes and (b) load a stateful checkbox tree from a hash url which provides the an array of `included` and `excluded` naics codes.

**Technical details:**
Would like some feedback on this. Definitely duplicating some things in redux and would like to iterate on our current design to possibly share a redux state for what is currently `naics.checked` and `filters.naics_codes.included`.

Also have something up in the air regarding how we communicate with the API. Currently when `11` is checked we pass all of `11s` lowest descendants rather than simply `11`. This makes it much easier to load the checkbox tree statefully from an array w/ accurate checked state, and counts.

**JIRA Ticket:**
[DEV-3484](https://federal-spending-transparency.atlassian.net/browse/DEV-3484)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [x] [API #2326](https://github.com/fedspendingtransparency/usaspending-api/pull/2326) merged concurrently `if applicable`
- [ ] Code review complete
- [ ] unMock API calls