### PR TITLE
[DEV-4278] Search TAS (moving to tab based layout)

### DIFF
--- a/src/_scss/pages/search/filters/otherFilters/_tasCheckbox.scss
+++ b/src/_scss/pages/search/filters/otherFilters/_tasCheckbox.scss
@@ -1,7 +1,6 @@
 .tas-checkbox {
     display: block;
-    padding: 0 rem(20);
-    margin-bottom: rem(12);
+    padding-top: rem(15);
     .autocomplete__input {
         width: 100%;
         padding-bottom: rem(10);

--- a/src/js/components/search/SearchSidebar.jsx
+++ b/src/js/components/search/SearchSidebar.jsx
@@ -40,7 +40,6 @@ const naicsComponent = kGlobalConstants.DEV ? NAICSContainer : NAICSSearchContai
 const naicsTitle = kGlobalConstants.DEV ?
     'North American Industry Classification System (NAICS)' :
     'NAICS Code';
-const tasComponent = kGlobalConstants.DEV ? TASCheckboxTree : ProgramSourceContainer;
 const tasTitle = kGlobalConstants.DEV ? 'Treasury Account Symbol (TAS)' : 'Product/Service Code (PSC)';
 
 const filters = {
@@ -67,7 +66,7 @@ const filters = {
         TimePeriodContainer,
         AwardTypeContainer,
         AgencyContainer,
-        tasComponent,
+        ProgramSourceContainer,
         LocationSectionContainer,
         RecipientSearchContainer,
         RecipientTypeContainer,

--- a/src/js/components/search/SearchSidebar.jsx
+++ b/src/js/components/search/SearchSidebar.jsx
@@ -15,7 +15,6 @@ import AgencyContainer from 'containers/search/filters/AgencyContainer';
 import LocationSectionContainer from 'containers/search/filters/location/LocationSectionContainer';
 import RecipientSearchContainer from 'containers/search/filters/recipient/RecipientSearchContainer';
 import ProgramSourceContainer from 'containers/search/filters/programSource/ProgramSourceContainer';
-import TASCheckboxTree from 'containers/search/filters/programSource/TASCheckboxTreeContainer';
 import RecipientTypeContainer from 'containers/search/filters/recipient/RecipientTypeContainer';
 import AwardIDSearchContainer from 'containers/search/filters/awardID/AwardIDSearchContainer';
 import AwardAmountSearchContainer from

--- a/src/js/components/search/filters/programSource/ProgramSourceSection.jsx
+++ b/src/js/components/search/filters/programSource/ProgramSourceSection.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import kGlobalConstants from 'GlobalConstants';
 import SubmitHint from 'components/sharedComponents/filterSidebar/SubmitHint';
 import TreasuryAccountFilters from './TreasuryAccountFilters';
 import SelectedSources from './SelectedSources';
@@ -18,6 +19,8 @@ const propTypes = {
     updateTreasuryAccountComponents: PropTypes.func,
     dirtyFilters: PropTypes.symbol
 };
+
+const isDev = kGlobalConstants.DEV;
 
 export default class ProgramSourceSection extends React.Component {
     constructor(props) {
@@ -190,6 +193,8 @@ export default class ProgramSourceSection extends React.Component {
             </React.Fragment>
         );
 
+        const tab2Title = isDev ? 'TAS Components' : 'Federal Account';
+
         return (
             <div className="program-source-filter search-filter">
                 <ul
@@ -200,7 +205,7 @@ export default class ProgramSourceSection extends React.Component {
                             className={`tab-toggle ${activeTreasury}`}
                             value="1"
                             role="menuitemradio"
-                            aria-checked={this.state.activeTab === 'treasury'}
+                            aria-checked={this.state.activeTab === 1}
                             title="Treasury Account"
                             aria-label="Treasury Account"
                             onClick={this.toggleTab} >
@@ -212,11 +217,11 @@ export default class ProgramSourceSection extends React.Component {
                             className={`tab-toggle ${activeFederal}`}
                             value="2"
                             role="menuitemradio"
-                            aria-checked={this.state.activeTab === 'federal'}
+                            aria-checked={this.state.activeTab === 2}
                             title="Federal Account"
                             aria-label="Federal Account"
                             onClick={this.toggleTab}>
-                            Federal Account
+                            {tab2Title}
                         </button>
                     </li>
                 </ul>

--- a/src/js/components/search/filters/programSource/ProgramSourceSection.jsx
+++ b/src/js/components/search/filters/programSource/ProgramSourceSection.jsx
@@ -24,7 +24,7 @@ export default class ProgramSourceSection extends React.Component {
         super(props);
 
         this.state = {
-            activeTab: 'treasury',
+            activeTab: 1,
             components: {
                 ata: '',
                 aid: '',
@@ -78,7 +78,7 @@ export default class ProgramSourceSection extends React.Component {
         // switch to the federal account tab if it has a filter applied and TAS does not
         if (this.props.selectedFederalComponents.size > 0 && this.props.selectedTreasuryComponents.size === 0) {
             this.setState({
-                activeTab: 'federal'
+                activeTab: 1
             });
         }
     }
@@ -87,7 +87,7 @@ export default class ProgramSourceSection extends React.Component {
         const type = e.target.value;
 
         this.setState({
-            activeTab: type
+            activeTab: parseInt(type, 10)
         });
     }
 
@@ -141,10 +141,9 @@ export default class ProgramSourceSection extends React.Component {
     }
 
     render() {
-        const activeTab = this.state.activeTab;
-        const activeTreasury = activeTab === 'treasury' ? '' : 'inactive';
-        const activeFederal = activeTab === 'federal' ? '' : 'inactive';
-        const components = this.state.components;
+        const { activeTab, components } = this.state;
+        const activeTreasury = activeTab === 1 ? '' : 'inactive';
+        const activeFederal = activeTab === 2 ? '' : 'inactive';
         const filter = (
             <TreasuryAccountFilters
                 updateComponent={this.updateComponent}
@@ -156,14 +155,14 @@ export default class ProgramSourceSection extends React.Component {
         );
 
         let selectedSources = null;
-        if (activeTab === 'federal' && this.props.selectedFederalComponents) {
+        if (activeTab === 2 && this.props.selectedFederalComponents) {
             selectedSources = (
                 <SelectedSources
                     removeSource={this.removeFilter}
                     label="FA #"
                     selectedSources={this.props.selectedFederalComponents} />);
         }
-        else if (activeTab === 'treasury' && this.props.selectedTreasuryComponents) {
+        else if (activeTab === 1 && this.props.selectedTreasuryComponents) {
             selectedSources = (
                 <SelectedSources
                     removeSource={this.removeFilter}
@@ -199,7 +198,7 @@ export default class ProgramSourceSection extends React.Component {
                     <li>
                         <button
                             className={`tab-toggle ${activeTreasury}`}
-                            value="treasury"
+                            value="1"
                             role="menuitemradio"
                             aria-checked={this.state.activeTab === 'treasury'}
                             title="Treasury Account"
@@ -211,7 +210,7 @@ export default class ProgramSourceSection extends React.Component {
                     <li>
                         <button
                             className={`tab-toggle ${activeFederal}`}
-                            value="federal"
+                            value="2"
                             role="menuitemradio"
                             aria-checked={this.state.activeTab === 'federal'}
                             title="Federal Account"

--- a/src/js/components/search/filters/programSource/TreasuryAccountFilters.jsx
+++ b/src/js/components/search/filters/programSource/TreasuryAccountFilters.jsx
@@ -122,12 +122,14 @@ export default class TreasuryAccountFilters extends React.Component {
                         onMouseEnter={this.showWarning}
                         onBlur={this.hideWarning}
                         onMouseLeave={this.hideWarning}>
-                        <button
-                            disabled={!enabled}
-                            onClick={this.props.applyFilter}
-                            className="program-source-components__button">
-                            Add Filter
-                        </button>
+                        {(!isDev || (isDev && activeTab === 2)) && (
+                            <button
+                                disabled={!enabled}
+                                onClick={this.props.applyFilter}
+                                className="program-source-components__button">
+                                Add Filter
+                            </button>
+                        )}
                         <div
                             className={`program-source-warning ${this.state.showWarning ? '' : 'hide'}`}
                             aria-hidden={enabled}>

--- a/src/js/components/search/filters/programSource/TreasuryAccountFilters.jsx
+++ b/src/js/components/search/filters/programSource/TreasuryAccountFilters.jsx
@@ -5,8 +5,11 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import EntityWarning from 'components/search/filters/location/EntityWarning';
+import kGlobalConstants from 'GlobalConstants';
 import ProgramSourceAutocompleteContainer from 'containers/search/filters/programSource/ProgramSourceAutocompleteContainer';
+import TASCheckboxTree from 'containers/search/filters/programSource/TASCheckboxTreeContainer';
 import { treasuryAccountComponents, federalAccountComponents } from 'dataMapping/search/programSourceComponents';
 
 const propTypes = {
@@ -15,8 +18,10 @@ const propTypes = {
     applyFilter: PropTypes.func,
     dirtyFilters: PropTypes.symbol,
     clearSelection: PropTypes.func,
-    activeTab: PropTypes.string
+    activeTab: PropTypes.number
 };
+
+const isDev = kGlobalConstants.DEV;
 
 export default class TreasuryAccountFilters extends React.Component {
     constructor(props) {
@@ -43,7 +48,23 @@ export default class TreasuryAccountFilters extends React.Component {
     }
 
     generateFilters() {
-        if (this.props.activeTab === 'treasury') {
+        if (this.props.activeTab === 1) {
+            if (isDev) {
+                return (
+                    <TASCheckboxTree />
+                );
+            }
+            return treasuryAccountComponents.map((option) => (
+                <ProgramSourceAutocompleteContainer
+                    dirtyFilters={this.props.dirtyFilters}
+                    key={option.code}
+                    component={option}
+                    selectedSources={this.props.components}
+                    updateComponent={this.props.updateComponent}
+                    clearSelection={this.props.clearSelection} />
+            ));
+        }
+        if (isDev) {
             return treasuryAccountComponents.map((option) => (
                 <ProgramSourceAutocompleteContainer
                     dirtyFilters={this.props.dirtyFilters}
@@ -66,7 +87,7 @@ export default class TreasuryAccountFilters extends React.Component {
     }
 
     render() {
-        const components = this.props.components;
+        const { components, activeTab } = this.props;
         const enabled = components.aid && components.main;
 
         let message = "Enter values for AID and MAIN";
@@ -77,14 +98,23 @@ export default class TreasuryAccountFilters extends React.Component {
             message = "Enter value for AID";
         }
 
-        const heading = this.props.activeTab === 'treasury' ? 'Treasury' : 'Federal';
+        const heading = activeTab === 1
+            ? 'Treasury'
+            : 'Federal';
 
         return (
             <div className="program-source-tab">
                 <form className="program-source-components">
-                    <div className="program-source-components__heading">
-                        {heading} Account Components
-                    </div>
+                    {isDev && activeTab === 2 && (
+                        <div className="program-source-components__heading">
+                            Treasury Account Components
+                        </div>
+                    )}
+                    {!isDev && (
+                        <div className="program-source-components__heading">
+                            {heading} Account Components
+                        </div>
+                    )}
                     {this.generateFilters()}
                     <div
                         className="program-source-components__button-wrapper"

--- a/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
@@ -187,6 +187,7 @@ export default class TASCheckboxTree extends React.Component {
         } = this.state;
         return (
             <div className="tas-checkbox">
+                <span>Search by Federal Account, TAS, or Title.</span>
                 <EntityDropdownAutocomplete
                     enabled
                     isClearable


### PR DESCRIPTION
**High level description:**
No real big changes, just changing the format to match the mocks. I missed that we are supposed to keep the Tab layout.

**Technical details:**
Using some dark-release logic and cleaning up some styles; small changes.

**JIRA Ticket:**
[DEV-4278](https://federal-spending-transparency.atlassian.net/browse/DEV-4278)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
