### PR TITLE
[DEV-4067] Add error for Elasticsearch paging over 10k records

### DIFF
--- a/src/js/components/search/visualizations/rank/RankVisualization.jsx
+++ b/src/js/components/search/visualizations/rank/RankVisualization.jsx
@@ -30,7 +30,8 @@ const propTypes = {
     error: PropTypes.bool,
     meta: PropTypes.object,
     disableTooltip: PropTypes.bool,
-    industryCodeError: PropTypes.bool
+    industryCodeError: PropTypes.bool,
+    recipientError: PropTypes.bool
 };
 
 export default class RankVisualization extends React.Component {
@@ -77,6 +78,8 @@ export default class RankVisualization extends React.Component {
             chart = (<ChartMessage message="An error has occurred." />);
             if (this.props.industryCodeError) {
                 chart = (<ChartMessage message="Industry codes are unavailable for Sub-Awards." />);
+            } else if (this.props.recipientError) {
+                chart = (<ChartMessage message="Paging to 10,000 records and above is not available for Spending by Recipient." />);
             }
         }
         else if (this.props.dataSeries.length > 0) {

--- a/src/js/components/search/visualizations/rank/sections/RankVisualizationSection.jsx
+++ b/src/js/components/search/visualizations/rank/sections/RankVisualizationSection.jsx
@@ -18,7 +18,8 @@ const propTypes = {
     error: PropTypes.bool,
     hasNextPage: PropTypes.bool,
     hasPreviousPage: PropTypes.bool,
-    children: PropTypes.node
+    children: PropTypes.node,
+    recipientError: PropTypes.bool
 };
 
 export default class RankVisualizationSection extends React.Component {
@@ -67,12 +68,15 @@ export default class RankVisualizationSection extends React.Component {
     }
 
     render() {
-        const disableNext = !this.props.hasNextPage;
+        const disableNext = !this.props.hasNextPage || this.props.recipientError;
         const disablePrev = !this.props.hasPreviousPage;
         let hidePager = '';
 
         if ((disableNext && disablePrev) || this.props.loading || this.props.error) {
             hidePager = 'hide';
+        }
+        if (this.props.recipientError) {
+            hidePager = '';
         }
 
         return (

--- a/src/js/containers/search/visualizations/rank/RankVisualizationWrapperContainer.jsx
+++ b/src/js/containers/search/visualizations/rank/RankVisualizationWrapperContainer.jsx
@@ -9,7 +9,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { isCancel } from 'axios';
 
-import { isEqual, max } from 'lodash';
+import { isEqual, max, get } from 'lodash';
 import * as searchFilterActions from 'redux/actions/search/searchFilterActions';
 import { setAppliedFilterCompletion } from 'redux/actions/search/appliedFilterActions';
 
@@ -54,7 +54,8 @@ export class RankVisualizationWrapperContainer extends React.Component {
             next: '',
             previous: '',
             hasNextPage: false,
-            hasPreviousPage: false
+            hasPreviousPage: false,
+            recipientError: false
         };
 
         this.changeSpendingBy = this.changeSpendingBy.bind(this);
@@ -125,7 +126,8 @@ export class RankVisualizationWrapperContainer extends React.Component {
         this.props.setAppliedFilterCompletion(false);
         this.setState({
             loading: true,
-            error: false
+            error: false,
+            recipientError: false
         });
 
         if (this.apiRequest) {
@@ -160,12 +162,14 @@ export class RankVisualizationWrapperContainer extends React.Component {
                     return;
                 }
 
+                const responseDetail = get(err, 'response.data.detail', '');
                 this.props.setAppliedFilterCompletion(true);
                 this.apiRequest = null;
                 console.log(err);
                 this.setState({
                     loading: false,
-                    error: true
+                    error: true,
+                    recipientError: responseDetail === 'Current filters return too many unique items. Narrow filters to return results.'
                 });
             });
     }
@@ -234,7 +238,8 @@ export class RankVisualizationWrapperContainer extends React.Component {
                         {...this.state}
                         changeScope={this.changeScope}
                         nextPage={this.nextPage}
-                        previousPage={this.previousPage} />
+                        previousPage={this.previousPage}
+                        recipientError={this.state.recipientError} />
                 );
             case 'cfda':
                 return (

--- a/tests/containers/search/visualizations/rank/RankVisualizationWrapperContainer-test.jsx
+++ b/tests/containers/search/visualizations/rank/RankVisualizationWrapperContainer-test.jsx
@@ -158,7 +158,8 @@ describe('RankVisualizationWrapperContainer', () => {
                 next: null,
                 previous: null,
                 hasNextPage: false,
-                hasPreviousPage: false
+                hasPreviousPage: false,
+                recipientError: false
             };
 
             expect(container.state()).toEqual(expectedState);


### PR DESCRIPTION
**High level description:**

Display a new error for the Spending by Recipient visualization when a user tries to page past 10k records.

**Technical details:**

Catching the specific error that is thrown by the Spending by Recipient endpoint to make sure that an error message is only displayed for when the new Elasticsearch functionality is hit. Ideally this would simply check if the `limit * page >= 10k` and could be changed to this in the future so that it is less fragile.

**JIRA Ticket:**
[DEV-4067](https://federal-spending-transparency.atlassian.net/browse/DEV-4067)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [X] Linked to this PR in JIRA ticket
- [X] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [X] Verified cross-browser compatibility
- [X] Verified mobile/tablet/desktop/monitor responsiveness
- [X] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [X] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [X] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [X] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [X] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Code review complete
