### PR TITLE
[DEV-3484] Clear NAICS tree on reset search

### DIFF
--- a/src/js/containers/search/SearchSidebarSubmitContainer.jsx
+++ b/src/js/containers/search/SearchSidebarSubmitContainer.jsx
@@ -11,6 +11,7 @@ import { is } from 'immutable';
 
 import * as appliedFilterActions from 'redux/actions/search/appliedFilterActions';
 import { clearAllFilters as clearStagedFilters } from 'redux/actions/search/searchFilterActions';
+import { setChecked, setUnchecked } from 'redux/actions/search/naicsActions';
 
 import SearchSidebarSubmit from 'components/search/SearchSidebarSubmit';
 
@@ -30,6 +31,7 @@ const propTypes = {
     requestsComplete: PropTypes.bool,
     applyStagedFilters: PropTypes.func,
     clearStagedFilters: PropTypes.func,
+    resetNaicsTree: PropTypes.func,
     setAppliedFilterCompletion: PropTypes.func,
     resetAppliedFilters: PropTypes.func
 };
@@ -100,6 +102,7 @@ export class SearchSidebarSubmitContainer extends React.Component {
     resetFilters() {
         this.props.clearStagedFilters();
         this.props.resetAppliedFilters();
+        this.props.resetNaicsTree();
     }
 
     render() {
@@ -120,7 +123,13 @@ export default connect(
         stagedFilters: state.filters,
         appliedFilters: state.appliedFilters.filters
     }),
-    (dispatch) => bindActionCreators(combinedActions, dispatch)
+    (dispatch) => ({
+        ...bindActionCreators(combinedActions, dispatch),
+        resetNaicsTree: () => {
+            dispatch(setChecked([]));
+            dispatch(setUnchecked([]));
+        }
+    })
 )(SearchSidebarSubmitContainer);
 
 SearchSidebarSubmitContainer.propTypes = propTypes;

--- a/tests/containers/search/SearchSidebarSubmitContainer-test.jsx
+++ b/tests/containers/search/SearchSidebarSubmitContainer-test.jsx
@@ -165,5 +165,19 @@ describe('SearchSidebarSubmitContainer', () => {
             container.instance().resetFilters();
             expect(actions.resetAppliedFilters).toHaveBeenCalledTimes(1);
         });
+        it('should reset all naics redux namespace, checked and unchecked', () => {
+            const actions = Object.assign({}, mockActions, {
+                resetNaicsTree: jest.fn()
+            });
+
+            const container = shallow(
+                <SearchSidebarSubmitContainer
+                    {...mockRedux}
+                    {...actions} />
+            );
+            
+            container.instance().resetFilters();
+            expect(actions.resetNaicsTree).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/tests/containers/search/mockSubmit.js
+++ b/tests/containers/search/mockSubmit.js
@@ -8,6 +8,7 @@ export const mockRedux = {
 };
 
 export const mockActions = {
+    resetNaicsTree: jest.fn(),
     applyStagedFilters: jest.fn(),
     clearStagedFilters: jest.fn(),
     setAppliedFilterCompletion: jest.fn(),


### PR DESCRIPTION
**High level description:**

Forgot to deliver functionality to clear NAICs tree when user selects "reset search"

**Technical details:**

SubmitSearchButtonContainer now takes a new action to clear `redux.naics.checked` and `redux.naics.unchecked`

**JIRA Ticket:**
[DEV-3484](https://federal-spending-transparency.atlassian.net/browse/DEV-3484)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
