### PR TITLE
[DEV-4430] Display text for 'All' option

### DIFF
--- a/src/js/components/bulkDownload/awards/UserSelections.jsx
+++ b/src/js/components/bulkDownload/awards/UserSelections.jsx
@@ -126,11 +126,18 @@ export default class UserSelections extends React.Component {
         if (this.props.awards.location.country.code && this.props.awards.location.country.code !== 'all') {
             if (this.props.awards.location.state.code && this.props.awards.location.state.code !== 'all') {
                 return (
-                    <div>{`${this.props.awards.location.state.name}, ${this.props.awards.location.country.name}`}</div>
+                    <div className="selection__content">
+                        {`${this.props.awards.location.state.name}, ${this.props.awards.location.country.name}`}
+                    </div>
                 );
             }
             return (
-                <div>{this.props.awards.location.country.name}</div>
+                <div className="selection__content">{this.props.awards.location.country.name}</div>
+            );
+        }
+        else if (this.props.awards.location.country.code === 'all') {
+            return (
+                <div className="selection__content">All</div>
             );
         }
         return (


### PR DESCRIPTION
**High level description:**

Display text in the UserSelection component for when the `All` option is selected. Also, change the font for country selection to match other selections.

![Screen Shot 2020-03-23 at 7 14 31 AM](https://user-images.githubusercontent.com/40359517/77327357-5e5b5100-6cd8-11ea-904f-24f6bdb641d4.png)
![Screen Shot 2020-03-23 at 7 14 22 AM](https://user-images.githubusercontent.com/40359517/77327362-5f8c7e00-6cd8-11ea-8639-3210d9cfec35.png)


**Technical details:**

Use the same CSS class for the country and state selection. Also, add conditional to display `All` when appropriate.

**JIRA Ticket:**
[DEV-4430](https://federal-spending-transparency.atlassian.net/browse/DEV-4430)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [X] Linked to this PR in JIRA ticket
- [N/A] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [X] Verified cross-browser compatibility
- [X] Verified mobile/tablet/desktop/monitor responsiveness
- [X] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [X] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [X] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [X] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
