### PR TITLE
[DEV-4844] Don't add 'foreign' as a country; only scope

### DIFF
--- a/src/js/models/search/SearchAwardsOperation.js
+++ b/src/js/models/search/SearchAwardsOperation.js
@@ -205,7 +205,7 @@ class SearchAwardsOperation {
         }
 
         if (this.selectedRecipientLocations.length > 0) {
-            const locationSet = this.selectedLocations.reduce((accLocationSet, currLocation) => {
+            const locationSet = this.selectedRecipientLocations.reduce((accLocationSet, currLocation) => {
                 if (!currLocation.filter.city && currLocation.filter.country && currLocation.filter.country.toLowerCase() === 'foreign') {
                     filters[rootKeys.recipientLocationScope] = 'foreign';
                 } else {

--- a/src/js/models/search/SearchAwardsOperation.js
+++ b/src/js/models/search/SearchAwardsOperation.js
@@ -205,12 +205,14 @@ class SearchAwardsOperation {
         }
 
         if (this.selectedRecipientLocations.length > 0) {
-            const locationSet = this.selectedRecipientLocations.map((location) => {
-                if (!location.filter.city && location.filter.country && location.filter.country.toLowerCase() === 'foreign') {
+            const locationSet = this.selectedLocations.reduce((accLocationSet, currLocation) => {
+                if (!currLocation.filter.city && currLocation.filter.country && currLocation.filter.country.toLowerCase() === 'foreign') {
                     filters[rootKeys.recipientLocationScope] = 'foreign';
+                } else {
+                    accLocationSet.push(currLocation.filter);
                 }
-                return location.filter;
-            });
+                return accLocationSet;
+            }, []);
 
             if (locationSet.length > 0) {
                 filters[rootKeys.recipientLocation] = locationSet;
@@ -223,12 +225,14 @@ class SearchAwardsOperation {
 
         // Add Locations
         if (this.selectedLocations.length > 0) {
-            const locationSet = this.selectedLocations.map((location) => {
-                if (!location.filter.city && location.filter.country && location.filter.country.toLowerCase() === 'foreign') {
+            const locationSet = this.selectedLocations.reduce((accLocationSet, currLocation) => {
+                if (!currLocation.filter.city && currLocation.filter.country && currLocation.filter.country.toLowerCase() === 'foreign') {
                     filters[rootKeys.placeOfPerformanceScope] = 'foreign';
+                } else {
+                    accLocationSet.push(currLocation.filter);
                 }
-                return location.filter;
-            });
+                return accLocationSet;
+            }, []);
 
             if (locationSet.length > 0) {
                 filters[rootKeys.placeOfPerformance] = locationSet;


### PR DESCRIPTION
**High level description:**

To support the upcoming change to Elasticsearch only use the `scope` filter when specifying `All Foreign Countries`. Currently both the `scope` and `location` filter are used and the backend handles the case of a "country" called foreign by ignoring it. 

**Technical details:**

Instead of using `.map()` when building the request parameters for location use `.reduce()` so that the country value of `foreign` can be ignored and instead added as a separate filter.

Request Before Fix:
```
{
    "filters": {
        "time_period": [
            {
                "start_date": "2007-10-01",
                "end_date": "2020-09-30"
            }
        ],
        "award_type_codes": [
            "A",
            "B",
            "C",
            "D"
        ],
        "place_of_performance_scope": "foreign",
        "place_of_performance_locations": [
            {
                "country": "FOREIGN"
            }
        ]
    },
    "fields": [
        "Award ID",
        "Recipient Name",
        "Start Date",
        "End Date",
        "Award Amount",
        "Awarding Agency",
        "Awarding Sub Agency",
        "Contract Award Type",
        "recipient_id",
        "prime_award_recipient_id"
    ],
    "page": 1,
    "limit": 60,
    "sort": "Award Amount",
    "order": "desc",
    "subawards": false
}
```
Request After Fix:
```
{
    "filters": {
        "time_period": [
            {
                "start_date": "2007-10-01",
                "end_date": "2020-09-30"
            }
        ],
        "award_type_codes": [
            "A",
            "B",
            "C",
            "D"
        ],
        "place_of_performance_scope": "foreign"
    },
    "fields": [
        "Award ID",
        "Recipient Name",
        "Start Date",
        "End Date",
        "Award Amount",
        "Awarding Agency",
        "Awarding Sub Agency",
        "Contract Award Type",
        "recipient_id",
        "prime_award_recipient_id"
    ],
    "page": 1,
    "limit": 60,
    "sort": "Award Amount",
    "order": "desc",
    "subawards": false
}
```

Request Showing with Location and Scope:
```
{
    "filters": {
        "time_period": [
            {
                "start_date": "2007-10-01",
                "end_date": "2020-09-30"
            }
        ],
        "award_type_codes": [
            "A",
            "B",
            "C",
            "D"
        ],
        "recipient_locations": [
            {
                "country": "GBR",
                "city": "LONDON"
            }
        ],
        "place_of_performance_scope": "foreign"
    },
    "fields": [
        "Award ID",
        "Recipient Name",
        "Start Date",
        "End Date",
        "Award Amount",
        "Awarding Agency",
        "Awarding Sub Agency",
        "Contract Award Type",
        "recipient_id",
        "prime_award_recipient_id"
    ],
    "page": 1,
    "limit": 60,
    "sort": "Award Amount",
    "order": "desc",
    "subawards": false
}
```
**JIRA Ticket:**
[DEV-4844](https://federal-spending-transparency.atlassian.net/browse/DEV-4844)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [X] Linked to this PR in JIRA ticket
- [X] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [X] Verified cross-browser compatibility
- [X] Verified mobile/tablet/desktop/monitor responsiveness
- [X] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [X] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [X] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [X] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [X] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Code review complete
