### PR TITLE
[DEV-4276] Showing counts w/ customized label for TAS Codes

### DIFF
--- a/src/js/components/sharedComponents/CheckboxTreeLabel.jsx
+++ b/src/js/components/sharedComponents/CheckboxTreeLabel.jsx
@@ -24,7 +24,7 @@ const CheckboxTreeLabel = ({
     countLabel = ''
 }) => {
     const countText = count > 1 ? 'codes' : 'code';
-    const countDisplay = countLabel || `${count} ${countText}`;
+    const countDisplay = countLabel === '' ? countText : countLabel;
     return (
         <div className="checkbox-tree-label">
             {displayId && (
@@ -33,7 +33,7 @@ const CheckboxTreeLabel = ({
                         {value}
                     </div>
                     <div className="checkbox-tree-label__value-container-count">
-                        {count ? countDisplay : ''}
+                        {count ? `${count} ${countDisplay}` : ''}
                     </div>
                 </div>
             )}

--- a/src/js/containers/search/filters/naics/NAICSContainer.jsx
+++ b/src/js/containers/search/filters/naics/NAICSContainer.jsx
@@ -85,7 +85,7 @@ export class NAICSContainer extends React.Component {
 
     componentDidMount() {
         const { checkedFromHash, uncheckedFromHash } = this.props;
-        // always get the top tier nodes.
+        if (this.props.nodes.length) return Promise.resolve();
         return this.fetchNAICS()
             .then(() => {
                 if (checkedFromHash.length > 0) {

--- a/src/js/containers/search/filters/naics/NAICSContainer.jsx
+++ b/src/js/containers/search/filters/naics/NAICSContainer.jsx
@@ -85,7 +85,6 @@ export class NAICSContainer extends React.Component {
 
     componentDidMount() {
         const { checkedFromHash, uncheckedFromHash } = this.props;
-        if (this.props.nodes.length) return Promise.resolve();
         return this.fetchNAICS()
             .then(() => {
                 if (checkedFromHash.length > 0) {


### PR DESCRIPTION
**High level description:**
Follow up addressing two bugs.

**Technical details:**
API was not returning counts until ~1hr ago; found that we weren't showing them properly with the customized label.

Realized a bug around not persisting the NACIS tree.

**JIRA Ticket:**
[DEV-4276](https://federal-spending-transparency.atlassian.net/browse/DEV-4276)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A`  Design review complete `if applicable`
- [x] [API #2396](https://github.com/fedspendingtransparency/usaspending-api/pull/2396) merged concurrently `if applicable`
- [x] Code review complete
