### PR TITLE
Dev-4788 Add Button Title to CFDA Section

### DIFF
--- a/src/_scss/pages/award/visualizations/cfdaSectionViz.scss
+++ b/src/_scss/pages/award/visualizations/cfdaSectionViz.scss
@@ -45,5 +45,28 @@
     .explorer-cell-box:hover {
         background-color: #f49c20;
     }
+    .usa-dt-picker {
+      .usa-dt-picker__dropdown-container {
+        border-bottom: 1px solid $color-primary-alt-darkest;
+        .usa-dt-picker__button {
+          margin-right: 0;
+          margin-left: 0.5rem;
+          padding-bottom: 0;
+          .usa-dt-picker__button-text {
+            font-size: 1.6rem;
+            font-weight: 600;
+          }
+        }
+        .usa-dt-picker__list {
+          .usa-dt-picker__item {
+            font-size: 1.6rem;
+            font-weight: 600;
+          }
+        }
+      }
+    }
+    .cfda-section-single-title {
+      margin-top: 0;
+    }
   }
 }

--- a/src/_scss/pages/award/visualizations/cfdaSectionViz.scss
+++ b/src/_scss/pages/award/visualizations/cfdaSectionViz.scss
@@ -56,6 +56,11 @@
             font-size: 1.6rem;
             font-weight: 600;
           }
+          .usa-dt-picker__button-icon {
+            path {
+              fill: $color-primary-alt-darkest;
+            }
+          }
         }
         .usa-dt-picker__list {
           .usa-dt-picker__item {

--- a/src/_scss/pages/award/visualizations/cfdaSectionViz.scss
+++ b/src/_scss/pages/award/visualizations/cfdaSectionViz.scss
@@ -63,6 +63,7 @@
           }
         }
         .usa-dt-picker__list {
+          max-height: 300px;
           .usa-dt-picker__item {
             font-size: 1.6rem;
             font-weight: 600;

--- a/src/js/components/award/financialAssistance/CFDAViz.jsx
+++ b/src/js/components/award/financialAssistance/CFDAViz.jsx
@@ -114,7 +114,6 @@ export default class CFDAViz extends React.Component {
         if (view === 'single' || !view) {
             if (allCFDAs.length > 1) {
                 const options = cloneDeep(allCFDAs)
-                // .filter((x) => x.cfdaNumber !== cfda.cfdaNumber)
                     .map((x) => ({
                         name: `${x.cfdaNumber} ${x.cfdaTitle}`,
                         onClick: onDropdownClick

--- a/src/js/components/award/financialAssistance/CFDAViz.jsx
+++ b/src/js/components/award/financialAssistance/CFDAViz.jsx
@@ -114,6 +114,7 @@ export default class CFDAViz extends React.Component {
         if (view === 'single' || !view) {
             if (allCFDAs.length > 1) {
                 const options = cloneDeep(allCFDAs)
+                    .sort((a, b) => parseFloat(a.cfdaNumber) - parseFloat(b.cfdaNumber))
                     .map((x) => ({
                         name: `${x.cfdaNumber} ${x.cfdaTitle}`,
                         onClick: onDropdownClick

--- a/src/js/components/award/financialAssistance/CFDAViz.jsx
+++ b/src/js/components/award/financialAssistance/CFDAViz.jsx
@@ -6,6 +6,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Picker } from 'data-transparency-ui';
+import { cloneDeep } from 'lodash';
 import ViewTypeButton from 'components/sharedComponents/buttons/ViewTypeButton';
 import SingleCFDA from 'components/award/financialAssistance/SingleCFDA';
 import CFDATree from './CFDATree';
@@ -29,7 +31,8 @@ const propTypes = {
     changeView: PropTypes.func,
     onTableClick: PropTypes.func,
     onBackClick: PropTypes.func,
-    onTreeClick: PropTypes.func
+    onTreeClick: PropTypes.func,
+    onDropdownClick: PropTypes.func
 };
 
 export default class CFDAViz extends React.Component {
@@ -97,7 +100,34 @@ export default class CFDAViz extends React.Component {
     content = () => {
         const { view } = this.props;
         if (view === 'table') return (<CFDATable {...this.props} />);
-        if (view === 'single' || !view) return (<SingleCFDA data={this.props.cfda} />);
+        if (view === 'single' || !view) return (<SingleCFDA currentCfda={this.props.cfda} />);
+        return null;
+    }
+
+    title = () => {
+        const {
+            cfda,
+            view,
+            allCFDAs,
+            onDropdownClick
+        } = this.props;
+        if (view === 'single' || !view) {
+            if (allCFDAs.length > 1) {
+                const options = cloneDeep(allCFDAs)
+                // .filter((x) => x.cfdaNumber !== cfda.cfdaNumber)
+                    .map((x) => ({
+                        name: `${x.cfdaNumber} ${x.cfdaTitle}`,
+                        onClick: onDropdownClick
+                    }));
+                return (<Picker
+                    options={options}
+                    dropdownDirection="right"
+                    backgroundColor="#215493"
+                    selectedOption={`${cfda.cfdaNumber} ${cfda.cfdaTitle}`}
+                    sortFn={() => 1} />);
+            }
+            return (<h4 className="cfda-section-single-title">{`${cfda.cfdaNumber}: ${cfda.cfdaTitle.toUpperCase()}`}</h4>);
+        }
         return null;
     }
 
@@ -146,6 +176,7 @@ export default class CFDAViz extends React.Component {
                 {this.state.showTooltip && <CFDATreeTooltip {...this.state.tooltip} />}
                 <div className="cfda-section-results">
                     {this.buttons()}
+                    {this.title()}
                     {this.content()}
                     <div
                         className="cfda-section-vis__width-reference"

--- a/src/js/components/award/financialAssistance/CFDAViz.jsx
+++ b/src/js/components/award/financialAssistance/CFDAViz.jsx
@@ -35,6 +35,8 @@ const propTypes = {
     onDropdownClick: PropTypes.func
 };
 
+const sortFunction = (a, b) => parseFloat(a.cfdaNumber) - parseFloat(b.cfdaNumber);
+
 export default class CFDAViz extends React.Component {
     constructor(props) {
         super(props);
@@ -124,7 +126,7 @@ export default class CFDAViz extends React.Component {
                     dropdownDirection="right"
                     backgroundColor="#215493"
                     selectedOption={`${cfda.cfdaNumber} ${cfda.cfdaTitle}`}
-                    sortFn={() => 1} />);
+                    sortFn={sortFunction} />);
             }
             return (<h4 className="cfda-section-single-title">{`${cfda.cfdaNumber}: ${cfda.cfdaTitle.toUpperCase()}`}</h4>);
         }

--- a/src/js/components/award/financialAssistance/SingleCFDA.jsx
+++ b/src/js/components/award/financialAssistance/SingleCFDA.jsx
@@ -5,7 +5,7 @@ import AwardSection from '../shared/AwardSection';
 import ExpandableAwardSection from '../shared/ExpandableAwardSection';
 
 const propTypes = {
-    data: PropTypes.shape({
+    currentCfda: PropTypes.shape({
         cfda_number: PropTypes.string,
         cfda_title: PropTypes.string,
         applicant_eligibility: PropTypes.string,
@@ -19,17 +19,15 @@ const propTypes = {
     })
 };
 
-const SingleCFDA = ({ data }) => {
+const SingleCFDA = ({ currentCfda }) => {
     const {
         samWebsite,
         cfdaWebsite,
         cfdaFederalAgency,
-        cfdaNumber,
-        cfdaTitle,
         applicantEligibility,
         beneficiaryEligibility,
         cfdaObjectives
-    } = data;
+    } = currentCfda;
     const expandableContent = (
         <React.Fragment>
             <h5>Applicant Eligibility</h5>
@@ -42,7 +40,6 @@ const SingleCFDA = ({ data }) => {
         <AwardSection type="column" className="cfda-section award-viz">
             <div className="award__col__content">
                 <ExpandableAwardSection content={expandableContent}>
-                    <h4>{`${cfdaNumber}: ${cfdaTitle.toUpperCase()}`}</h4>
                     <h5>Objectives</h5>
                     <ExpandableAwardSection type="secondary" content={cfdaObjectives} />
                     <h5>Administrative Agency</h5>

--- a/src/js/containers/award/financialAssistance/CFDAVizContainer.jsx
+++ b/src/js/containers/award/financialAssistance/CFDAVizContainer.jsx
@@ -64,6 +64,11 @@ export default class CFDAVizContainer extends React.Component {
         this.setState({ previousView: 'tree', view: 'single', cfda });
     }
 
+    onDropdownClick = (title) => {
+        const cfda = this.props.cfdas.find((x) => x.cfdaNumber.toString() === title.split(' ')[0].trim());
+        this.setState({ view: 'single', cfda });
+    }
+
     updateViewFromCFDAOverviewClick = (view) => {
         this.setState({ view });
         this.props.updateCFDAOverviewLinkClicked();
@@ -118,7 +123,8 @@ export default class CFDAVizContainer extends React.Component {
                 onTableClick={this.onTableClick}
                 onBackClick={this.onBackClick}
                 allCFDAs={this.props.cfdas}
-                onTreeClick={this.onTreeClick} />
+                onTreeClick={this.onTreeClick}
+                onDropdownClick={this.onDropdownClick} />
         );
     }
 }


### PR DESCRIPTION
**High level description:**

Implements a dropdown button that acts as the single cfda sections title when there are multiple cfdas for an award and allows users to switch between cfdas in the single cfda view.

**Technical details:**

N/A

**JIRA Ticket:**
[DEV-4788](https://federal-spending-transparency.atlassian.net/browse/DEV-4788)

**Mockup:**
[Please refer to the ticket.](https://federal-spending-transparency.atlassian.net/browse/DEV-4788)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension) Tested between local and dev with award ASST_NON_CTA01T340_1450 both have 71 issues.
- [N/A] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete

- [x] Warmfix for titles https://github.com/fedspendingtransparency/usaspending-website/pull/1594 merged and downmerged to dev.
