### PR TITLE
Dev-4697 update cfda overview onclick logic

### DIFF
--- a/src/js/components/award/financialAssistance/CFDAOverview.jsx
+++ b/src/js/components/award/financialAssistance/CFDAOverview.jsx
@@ -18,7 +18,7 @@ const CFDAOverview = ({
     updateCFDAOverviewLinkClicked
 }) => {
     const jumpToCFDASection = () => {
-        updateCFDAOverviewLinkClicked();
+        updateCFDAOverviewLinkClicked(true);
         jumpToSection('cfda');
     };
     return (

--- a/src/js/components/award/financialAssistance/FinancialAssistanceContent.jsx
+++ b/src/js/components/award/financialAssistance/FinancialAssistanceContent.jsx
@@ -42,8 +42,8 @@ const FinancialAssistanceContent = ({
     const [activeTab, setActiveTab] = useState("transaction");
     const [CFDAOverviewLinkClicked, setCFDAOverviewLinkClicked] = useState(false);
 
-    const updateCFDAOverviewLinkClicked = () => {
-        setCFDAOverviewLinkClicked(!CFDAOverviewLinkClicked);
+    const updateCFDAOverviewLinkClicked = (didClick) => {
+        setCFDAOverviewLinkClicked(didClick);
     };
 
     const glossaryLink = glossaryLinks[overview.type]

--- a/src/js/containers/award/financialAssistance/CFDAVizContainer.jsx
+++ b/src/js/containers/award/financialAssistance/CFDAVizContainer.jsx
@@ -35,12 +35,13 @@ export default class CFDAVizContainer extends React.Component {
 
     componentDidMount = () => this.updateCFDAs();
     componentDidUpdate(prevProps) {
-        if (!isEqual(prevProps.CFDAOverviewLinkClicked, this.props.CFDAOverviewLinkClicked)) {
-            if (
-                this.props.CFDAOverviewLinkClicked &&
-                this.state.view !== 'table' &&
-                this.props.cfdas.length > 1
-            ) this.updateViewFromCFDAOverviewClick('table');
+        if (this.props.CFDAOverviewLinkClicked) {
+            if (this.state.view !== 'table' && this.props.cfdas.length > 1) {
+                this.updateViewFromCFDAOverviewClick('table');
+            }
+            else {
+                this.props.updateCFDAOverviewLinkClicked(false);
+            }
         }
         if (!isEqual(prevProps.cfdas, this.props.cfdas)) {
             this.updateCFDAs();


### PR DESCRIPTION
**High level description:**

Fixes a bug with CFDA Overview onClick. If you click the link in the overview section initially when in the table view you will have and then navigate to the tree view and then click on the overview link you will not be redirected to the table view.

**Technical details:**

Fixes a bug with CFDA Overview onClick. If you click the link in the overview section initially when in the table view you will have and then navigate to the tree view and then click on the overview link you will not be redirected to the table view.

**JIRA Ticket:**
[DEV-4697](https://federal-spending-transparency.atlassian.net/browse/DEV-4697)

**Mockup:**
https://bahdigital.invisionapp.com/share/57IAC6CHK84#/screens/295998954

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [N/A] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
