### PR TITLE
[DEV-3142] Federal Account Awards table links to Recipient Profile 

### DIFF
--- a/src/js/containers/account/awards/AccountAwardsContainer.jsx
+++ b/src/js/containers/account/awards/AccountAwardsContainer.jsx
@@ -249,6 +249,9 @@ export class AccountAwardsContainer extends React.Component {
                 requestFields.push(field);
             }
         });
+
+        requestFields.push('recipient_id')
+
         newParams.fields = requestFields;
         newParams.limit = resultLimit;
         newParams.order = this.state.sort.direction;

--- a/src/js/containers/account/awards/AccountAwardsContainer.jsx
+++ b/src/js/containers/account/awards/AccountAwardsContainer.jsx
@@ -250,7 +250,7 @@ export class AccountAwardsContainer extends React.Component {
             }
         });
 
-        requestFields.push('recipient_id')
+        requestFields.push('recipient_id');
 
         newParams.fields = requestFields;
         newParams.limit = resultLimit;


### PR DESCRIPTION
**High level description:**

Federal Account pages contain a Spending By Award table. The Recipient column cells are now hyperlinks to the appropriate Recipient Profile page.

**Technical details:**

N/A

**JIRA Ticket:**
[DEV-3142](https://federal-spending-transparency.atlassian.net/browse/DEV-3142)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Verified cross-browser compatibility
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)

Reviewer(s):
- [x] Code review complete
