### PR TITLE
[DEV-4642] Add alternate names modal to recipient profile

### DIFF
--- a/src/_scss/pages/modals/recipient/_table.scss
+++ b/src/_scss/pages/modals/recipient/_table.scss
@@ -1,5 +1,6 @@
 .recipients-list {
     border: none;
+    margin-top: rem(5);
     .recipients-list__head-row {
         border-bottom: solid 1px $color-gray-lighter;
         .recipients-list__head-cell {

--- a/src/_scss/pages/modals/recipient/recipient.scss
+++ b/src/_scss/pages/modals/recipient/recipient.scss
@@ -1,13 +1,13 @@
-.child-recipients-modal {
+.recipients-modal {
     background-color: $color-white;
-    .child-recipients-modal__wrapper {
-        .child-recipients-modal__header {
+    .recipients-modal__wrapper {
+        .recipients-modal__header {
             @include display(flex);
             @include justify-content(space-between);
             @include align-items(flex-start);
             padding: rem(20) rem(35);
             background-color: $color-gray-light;
-            h1.child-recipients-modal__title {
+            h1.recipients-modal__title {
                 @include display(flex);
                 @include flex(1 1 auto);
                 margin: 0;
@@ -15,7 +15,7 @@
                 color: $color-white;
                 font-weight: $font-light;
             }
-            button.child-recipients-modal__close-button {
+            button.recipients-modal__close-button {
                 @include display(flex);
                 @include flex(0 0 auto);
                 @include button-unstyled;
@@ -27,10 +27,10 @@
                 }
             }
         }
-        .child-recipients-modal__body {
+        .recipients-modal__body {
             padding: rem(20) rem(60) rem(40);
             @import "table";
-            .child-recipients-modal__message {
+            .recipients-modal__message {
                 @include h4;
                 text-align: center;
                 @include media($medium-screen) {

--- a/src/_scss/pages/recipient/_overview.scss
+++ b/src/_scss/pages/recipient/_overview.scss
@@ -4,7 +4,26 @@
 		margin: rem(5) 0;
         font-weight: $font-semibold;
         font-size: rem(36);
-	}
+    }
+    .recipient-overview__alternate-names-button {
+        @include display(flex);
+        @include flex(0 0 auto);
+        @include align-items(center);
+        @include button-unstyled;
+        color: $color-primary;
+        padding: rem(5);
+        svg {
+            height: rem(15);
+            width: rem(15);
+            fill: $color-primary;
+        }
+        &:hover {
+            color: $color-primary-darker;
+            svg {
+                fill: $color-primary-darker;
+            }
+        }
+    }
 	.recipient-overview__content {
 		h3.recipient-overview__heading {
 			@include h4;

--- a/src/js/components/recipient/RecipientContent.jsx
+++ b/src/js/components/recipient/RecipientContent.jsx
@@ -32,10 +32,16 @@ const recipientSections = [
 const propTypes = {
     recipient: PropTypes.object,
     pickedFy: PropTypes.func,
-    showModal: PropTypes.func
+    showChildRecipientModal: PropTypes.func,
+    showAlternateNamesRecipientModal: PropTypes.func
 };
 
-const RecipientContent = ({ recipient, pickedFy, showModal }) => {
+const RecipientContent = ({
+    recipient,
+    pickedFy,
+    showChildRecipientModal,
+    showAlternateNamesRecipientModal
+}) => {
     const [activeSection, setActiveSection] = useState('overview');
 
     const jumpToSection = (section = '') => {
@@ -77,7 +83,8 @@ const RecipientContent = ({ recipient, pickedFy, showModal }) => {
             </div>
             <div className="recipient-content">
                 <RecipientOverview
-                    showModal={showModal}
+                    showChildRecipientModal={showChildRecipientModal}
+                    showAlternateNamesRecipientModal={showAlternateNamesRecipientModal}
                     recipient={recipient} />
                 <RecipientTimeVisualizationSectionContainer
                     recipient={recipient} />

--- a/src/js/components/recipient/RecipientOverview.jsx
+++ b/src/js/components/recipient/RecipientOverview.jsx
@@ -11,7 +11,8 @@ import RecipientMultiParentCollapse from './RecipientMultiParentCollapse';
 
 const propTypes = {
     recipient: PropTypes.object,
-    showModal: PropTypes.func
+    showChildRecipientModal: PropTypes.func,
+    showAlternateNamesRecipientModal: PropTypes.func
 };
 
 export default class RecipientOverview extends React.Component {
@@ -45,11 +46,22 @@ export default class RecipientOverview extends React.Component {
             viewChildren = (
                 <button
                     className="recipient-overview__children-button"
-                    onClick={this.props.showModal}>
+                    onClick={this.props.showChildRecipientModal}>
                     View child recipients <CaretRight />
                 </button>
             );
         }
+        const numberOfAlternateNames = recipient.alternateNames.length;
+        const pluralizeAltNamesLabel = numberOfAlternateNames > 1 ? "names" : "name";
+        const viewAlternateNames = numberOfAlternateNames > 0
+            ? (
+                <button
+                    className="recipient-overview__alternate-names-button"
+                    onClick={this.props.showAlternateNamesRecipientModal}>
+                    {`Also known by ${numberOfAlternateNames} other ${pluralizeAltNamesLabel}`} <CaretRight />
+                </button>
+            )
+            : null;
 
         // Format the location data
         let address = (
@@ -86,6 +98,7 @@ export default class RecipientOverview extends React.Component {
                 className="recipient-section recipient-overview">
                 <h2 className="recipient-overview__title">
                     {recipient.name}
+                    {viewAlternateNames}
                 </h2>
                 <hr className="results-divider" />
                 <div className="recipient-overview__content">

--- a/src/js/components/recipient/RecipientPage.jsx
+++ b/src/js/components/recipient/RecipientPage.jsx
@@ -36,36 +36,15 @@ export default class RecipientPage extends React.Component {
             showChildRecipientModal: false,
             showAlternateNamesRecipientModal: false
         };
-
-        this.showChildRecipientModal = this.showChildRecipientModal.bind(this);
-        this.hideChildRecipientModal = this.hideChildRecipientModal.bind(this);
-        this.showAlternateNamesRecipientModal = this.showAlternateNamesRecipientModal.bind(this);
-        this.hideAlternateNamesRecipientModal = this.hideAlternateNamesRecipientModal.bind(this);
     }
 
-    showAlternateNamesRecipientModal() {
-        this.setState({
-            showAlternateNamesRecipientModal: true
-        });
-    }
+    showAlternateNamesRecipientModal = () => this.setState({ showAlternateNamesRecipientModal: true });
 
-    hideAlternateNamesRecipientModal() {
-        this.setState({
-            showAlternateNamesRecipientModal: false
-        });
-    }
+    hideAlternateNamesRecipientModal = () => this.setState({ showAlternateNamesRecipientModal: false });
 
-    showChildRecipientModal() {
-        this.setState({
-            showChildRecipientModal: true
-        });
-    }
+    showChildRecipientModal = () => this.setState({ showChildRecipientModal: true });
 
-    hideChildRecipientModal() {
-        this.setState({
-            showChildRecipientModal: false
-        });
-    }
+    hideChildRecipientModal = () => this.setState({ showChildRecipientModal: false });
 
     render() {
         let content = (

--- a/src/js/components/recipient/RecipientPage.jsx
+++ b/src/js/components/recipient/RecipientPage.jsx
@@ -15,8 +15,9 @@ import StickyHeader from 'components/sharedComponents/stickyHeader/StickyHeader'
 import Error from 'components/sharedComponents/Error';
 import { LoadingWrapper } from "components/sharedComponents/Loading";
 
-import RecipientModalContainer from 'containers/recipient/modal/RecipientModalContainer';
+import ChildRecipientModalContainer from 'containers/recipient/modal/ChildRecipientModalContainer';
 import RecipientContent from './RecipientContent';
+import { AlternateNamesRecipientModalContainer } from '../../containers/recipient/modal/AlternateNamesRecipientModalContainer';
 
 
 const propTypes = {
@@ -32,29 +33,45 @@ export default class RecipientPage extends React.Component {
         super(props);
 
         this.state = {
-            showModal: false
+            showChildRecipientModal: false,
+            showAlternateNamesRecipientModal: false
         };
 
-        this.showModal = this.showModal.bind(this);
-        this.hideModal = this.hideModal.bind(this);
+        this.showChildRecipientModal = this.showChildRecipientModal.bind(this);
+        this.hideChildRecipientModal = this.hideChildRecipientModal.bind(this);
+        this.showAlternateNamesRecipientModal = this.showAlternateNamesRecipientModal.bind(this);
+        this.hideAlternateNamesRecipientModal = this.hideAlternateNamesRecipientModal.bind(this);
     }
 
-    showModal() {
+    showAlternateNamesRecipientModal() {
         this.setState({
-            showModal: true
+            showAlternateNamesRecipientModal: true
         });
     }
 
-    hideModal() {
+    hideAlternateNamesRecipientModal() {
         this.setState({
-            showModal: false
+            showAlternateNamesRecipientModal: false
+        });
+    }
+
+    showChildRecipientModal() {
+        this.setState({
+            showChildRecipientModal: true
+        });
+    }
+
+    hideChildRecipientModal() {
+        this.setState({
+            showChildRecipientModal: false
         });
     }
 
     render() {
         let content = (
             <RecipientContent
-                showModal={this.showModal}
+                showChildRecipientModal={this.showChildRecipientModal}
+                showAlternateNamesRecipientModal={this.showAlternateNamesRecipientModal}
                 {...this.props} />
         );
         if (this.props.error) {
@@ -79,9 +96,13 @@ export default class RecipientPage extends React.Component {
                     className="main-content">
                     <LoadingWrapper isLoading={this.props.loading}>
                         {content}
-                        <RecipientModalContainer
-                            mounted={this.state.showModal}
-                            hideModal={this.hideModal}
+                        <ChildRecipientModalContainer
+                            mounted={this.state.showChildRecipientModal}
+                            hideModal={this.hideChildRecipientModal}
+                            recipient={this.props.recipient} />
+                        <AlternateNamesRecipientModalContainer
+                            mounted={this.state.showAlternateNamesRecipientModal}
+                            hideModal={this.hideAlternateNamesRecipientModal}
                             recipient={this.props.recipient} />
                     </LoadingWrapper>
                 </main>

--- a/src/js/components/recipient/modal/AlternateNamesRecipientModal.jsx
+++ b/src/js/components/recipient/modal/AlternateNamesRecipientModal.jsx
@@ -1,0 +1,73 @@
+/**
+ * AlternateNamesRecipientModal.jsx
+ * Created by Seth Stoudenmier 4/17/20
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import Modal from 'react-aria-modal';
+
+import { Close } from 'components/sharedComponents/icons/Icons';
+import AlternateNamesRecipientModalTable from './table/AlternateNamesRecipientModalTable';
+
+const propTypes = {
+    mounted: PropTypes.bool,
+    hideModal: PropTypes.func,
+    recipient: PropTypes.object,
+    sortField: PropTypes.string,
+    sortDirection: PropTypes.string,
+    updateSort: PropTypes.func,
+    alternateNames: PropTypes.array
+};
+
+export default class AlternateNamesRecipientModal extends React.Component {
+    render() {
+        let table = (<AlternateNamesRecipientModalTable
+            sortField={this.props.sortField}
+            hideModal={this.props.hideModal}
+            sortDirection={this.props.sortDirection}
+            updateSort={this.props.updateSort}
+            alternateNames={this.props.alternateNames} />);
+        let message = null;
+        if (this.props.alternateNames.length === 0) {
+            message = "No results found.";
+            table = null;
+        }
+        const resultCount = this.props.alternateNames.length;
+        const resultCountDisplay = table
+            ? `${resultCount} ${resultCount > 1 ? "results" : "result"}`
+            : null;
+        return (
+            <Modal
+                mounted={this.props.mounted}
+                onExit={this.props.hideModal}
+                titleText={`Other Names for ${this.props.recipient.overview.name}`}
+                dialogClass="recipients-modal"
+                verticallyCenter
+                escapeExits>
+                <div className="recipients-modal__wrapper">
+                    <div className="recipients-modal__header">
+                        <h1 className="recipients-modal__title">{`Other Names for ${this.props.recipient.overview.name}`}</h1>
+                        <button
+                            className="recipients-modal__close-button"
+                            onClick={this.props.hideModal}
+                            title="Close"
+                            aria-label="Close">
+                            <Close alt="Close modal" />
+                        </button>
+                    </div>
+                    <div className="recipients-modal__body">
+                        {resultCountDisplay}
+                        {table}
+                        {resultCountDisplay}
+                        <div className="recipients-modal__message">
+                            {message}
+                        </div>
+                    </div>
+                </div>
+            </Modal>
+        );
+    }
+}
+
+AlternateNamesRecipientModal.propTypes = propTypes;

--- a/src/js/components/recipient/modal/AlternateNamesRecipientModal.jsx
+++ b/src/js/components/recipient/modal/AlternateNamesRecipientModal.jsx
@@ -20,54 +20,52 @@ const propTypes = {
     alternateNames: PropTypes.array
 };
 
-export default class AlternateNamesRecipientModal extends React.Component {
-    render() {
-        let table = (<AlternateNamesRecipientModalTable
-            sortField={this.props.sortField}
-            hideModal={this.props.hideModal}
-            sortDirection={this.props.sortDirection}
-            updateSort={this.props.updateSort}
-            alternateNames={this.props.alternateNames} />);
-        let message = null;
-        if (this.props.alternateNames.length === 0) {
-            message = "No results found.";
-            table = null;
-        }
-        const resultCount = this.props.alternateNames.length;
-        const resultCountDisplay = table
-            ? `${resultCount} ${resultCount > 1 ? "results" : "result"}`
-            : null;
-        return (
-            <Modal
-                mounted={this.props.mounted}
-                onExit={this.props.hideModal}
-                titleText={`Other Names for ${this.props.recipient.overview.name}`}
-                dialogClass="recipients-modal"
-                verticallyCenter
-                escapeExits>
-                <div className="recipients-modal__wrapper">
-                    <div className="recipients-modal__header">
-                        <h1 className="recipients-modal__title">{`Other Names for ${this.props.recipient.overview.name}`}</h1>
-                        <button
-                            className="recipients-modal__close-button"
-                            onClick={this.props.hideModal}
-                            title="Close"
-                            aria-label="Close">
-                            <Close alt="Close modal" />
-                        </button>
-                    </div>
-                    <div className="recipients-modal__body">
-                        {resultCountDisplay}
-                        {table}
-                        {resultCountDisplay}
-                        <div className="recipients-modal__message">
-                            {message}
-                        </div>
+const AlternateNamesRecipientModal = (props) => {
+    let table = (<AlternateNamesRecipientModalTable
+        sortField={props.sortField}
+        hideModal={props.hideModal}
+        sortDirection={props.sortDirection}
+        updateSort={props.updateSort}
+        alternateNames={props.alternateNames} />);
+    let message = null;
+    if (props.alternateNames.length === 0) {
+        message = "No results found.";
+        table = null;
+    }
+    const resultCount = props.alternateNames.length;
+    const resultPluralize = resultCount > 1 ? "results" : "result";
+    const resultCountDisplay = table ? `${resultCount} ${resultPluralize}` : null;
+    return (
+        <Modal
+            mounted={props.mounted}
+            onExit={props.hideModal}
+            titleText={`Other Names for ${props.recipient.overview.name}`}
+            dialogClass="recipients-modal"
+            verticallyCenter
+            escapeExits>
+            <div className="recipients-modal__wrapper">
+                <div className="recipients-modal__header">
+                    <h1 className="recipients-modal__title">{`Other Names for ${props.recipient.overview.name}`}</h1>
+                    <button
+                        className="recipients-modal__close-button"
+                        onClick={props.hideModal}
+                        title="Close"
+                        aria-label="Close">
+                        <Close alt="Close modal" />
+                    </button>
+                </div>
+                <div className="recipients-modal__body">
+                    {resultCountDisplay}
+                    {table}
+                    {resultCountDisplay}
+                    <div className="recipients-modal__message">
+                        {message}
                     </div>
                 </div>
-            </Modal>
-        );
-    }
-}
+            </div>
+        </Modal>
+    );
+};
 
 AlternateNamesRecipientModal.propTypes = propTypes;
+export default AlternateNamesRecipientModal;

--- a/src/js/components/recipient/modal/ChildRecipientModal.jsx
+++ b/src/js/components/recipient/modal/ChildRecipientModal.jsx
@@ -46,9 +46,8 @@ export default class ChildRecipientModal extends React.Component {
             table = null;
         }
         const resultCount = this.props.childRecipients.length;
-        const resultCountDisplay = table
-            ? `${resultCount} ${resultCount > 1 ? "results" : "result"}`
-            : null;
+        const resultPluralize = resultCount > 1 ? "results" : "result";
+        const resultCountDisplay = table ? `${resultCount} ${resultPluralize}` : null;
         return (
             <Modal
                 mounted={this.props.mounted}

--- a/src/js/components/recipient/modal/ChildRecipientModal.jsx
+++ b/src/js/components/recipient/modal/ChildRecipientModal.jsx
@@ -1,5 +1,5 @@
 /**
- * RecipientModal.jsx
+ * ChildRecipientModal.jsx
  * Created by Lizzie Salita 6/18/18
  */
 
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import Modal from 'react-aria-modal';
 
 import { Close } from 'components/sharedComponents/icons/Icons';
-import RecipientModalTable from './table/RecipientModalTable';
+import ChildRecipientModalTable from './table/ChildRecipientModalTable';
 
 const propTypes = {
     mounted: PropTypes.bool,
@@ -22,9 +22,9 @@ const propTypes = {
     childRecipients: PropTypes.array
 };
 
-export default class RecipientModal extends React.Component {
+export default class ChildRecipientModal extends React.Component {
     render() {
-        let table = (<RecipientModalTable
+        let table = (<ChildRecipientModalTable
             sortField={this.props.sortField}
             hideModal={this.props.hideModal}
             sortDirection={this.props.sortDirection}
@@ -45,28 +45,34 @@ export default class RecipientModal extends React.Component {
             message = "No results found.";
             table = null;
         }
+        const resultCount = this.props.childRecipients.length;
+        const resultCountDisplay = table
+            ? `${resultCount} ${resultCount > 1 ? "results" : "result"}`
+            : null;
         return (
             <Modal
                 mounted={this.props.mounted}
                 onExit={this.props.hideModal}
                 titleText="Child Recipients"
-                dialogClass="child-recipients-modal"
+                dialogClass="recipients-modal"
                 verticallyCenter
                 escapeExits>
-                <div className="child-recipients-modal__wrapper">
-                    <div className="child-recipients-modal__header">
-                        <h1 className="child-recipients-modal__title">Child Recipients</h1>
+                <div className="recipients-modal__wrapper">
+                    <div className="recipients-modal__header">
+                        <h1 className="recipients-modal__title">Child Recipients</h1>
                         <button
-                            className="child-recipients-modal__close-button"
+                            className="recipients-modal__close-button"
                             onClick={this.props.hideModal}
                             title="Close"
                             aria-label="Close">
                             <Close alt="Close modal" />
                         </button>
                     </div>
-                    <div className="child-recipients-modal__body">
+                    <div className="recipients-modal__body">
+                        {resultCountDisplay}
                         {table}
-                        <div className="child-recipients-modal__message">
+                        {resultCountDisplay}
+                        <div className="recipients-modal__message">
                             {message}
                         </div>
                     </div>
@@ -76,4 +82,4 @@ export default class RecipientModal extends React.Component {
     }
 }
 
-RecipientModal.propTypes = propTypes;
+ChildRecipientModal.propTypes = propTypes;

--- a/src/js/components/recipient/modal/table/AlternateNamesRecipientModalTable.jsx
+++ b/src/js/components/recipient/modal/table/AlternateNamesRecipientModalTable.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { uniqueId } from 'lodash';
 
 import Sorter from 'components/stateLanding/table/StateLandingTableSorter';
 
@@ -16,44 +17,43 @@ const propTypes = {
     sortDirection: PropTypes.string
 };
 
-export default class AlternateNamesRecipientModalTable extends React.Component {
-    render() {
-        const body = this.props.alternateNames.map((altName) => (
-            <tr
-                className="recipients-list__body-row"
-                key={altName}>
-                <td className="recipients-list__body-cell">
-                    {altName}
-                </td>
-            </tr>
-        ));
+const AlternateNamesRecipientModalTable = (props) => {
+    const body = props.alternateNames.map((altName) => (
+        <tr
+            className="recipients-list__body-row"
+            key={uniqueId(altName)}>
+            <td className="recipients-list__body-cell">
+                {altName}
+            </td>
+        </tr>
+    ));
 
-        return (
-            <table className="recipients-list">
-                <thead className="recipients-list__head">
-                    <tr className="recipients-list__head-row">
-                        <th className="recipients-list__head-cell">
-                            <div className="header-cell">
-                                <div className="header-cell__text">
-                                    <div className="header-cell__title">
-                                    Name
-                                    </div>
+    return (
+        <table className="recipients-list">
+            <thead className="recipients-list__head">
+                <tr className="recipients-list__head-row">
+                    <th className="recipients-list__head-cell">
+                        <div className="header-cell">
+                            <div className="header-cell__text">
+                                <div className="header-cell__title">
+                                Name
                                 </div>
-                                <Sorter
-                                    field="alternateName"
-                                    label="name"
-                                    active={{ field: this.props.sortField, direction: this.props.sortDirection }}
-                                    setSort={this.props.updateSort} />
                             </div>
-                        </th>
-                    </tr>
-                </thead>
-                <tbody className="recipients-list__body">
-                    {body}
-                </tbody>
-            </table>
-        );
-    }
-}
+                            <Sorter
+                                field="alternateName"
+                                label="name"
+                                active={{ field: props.sortField, direction: props.sortDirection }}
+                                setSort={props.updateSort} />
+                        </div>
+                    </th>
+                </tr>
+            </thead>
+            <tbody className="recipients-list__body">
+                {body}
+            </tbody>
+        </table>
+    );
+};
 
 AlternateNamesRecipientModalTable.propTypes = propTypes;
+export default AlternateNamesRecipientModalTable;

--- a/src/js/components/recipient/modal/table/AlternateNamesRecipientModalTable.jsx
+++ b/src/js/components/recipient/modal/table/AlternateNamesRecipientModalTable.jsx
@@ -1,0 +1,59 @@
+/**
+ * AlternateNamesRecipientModalTable.jsx
+ * Created by Seth Stoudenmier 4/17/20
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Sorter from 'components/stateLanding/table/StateLandingTableSorter';
+
+const propTypes = {
+    alternateNames: PropTypes.array,
+    updateSort: PropTypes.func,
+    sortField: PropTypes.string,
+    hideModal: PropTypes.func,
+    sortDirection: PropTypes.string
+};
+
+export default class AlternateNamesRecipientModalTable extends React.Component {
+    render() {
+        const body = this.props.alternateNames.map((altName) => (
+            <tr
+                className="recipients-list__body-row"
+                key={altName}>
+                <td className="recipients-list__body-cell">
+                    {altName}
+                </td>
+            </tr>
+        ));
+
+        return (
+            <table className="recipients-list">
+                <thead className="recipients-list__head">
+                    <tr className="recipients-list__head-row">
+                        <th className="recipients-list__head-cell">
+                            <div className="header-cell">
+                                <div className="header-cell__text">
+                                    <div className="header-cell__title">
+                                    Name
+                                    </div>
+                                </div>
+                                <Sorter
+                                    field="alternateName"
+                                    label="name"
+                                    active={{ field: this.props.sortField, direction: this.props.sortDirection }}
+                                    setSort={this.props.updateSort} />
+                            </div>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody className="recipients-list__body">
+                    {body}
+                </tbody>
+            </table>
+        );
+    }
+}
+
+AlternateNamesRecipientModalTable.propTypes = propTypes;

--- a/src/js/components/recipient/modal/table/ChildRecipientModalTable.jsx
+++ b/src/js/components/recipient/modal/table/ChildRecipientModalTable.jsx
@@ -1,5 +1,5 @@
 /**
- * RecipientModalTable.jsx
+ * ChildRecipientModalTable.jsx
  * Created by Lizzie Salita 6/19/18
  */
 
@@ -18,7 +18,7 @@ const propTypes = {
     sortDirection: PropTypes.string
 };
 
-export default class RecipientModalTable extends React.Component {
+export default class ChildRecipientModalTable extends React.Component {
     render() {
         const body = this.props.childRecipients.map((child) => (
             <tr
@@ -136,4 +136,4 @@ export default class RecipientModalTable extends React.Component {
     }
 }
 
-RecipientModalTable.propTypes = propTypes;
+ChildRecipientModalTable.propTypes = propTypes;

--- a/src/js/containers/recipient/modal/AlternateNamesRecipientModalContainer.jsx
+++ b/src/js/containers/recipient/modal/AlternateNamesRecipientModalContainer.jsx
@@ -6,13 +6,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { isEqual } from 'lodash';
 
 import AlternateNamesRecipientModal from 'components/recipient/modal/AlternateNamesRecipientModal';
 
 const propTypes = {
     recipient: PropTypes.object,
-    mounted: PropTypes.bool,
     hideModal: PropTypes.func
 };
 
@@ -22,52 +20,24 @@ export class AlternateNamesRecipientModalContainer extends React.Component {
 
         this.state = {
             sortField: "alternateNames",
-            sortDirection: "desc",
-            alternateNames: []
+            sortDirection: "asc"
         };
-
-        this.request = null;
-        this.updateSort = this.updateSort.bind(this);
     }
 
-    componentDidUpdate(prevProps) {
-        if (this.props.mounted && !prevProps.mounted) {
-            // The modal went from hidden to visible
-            this.loadAlternateNames();
-        }
-        if (!isEqual(this.props.recipient.alternateNames, prevProps.recipient.alternateNames)) {
-            // Sort the new results by the default sort order
-            this.updateSort("alternateName", "desc");
-        }
-    }
-
-    loadAlternateNames() {
-        // Load the initial state
-        this.setState({ alternateNames: this.props.recipient.overview.alternateNames });
-    }
-
-    updateSort(sortField, sortDirection) {
-        const ascSortFunction = (a, b) => (a > b ? 1 : -1);
-        const descSortFunction = (a, b) => (a < b ? 1 : -1);
-        const sortFunction = sortDirection === "asc"
-            ? ascSortFunction
-            : descSortFunction;
-        const orderedResults = this.props.recipient.overview.alternateNames.sort(sortFunction);
-        this.setState({
-            sortField,
-            sortDirection,
-            alternateNames: orderedResults
-        });
-    }
+    updateSort = (sortField, sortDirection) => this.setState({ sortField, sortDirection });
 
     render() {
+        const sortedAlternateNames = this.state.sortDirection === "asc"
+            ? this.props.recipient.overview.alternateNames.sort()
+            : this.props.recipient.overview.alternateNames.sort((a, b) => (b.localeCompare(a)));
+
         return (
             <AlternateNamesRecipientModal
                 {...this.props}
                 sortField={this.state.sortField}
                 sortDirection={this.state.sortDirection}
                 updateSort={this.updateSort}
-                alternateNames={this.state.alternateNames} />
+                alternateNames={sortedAlternateNames} />
         );
     }
 }

--- a/src/js/containers/recipient/modal/AlternateNamesRecipientModalContainer.jsx
+++ b/src/js/containers/recipient/modal/AlternateNamesRecipientModalContainer.jsx
@@ -28,7 +28,7 @@ export class AlternateNamesRecipientModalContainer extends React.Component {
 
     render() {
         const sortedAlternateNames = this.state.sortDirection === "asc"
-            ? this.props.recipient.overview.alternateNames.sort()
+            ? this.props.recipient.overview.alternateNames.sort((a, b) => (a.localeCompare(b)))
             : this.props.recipient.overview.alternateNames.sort((a, b) => (b.localeCompare(a)));
 
         return (

--- a/src/js/containers/recipient/modal/AlternateNamesRecipientModalContainer.jsx
+++ b/src/js/containers/recipient/modal/AlternateNamesRecipientModalContainer.jsx
@@ -1,0 +1,81 @@
+/**
+ * AlternateNamesRecipientModalContainer.jsx
+ * Created by Seth Stoudenmier 4/17/20
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { isEqual } from 'lodash';
+
+import AlternateNamesRecipientModal from 'components/recipient/modal/AlternateNamesRecipientModal';
+
+const propTypes = {
+    recipient: PropTypes.object,
+    mounted: PropTypes.bool,
+    hideModal: PropTypes.func
+};
+
+export class AlternateNamesRecipientModalContainer extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            sortField: "alternateNames",
+            sortDirection: "desc",
+            alternateNames: []
+        };
+
+        this.request = null;
+        this.updateSort = this.updateSort.bind(this);
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.mounted && !prevProps.mounted) {
+            // The modal went from hidden to visible
+            this.loadAlternateNames();
+        }
+        if (!isEqual(this.props.recipient.alternateNames, prevProps.recipient.alternateNames)) {
+            // Sort the new results by the default sort order
+            this.updateSort("alternateName", "desc");
+        }
+    }
+
+    loadAlternateNames() {
+        // Load the initial state
+        this.setState({ alternateNames: this.props.recipient.overview.alternateNames });
+    }
+
+    updateSort(sortField, sortDirection) {
+        const ascSortFunction = (a, b) => (a > b ? 1 : -1);
+        const descSortFunction = (a, b) => (a < b ? 1 : -1);
+        const sortFunction = sortDirection === "asc"
+            ? ascSortFunction
+            : descSortFunction;
+        const orderedResults = this.props.recipient.overview.alternateNames.sort(sortFunction);
+        this.setState({
+            sortField,
+            sortDirection,
+            alternateNames: orderedResults
+        });
+    }
+
+    render() {
+        return (
+            <AlternateNamesRecipientModal
+                {...this.props}
+                sortField={this.state.sortField}
+                sortDirection={this.state.sortDirection}
+                updateSort={this.updateSort}
+                alternateNames={this.state.alternateNames} />
+        );
+    }
+}
+
+export default connect(
+    (state) => ({
+        recipient: state.recipient
+    })
+)(AlternateNamesRecipientModalContainer);
+
+AlternateNamesRecipientModalContainer.propTypes = propTypes;

--- a/src/js/containers/recipient/modal/ChildRecipientModalContainer.jsx
+++ b/src/js/containers/recipient/modal/ChildRecipientModalContainer.jsx
@@ -1,5 +1,5 @@
 /**
- * RecipientModalContainer.jsx
+ * ChildRecipientModalContainer.jsx
  * Created by Lizzie Salita 6/20/18
  */
 
@@ -13,7 +13,7 @@ import { orderBy, isEqual } from 'lodash';
 import * as recipientActions from 'redux/actions/recipient/recipientActions';
 import * as RecipientHelper from 'helpers/recipientHelper';
 
-import RecipientModal from 'components/recipient/modal/RecipientModal';
+import ChildRecipientModal from 'components/recipient/modal/ChildRecipientModal';
 import BaseChildRecipient from 'models/v2/recipient/BaseChildRecipient';
 
 const propTypes = {
@@ -23,7 +23,7 @@ const propTypes = {
     hideModal: PropTypes.func
 };
 
-export class RecipientModalContainer extends React.Component {
+export class ChildRecipientModalContainer extends React.Component {
     constructor(props) {
         super(props);
 
@@ -111,7 +111,7 @@ export class RecipientModalContainer extends React.Component {
 
     render() {
         return (
-            <RecipientModal
+            <ChildRecipientModal
                 {...this.props}
                 error={this.state.error}
                 loading={this.state.inFlight}
@@ -128,6 +128,6 @@ export default connect(
         recipient: state.recipient
     }),
     (dispatch) => bindActionCreators(recipientActions, dispatch)
-)(RecipientModalContainer);
+)(ChildRecipientModalContainer);
 
-RecipientModalContainer.propTypes = propTypes;
+ChildRecipientModalContainer.propTypes = propTypes;

--- a/src/js/models/v2/recipient/BaseRecipientOverview.js
+++ b/src/js/models/v2/recipient/BaseRecipientOverview.js
@@ -13,6 +13,7 @@ const BaseRecipientOverview = {
     populate(data) {
         this.id = data.recipient_id || null;
         this.name = data.name || 'Name not provided';
+        this.alternateNames = data.alternate_names || [];
         this.duns = data.duns || 'DUNS not provided';
         this.parentName = data.parent_name || '';
         this.parentDuns = data.parent_duns || '';

--- a/tests/containers/recipient/modal/AlternateNamesModalContainer-test.jsx
+++ b/tests/containers/recipient/modal/AlternateNamesModalContainer-test.jsx
@@ -1,0 +1,52 @@
+/**
+ * AlternateNamesModalContainer-test.jsx
+ * Created by Seth Stoudenmier 4/17/20
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+// mock the state helper
+jest.mock('helpers/recipientHelper', () => require('../mockRecipientHelper'));
+
+import { AlternateNamesRecipientModalContainer } from 'containers/recipient/modal/AlternateNamesRecipientModalContainer';
+import { mockModalActions, mockModalRedux } from '../mockData';
+
+// mock the child component by replacing it with a function that returns a null element
+jest.mock('components/recipient/modal/AlternateNamesRecipientModal', () => jest.fn(() => null));
+
+describe('AlternateNamesModalContainer', () => {
+    describe('updateSort', () => {
+        it('should update the state and store alternate names in the given order', () => {
+            const container = shallow(<AlternateNamesRecipientModalContainer
+                {...mockModalRedux}
+                {...mockModalActions} />);
+
+            // Add alternate recipient names to the props
+            const alternateNames = ["GHI", "DEF", "ABC"];
+
+            const overview = Object.assign({}, mockModalRedux.recipient.overview, {
+                alternateNames
+            });
+
+            const recipient = Object.assign({}, mockModalRedux.recipient, {
+                overview
+            });
+
+            const nextProps = Object.assign({}, mockModalRedux, {
+                recipient
+            });
+
+            container.setProps(nextProps);
+
+            // Call updateSort
+            container.instance().updateSort('alternateName', 'asc');
+
+            const expectedOrder = ["ABC", "DEF", "GHI"];
+
+            expect(container.state().sortField).toEqual('alternateName');
+            expect(container.state().sortDirection).toEqual('asc');
+            expect(container.state().alternateNames).toEqual(expectedOrder);
+        });
+    });
+});

--- a/tests/containers/recipient/modal/AlternateNamesModalContainer-test.jsx
+++ b/tests/containers/recipient/modal/AlternateNamesModalContainer-test.jsx
@@ -12,7 +12,7 @@ jest.mock('helpers/recipientHelper', () => require('../mockRecipientHelper'));
 import { AlternateNamesRecipientModalContainer } from 'containers/recipient/modal/AlternateNamesRecipientModalContainer';
 import { mockModalActions, mockModalRedux } from '../mockData';
 
-// mock the child component by replacing it with a function that returns a null element
+// mock the alternate names component by replacing it with a function that returns a null element
 jest.mock('components/recipient/modal/AlternateNamesRecipientModal', () => jest.fn(() => null));
 
 describe('AlternateNamesModalContainer', () => {

--- a/tests/containers/recipient/modal/AlternateNamesModalContainer-test.jsx
+++ b/tests/containers/recipient/modal/AlternateNamesModalContainer-test.jsx
@@ -17,36 +17,44 @@ jest.mock('components/recipient/modal/AlternateNamesRecipientModal', () => jest.
 
 describe('AlternateNamesModalContainer', () => {
     describe('updateSort', () => {
-        it('should update the state and store alternate names in the given order', () => {
-            const container = shallow(<AlternateNamesRecipientModalContainer
-                {...mockModalRedux}
-                {...mockModalActions} />);
+        const container = shallow(<AlternateNamesRecipientModalContainer
+            {...mockModalRedux}
+            {...mockModalActions} />);
 
-            // Add alternate recipient names to the props
-            const alternateNames = ["GHI", "DEF", "ABC"];
+        // Add alternate recipient names to the props
+        const alternateNames = ["GHI", "DEF", "ABC"];
 
-            const overview = Object.assign({}, mockModalRedux.recipient.overview, {
-                alternateNames
-            });
+        const overview = Object.assign({}, mockModalRedux.recipient.overview, {
+            alternateNames
+        });
+        const recipient = Object.assign({}, mockModalRedux.recipient, {
+            overview
+        });
+        const nextProps = Object.assign({}, mockModalRedux, {
+            recipient
+        });
 
-            const recipient = Object.assign({}, mockModalRedux.recipient, {
-                overview
-            });
-
-            const nextProps = Object.assign({}, mockModalRedux, {
-                recipient
-            });
-
-            container.setProps(nextProps);
-
+        container.setProps(nextProps);
+        it('should update the state and store alternate names in the asc order', () => {
             // Call updateSort
-            container.instance().updateSort('alternateName', 'asc');
+            container.instance().updateSort('alternateNames', 'asc');
 
             const expectedOrder = ["ABC", "DEF", "GHI"];
 
-            expect(container.state().sortField).toEqual('alternateName');
+            expect(container.state().sortField).toEqual('alternateNames');
             expect(container.state().sortDirection).toEqual('asc');
-            expect(container.state().alternateNames).toEqual(expectedOrder);
+            expect(container.props().alternateNames).toEqual(expectedOrder);
+        });
+
+        it('should update the state and store alternate names in the desc order', () => {
+            // Call updateSort
+            container.instance().updateSort('alternateNames', 'desc');
+
+            const expectedOrder = ["GHI", "DEF", "ABC"];
+
+            expect(container.state().sortField).toEqual('alternateNames');
+            expect(container.state().sortDirection).toEqual('desc');
+            expect(container.props().alternateNames).toEqual(expectedOrder);
         });
     });
 });

--- a/tests/containers/recipient/modal/ChildRecipientModalContainer-test.jsx
+++ b/tests/containers/recipient/modal/ChildRecipientModalContainer-test.jsx
@@ -1,25 +1,25 @@
 /**
- * RecipientModalContainer-test.jsx
+ * ChildRecipientModalContainer-test.jsx
  * Created by Lizzie Salita 6/26/18
  */
 
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 // mock the state helper
 jest.mock('helpers/recipientHelper', () => require('../mockRecipientHelper'));
 
-import { RecipientModalContainer } from 'containers/recipient/modal/RecipientModalContainer';
+import { ChildRecipientModalContainer } from 'containers/recipient/modal/ChildRecipientModalContainer';
 import { mockModalActions, mockModalRedux } from '../mockData';
 import { mockChildRecipients } from '../../../models/recipient/mockRecipientApi';
 import BaseChildRecipient from 'models/v2/recipient/BaseChildRecipient';
 
 // mock the child component by replacing it with a function that returns a null element
-jest.mock('components/recipient/modal/RecipientModal', () => jest.fn(() => null));
+jest.mock('components/recipient/modal/ChildRecipientModal', () => jest.fn(() => null));
 
-describe('RecipientModalContainer', () => {
+describe('ChildRecipientModalContainer', () => {
     it('should make an API call when the modal mounts', () => {
-        const container = shallow(<RecipientModalContainer
+        const container = shallow(<ChildRecipientModalContainer
             {...mockModalRedux}
             {...mockModalActions} />);
 
@@ -35,7 +35,7 @@ describe('RecipientModalContainer', () => {
         expect(loadChildRecipients).toHaveBeenCalledTimes(1);
     });
     it('should call updateSort with the default params when recipient.children changes', () => {
-        const container = shallow(<RecipientModalContainer
+        const container = shallow(<ChildRecipientModalContainer
             {...mockModalRedux}
             {...mockModalActions} />);
 
@@ -66,7 +66,7 @@ describe('RecipientModalContainer', () => {
     });
     describe('parseChildren', () => {
         it('should update the Redux state with a new BaseChildRecipient', () => {
-            const container = shallow(<RecipientModalContainer
+            const container = shallow(<ChildRecipientModalContainer
                 {...mockModalRedux}
                 {...mockModalActions} />);
 
@@ -87,7 +87,7 @@ describe('RecipientModalContainer', () => {
     });
     describe('updateSort', () => {
         it('should update the state and store child recipients in the given order', () => {
-            const container = shallow(<RecipientModalContainer
+            const container = shallow(<ChildRecipientModalContainer
                 {...mockModalRedux}
                 {...mockModalActions} />);
 

--- a/tests/models/recipient/mockRecipientApi.js
+++ b/tests/models/recipient/mockRecipientApi.js
@@ -6,6 +6,7 @@
 export const mockRecipientOverview = {
     recipient_id: '0123456-ABC-P',
     name: 'The ABC Corporation',
+    alternateNames: ['The ABC Corp', 'ABC Corporation, The'],
     duns: '0123456',
     parent_name: 'The XYZ Corporation',
     parent_duns: '0987654',


### PR DESCRIPTION
**High level description:**

Added new modal to display recipient alternate names on the recipient profile. Attached are two screenshots taken from local to demonstrate this behavior: 

![Screen Shot 2020-04-17 at 5 46 05 AM](https://user-images.githubusercontent.com/40359517/79592619-14734a00-808f-11ea-80bd-8c8f4049663b.png)
![Screen Shot 2020-04-17 at 5 45 52 AM](https://user-images.githubusercontent.com/40359517/79592622-150be080-808f-11ea-94eb-4bc5a5c593b2.png)

**Technical details:**

Followed a similar approach used to display child recipient modal. Since there are now two modals on the recipient page that child recipient modal was renamed to avoid future confusion.

**JIRA Ticket:**
[DEV-4642](https://federal-spending-transparency.atlassian.net/browse/DEV-4642)

**Mockup:**
https://bahdigital.invisionapp.com/share/QPIADGPK4FZ#/screens/296035186
https://bahdigital.invisionapp.com/share/QPIADGPK4FZ#/screens/296035190

The following are ALL required for the PR to be merged:

Author:
- [X] Linked to this PR in JIRA ticket
- [X] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [X] Verified cross-browser compatibility
- [X] Verified mobile/tablet/desktop/monitor responsiveness
- [X] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [X] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [X] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [X] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [X] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [X] Design review complete `if applicable`
- [ ] Code review complete
