### PR TITLE
[DEV-4267] fixes bug in decrement/onUncheck logic.

### DIFF
--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -165,10 +165,13 @@ export const decrementCountAndUpdateUnchecked = (
     const nodeFromTree = traverseTreeByCodeFn(nodes, value);
     const parentKey = getHighestAncestorFn(nodeFromTree);
     const ancestorKey = getImmediateAncestorFn(nodeFromTree);
-    const count = nodeFromTree.count > 0 ? nodeFromTree.count : 1;
+    const amountToDecrement = nodeFromTree.count > 0 ? nodeFromTree.count : 1;
     const shouldRemoveNode = counts.some((nodeFromCounts) => (
         !uncheckedNode.checked &&
-        (nodeFromCounts.value === value || nodeFromCounts.count <= count)
+        (
+            (nodeFromCounts.value === value) ||
+            (nodeFromCounts.count <= amountToDecrement && nodeFromCounts.value === parentKey)
+        )
     ));
     let newCounts;
     if (shouldRemoveNode) {
@@ -176,7 +179,7 @@ export const decrementCountAndUpdateUnchecked = (
     }
     else {
         newCounts = counts.map((nodeFromCounts) => {
-            const newCount = nodeFromCounts.count - count;
+            const newCount = nodeFromCounts.count - amountToDecrement;
             if (nodeFromCounts.value === parentKey) {
                 return { ...nodeFromCounts, count: newCount };
             }

--- a/tests/helpers/checkboxTreeHelper-test.js
+++ b/tests/helpers/checkboxTreeHelper-test.js
@@ -197,6 +197,19 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
             expect(newCount[0].count).toEqual(56);
             expect(newUnchecked.length).toEqual(1);
         });
+        it('decrements the appropriate count object when more than one exists', () => {
+            const [newCount] = decrementCountAndUpdateUnchecked(
+                { value: '1111' },
+                [],
+                ['11'],
+                [{ value: '11', count: 64 }, { value: '21', count: 8 }],
+                mockData.reallyBigTree,
+                getNaicsNodeFromTree,
+                getImmediateAncestorNaicsCode,
+                getHighestAncestorNaicsCode
+            );
+            expect(newCount[0].count).toEqual(56);
+        });
         it('when a placeholder is checked and a checked node under that placeholder is unchecked, decrement the count and update the unchecked array', async () => {
             const [counts, newUnchecked] = decrementCountAndUpdateUnchecked(
                 { checked: false, value: "111110" },


### PR DESCRIPTION
**High level description:**
Bug fix for logic in decrementCount invoked onUncheck in TAS and NAICS

**Technical details:**
Added additional condition to `shouldRemoveCount`.

**JIRA Ticket:**
[DEV-4267](https://federal-spending-transparency.atlassian.net/browse/DEV-4267)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
