### PR TITLE
Dev-4556 Contract Grant Activity Chart Potential Award Amount Line

### DIFF
--- a/src/_scss/components/_verticalLine.scss
+++ b/src/_scss/components/_verticalLine.scss
@@ -1,12 +1,12 @@
-.vertical-line__container {
-  .vertical-line {
+.svg-line__container {
+  .svg-line {
     stroke: rgb(0,0,0);
     stroke-width: 1;
     opacity: 0.25;
     shape-rendering: auto;
   }
   
-  .vertical-line__text {
+  .svg-line__text {
     font-size: rem(12);
   }
 }

--- a/src/_scss/pages/award/shared/contractGrantsActivity.scss
+++ b/src/_scss/pages/award/shared/contractGrantsActivity.scss
@@ -86,7 +86,7 @@
       fill: $color-gray-lighter;
       opacity: 0.3;
     }
-    .vertical-line {
+    .svg-line {
       &.start {
         stroke: $color-green-lighter;
       }
@@ -99,8 +99,11 @@
       &.potential-end {
         stroke: $color-secondary-dark;
       }
+      &.potential-award-amount-line {
+        stroke: $color-primary-darker;
+      }
     }
-    .vertical-line__text {
+    .svg-line__text {
       font-weight: $font-semibold;
       &.start {
         fill: $color-green-lighter;

--- a/src/js/components/award/contract/ContractContent.jsx
+++ b/src/js/components/award/contract/ContractContent.jsx
@@ -106,7 +106,8 @@ const ContractContent = ({
                         <ContractGrantActivityContainer
                             awardId={awardId}
                             awardType={overview.category}
-                            dates={overview.periodOfPerformance} />
+                            dates={overview.periodOfPerformance}
+                            totalObligation={overview._totalObligation} />
                         : <ComingSoonSection
                             toolTipWide
                             toolTipContent={contractActivityInfoContracts}

--- a/src/js/components/award/financialAssistance/FinancialAssistanceContent.jsx
+++ b/src/js/components/award/financialAssistance/FinancialAssistanceContent.jsx
@@ -83,7 +83,8 @@ const FinancialAssistanceContent = ({
                 <ContractGrantActivityContainer
                     awardId={awardId}
                     awardType={overview.category}
-                    dates={overview.periodOfPerformance} />
+                    dates={overview.periodOfPerformance}
+                    totalObligation={overview._totalObligation} />
                 : <ComingSoonSection
                     title="Grant Activity"
                     icon="chart-area"

--- a/src/js/components/award/idv/activity/chart/ActivityChart.jsx
+++ b/src/js/components/award/idv/activity/chart/ActivityChart.jsx
@@ -10,7 +10,7 @@ import { scaleLinear } from 'd3-scale';
 import { calculateTreemapPercentage } from 'helpers/moneyFormatter';
 import { nearestQuarterDate } from 'helpers/fiscalYearHelper';
 import RectanglePattern from 'components/sharedComponents/patterns/RectanglePattern';
-import VerticalLine from 'components/sharedComponents/VerticalLine';
+import SVGLine from 'components/sharedComponents/SVGLine';
 import ActivityXAxis from 'components/award/shared/activity/ActivityXAxis';
 import ActivityYAxis from 'components/award/shared/activity/ActivityYAxis';
 import ActivityChartBar from './ActivityChartBar';
@@ -354,15 +354,15 @@ export default class ActivityChart extends React.Component {
                         className="activity-chart-data">
                         {bars}
                         {/* Today Line */}
-                        {xScale && <VerticalLine
-                            xScale={xScale}
+                        {xScale && <SVGLine
+                            scale={xScale}
                             y1={-10}
                             y2={height - padding.bottom}
                             textY={0}
                             text="Today"
-                            xMax={xRange[1]}
-                            xMin={xRange[0]}
-                            xValue={currentDate}
+                            max={xRange[1]}
+                            min={xRange[0]}
+                            position={currentDate}
                             showTextPosition="top"
                             adjustmentX={padding.left} />}
                     </g>

--- a/src/js/components/award/shared/activity/ContractGrantActivity.jsx
+++ b/src/js/components/award/shared/activity/ContractGrantActivity.jsx
@@ -6,10 +6,16 @@ import ContractGrantActivityChart from './ContractGrantActivityChart';
 const propTypes = {
     transactions: PropTypes.array,
     dates: PropTypes.object,
-    awardType: PropTypes.string
+    awardType: PropTypes.string,
+    totalObligation: PropTypes.number
 };
 
-const ContractGrantActivity = ({ transactions, dates, awardType }) => {
+const ContractGrantActivity = ({
+    transactions,
+    dates,
+    awardType,
+    totalObligation
+}) => {
     // reference to the div - using to get the width
     const divReference = useRef(null);
     // window width
@@ -49,7 +55,8 @@ const ContractGrantActivity = ({ transactions, dates, awardType }) => {
                 height={360}
                 padding={{ left: 45, bottom: 30 }}
                 dates={dates}
-                awardType={awardType} />
+                awardType={awardType}
+                totalObligation={totalObligation} />
         </div>
     );
 };

--- a/src/js/components/award/shared/activity/ContractGrantActivityChart.jsx
+++ b/src/js/components/award/shared/activity/ContractGrantActivityChart.jsx
@@ -514,7 +514,7 @@ const ContractGrantsActivityChart = ({
     // updates the x position of our labels
     const paddingForYAxis = Object.assign(padding, { labels: 20 });
     // text for end line
-    const endLineText = awardType === 'grant' ? 'End' : ['Current', 'End'];
+    const endLineText = awardType === 'grant' ? 'End' : 'Current End';
     // class name for end line and text
     const endLineClassName = awardType === 'grant' ? 'grant-end' : 'contract-end';
 
@@ -639,7 +639,7 @@ const ContractGrantsActivityChart = ({
                     y1={-10}
                     y2={height}
                     textY={0}
-                    text={['Potential', 'End']}
+                    text="Potential End"
                     xMax={xDomain[1]}
                     xMin={xDomain[0]}
                     xValue={potentialEndLineValue}

--- a/src/js/components/award/shared/activity/ContractGrantActivityChart.jsx
+++ b/src/js/components/award/shared/activity/ContractGrantActivityChart.jsx
@@ -6,7 +6,6 @@ import moment from 'moment';
 
 import ActivityYAxis from 'components/award/shared/activity/ActivityYAxis';
 import ActivityXAxis from 'components/award/shared/activity/ActivityXAxis';
-import VerticalLine from 'components/sharedComponents/VerticalLine';
 import {
     getXDomain,
     lineHelper,
@@ -17,6 +16,7 @@ import {
 } from 'helpers/contractGrantActivityHelper';
 import { convertDateToFY } from 'helpers/fiscalYearHelper';
 import { formatMoney } from 'helpers/moneyFormatter';
+import ContractGrantActivityChartVerticalLines from './ContractGrantActivityChartVerticalLines';
 
 const propTypes = {
     height: PropTypes.number,
@@ -513,10 +513,6 @@ const ContractGrantsActivityChart = ({
     const svgHeight = height + padding.bottom + 40;
     // updates the x position of our labels
     const paddingForYAxis = Object.assign(padding, { labels: 20 });
-    // text for end line
-    const endLineText = awardType === 'grant' ? 'End' : 'Current End';
-    // class name for end line and text
-    const endLineClassName = awardType === 'grant' ? 'grant-end' : 'contract-end';
 
     return (
         <svg
@@ -591,62 +587,16 @@ const ContractGrantsActivityChart = ({
                         </g>
                     );
                 })}
-                {/* start line */}
-                {xScale && <VerticalLine
+                {xScale && <ContractGrantActivityChartVerticalLines
                     xScale={xScale}
-                    y1={-10}
-                    y2={height}
-                    textY={0}
-                    text="Start"
-                    xMax={xDomain[1]}
-                    xMin={xDomain[0]}
-                    xValue={startLineValue}
-                    showTextPosition="right"
-                    adjustmentX={padding.left}
-                    textClassname="vertical-line__text start"
-                    lineClassname="vertical-line start" />}
-                {/* today line */}
-                {xScale && <VerticalLine
-                    xScale={xScale}
-                    y1={-10}
-                    y2={height}
-                    textY={0}
-                    text="Today"
-                    xMax={xDomain[1]}
-                    xMin={xDomain[0]}
-                    xValue={todayLineValue}
-                    showTextPosition="left"
-                    adjustmentX={padding.left}
-                    textClassname="vertical-line__text today"
-                    lineClassname="vertical-line today" />}
-                {/* end line */}
-                {xScale && <VerticalLine
-                    xScale={xScale}
-                    y1={-10}
-                    y2={height}
-                    textY={0}
-                    text={endLineText}
-                    xMax={xDomain[1]}
-                    xMin={xDomain[0]}
-                    xValue={endLineValue}
-                    showTextPosition="left"
-                    adjustmentX={padding.left}
-                    textClassname={`vertical-line__text ${endLineClassName}`}
-                    lineClassname={`vertical-line ${endLineClassName}`} />}
-                {/* potential end line */}
-                {xScale && <VerticalLine
-                    xScale={xScale}
-                    y1={-10}
-                    y2={height}
-                    textY={0}
-                    text="Potential End"
-                    xMax={xDomain[1]}
-                    xMin={xDomain[0]}
-                    xValue={potentialEndLineValue}
-                    showTextPosition="left"
-                    adjustmentX={padding.left}
-                    textClassname="vertical-line__text potential-end"
-                    lineClassname="vertical-line potential-end" />}
+                    height={height}
+                    xDomain={xDomain}
+                    padding={padding}
+                    startLineValue={startLineValue}
+                    todayLineValue={todayLineValue}
+                    endLineValue={endLineValue}
+                    potentialEndLineValue={potentialEndLineValue}
+                    awardType={awardType} />}
             </g>
         </svg>
     );

--- a/src/js/components/award/shared/activity/ContractGrantActivityChart.jsx
+++ b/src/js/components/award/shared/activity/ContractGrantActivityChart.jsx
@@ -8,16 +8,12 @@ import ActivityYAxis from 'components/award/shared/activity/ActivityYAxis';
 import ActivityXAxis from 'components/award/shared/activity/ActivityXAxis';
 import {
     getXDomain,
-    lineHelper,
-    createSteppedAreaPath,
-    filteredAndSortedLinesFirstToLast,
-    dateMatchingFirstLineValue,
-    shouldExtendAreaPathWhenLastDataPointYValueChange
+    lineHelper
 } from 'helpers/contractGrantActivityHelper';
 import { convertDateToFY } from 'helpers/fiscalYearHelper';
-import { formatMoney } from 'helpers/moneyFormatter';
 import ContractGrantActivityChartVerticalLines from './ContractGrantActivityChartVerticalLines';
 import ContractGrantActivityChartCircles from './ContractGrantActivityChartCircles';
+import ContractGrantActivityChartAreaPaths from './ContractGrantActivityChartAreaPaths';
 
 const propTypes = {
     height: PropTypes.number,
@@ -29,12 +25,7 @@ const propTypes = {
 };
 
 const xAxisSpacingPercentage = 0.05;
-
 const todayLineValue = Date.now();
-
-const transactionPathDescription = 'A shaded light blue area moving horizontally between each transactions action date and vertically between each transactions federal action obligation difference';
-const areaPathToTodayLineDescription = 'An area path of color light blue representing an area path from the first transaction to the today line';
-const areaPathPastEndLineDescription = 'An area path of color grey representing an extension of the area path from the first end date line to the last transaction';
 
 const ContractGrantsActivityChart = ({
     height,
@@ -64,23 +55,6 @@ const ContractGrantsActivityChart = ({
     const [potentialEndLineValue, setPotentialEndLineValue] = useState(null);
     // x axis spacing
     const [xAxisSpacing, setXAxisSpacing] = useState(0);
-    // circle data
-    const [circleData, setCircleData] = useState([]);
-    // area path
-    const [areaPath, setAreaPath] = useState('');
-    // area path extension to today line
-    const [areaPathExtensionToTodayLine, setAreaPathExtensionToToday] = useState(null);
-    // area path past end line
-    const [areaPathPastEndLine, setAreaPathPastEndLine] = useState(null);
-    // area path extension last data point y value change
-    const [
-        areaPathExtensionLastDataPointYValueChange,
-        setAreaPathExtensionLastDataPointYValueChange
-    ] = useState({
-        path: null,
-        className: '',
-        description: ''
-    });
     /**
      * createXSeries
      * - creates the x domain and updates state
@@ -293,223 +267,6 @@ const ContractGrantsActivityChart = ({
         setEndLineValue(lineHelper(dates._endDate));
         setPotentialEndLineValue(lineHelper(dates._potentialEndDate));
     }, [dates]);
-    // sets circle data - hook - on mount and when transactions change
-    useEffect(() => {
-        if (xScale && yScale) {
-            const circles = transactions
-                .map((data, i) => ({
-                    key: `${data.federal_action_obligation}${i}`,
-                    description: `A circle representing the transaction date, ${data.action_date.format('MM-DD-YYYY')} and running total obligation of ${formatMoney(data.running_obligation_total)}`,
-                    className: 'transaction-date-circle',
-                    cx: xScale(data.action_date.valueOf()) + padding.left,
-                    cy: (height - yScale(data.running_obligation_total)),
-                    r: 1.5
-                }));
-            setCircleData(circles);
-        }
-    }, [
-        transactions,
-        padding,
-        xScale,
-        yScale,
-        xAxisSpacing,
-        height
-    ]);
-    // area path - hook
-    useEffect(() => {
-        if (xScale && yScale) {
-            setAreaPath(
-                createSteppedAreaPath(
-                    transactions,
-                    xScale,
-                    yScale,
-                    height,
-                    padding.left,
-                    'action_date',
-                    'running_obligation_total'
-                )
-            );
-        }
-    }, [
-        xScale,
-        yScale,
-        transactions,
-        height,
-        padding
-    ]);
-    // should we extend area path to today line
-    const shouldWeExtendAreaPathToTodayLine = useCallback(() => {
-        const lastTransaction = transactions[transactions.length - 1];
-        const todayLineIsBeforeAllEndDates = [endLineValue, potentialEndLineValue]
-            .filter((line) => line).every((line) => moment(todayLineValue).isBefore(moment(line)));
-        const everyLineIsAfterLastTransaction = filteredAndSortedLinesFirstToLast(
-            [todayLineValue, endLineValue, potentialEndLineValue]).every((line) => (
-            lastTransaction.action_date.isBefore(moment(line))
-        ));
-        if (todayLineIsBeforeAllEndDates && everyLineIsAfterLastTransaction) return true;
-        return false;
-    }, [
-        transactions,
-        endLineValue,
-        potentialEndLineValue
-    ]);
-    // extend area path to today
-    const extendAreaPathToTodayLine = useCallback(() => {
-        const lastTransaction = transactions[transactions.length - 1];
-        if (shouldWeExtendAreaPathToTodayLine() && xScale && yScale) {
-            setAreaPathExtensionToToday(createSteppedAreaPath(
-                [
-                    ...transactions,
-                    {
-                        action_date: dateMatchingFirstLineValue([todayLineValue, endLineValue, potentialEndLineValue], dates, todayLineValue, endLineValue),
-                        running_obligation_total: lastTransaction.running_obligation_total
-                    }
-                ],
-                xScale,
-                yScale,
-                height,
-                padding.left,
-                'action_date',
-                'running_obligation_total'
-            ));
-            setAreaPath(null);
-        }
-    }, [
-        transactions,
-        xScale,
-        yScale,
-        height,
-        padding,
-        shouldWeExtendAreaPathToTodayLine,
-        endLineValue,
-        potentialEndLineValue,
-        dates
-    ]);
-    // extend area path to today hook
-    useEffect(() => {
-        extendAreaPathToTodayLine();
-    }, [extendAreaPathToTodayLine]);
-    // extend aria path past end line hook
-    useEffect(() => {
-        if (!areaPathExtensionToTodayLine && xScale && yScale) {
-            const firstEndLine = filteredAndSortedLinesFirstToLast([endLineValue, potentialEndLineValue])[0];
-            // find index of first transaction after the first end line
-            const firstTransactionAfterFirstEndLineIndex = transactions.findIndex((t) => {
-                if (t.action_date.isAfter(moment(firstEndLine))) return true;
-                return false;
-            });
-            if (firstTransactionAfterFirstEndLineIndex !== -1) {
-                // isolate all transaction before the first end line
-                const transactionsBeforeFirstEndLine = transactions.slice(0, firstTransactionAfterFirstEndLineIndex);
-                // isolate all transactions after the first end line
-                const transactionsAfterFirstEndLine = transactions.slice(firstTransactionAfterFirstEndLineIndex, transactions.length);
-                const firstEndLineDate = dateMatchingFirstLineValue([endLineValue, potentialEndLineValue], dates, todayLineValue, endLineValue);
-                // create a new area path to the first endline
-                if (transactionsBeforeFirstEndLine.length) {
-                    setAreaPath(
-                        createSteppedAreaPath(
-                            [
-                                ...transactionsBeforeFirstEndLine,
-                                {
-                                    action_date: firstEndLineDate,
-                                    running_obligation_total: transactionsBeforeFirstEndLine[transactionsBeforeFirstEndLine.length - 1].running_obligation_total
-                                }
-                            ],
-                            xScale,
-                            yScale,
-                            height,
-                            padding.left,
-                            'action_date',
-                            'running_obligation_total'
-                        )
-                    );
-                }
-                // create a new area path after the first endline
-                if (transactionsAfterFirstEndLine.length) {
-                    const startingYValueForGreyShading = transactionsBeforeFirstEndLine.length ?
-                        transactionsBeforeFirstEndLine[transactionsBeforeFirstEndLine.length - 1].running_obligation_total :
-                        transactionsAfterFirstEndLine[0].running_obligation_total;
-                    setAreaPathPastEndLine(createSteppedAreaPath(
-                        [
-                            {
-                                action_date: firstEndLineDate,
-                                running_obligation_total: startingYValueForGreyShading
-                            },
-                            ...transactionsAfterFirstEndLine
-                        ],
-                        xScale,
-                        yScale,
-                        height - 0.5,
-                        padding.left,
-                        'action_date',
-                        'running_obligation_total'
-                    ));
-                }
-            }
-        }
-    }, [
-        endLineValue,
-        potentialEndLineValue,
-        dates,
-        xScale,
-        yScale,
-        height,
-        padding,
-        transactions,
-        areaPathExtensionToTodayLine
-    ]);
-    // extend area path when last data point y value changes
-    useEffect(() => {
-        if (shouldExtendAreaPathWhenLastDataPointYValueChange(transactions, areaPathExtensionToTodayLine) && xScale && yScale) {
-            const lastTransaction = transactions[transactions.length - 1];
-            const className = areaPathPastEndLine ? 'area-path__past-end-line' : 'area-path';
-            const colorForDescription = className === 'area-path' ? 'light blue' : 'grey';
-            const description = `An area path of color ${colorForDescription} representing an
-            extension of 0.5 pixels to the area path when the y value of the last transaction is greater than
-            the second to last transaction`;
-
-            const xAdjustment = xScale.invert(xAxisSpacing + 1) - (xDomain[0]);
-            const heightAdjustment = areaPathPastEndLine ? height - 0.5 : height;
-
-            setAreaPathExtensionLastDataPointYValueChange(
-                {
-                    path: createSteppedAreaPath(
-                        [
-                            {
-                                x: lastTransaction.action_date,
-                                y: lastTransaction.running_obligation_total
-                            },
-                            {
-                                x: moment(lastTransaction.action_date.valueOf() + xAdjustment),
-                                y: lastTransaction.running_obligation_total
-                            }
-                        ],
-                        xScale,
-                        yScale,
-                        heightAdjustment,
-                        padding.left,
-                        'x',
-                        'y'
-                    ),
-                    className,
-                    description
-                }
-            );
-        }
-        else {
-            setAreaPathExtensionLastDataPointYValueChange({ path: null, className: '', description: '' });
-        }
-    }, [
-        xScale,
-        yScale,
-        height,
-        padding,
-        areaPathPastEndLine,
-        transactions,
-        xDomain,
-        xAxisSpacing,
-        areaPathExtensionToTodayLine
-    ]);
     // Adds padding bottom and 40 extra pixels for the x-axis
     const svgHeight = height + padding.bottom + 40;
     // updates the x position of our labels
@@ -535,40 +292,27 @@ const ContractGrantsActivityChart = ({
                     ticks={xTicks}
                     scale={xScale}
                     line />
-                {/* area path */}
-                {areaPath &&
-                    <g tabIndex="0">
-                        <desc>{transactionPathDescription}</desc>
-                        <path
-                            className="area-path"
-                            d={areaPath} />
-                    </g>}
-                {/* extend area path to today */}
-                {areaPathExtensionToTodayLine &&
-                    <g tabIndex="0">
-                        <desc>{areaPathToTodayLineDescription}</desc>
-                        <path
-                            className="area-path"
-                            d={areaPathExtensionToTodayLine} />
-                    </g>}
-                {/* extend area path past end line */}
-                {areaPathPastEndLine &&
-                    <g tabIndex="0">
-                        <desc>{areaPathPastEndLineDescription}</desc>
-                        <path
-                            className="area-path__past-end-line"
-                            d={areaPathPastEndLine} />
-                    </g>}
-                {/* area Path Extension Last Data Point Y Value Change */}
-                {areaPathExtensionLastDataPointYValueChange.path &&
-                    <g tabIndex="0">
-                        <desc>{areaPathExtensionLastDataPointYValueChange.description}</desc>
-                        <path
-                            className={areaPathExtensionLastDataPointYValueChange.className}
-                            d={areaPathExtensionLastDataPointYValueChange.path} />
-                    </g>}
+                {/* area paths */}
+                {xScale && <ContractGrantActivityChartAreaPaths
+                    xScale={xScale}
+                    yScale={yScale}
+                    transactions={transactions}
+                    height={height}
+                    padding={padding}
+                    todayLineValue={todayLineValue}
+                    endLineValue={endLineValue}
+                    potentialEndLineValue={potentialEndLineValue}
+                    dates={dates}
+                    xDomain={xDomain}
+                    xAxisSpacing={xAxisSpacing} />}
                 {/* circles */}
-                {circleData.length && <ContractGrantActivityChartCircles circles={circleData} />}
+                {transactions.length && <ContractGrantActivityChartCircles
+                    transactions={transactions}
+                    padding={padding}
+                    xScale={xScale}
+                    yScale={yScale}
+                    xAxisSpacing={xAxisSpacing}
+                    height={height} />}
                 {/* vertical lines */}
                 {xScale && <ContractGrantActivityChartVerticalLines
                     xScale={xScale}

--- a/src/js/components/award/shared/activity/ContractGrantActivityChart.jsx
+++ b/src/js/components/award/shared/activity/ContractGrantActivityChart.jsx
@@ -12,10 +12,10 @@ import {
     lineHelper
 } from 'helpers/contractGrantActivityHelper';
 import { convertDateToFY } from 'helpers/fiscalYearHelper';
+import { formatMoney } from 'helpers/moneyFormatter';
 import ContractGrantActivityChartVerticalLines from './ContractGrantActivityChartVerticalLines';
 import ContractGrantActivityChartCircles from './ContractGrantActivityChartCircles';
 import ContractGrantActivityChartAreaPaths from './ContractGrantActivityChartAreaPaths';
-// import ContractGrantActivityPotentialAwardAmountLine from './ContractGrantActivityChartPotentialAwardAmountLine';
 
 
 const propTypes = {
@@ -84,9 +84,9 @@ const ContractGrantsActivityChart = ({
             0;
         const yOne = !clonedTransactions.length ?
             0 :
-            clonedTransactions.pop().running_obligation_total;
+            totalObligation || clonedTransactions.pop().running_obligation_total;
         setYDomain([yZero, yOne]);
-    }, [transactions]);
+    }, [transactions, totalObligation]);
     // hook - runs only on mount unless transactions change
     useEffect(() => {
         createXDomain();
@@ -276,6 +276,7 @@ const ContractGrantsActivityChart = ({
     const svgHeight = height + padding.bottom + 40;
     // updates the x position of our labels
     const paddingForYAxis = Object.assign(padding, { labels: 20 });
+    const potentialAwardAmountLineDescription = `A horizontal line representing the total award obligation of ${formatMoney(totalObligation)}`;
     return (
         <svg
             className="contract-grant-activity-chart"
@@ -331,6 +332,7 @@ const ContractGrantsActivityChart = ({
                 {/* potential award amount line */}
                 {xScale && <SVGLine
                     lineClassname="potential-award-amount-line"
+                    description={potentialAwardAmountLineDescription}
                     scale={yScale}
                     x1={padding.left}
                     x2={visualizationWidth}

--- a/src/js/components/award/shared/activity/ContractGrantActivityChart.jsx
+++ b/src/js/components/award/shared/activity/ContractGrantActivityChart.jsx
@@ -17,6 +17,7 @@ import {
 import { convertDateToFY } from 'helpers/fiscalYearHelper';
 import { formatMoney } from 'helpers/moneyFormatter';
 import ContractGrantActivityChartVerticalLines from './ContractGrantActivityChartVerticalLines';
+import ContractGrantActivityChartCircles from './ContractGrantActivityChartCircles';
 
 const propTypes = {
     height: PropTypes.number,
@@ -567,26 +568,8 @@ const ContractGrantsActivityChart = ({
                             d={areaPathExtensionLastDataPointYValueChange.path} />
                     </g>}
                 {/* circles */}
-                {circleData.length && circleData.map((circle) => {
-                    const {
-                        key,
-                        description,
-                        className,
-                        cx,
-                        cy,
-                        r
-                    } = circle;
-                    return (
-                        <g key={key} tabIndex="0">
-                            <desc>{description}</desc>
-                            <circle
-                                className={className}
-                                cx={cx}
-                                cy={cy}
-                                r={r} />
-                        </g>
-                    );
-                })}
+                {circleData.length && <ContractGrantActivityChartCircles circles={circleData} />}
+                {/* vertical lines */}
                 {xScale && <ContractGrantActivityChartVerticalLines
                     xScale={xScale}
                     height={height}

--- a/src/js/components/award/shared/activity/ContractGrantActivityChart.jsx
+++ b/src/js/components/award/shared/activity/ContractGrantActivityChart.jsx
@@ -6,6 +6,7 @@ import moment from 'moment';
 
 import ActivityYAxis from 'components/award/shared/activity/ActivityYAxis';
 import ActivityXAxis from 'components/award/shared/activity/ActivityXAxis';
+import SVGLine from 'components/sharedComponents/SVGLine';
 import {
     getXDomain,
     lineHelper
@@ -14,6 +15,8 @@ import { convertDateToFY } from 'helpers/fiscalYearHelper';
 import ContractGrantActivityChartVerticalLines from './ContractGrantActivityChartVerticalLines';
 import ContractGrantActivityChartCircles from './ContractGrantActivityChartCircles';
 import ContractGrantActivityChartAreaPaths from './ContractGrantActivityChartAreaPaths';
+// import ContractGrantActivityPotentialAwardAmountLine from './ContractGrantActivityChartPotentialAwardAmountLine';
+
 
 const propTypes = {
     height: PropTypes.number,
@@ -21,7 +24,8 @@ const propTypes = {
     visualizationWidth: PropTypes.number,
     transactions: PropTypes.array,
     awardType: PropTypes.string,
-    dates: PropTypes.object
+    dates: PropTypes.object,
+    totalObligation: PropTypes.number
 };
 
 const xAxisSpacingPercentage = 0.05;
@@ -33,7 +37,8 @@ const ContractGrantsActivityChart = ({
     visualizationWidth,
     transactions,
     awardType,
-    dates
+    dates,
+    totalObligation
 }) => {
     // x series
     const [xDomain, setXDomain] = useState([]);
@@ -271,7 +276,6 @@ const ContractGrantsActivityChart = ({
     const svgHeight = height + padding.bottom + 40;
     // updates the x position of our labels
     const paddingForYAxis = Object.assign(padding, { labels: 20 });
-
     return (
         <svg
             className="contract-grant-activity-chart"
@@ -324,6 +328,17 @@ const ContractGrantsActivityChart = ({
                     endLineValue={endLineValue}
                     potentialEndLineValue={potentialEndLineValue}
                     awardType={awardType} />}
+                {/* potential award amount line */}
+                {xScale && <SVGLine
+                    lineClassname="potential-award-amount-line"
+                    scale={yScale}
+                    x1={padding.left}
+                    x2={visualizationWidth}
+                    max={yDomain[1]}
+                    min={yDomain[0]}
+                    position={totalObligation}
+                    graphHeight={height}
+                    isHorizontal />}
             </g>
         </svg>
     );

--- a/src/js/components/award/shared/activity/ContractGrantActivityChartAreaPaths.jsx
+++ b/src/js/components/award/shared/activity/ContractGrantActivityChartAreaPaths.jsx
@@ -1,0 +1,300 @@
+/**
+ * ContractGrantActivityChartAreaPaths.jsx
+ * Created by Jonathan Hill 04/23/2020
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import {
+    createSteppedAreaPath,
+    filteredAndSortedLinesFirstToLast,
+    dateMatchingFirstLineValue,
+    shouldExtendAreaPathWhenLastDataPointYValueChange
+} from 'helpers/contractGrantActivityHelper';
+
+const propTypes = {
+    xScale: PropTypes.func,
+    yScale: PropTypes.func,
+    transactions: PropTypes.array,
+    height: PropTypes.number,
+    padding: PropTypes.object,
+    todayLineValue: PropTypes.number,
+    endLineValue: PropTypes.number,
+    potentialEndLineValue: PropTypes.number,
+    dates: PropTypes.object,
+    xDomain: PropTypes.array,
+    xAxisSpacing: PropTypes.number
+};
+
+const transactionPathDescription = 'A shaded light blue area moving horizontally between each transactions action date and vertically between each transactions federal action obligation difference';
+const areaPathToTodayLineDescription = 'An area path of color light blue representing an area path from the first transaction to the today line';
+const areaPathPastEndLineDescription = 'An area path of color grey representing an extension of the area path from the first end date line to the last transaction';
+
+const ContractGrantActivityChartAreaPaths = ({
+    xScale,
+    yScale,
+    transactions,
+    height,
+    padding,
+    todayLineValue,
+    endLineValue,
+    potentialEndLineValue,
+    dates,
+    xDomain,
+    xAxisSpacing
+}) => {
+    // area path
+    const [areaPath, setAreaPath] = useState('');
+    // area path extension to today line
+    const [areaPathExtensionToTodayLine, setAreaPathExtensionToToday] = useState(null);
+    // area path past end line
+    const [areaPathPastEndLine, setAreaPathPastEndLine] = useState(null);
+    // area path extension last data point y value change
+    const [
+        areaPathExtensionLastDataPointYValueChange,
+        setAreaPathExtensionLastDataPointYValueChange
+    ] = useState({
+        path: null,
+        className: '',
+        description: ''
+    });
+    // area path - hook
+    useEffect(() => {
+        if (xScale && yScale) {
+            setAreaPath(
+                createSteppedAreaPath(
+                    transactions,
+                    xScale,
+                    yScale,
+                    height,
+                    padding.left,
+                    'action_date',
+                    'running_obligation_total'
+                )
+            );
+        }
+    }, [
+        xScale,
+        yScale,
+        transactions,
+        height,
+        padding
+    ]);
+    // should we extend area path to today line
+    const shouldWeExtendAreaPathToTodayLine = useCallback(() => {
+        const lastTransaction = transactions[transactions.length - 1];
+        const todayLineIsBeforeAllEndDates = [endLineValue, potentialEndLineValue]
+            .filter((line) => line).every((line) => moment(todayLineValue).isBefore(moment(line)));
+        const everyLineIsAfterLastTransaction = filteredAndSortedLinesFirstToLast(
+            [todayLineValue, endLineValue, potentialEndLineValue]).every((line) => (
+            lastTransaction.action_date.isBefore(moment(line))
+        ));
+        if (todayLineIsBeforeAllEndDates && everyLineIsAfterLastTransaction) return true;
+        return false;
+    }, [
+        transactions,
+        todayLineValue,
+        endLineValue,
+        potentialEndLineValue
+    ]);
+    // extend area path to today
+    const extendAreaPathToTodayLine = useCallback(() => {
+        const lastTransaction = transactions[transactions.length - 1];
+        if (shouldWeExtendAreaPathToTodayLine() && xScale && yScale) {
+            setAreaPathExtensionToToday(createSteppedAreaPath(
+                [
+                    ...transactions,
+                    {
+                        action_date: dateMatchingFirstLineValue([todayLineValue, endLineValue, potentialEndLineValue], dates, todayLineValue, endLineValue),
+                        running_obligation_total: lastTransaction.running_obligation_total
+                    }
+                ],
+                xScale,
+                yScale,
+                height,
+                padding.left,
+                'action_date',
+                'running_obligation_total'
+            ));
+            setAreaPath(null);
+        }
+    }, [
+        transactions,
+        xScale,
+        yScale,
+        height,
+        padding,
+        shouldWeExtendAreaPathToTodayLine,
+        todayLineValue,
+        endLineValue,
+        potentialEndLineValue,
+        dates
+    ]);
+    // extend area path to today hook
+    useEffect(() => {
+        extendAreaPathToTodayLine();
+    }, [extendAreaPathToTodayLine]);
+    // extend aria path past end line hook
+    useEffect(() => {
+        if (!areaPathExtensionToTodayLine && xScale && yScale) {
+            const firstEndLine = filteredAndSortedLinesFirstToLast([endLineValue, potentialEndLineValue])[0];
+            // find index of first transaction after the first end line
+            const firstTransactionAfterFirstEndLineIndex = transactions.findIndex((t) => {
+                if (t.action_date.isAfter(moment(firstEndLine))) return true;
+                return false;
+            });
+            if (firstTransactionAfterFirstEndLineIndex !== -1) {
+                // isolate all transaction before the first end line
+                const transactionsBeforeFirstEndLine = transactions.slice(0, firstTransactionAfterFirstEndLineIndex);
+                // isolate all transactions after the first end line
+                const transactionsAfterFirstEndLine = transactions.slice(firstTransactionAfterFirstEndLineIndex, transactions.length);
+                const firstEndLineDate = dateMatchingFirstLineValue([endLineValue, potentialEndLineValue], dates, todayLineValue, endLineValue);
+                // create a new area path to the first endline
+                if (transactionsBeforeFirstEndLine.length) {
+                    setAreaPath(
+                        createSteppedAreaPath(
+                            [
+                                ...transactionsBeforeFirstEndLine,
+                                {
+                                    action_date: firstEndLineDate,
+                                    running_obligation_total: transactionsBeforeFirstEndLine[transactionsBeforeFirstEndLine.length - 1].running_obligation_total
+                                }
+                            ],
+                            xScale,
+                            yScale,
+                            height,
+                            padding.left,
+                            'action_date',
+                            'running_obligation_total'
+                        )
+                    );
+                }
+                // create a new area path after the first endline
+                if (transactionsAfterFirstEndLine.length) {
+                    const startingYValueForGreyShading = transactionsBeforeFirstEndLine.length ?
+                        transactionsBeforeFirstEndLine[transactionsBeforeFirstEndLine.length - 1].running_obligation_total :
+                        transactionsAfterFirstEndLine[0].running_obligation_total;
+                    setAreaPathPastEndLine(createSteppedAreaPath(
+                        [
+                            {
+                                action_date: firstEndLineDate,
+                                running_obligation_total: startingYValueForGreyShading
+                            },
+                            ...transactionsAfterFirstEndLine
+                        ],
+                        xScale,
+                        yScale,
+                        height - 0.5,
+                        padding.left,
+                        'action_date',
+                        'running_obligation_total'
+                    ));
+                }
+            }
+        }
+    }, [
+        todayLineValue,
+        endLineValue,
+        potentialEndLineValue,
+        dates,
+        xScale,
+        yScale,
+        height,
+        padding,
+        transactions,
+        areaPathExtensionToTodayLine
+    ]);
+    // extend area path when last data point y value changes
+    useEffect(() => {
+        if (shouldExtendAreaPathWhenLastDataPointYValueChange(transactions, areaPathExtensionToTodayLine) && xScale && yScale) {
+            const lastTransaction = transactions[transactions.length - 1];
+            const className = areaPathPastEndLine ? 'area-path__past-end-line' : 'area-path';
+            const colorForDescription = className === 'area-path' ? 'light blue' : 'grey';
+            const description = `An area path of color ${colorForDescription} representing an
+            extension of 0.5 pixels to the area path when the y value of the last transaction is greater than
+            the second to last transaction`;
+
+            const xAdjustment = xScale.invert(xAxisSpacing + 1) - (xDomain[0]);
+            const heightAdjustment = areaPathPastEndLine ? height - 0.5 : height;
+
+            setAreaPathExtensionLastDataPointYValueChange(
+                {
+                    path: createSteppedAreaPath(
+                        [
+                            {
+                                x: lastTransaction.action_date,
+                                y: lastTransaction.running_obligation_total
+                            },
+                            {
+                                x: moment(lastTransaction.action_date.valueOf() + xAdjustment),
+                                y: lastTransaction.running_obligation_total
+                            }
+                        ],
+                        xScale,
+                        yScale,
+                        heightAdjustment,
+                        padding.left,
+                        'x',
+                        'y'
+                    ),
+                    className,
+                    description
+                }
+            );
+        }
+        else {
+            setAreaPathExtensionLastDataPointYValueChange({ path: null, className: '', description: '' });
+        }
+    }, [
+        xScale,
+        yScale,
+        height,
+        padding,
+        areaPathPastEndLine,
+        transactions,
+        xDomain,
+        xAxisSpacing,
+        areaPathExtensionToTodayLine
+    ]);
+
+    return (
+        <g className="contract-grant-activity-chart__area-paths">
+            {/* area path */}
+            {areaPath &&
+                <g tabIndex="0">
+                    <desc>{transactionPathDescription}</desc>
+                    <path
+                        className="area-path"
+                        d={areaPath} />
+                </g>}
+            {/* extend area path to today */}
+            {areaPathExtensionToTodayLine &&
+                <g tabIndex="0">
+                    <desc>{areaPathToTodayLineDescription}</desc>
+                    <path
+                        className="area-path"
+                        d={areaPathExtensionToTodayLine} />
+                </g>}
+            {/* extend area path past end line */}
+            {areaPathPastEndLine &&
+                <g tabIndex="0">
+                    <desc>{areaPathPastEndLineDescription}</desc>
+                    <path
+                        className="area-path__past-end-line"
+                        d={areaPathPastEndLine} />
+                </g>}
+            {/* area Path Extension Last Data Point Y Value Change */}
+            {areaPathExtensionLastDataPointYValueChange.path &&
+                <g tabIndex="0">
+                    <desc>{areaPathExtensionLastDataPointYValueChange.description}</desc>
+                    <path
+                        className={areaPathExtensionLastDataPointYValueChange.className}
+                        d={areaPathExtensionLastDataPointYValueChange.path} />
+                </g>}
+        </g>
+    );
+};
+
+ContractGrantActivityChartAreaPaths.propTypes = propTypes;
+export default ContractGrantActivityChartAreaPaths;

--- a/src/js/components/award/shared/activity/ContractGrantActivityChartCircles.jsx
+++ b/src/js/components/award/shared/activity/ContractGrantActivityChartCircles.jsx
@@ -3,26 +3,55 @@
  * Created by Jonathan Hill 04/23/2020
  */
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { formatMoney } from 'helpers/moneyFormatter';
 
 const propTypes = {
-    circles: PropTypes.arrayOf(PropTypes.shape({
-        key: PropTypes.string,
-        description: PropTypes.string,
-        className: PropTypes.string,
-        cx: PropTypes.number,
-        cy: PropTypes.number,
-        r: PropTypes.number
-    }))
+    transactions: PropTypes.array,
+    padding: PropTypes.object,
+    xScale: PropTypes.func,
+    yScale: PropTypes.func,
+    xAxisSpacing: PropTypes.number,
+    height: PropTypes.number
 };
 
-const ContractGrantActivityChartCircles = ({ circles }) => {
-    if (!circles.length) return null;
+const ContractGrantActivityChartCircles = ({
+    transactions,
+    padding,
+    xScale,
+    yScale,
+    xAxisSpacing,
+    height
+}) => {
+    // circle data
+    const [circleData, setCircleData] = useState([]);
+    // sets circle data - hook - on mount and when transactions change
+    useEffect(() => {
+        if (xScale && yScale) {
+            const circles = transactions
+                .map((data, i) => ({
+                    key: `${data.federal_action_obligation}${i}`,
+                    description: `A circle representing the transaction date, ${data.action_date.format('MM-DD-YYYY')} and running total obligation of ${formatMoney(data.running_obligation_total)}`,
+                    className: 'transaction-date-circle',
+                    cx: xScale(data.action_date.valueOf()) + padding.left,
+                    cy: (height - yScale(data.running_obligation_total)),
+                    r: 1.5
+                }));
+            setCircleData(circles);
+        }
+    }, [
+        transactions,
+        padding,
+        xScale,
+        yScale,
+        xAxisSpacing,
+        height
+    ]);
     return (
         <g className="contract-grant-activity-chart__circles">
             {
-                circles.map((circle) => {
+                circleData.map((circle) => {
                     const {
                         key,
                         description,

--- a/src/js/components/award/shared/activity/ContractGrantActivityChartCircles.jsx
+++ b/src/js/components/award/shared/activity/ContractGrantActivityChartCircles.jsx
@@ -1,0 +1,51 @@
+/**
+ * ContractGrantActivityChartCircles.jsx
+ * Created by Jonathan Hill 04/23/2020
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+    circles: PropTypes.arrayOf(PropTypes.shape({
+        key: PropTypes.string,
+        description: PropTypes.string,
+        className: PropTypes.string,
+        cx: PropTypes.number,
+        cy: PropTypes.number,
+        r: PropTypes.number
+    }))
+};
+
+const ContractGrantActivityChartCircles = ({ circles }) => {
+    if (!circles.length) return null;
+    return (
+        <g className="contract-grant-activity-chart__circles">
+            {
+                circles.map((circle) => {
+                    const {
+                        key,
+                        description,
+                        className,
+                        cx,
+                        cy,
+                        r
+                    } = circle;
+                    return (
+                        <g key={key} tabIndex="0">
+                            <desc>{description}</desc>
+                            <circle
+                                className={className}
+                                cx={cx}
+                                cy={cy}
+                                r={r} />
+                        </g>
+                    );
+                })
+            }
+        </g>
+    );
+};
+
+ContractGrantActivityChartCircles.propTypes = propTypes;
+export default ContractGrantActivityChartCircles;

--- a/src/js/components/award/shared/activity/ContractGrantActivityChartVerticalLines.jsx
+++ b/src/js/components/award/shared/activity/ContractGrantActivityChartVerticalLines.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import VerticalLine from 'components/sharedComponents/VerticalLine';
+import SVGLine from 'components/sharedComponents/SVGLine';
 
 const propTypes = {
     xScale: PropTypes.func,
@@ -58,65 +58,65 @@ const ContractGrantActivityChartVerticalLines = ({
     return (
         <g className="contract-grant-activity-chart__vertical-lines">
             {/* start line */}
-            {xScale && <VerticalLine
-                xScale={xScale}
+            {xScale && <SVGLine
+                scale={xScale}
                 y1={-10}
                 y2={height}
                 textY={0}
                 text="Start"
                 description={descriptions[0]}
-                xMax={xDomain[1]}
-                xMin={xDomain[0]}
-                xValue={startLineValue}
+                max={xDomain[1]}
+                min={xDomain[0]}
+                position={startLineValue}
                 showTextPosition="right"
                 adjustmentX={padding.left}
-                textClassname="vertical-line__text start"
-                lineClassname="vertical-line start" />}
+                textClassname="start"
+                lineClassname="start" />}
             {/* today line */}
-            {xScale && <VerticalLine
-                xScale={xScale}
+            {xScale && <SVGLine
+                scale={xScale}
                 y1={-10}
                 y2={height}
                 textY={0}
                 text="Today"
                 description={descriptions[1]}
-                xMax={xDomain[1]}
-                xMin={xDomain[0]}
-                xValue={todayLineValue}
+                max={xDomain[1]}
+                min={xDomain[0]}
+                position={todayLineValue}
                 showTextPosition="left"
                 adjustmentX={padding.left}
-                textClassname="vertical-line__text today"
-                lineClassname="vertical-line today" />}
+                textClassname="today"
+                lineClassname="today" />}
             {/* end line */}
-            {xScale && <VerticalLine
-                xScale={xScale}
+            {xScale && <SVGLine
+                scale={xScale}
                 y1={-10}
                 y2={height}
                 textY={0}
                 text={endLineText}
                 description={descriptions[2]}
-                xMax={xDomain[1]}
-                xMin={xDomain[0]}
-                xValue={endLineValue}
+                max={xDomain[1]}
+                min={xDomain[0]}
+                position={endLineValue}
                 showTextPosition="left"
                 adjustmentX={padding.left}
-                textClassname={`vertical-line__text ${endLineClassName}`}
-                lineClassname={`vertical-line ${endLineClassName}`} />}
+                textClassname={`${endLineClassName}`}
+                lineClassname={`${endLineClassName}`} />}
             {/* potential end line */}
-            {xScale && <VerticalLine
-                xScale={xScale}
+            {xScale && <SVGLine
+                scale={xScale}
                 y1={-10}
                 y2={height}
                 textY={0}
                 text="Potential End"
                 description={descriptions[3]}
-                xMax={xDomain[1]}
-                xMin={xDomain[0]}
-                xValue={potentialEndLineValue}
+                max={xDomain[1]}
+                min={xDomain[0]}
+                position={potentialEndLineValue}
                 showTextPosition="left"
                 adjustmentX={padding.left}
-                textClassname="vertical-line__text potential-end"
-                lineClassname="vertical-line potential-end" />}
+                textClassname="potential-end"
+                lineClassname="potential-end" />}
         </g>
     );
 };

--- a/src/js/components/award/shared/activity/ContractGrantActivityChartVerticalLines.jsx
+++ b/src/js/components/award/shared/activity/ContractGrantActivityChartVerticalLines.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 import VerticalLine from 'components/sharedComponents/VerticalLine';
 
 const propTypes = {
@@ -34,6 +35,26 @@ const ContractGrantActivityChartVerticalLines = ({
     const endLineText = awardType === 'grant' ? 'End' : 'Current End';
     // class name for end line and text
     const endLineClassName = awardType === 'grant' ? 'grant-end' : 'contract-end';
+    const lineData = [
+        {
+            text: 'Start Date',
+            date: startLineValue
+        },
+        {
+            text: 'Todays Date',
+            date: todayLineValue
+        },
+        {
+            text: 'End Date',
+            date: endLineValue
+        },
+        {
+            text: 'Potential End Date',
+            date: potentialEndLineValue
+        }
+    ];
+    const descriptions = [startLineValue, todayLineValue, endLineValue, potentialEndLineValue]
+        .map((line, i) => `A vertical line representing the ${lineData[i].text}, ${moment(lineData[i].date).format("dddd, MMMM Do YYYY") || ''}`);
     return (
         <g className="contract-grant-activity-chart__vertical-lines">
             {/* start line */}
@@ -43,6 +64,7 @@ const ContractGrantActivityChartVerticalLines = ({
                 y2={height}
                 textY={0}
                 text="Start"
+                description={descriptions[0]}
                 xMax={xDomain[1]}
                 xMin={xDomain[0]}
                 xValue={startLineValue}
@@ -57,6 +79,7 @@ const ContractGrantActivityChartVerticalLines = ({
                 y2={height}
                 textY={0}
                 text="Today"
+                description={descriptions[1]}
                 xMax={xDomain[1]}
                 xMin={xDomain[0]}
                 xValue={todayLineValue}
@@ -71,6 +94,7 @@ const ContractGrantActivityChartVerticalLines = ({
                 y2={height}
                 textY={0}
                 text={endLineText}
+                description={descriptions[2]}
                 xMax={xDomain[1]}
                 xMin={xDomain[0]}
                 xValue={endLineValue}
@@ -85,6 +109,7 @@ const ContractGrantActivityChartVerticalLines = ({
                 y2={height}
                 textY={0}
                 text="Potential End"
+                description={descriptions[3]}
                 xMax={xDomain[1]}
                 xMin={xDomain[0]}
                 xValue={potentialEndLineValue}

--- a/src/js/components/award/shared/activity/ContractGrantActivityChartVerticalLines.jsx
+++ b/src/js/components/award/shared/activity/ContractGrantActivityChartVerticalLines.jsx
@@ -1,0 +1,100 @@
+/**
+ * ContractGrantActivityChartVerticalLines.jsx
+ * Created by Jonathan Hill 04/23/2020
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import VerticalLine from 'components/sharedComponents/VerticalLine';
+
+const propTypes = {
+    xScale: PropTypes.func,
+    height: PropTypes.number,
+    xDomain: PropTypes.array,
+    padding: PropTypes.object,
+    startLineValue: PropTypes.number,
+    todayLineValue: PropTypes.number,
+    endLineValue: PropTypes.number,
+    potentialEndLineValue: PropTypes.number,
+    awardType: PropTypes.string
+};
+
+const ContractGrantActivityChartVerticalLines = ({
+    xScale,
+    height,
+    xDomain,
+    padding,
+    startLineValue,
+    todayLineValue,
+    endLineValue,
+    potentialEndLineValue,
+    awardType
+}) => {
+    // text for end line
+    const endLineText = awardType === 'grant' ? 'End' : 'Current End';
+    // class name for end line and text
+    const endLineClassName = awardType === 'grant' ? 'grant-end' : 'contract-end';
+    return (
+        <g className="contract-grant-activity-chart__vertical-lines">
+            {/* start line */}
+            {xScale && <VerticalLine
+                xScale={xScale}
+                y1={-10}
+                y2={height}
+                textY={0}
+                text="Start"
+                xMax={xDomain[1]}
+                xMin={xDomain[0]}
+                xValue={startLineValue}
+                showTextPosition="right"
+                adjustmentX={padding.left}
+                textClassname="vertical-line__text start"
+                lineClassname="vertical-line start" />}
+            {/* today line */}
+            {xScale && <VerticalLine
+                xScale={xScale}
+                y1={-10}
+                y2={height}
+                textY={0}
+                text="Today"
+                xMax={xDomain[1]}
+                xMin={xDomain[0]}
+                xValue={todayLineValue}
+                showTextPosition="left"
+                adjustmentX={padding.left}
+                textClassname="vertical-line__text today"
+                lineClassname="vertical-line today" />}
+            {/* end line */}
+            {xScale && <VerticalLine
+                xScale={xScale}
+                y1={-10}
+                y2={height}
+                textY={0}
+                text={endLineText}
+                xMax={xDomain[1]}
+                xMin={xDomain[0]}
+                xValue={endLineValue}
+                showTextPosition="left"
+                adjustmentX={padding.left}
+                textClassname={`vertical-line__text ${endLineClassName}`}
+                lineClassname={`vertical-line ${endLineClassName}`} />}
+            {/* potential end line */}
+            {xScale && <VerticalLine
+                xScale={xScale}
+                y1={-10}
+                y2={height}
+                textY={0}
+                text="Potential End"
+                xMax={xDomain[1]}
+                xMin={xDomain[0]}
+                xValue={potentialEndLineValue}
+                showTextPosition="left"
+                adjustmentX={padding.left}
+                textClassname="vertical-line__text potential-end"
+                lineClassname="vertical-line potential-end" />}
+        </g>
+    );
+};
+
+ContractGrantActivityChartVerticalLines.propTypes = propTypes;
+export default ContractGrantActivityChartVerticalLines;

--- a/src/js/components/sharedComponents/SVGLine.jsx
+++ b/src/js/components/sharedComponents/SVGLine.jsx
@@ -173,7 +173,7 @@ export default class SVGLine extends Component {
     }
 
     description = () => (this.props.description ||
-        `A ${this.props.isHorizontal ? 'horizontal' : 'vertical'} line representing today\'s date`);
+        `A ${this.props.isHorizontal ? 'horizontal' : 'vertical'} line representing today's date`);
     render() {
         const line = this.line();
         const text = this.text(line);

--- a/src/js/components/sharedComponents/SVGLine.jsx
+++ b/src/js/components/sharedComponents/SVGLine.jsx
@@ -1,5 +1,5 @@
 /**
- * VerticalLine.jsx
+ * VerticalLine.jsx -> SVGLine.jsx
  * Created by Jonathan Hill 07/05/19
  **/
 
@@ -8,25 +8,30 @@ import PropTypes from 'prop-types';
 import { throttle } from 'lodash';
 
 const propTypes = {
-    xScale: PropTypes.func, // function to set line position
+    scale: PropTypes.func, // function to set line position
     text: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.array
     ]), // text to display with line
-    y1: PropTypes.number, // top of graph
-    y2: PropTypes.number, // bottom of graph
-    xMax: PropTypes.number, // max possible value of x
-    xMin: PropTypes.number, // max possible value of x
-    xValue: PropTypes.number, // actual value of x
+    y1: PropTypes.number, // end of line - vertical
+    y2: PropTypes.number, // start of line - vertical
+    x1: PropTypes.number, // start of line - horizontal
+    x2: PropTypes.number, // end of line - horizontal
+    min: PropTypes.number, // max possible value of x or y
+    max: PropTypes.number, // max possible value of x or y
+    position: PropTypes.number, // value of position
     showTextPosition: PropTypes.string, // show text left, right, and top are valid
     textY: PropTypes.number, // show text at this height
     description: PropTypes.string,
     adjustmentX: PropTypes.number, // adjust x for padding
     textClassname: PropTypes.string,
-    lineClassname: PropTypes.string
+    lineClassname: PropTypes.string,
+    noText: PropTypes.bool, // do not show text,
+    isHorizontal: PropTypes.bool,
+    graphHeight: PropTypes.number
 };
 
-export default class VerticalLine extends Component {
+export default class SVGLine extends Component {
     constructor(props) {
         super(props);
 
@@ -52,6 +57,30 @@ export default class VerticalLine extends Component {
     componentWillUnmount() {
         window.removeEventListener('resize', this.handleWindowResize);
     }
+
+    getLinePosition = () => {
+        const {
+            isHorizontal,
+            graphHeight,
+            position,
+            adjustmentX,
+            scale
+        } = this.props;
+        if (isHorizontal) return graphHeight - scale(position);
+        return scale(position) + (adjustmentX || 0);
+    }
+
+    getMaximum = () => {
+        const {
+            isHorizontal,
+            graphHeight,
+            scale,
+            max,
+            adjustmentX
+        } = this.props;
+        if (isHorizontal) return graphHeight - scale(max);
+        return scale(max) + (adjustmentX || 0);
+    }
     // since we set the position of the text we need to update it on window resize
     handleWindowResize = throttle(() => {
         const windowWidth = window.innerWidth;
@@ -65,13 +94,15 @@ export default class VerticalLine extends Component {
 
     positionText = (text) => {
         const {
-            xScale,
-            xValue,
+            scale,
+            position,
             showTextPosition,
             textY,
-            adjustmentX
+            adjustmentX,
+            noText
         } = this.props;
-        let positionX = xScale(xValue || Date.now()) + (adjustmentX || 0);
+        if (noText) return null;
+        let positionX = scale(position || Date.now()) + (adjustmentX || 0);
         let modifiedTextY = textY;
         // the text div starts null since React only calls the callback ref function
         // when the DOM draws the element, without this you will get an error since
@@ -91,34 +122,34 @@ export default class VerticalLine extends Component {
                 modifiedTextY += (textDivDimensions.height * (parseInt(wordIndex, 10)));
             }
         }
-        this.setState({ [`${text}TextX`]: positionX, [`${text}TextY`]: modifiedTextY });
+        return this.setState({ [`${text}TextX`]: positionX, [`${text}TextY`]: modifiedTextY });
     }
 
-    verticalLine = () => {
+    line = () => {
         const {
-            xMin,
-            xMax,
-            xValue,
-            xScale,
-            adjustmentX,
+            min,
+            position,
+            scale,
+            x1,
+            x2,
             y1,
             y2,
-            lineClassname
+            lineClassname,
+            isHorizontal
         } = this.props;
-        if (!xValue) return null;
-        const linePosition = xScale(xValue) + (adjustmentX || 0);
-        // get x position of minimum
-        const minimumX = xScale(xMin);
-        // get x position of maximum
-        const maximumX = xScale(xMax) + (adjustmentX || 0);
-        if ((linePosition > maximumX) || (linePosition < minimumX)) return null;
+        if (!position) return null;
+        const linePosition = this.getLinePosition();
+        const minimum = scale(min);
+        const maximum = this.getMaximum();
+        if ((linePosition > maximum) || (linePosition < minimum)) return null;
+        const classname = lineClassname ? `svg-line ${lineClassname}` : 'svg-line';
         return (
             <line
-                className={lineClassname || "vertical-line"}
-                x1={linePosition}
-                x2={linePosition}
-                y1={y1}
-                y2={y2} />
+                className={classname}
+                x1={isHorizontal ? x1 : linePosition}
+                x2={isHorizontal ? x2 : linePosition}
+                y1={isHorizontal ? linePosition : y1}
+                y2={isHorizontal ? linePosition : y2} />
         );
     }
 
@@ -126,11 +157,12 @@ export default class VerticalLine extends Component {
         const { text, textClassname } = this.props;
         if (!lineIsDisplayed || !text) return null;
         const textArray = Array.isArray(text) ? text : [text];
+        const classname = textClassname ? `svg-line__text ${textClassname}` : 'svg-line__text';
         return textArray.map((data, i) => (
             <text
                 key={data}
                 tabIndex="0"
-                className={textClassname || "vertical-line__text"}
+                className={classname}
                 x={this.state[`${data}TextX`]}
                 y={this.state[`${data}TextY`]}
                 ref={this[`setTextDiv${data}`]}
@@ -140,19 +172,19 @@ export default class VerticalLine extends Component {
         ));
     }
 
+    description = () => (this.props.description ||
+        `A ${this.props.isHorizontal ? 'horizontal' : 'vertical'} line representing today\'s date`);
     render() {
-        // show nothing if not within x Range
-        const verticalLine = this.verticalLine();
-        const text = this.text(verticalLine);
-        const description = this.props.description || 'A vertical line representing today\'s date';
+        const line = this.line();
+        const text = this.text(line);
         return (
-            <g className="vertical-line__container" tabIndex="0">
-                <desc>{description}</desc>
+            <g className="svg-line__container" tabIndex="0">
+                <desc>{this.description()}</desc>
                 {text}
-                {verticalLine}
+                {line}
             </g>
         );
     }
 }
 
-VerticalLine.propTypes = propTypes;
+SVGLine.propTypes = propTypes;

--- a/src/js/components/sharedComponents/VerticalLine.jsx
+++ b/src/js/components/sharedComponents/VerticalLine.jsx
@@ -105,6 +105,7 @@ export default class VerticalLine extends Component {
             y2,
             lineClassname
         } = this.props;
+        if (!xValue) return null;
         const linePosition = xScale(xValue) + (adjustmentX || 0);
         // get x position of minimum
         const minimumX = xScale(xMin);

--- a/src/js/components/sharedComponents/VerticalLine.jsx
+++ b/src/js/components/sharedComponents/VerticalLine.jsx
@@ -128,6 +128,7 @@ export default class VerticalLine extends Component {
         return textArray.map((data, i) => (
             <text
                 key={data}
+                tabIndex="0"
                 className={textClassname || "vertical-line__text"}
                 x={this.state[`${data}TextX`]}
                 y={this.state[`${data}TextY`]}
@@ -144,7 +145,7 @@ export default class VerticalLine extends Component {
         const text = this.text(verticalLine);
         const description = this.props.description || 'A vertical line representing today\'s date';
         return (
-            <g className="vertical-line__container">
+            <g className="vertical-line__container" tabIndex="0">
                 <desc>{description}</desc>
                 {text}
                 {verticalLine}

--- a/src/js/containers/award/shared/ContractGrantActivityContainer.jsx
+++ b/src/js/containers/award/shared/ContractGrantActivityContainer.jsx
@@ -19,10 +19,16 @@ import {
 const propTypes = {
     awardId: PropTypes.string,
     awardType: PropTypes.string,
-    dates: PropTypes.object
+    dates: PropTypes.object,
+    totalObligation: PropTypes.number
 };
 
-const ContractGrantActivityContainer = ({ awardId, awardType, dates }) => {
+const ContractGrantActivityContainer = ({
+    awardId,
+    awardType,
+    dates,
+    totalObligation
+}) => {
     // bad dates
     const [badDates, setBadDates] = useState(false);
     // loading
@@ -214,7 +220,8 @@ const ContractGrantActivityContainer = ({ awardId, awardType, dates }) => {
                 <ContractGrantActivity
                     transactions={transactions}
                     dates={dates}
-                    awardType={awardType} />
+                    awardType={awardType}
+                    totalObligation={totalObligation} />
             );
         }
         return null;


### PR DESCRIPTION
**High level description:**

Implement the Potential Award Amount Line for the Contract Grants Activity Chart.

**Technical details:**

> • refactor vertical line component into svg line

> • confirmed with design no text.

**JIRA Ticket:**
[DEV-4556](https://federal-spending-transparency.atlassian.net/browse/DEV-4556)

**Mockup:**
https://bahdigital.invisionapp.com/share/7HIADD8Q53D#/screens/296034817

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension) Test with award, 66945037, in dev and local.  A decrease was viewed from 60 errors in dev to 58 errors locally.
- [N/A] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
