### PR TITLE
[DEV-4267] Auto Check Nodes on Expand when Placeholder is checked

### DIFF
--- a/src/js/containers/search/filters/naics/NAICSContainer.jsx
+++ b/src/js/containers/search/filters/naics/NAICSContainer.jsx
@@ -16,7 +16,8 @@ import {
     decrementNaicsCountAndUpdateUnchecked,
     getImmediateAncestorNaicsCode,
     getNaicsNodeFromTree,
-    removeStagedNaicsFilter
+    removeStagedNaicsFilter,
+    autoCheckNaicsAfterExpand
 } from 'helpers/naicsHelper';
 
 import {
@@ -301,24 +302,6 @@ export class NAICSContainer extends React.Component {
         return this.setState({ searchString: text, isSearch: true, isLoading: true }, this.onSearchChange);
     }
 
-    autoCheckImmediateChildrenAfterDynamicExpand = (parentNode) => {
-        const value = parentNode.naics;
-        // deselect placeholder values for node!
-        const removeParentPlaceholders = this.props.checked
-            .filter((checked) => !checked.includes(`children_of_${value}`));
-
-        const newValues = parentNode
-            .children
-            .filter((child) => !this.props.unchecked.includes(child.naics))
-            .map((child) => {
-                // at child level, check all grand children w/ the placeholder
-                if (child.naics.length === 4) return `children_of_${child.naics}`;
-                return child.naics;
-            });
-
-        this.props.setChecked([...new Set([...removeParentPlaceholders, ...newValues])]);
-    }
-
     autoCheckSearchedResultDescendants = (checked, expanded) => {
         const { nodes } = this.props;
         const placeholderNodes = checked
@@ -390,7 +373,12 @@ export class NAICSContainer extends React.Component {
                 }
                 // we've searched for a specific naics reference; ie '11' or '1111' and their immediate descendants should be checked.
                 if (checked.includes(`children_of_${param}`)) {
-                    this.autoCheckImmediateChildrenAfterDynamicExpand(results[0], param);
+                    const newChecked = autoCheckNaicsAfterExpand(
+                        results[0],
+                        this.props.checked,
+                        this.props.unchecked
+                    );
+                    this.props.setChecked(newChecked);
                 }
 
                 this.setState({

--- a/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
@@ -6,7 +6,8 @@ import {
     cleanTasData,
     incrementTasCountAndUpdateUnchecked,
     decrementTasCountAndUpdateUnchecked,
-    removeStagedTasFilter
+    removeStagedTasFilter,
+    autoCheckTasAfterExpand
 } from 'helpers/tasHelper';
 import { fetchTas } from 'helpers/searchHelper';
 
@@ -138,7 +139,12 @@ export default class TASCheckboxTree extends React.Component {
                                         return federalAccount;
                                     })
                                 };
-                            })
+                            }),
+                        checked: autoCheckTasAfterExpand(
+                            { children: nodes, value: key },
+                            this.state.checked,
+                            this.state.unchecked
+                        )
                     });
                 }
                 else {

--- a/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
@@ -42,7 +42,7 @@ export default class TASCheckboxTree extends React.Component {
                 const selectedAgency = this.state.nodes
                     .find((agency) => agency.children.some((federalAccount) => federalAccount.value === expandedValue));
                 const agencyAndFederalAccountString = `${selectedAgency.value}/${expandedValue}`;
-                this.fetchTas(agencyAndFederalAccountString, 1);
+                this.fetchTas(agencyAndFederalAccountString);
             }
             else {
                 this.fetchTas(expandedValue);
@@ -109,7 +109,7 @@ export default class TASCheckboxTree extends React.Component {
         this.onUncheck(newChecked, { ...node, checked: false });
     }
 
-    fetchTas = (id = '', depth = 0) => {
+    fetchTas = (id = '') => {
         if (this.request) this.request.cancel();
         this.request = fetchTas(id);
         const isPartialTree = id !== '';
@@ -118,9 +118,10 @@ export default class TASCheckboxTree extends React.Component {
                 // dynamically populating tree branches
                 const nodes = cleanTasData(data.results);
                 if (isPartialTree) {
-                    const key = depth === 0
-                        ? id
-                        : id.split('/')[1];
+                    // parsing the prepended agency (format in url is agencyId/federalAccountId when fetching federalAccount level data)
+                    const key = id.includes('/')
+                        ? id.split('/')[1]
+                        : id;
                     this.setState({
                         isLoading: false,
                         nodes: this.state.nodes

--- a/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
@@ -140,11 +140,13 @@ export default class TASCheckboxTree extends React.Component {
                                     })
                                 };
                             }),
-                        checked: autoCheckTasAfterExpand(
-                            { children: nodes, value: key },
-                            this.state.checked,
-                            this.state.unchecked
-                        )
+                        checked: this.state.checked.includes(`children_of_${key}`)
+                            ? autoCheckTasAfterExpand(
+                                { children: nodes, value: key },
+                                this.state.checked,
+                                this.state.unchecked
+                            )
+                            : this.state.checked
                     });
                 }
                 else {

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -541,3 +541,37 @@ export const showAllTreeItems = (tree, key = '', newNodes = [], getHighestAncest
                 : []
         };
     });
+
+export const autoCheckImmediateChildrenAfterDynamicExpand = (
+    parentNode,
+    checked,
+    unchecked,
+    keyForCode,
+    shouldNodeHaveChildren
+) => {
+    const value = parentNode[keyForCode];
+    // deselect placeholder values for node!
+    const removeParentPlaceholders = checked
+        .filter((code) => !code.includes(`children_of_${value}`));
+
+    const newValues = parentNode
+        .children
+        // does unchecked have placeholders...?
+        .filter((child) => !unchecked.includes(child[keyForCode]))
+        .map((child) => {
+            // at child level, check all grand children w/ the placeholder
+            const willNodeHavePlaceholderChildren = (
+                (
+                    !Object.keys(child).includes('children') ||
+                    !child?.children?.length
+                ) &&
+                shouldNodeHaveChildren(child)
+            );
+            if (willNodeHavePlaceholderChildren) {
+                return `children_of_${child[keyForCode]}`;
+            }
+            return child[keyForCode];
+        });
+
+    return [...new Set([...removeParentPlaceholders, ...newValues])];
+}

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -574,4 +574,4 @@ export const autoCheckImmediateChildrenAfterDynamicExpand = (
         });
 
     return [...new Set([...removeParentPlaceholders, ...newValues])];
-}
+};

--- a/src/js/helpers/naicsHelper.js
+++ b/src/js/helpers/naicsHelper.js
@@ -13,7 +13,7 @@ import {
 
 export const formatSelectedNaics = (value, description, count) => `${value} | ${description} | ${count}`;
 
-const shouldNaicsNodeHaveChildren = (node) => node.naics.length < 6;
+export const shouldNaicsNodeHaveChildren = (node) => node.naics.length < 6;
 // key map for traversing the naics-tree
 export const naicsKeyMap = { label: 'naics_description', value: 'naics', isParent: shouldNaicsNodeHaveChildren };
 

--- a/src/js/helpers/naicsHelper.js
+++ b/src/js/helpers/naicsHelper.js
@@ -7,7 +7,8 @@ import {
     cleanTreeData,
     incrementCountAndUpdateUnchecked,
     decrementCountAndUpdateUnchecked,
-    removeStagedFilter
+    removeStagedFilter,
+    autoCheckImmediateChildrenAfterDynamicExpand
 } from './checkboxTreeHelper';
 
 export const formatSelectedNaics = (value, description, count) => `${value} | ${description} | ${count}`;
@@ -103,4 +104,16 @@ export const removeStagedNaicsFilter = (
     getNaicsNodeFromTree,
     getHighestAncestorNaicsCode,
     getImmediateAncestorNaicsCode
+);
+
+export const autoCheckNaicsAfterExpand = (
+    parentNode,
+    checked,
+    unchecked
+) => autoCheckImmediateChildrenAfterDynamicExpand(
+    parentNode,
+    checked,
+    unchecked,
+    'naics',
+    shouldNaicsNodeHaveChildren
 );

--- a/src/js/helpers/tasHelper.js
+++ b/src/js/helpers/tasHelper.js
@@ -2,7 +2,8 @@ import {
     decrementCountAndUpdateUnchecked,
     incrementCountAndUpdateUnchecked,
     cleanTreeData,
-    removeStagedFilter
+    removeStagedFilter,
+    autoCheckImmediateChildrenAfterDynamicExpand
 } from "./checkboxTreeHelper";
 
 export const isAgency = (tasNode) => tasNode.ancestors.length === 0;
@@ -111,4 +112,16 @@ export const incrementTasCountAndUpdateUnchecked = (
     getTasNodeFromTree,
     getImmediateTasAncestorCode,
     getHighestTasAncestorCode
+);
+
+export const autoCheckTasAfterExpand = (
+    parentNode,
+    checked,
+    unchecked
+) => autoCheckImmediateChildrenAfterDynamicExpand(
+    parentNode,
+    checked,
+    unchecked,
+    'value',
+    shouldTasNodeHaveChildren
 );

--- a/tests/containers/search/filters/naics/NAICSContainer-test.jsx
+++ b/tests/containers/search/filters/naics/NAICSContainer-test.jsx
@@ -82,20 +82,6 @@ describe('NAICS Search Filter Container', () => {
             expect(container.instance().state.stagedNaicsFilters[0].count).toEqual(63);
         });
     });
-    describe('autoCheckImmediateChildrenAfterDynamicExpand fn', () => {
-        it('auto checks unchecked descendants of selected parent', async () => {
-            const setChecked = jest.fn();
-            const container = shallow(<NAICSContainer
-                {...defaultProps}
-                checked={["children_of_11"]}
-                setChecked={setChecked} />);
-                
-            await container.instance().autoCheckImmediateChildrenAfterDynamicExpand(treeWithPlaceholdersAndRealData[0]);
-
-            // removing the placeholder selection for 11 and adding all the descendants grandchildren (placeholders) to checked. In this test case, we only have one immediate child of 11. Non-placeholder children should not be auto checked.
-            expect(setChecked).toHaveBeenCalledWith(["children_of_1111", "children_of_1112"]);
-        });
-    });
     describe('autoCheckSearchedResultDescendants fn', () => {
         it('auto checks unchecked descendants of selected parent', async () => {
             const addChecked = jest.fn();

--- a/tests/containers/search/filters/programSource/TASCheckboxContainer-test.jsx
+++ b/tests/containers/search/filters/programSource/TASCheckboxContainer-test.jsx
@@ -62,7 +62,7 @@ describe('TASCheckboxContainer', () => {
             fetchTas.mockImplementation(() => ({
                 promise: Promise.resolve({ data: tasLevel })
             }));
-            await container.instance().fetchTas('1/11', 1);
+            await container.instance().fetchTas('1/11');
 
             // 1. same number of agencies in tree; none are removed.
             expect(container.state().nodes.length).toEqual(10);
@@ -105,7 +105,7 @@ describe('TASCheckboxContainer', () => {
             container.instance().fetchTas = mockFn;
             container.instance().onExpand('11', ['1', '11'], true, { treeDepth: 1 });
 
-            expect(mockFn).toHaveBeenLastCalledWith('1/11', 1);
+            expect(mockFn).toHaveBeenLastCalledWith('1/11');
         });
         it('calls fetchTas w/ only agency when necessary', () => {
             const mockFn = jest.fn();

--- a/tests/helpers/checkboxTreeHelper-test.js
+++ b/tests/helpers/checkboxTreeHelper-test.js
@@ -7,13 +7,15 @@ import {
     removeStagedFilter,
     getCountOfAllCheckedDescendants,
     decrementCountAndUpdateUnchecked,
-    incrementCountAndUpdateUnchecked
+    incrementCountAndUpdateUnchecked,
+    autoCheckImmediateChildrenAfterDynamicExpand
 } from 'helpers/checkboxTreeHelper';
 import {
     getHighestAncestorNaicsCode,
     getImmediateAncestorNaicsCode,
     getNaicsNodeFromTree,
-    naicsKeyMap
+    naicsKeyMap,
+    shouldNaicsNodeHaveChildren
 } from 'helpers/naicsHelper';
 
 import * as mockData from '../containers/search/filters/naics/mockNaics_v2';
@@ -296,6 +298,50 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
 
             expect(newCounts[0].count).toEqual(7);
             expect(newUnchecked[0]).toEqual('1111');
+        });
+    });
+    describe('autoCheckImmediateChildrenAfterDynamicExpand', () => {
+        it('returns an array that replaces placeholders w/ real checked codes', () => {
+            // naics code 1111
+            const mockParentNode = mockData.reallyBigTree[0].children[0];
+            const newChecked = autoCheckImmediateChildrenAfterDynamicExpand(
+                mockParentNode,
+                ["children_of_1111", 'children_of_21'],
+                [],
+                'naics',
+                shouldNaicsNodeHaveChildren
+            );
+            expect(newChecked).toEqual([
+                "children_of_21",
+                "111110",
+                "111120",
+                "111130",
+                "111140",
+                "111150",
+                "111160",
+                "111191",
+                "111199"
+            ]);
+        });
+        it('does not add codes descendant from placeholder that are in the unchecked array', () => {
+            // naics code 1111
+            const mockParentNode = mockData.reallyBigTree[0].children[0];
+            const newChecked = autoCheckImmediateChildrenAfterDynamicExpand(
+                mockParentNode,
+                ["children_of_1111"],
+                ['111120'],
+                'naics',
+                shouldNaicsNodeHaveChildren
+            );
+            expect(newChecked).toEqual([
+                "111110",
+                "111130",
+                "111140",
+                "111150",
+                "111160",
+                "111191",
+                "111199"
+            ]);
         });
     });
 });


### PR DESCRIPTION
**High level description:**
When a placeholder is in the checked array, and you expand the parent, we need to replace the placeholder checked w/ the real checked data.

**Technical details:**
This was already implemented and tested code; just moved it to a helper and implemented it in NAICS and TAS.

**JIRA Ticket:**
[DEV-4267](https://federal-spending-transparency.atlassian.net/browse/DEV-4267)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
