### PR TITLE
[DEV-4563] Google Analytics for downloading Data Dictionary

### DIFF
--- a/src/js/components/bulkDownload/dictionary/DataDictionary.jsx
+++ b/src/js/components/bulkDownload/dictionary/DataDictionary.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import Analytics from 'helpers/analytics/Analytics';
 import { Spreadsheet } from 'components/sharedComponents/icons/Icons';
 import DataDictionaryTable from './table/DataDictionaryTable';
 import DataDictionarySearchBar from "./DataDictionarySearchBar";
@@ -21,6 +22,10 @@ const propTypes = {
     setSearchString: PropTypes.func,
     searchTerm: PropTypes.string,
     downloadLocation: PropTypes.string
+};
+
+const handleDownloadClick = () => {
+    Analytics.event({ category: 'Download Center - Data Dictionary', action: 'Download' });
 };
 
 export default class DataDictionary extends React.Component {
@@ -39,6 +44,7 @@ export default class DataDictionary extends React.Component {
                     <div className="data-dictionary__download">
                         <a
                             className="data-dictionary__download-link"
+                            onClick={handleDownloadClick}
                             href={this.props.downloadLocation}>
                             <div className="data-dictionary__download-icon">
                                 <Spreadsheet />


### PR DESCRIPTION
**High level description:**
Track clicks of data dictionary download

**Technical details:**
Adds event w/ similar event category to other download center actions

`USAspending - Download Center - Data Dictionary`,

action: `download`
**JIRA Ticket:**
[DEV-4606](https://federal-spending-transparency.atlassian.net/browse/DEV-4606)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
