### PR TITLE
Quick BugFix for removing checked items from tree via clicking the Staged Filters tag

### DIFF
--- a/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
@@ -104,7 +104,8 @@ export default class TASCheckboxTree extends React.Component {
         this.setState({ expanded: newExpandedArray });
     }
 
-    removeSelectedFilter = (node) => {
+    removeSelectedFilter = (e, node) => {
+        e.preventDefault();
         const newChecked = removeStagedTasFilter(this.state.nodes, this.state.checked, node.value);
         this.onUncheck(newChecked, { ...node, checked: false });
     }
@@ -219,7 +220,7 @@ export default class TASCheckboxTree extends React.Component {
                                 <button
                                     className="shown-filter-button"
                                     value={label}
-                                    onClick={() => this.removeSelectedFilter(node)}
+                                    onClick={(e) => this.removeSelectedFilter(e, node)}
                                     title="Click to remove."
                                     aria-label={`Applied filter: ${label}`}>
                                     {label}

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -61,12 +61,11 @@ export const removeStagedFilter = (
     getHighestAncestorFn,
     getImmediateAncestorFn
 ) => checkedNodes
-    .map((checkedCode) => removePlaceholderString(checkedCode))
     .filter((checked) => {
-        const checkedNode = traverseTreeByCodeFn(nodes, checked);
+        const checkedNode = traverseTreeByCodeFn(nodes, removePlaceholderString(checked));
         if (getHighestAncestorFn(checkedNode) === removedNode) return false;
         if (getImmediateAncestorFn(checkedNode) === removedNode) return false;
-        if (checkedNode === removedNode) return false;
+        if (checkedNode.value === removedNode) return false;
         return true;
     });
 


### PR DESCRIPTION
**High level description:**
Quick BugFix PR for removing checked items from tree via clicking the Staged Filters tag

**Technical details:**
Two things:
1. Was passing an object when the fn was expecting a string
2. Was removing `children_of_` from checked array

**JIRA Ticket:**
[DEV-4627](https://federal-spending-transparency.atlassian.net/browse/DEV-4627)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
