### PR TITLE
Dev-4746 Add Extension of Shading

### DIFF
--- a/src/_scss/pages/award/shared/contractGrantsActivity.scss
+++ b/src/_scss/pages/award/shared/contractGrantsActivity.scss
@@ -82,6 +82,9 @@
       fill: $color-primary;
       opacity: 0.3;
     }
+    .area-path__past-end-line {
+      fill: $color-gray-lighter;
+    }
     .vertical-line {
       &.start {
         stroke: $color-green-lighter;

--- a/src/_scss/pages/award/shared/contractGrantsActivity.scss
+++ b/src/_scss/pages/award/shared/contractGrantsActivity.scss
@@ -80,10 +80,11 @@
     }
     .area-path {
       fill: $color-primary;
-      opacity: 0.3;
+      opacity: 0.2;
     }
     .area-path__past-end-line {
       fill: $color-gray-lighter;
+      opacity: 0.3;
     }
     .vertical-line {
       &.start {

--- a/src/js/helpers/contractGrantActivityHelper.js
+++ b/src/js/helpers/contractGrantActivityHelper.js
@@ -184,9 +184,9 @@ export const getXDomain = (dates, awardType, transactions) => {
     /**
      * handles null, '', or 'random string' passed to moment
      */
-    const badStart = isNaN(startDate.valueOf());
-    const badCurrent = isNaN(currentEndDate.valueOf());
-    const badEnd = isNaN(potentialEndDate.valueOf());
+    const badStart = isNaN(startDate.valueOf()) || !startDate;
+    const badCurrent = isNaN(currentEndDate.valueOf()) || !currentEndDate;
+    const badEnd = isNaN(potentialEndDate.valueOf()) || !potentialEndDate;
     const onlyOneTransaction = transactions.length === 1;
 
     // only one transaction

--- a/src/js/helpers/contractGrantActivityHelper.js
+++ b/src/js/helpers/contractGrantActivityHelper.js
@@ -18,7 +18,7 @@ export const dateMatchingFirstLineValue = (lines, dates, todayLineValue, endLine
 };
 
 // should we extend path for last data point y value change
-export const shouldExtendAreaPathYValueChange = (transactions, areaPathExtensionToTodayLine) => {
+export const shouldExtendAreaPathWhenLastDataPointYValueChange = (transactions, areaPathExtensionToTodayLine) => {
     if (transactions.length <= 1) return false;
     const lastTransactionValueChange = transactions[transactions.length - 1].running_obligation_total > transactions[transactions.length - 2].running_obligation_total;
     if (!lastTransactionValueChange) return false;

--- a/tests/helpers/contractGrantActivityHelper-test.js
+++ b/tests/helpers/contractGrantActivityHelper-test.js
@@ -13,7 +13,7 @@ import {
     lineHelper,
     filteredAndSortedLinesFirstToLast,
     dateMatchingFirstLineValue,
-    shouldExtendAreaPathYValueChange,
+    shouldExtendAreaPathWhenLastDataPointYValueChange,
     createSteppedAreaPath
 } from 'helpers/contractGrantActivityHelper';
 import {
@@ -295,7 +295,7 @@ describe('Date Matching First Line Value', () => {
 describe('Should Extend Area Path Y Value Change', () => {
   // transactions, areaPathExtensionToTodayLine
     it('should return false when transactions <= 1', () => {
-        expect(shouldExtendAreaPathYValueChange([], '')).toEqual(false);
+        expect(shouldExtendAreaPathWhenLastDataPointYValueChange([], '')).toEqual(false);
     });
     it('should return false when the last transaction running total does not change', () => {
         const transactions = [
@@ -306,7 +306,7 @@ describe('Should Extend Area Path Y Value Change', () => {
                 running_obligation_total: 1
             }
         ];
-        expect(shouldExtendAreaPathYValueChange(transactions, '')).toEqual(false);
+        expect(shouldExtendAreaPathWhenLastDataPointYValueChange(transactions, '')).toEqual(false);
     });
     it('should return false when we extend to the today line', () => {
         const transactions = [
@@ -317,7 +317,7 @@ describe('Should Extend Area Path Y Value Change', () => {
                 running_obligation_total: 2
             }
         ];
-        expect(shouldExtendAreaPathYValueChange(transactions, 2345)).toEqual(false);
+        expect(shouldExtendAreaPathWhenLastDataPointYValueChange(transactions, 2345)).toEqual(false);
     });
     it('should return true when all criteria is met', () => {
         const transactions = [
@@ -328,7 +328,7 @@ describe('Should Extend Area Path Y Value Change', () => {
                 running_obligation_total: 2
             }
         ];
-        expect(shouldExtendAreaPathYValueChange(transactions, null)).toEqual(true);
+        expect(shouldExtendAreaPathWhenLastDataPointYValueChange(transactions, null)).toEqual(true);
     });
 });
 

--- a/tests/helpers/contractGrantActivityHelper-test.js
+++ b/tests/helpers/contractGrantActivityHelper-test.js
@@ -4,12 +4,17 @@
 
 import moment from 'moment';
 import { cloneDeep } from 'lodash';
+import { scaleLinear } from 'd3-scale';
 import {
     areTransactionDatesOrAwardAmountsInvalid,
     getXDomain,
     beforeDate,
     afterDate,
-    lineHelper
+    lineHelper,
+    filteredAndSortedLinesFirstToLast,
+    dateMatchingFirstLineValue,
+    shouldExtendAreaPathYValueChange,
+    createSteppedAreaPath
 } from 'helpers/contractGrantActivityHelper';
 import {
     goodDates,
@@ -40,6 +45,15 @@ describe('Contract Grant Activity Helper', () => {
                 return data;
             });
             expect(areTransactionDatesOrAwardAmountsInvalid(goodDates, 'grant', noDates)).toBe(true);
+        });
+        it('should return true when there are no dates and one transaction', () => {
+            const dates = {
+                _startDate: '',
+                _endDate: '',
+                _potentialEndDate: ''
+            };
+            expect(areTransactionDatesOrAwardAmountsInvalid(dates, 'contract', oneTransaction)).toEqual(true);
+            expect(areTransactionDatesOrAwardAmountsInvalid(dates, 'grant', oneTransaction)).toEqual(true);
         });
         describe('Grant', () => {
             // 3
@@ -247,5 +261,115 @@ describe('Line Helper', () => {
     });
     it('should return a number if date exists', () => {
         expect(lineHelper(goodDates._startDate)).toBe(goodDates._startDate.valueOf());
+    });
+});
+
+describe(' Filtered and Sorted Lines First To Last', () => {
+    const lines = [3, null, 2];
+    it('should sort and filter lines', () => {
+        expect(filteredAndSortedLinesFirstToLast(lines)).toEqual([2, 3]);
+    });
+});
+
+describe('Date Matching First Line Value', () => {
+    it('should match today line date', () => {
+        const lines = [
+            goodDates._startDate.valueOf(), 
+            goodDates._endDate.valueOf(),
+            goodDates._potentialEndDate.valueOf()
+        ];
+        expect(dateMatchingFirstLineValue(lines, goodDates, goodDates._startDate.valueOf(), goodDates._endDate).valueOf())
+            .toEqual(goodDates._startDate.valueOf());
+    });
+    it('should match end line date', () => {
+        const lines = [
+            null, 
+            goodDates._endDate.valueOf(),
+            goodDates._potentialEndDate.valueOf()
+        ];
+        expect(dateMatchingFirstLineValue(lines, goodDates, goodDates._startDate.valueOf(), goodDates._endDate.valueOf()).valueOf())
+            .toEqual(goodDates._endDate.valueOf());
+    });
+});
+
+describe('Should Extend Area Path Y Value Change', () => {
+  // transactions, areaPathExtensionToTodayLine
+    it('should return false when transactions <= 1', () => {
+        expect(shouldExtendAreaPathYValueChange([], '')).toEqual(false);
+    });
+    it('should return false when the last transaction running total does not change', () => {
+        const transactions = [
+            {
+                running_obligation_total: 1
+            },
+            {
+                running_obligation_total: 1
+            }
+        ];
+        expect(shouldExtendAreaPathYValueChange(transactions, '')).toEqual(false);
+    });
+    it('should return false when we extend to the today line', () => {
+        const transactions = [
+            {
+                running_obligation_total: 1
+            },
+            {
+                running_obligation_total: 2
+            }
+        ];
+        expect(shouldExtendAreaPathYValueChange(transactions, 2345)).toEqual(false);
+    });
+    it('should return true when all criteria is met', () => {
+        const transactions = [
+            {
+                running_obligation_total: 1
+            },
+            {
+                running_obligation_total: 2
+            }
+        ];
+        expect(shouldExtendAreaPathYValueChange(transactions, null)).toEqual(true);
+    });
+});
+
+describe('Create Stepped Area Path', () => {
+    it('should create a stepped area path', () => {
+        const transactions = [
+            {
+                running_obligation_total: 1000,
+                action_date: goodDates._startDate
+            },
+            {
+                running_obligation_total: 2000,
+                action_date: goodDates._endDate
+            },
+            {
+                running_obligation_total: 3000,
+                action_date: goodDates._potentialEndDate
+            }
+        ];
+        const xScale = scaleLinear(
+            [transactions[0].action_date, transactions[2].action_date],
+            [0, 300]
+        );
+        const yScale = scaleLinear(
+            [transactions[0].running_obligation_total, transactions[2].running_obligation_total],
+            [0, 400]
+        );
+        
+        const path = createSteppedAreaPath(
+            mockTransactions,
+            xScale, // d3 linear scale
+            yScale, // d3 linear scale
+            400, // height of the graph
+            { left: 45 }, // horizontal padding for the svg
+            'action_date', // x property of the data point must be moment object
+            'running_obligation_total' // y property of the data point
+        );
+        const steppedPath = path.split('').reduce((acc, char) => {
+            if (char === 'M' || char === 'H' || char === 'V' || char === 'Z') acc.push(char);
+            return acc;
+        }, []);
+        expect(steppedPath).toEqual(['M', 'V', 'H', 'V', 'H', 'V', 'H', 'V', 'Z']);
     });
 });


### PR DESCRIPTION
**High level description:**

Adds extension of shading for cases when transactions are before the today line and the today line is before all end dates and a different color of shading when a transaction is past any end date and an extension of shading when the last transaction has an increase in running total obligation.

**Technical details:**

> • add three extra svg paths to the charts

**JIRA Ticket:**
[DEV-4746](https://federal-spending-transparency.atlassian.net/browse/DEV-4746)

**Mockup:**
https://bahdigital.invisionapp.com/share/7HIADD8Q53D#/screens/296034818

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension) Verified locally and in dev with award CONT_AWD_N0001917C0001_9700_-NONE-_-NONE-.  There is an increase from 93 to 95 due to color contrast. @AGuyNamedMarco 
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently
- [x] Code review complete
