### PR TITLE
[DEV-4534] Very minor tweak to Profiles -> Federal Accounts page

### DIFF
--- a/src/js/models/accountLanding/BaseFederalAccountLandingRow.js
+++ b/src/js/models/accountLanding/BaseFederalAccountLandingRow.js
@@ -13,7 +13,7 @@ const BaseFederalAccountLandingRow = {
         this._managingAgency = data.managing_agency || '';
         this._managingAgencyAcronym = data.managing_agency_acronym || '';
         this.accountName = data.account_name || '';
-        this._budgetaryResources = data.budgetary_resources || 0;
+        this._budgetaryResources = data.budgetary_resources;
     },
     get managingAgency() {
         if (!this._managingAgencyAcronym) {
@@ -22,7 +22,7 @@ const BaseFederalAccountLandingRow = {
         return `${this._managingAgency} (${this._managingAgencyAcronym})`;
     },
     get budgetaryResources() {
-        return formatMoney(this._budgetaryResources);
+        return this._budgetaryResources == null ? '--' : formatMoney(this._budgetaryResources);
     }
 };
 /* eslint-enable object-shorthand */


### PR DESCRIPTION
**High level description:**

Display `--` for federal accounts with no Budgetary Resources.

**JIRA Ticket:**

[DEV-4534](https://federal-spending-transparency.atlassian.net/browse/DEV-4534)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Demo not required
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Unit Tests not required
- [x] Change is totally future compatible
- [x] No API contracts were harmed in the creation of this pull request
- [x] No new Component Library stuff

Reviewer(s):
- [x] Design review not required
- [x] Related to [API #pull](https://github.com/fedspendingtransparency/usaspending-api/pull/pull) BUT CAN BE MERGED INDEPENDENTLY
- [x] Code review complete
