### PR TITLE
[DEV-4528] Adding Recursion and a few Helpers to Clean Up Logic

### DIFF
--- a/src/js/containers/search/filters/naics/NAICSContainer.jsx
+++ b/src/js/containers/search/filters/naics/NAICSContainer.jsx
@@ -197,19 +197,24 @@ export class NAICSContainer extends React.Component {
     }
 
     onUncheck = (newChecked, uncheckedNode) => {
-        const [stagedNaicsFilters, newUnchecked] = decrementNaicsCountAndUpdateUnchecked(
-            uncheckedNode,
-            this.props.unchecked,
-            this.props.checked,
-            this.state.stagedNaicsFilters,
-            this.props.nodes
-        );
+        if (uncheckedNode.checked) {
+            this.onCheck(newChecked);
+        }
+        else {
+            const [stagedNaicsFilters, newUnchecked] = decrementNaicsCountAndUpdateUnchecked(
+                uncheckedNode,
+                this.props.unchecked,
+                this.props.checked,
+                this.state.stagedNaicsFilters,
+                this.props.nodes
+            );
 
-        this.props.setUncheckedNaics(newUnchecked);
-        this.props.stageNaics(newChecked, newUnchecked, stagedNaicsFilters);
-        this.props.setCheckedNaics(newChecked);
+            this.props.setUncheckedNaics(newUnchecked);
+            this.props.stageNaics(newChecked, newUnchecked, stagedNaicsFilters);
+            this.props.setCheckedNaics(newChecked);
 
-        this.setState({ stagedNaicsFilters });
+            this.setState({ stagedNaicsFilters });
+        }
     }
 
     onExpand = (value, expanded, fetch) => {

--- a/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
@@ -15,7 +15,10 @@ import {
     getPscNodeFromTree
 } from 'helpers/pscHelper';
 import { fetchPsc } from 'helpers/searchHelper';
-import { removePlaceholderString } from 'helpers/checkboxTreeHelper';
+import {
+    getAllDescendants,
+    removePlaceholderString
+} from 'helpers/checkboxTreeHelper';
 
 import {
     setPscNodes,
@@ -172,7 +175,7 @@ export class PSCCheckboxTreeContainer extends React.Component {
                 const node = getPscNodeFromTree(nodes, expandedAndChecked);
                 return [
                     ...acc,
-                    ...expandPscNodeAndAllDescendantParents([node])
+                    ...getAllDescendants(node)
                 ];
             }, []);
 

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -57,7 +57,7 @@ export const removePlaceholderString = (str) => {
 };
 
 export const getAllDescendants = (node) => {
-    if (!node.children) return [node.value];
+    if (!node.children || node?.children?.length === 0) return [node.value];
     return [
         ...node.children
             .reduce((acc, descendant) => ([...acc, ...getAllDescendants(descendant)]), [])

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -695,7 +695,7 @@ export const showAllNodes = (tree) => tree
                 .map((child) => ({
                     ...child,
                     className: '',
-                    children: Object.keys(child).includes('children') ? showAllNodes(child.children) : []
+                    children: child?.children?.length > 0 ? showAllNodes(child.children) : []
                 }))
                 .sort(sortNodesByValue)
             : []

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -564,6 +564,7 @@ export const populateBranchOrLeafLevelNodes = (
                     ? node.children
                         .map((child) => {
                             if (child.value === key) {
+                                debugger;
                                 const isPopulated = (
                                     child.children.length === child.count &&
                                     !child.children.some((grandChild) => grandChild.isPlaceHolder)

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -355,23 +355,42 @@ export const expandNodeAndAllDescendantParents = (nodes, propForNode = 'value', 
         .reduce(getValue, []);
 };
 
-const shouldAddPlaceholder = (count, children) => {
+const addPlaceholder = (children, parentValue, hide = true) => {
+    const placeHolderExists = children.some((child) => child.isPlaceHolder);
+    if (placeHolderExists) return children;
+    return children.concat([{
+        isPlaceHolder: true,
+        label: 'Child Placeholder',
+        value: `children_of_${parentValue}`,
+        className: hide ? 'hide' : ''
+    }]);
+};
+
+const removePlaceHolders = (children) => children.filter((child) => !child.isPlaceHolder);
+
+const areChildrenPartial = (count, children) => {
+    if (!children) return false;
     const sumOfAllChildren = children
         .filter((child) => !child.isPlaceHolder)
         .reduce((acc, child) => {
             const childCount = child.count || 1;
             return acc + childCount;
         }, 0);
-    return (
-        sumOfAllChildren < count &&
-        !children.some((child) => child.isPlaceHolder)
-    );
+    return sumOfAllChildren < count;
 };
 
+/**
+ * NOTE: This fn is only used to populate the checkbox tree w/ search results. It handles the complexity of how to add new children w/o removing existing children or necessary placeholders to represent a partial tree
+ * @param {<Object>} parentFromSearch an object representing part of the search results
+ * @param {<Object>} existingParent an object representing the tree
+ * @returns {Array.<Object>} a new array of Objects representing "merged" children constituting:
+ * (a) the nodes from search results
+ * (b) the pre-existing nodes not apart of search results that are hidden via the className obj property w/ the value "hide"
+ * (c) placeholder nodes to represent the presence of partial children
+*/
 export const mergeChildren = (parentFromSearch, existingParent) => {
-    // 1. hide node not in search
-    // 2. add placeholders if not there
     if (existingParent.children && parentFromSearch.children) {
+        // Hide all existing children by default.
         const existingChildArray = existingParent
             .children
             .map((node) => ({ ...node, className: 'hide' }));
@@ -382,11 +401,11 @@ export const mergeChildren = (parentFromSearch, existingParent) => {
                     .findIndex((existingChild) => existingChild.value === searchChild.value);
 
                 if (existingChildIndex !== -1) {
-                    // show this child
                     const existingChild = acc[existingChildIndex];
+                    // Show existingChildren if they are in the search results.
                     existingChild.className = '';
                     if (existingChild.children) {
-                        // hide this child's children
+                        // Hide this node's children.
                         existingChild.children = existingChild.children.map((grand) => ({ ...grand, className: 'hide' }));
                     }
 
@@ -397,8 +416,8 @@ export const mergeChildren = (parentFromSearch, existingParent) => {
                                     .findIndex((existingGC) => existingGC.value === searchGrandChild.value);
 
                                 if (existingGrandChildIndex !== -1) {
-                                    // unless it's in the search array
                                     const existingGrandChild = existingChild.children[existingGrandChildIndex];
+                                    // Show the existingGrandChildren if they are also in the search array.
                                     existingGrandChild.className = '';
                                     const isParent = (
                                         Object.keys(existingGrandChild).includes('children') &&
@@ -410,32 +429,28 @@ export const mergeChildren = (parentFromSearch, existingParent) => {
                                                 const greatGrandIsInSearchResults = searchGrandChild.children
                                                     .some((nodeFromSearch) => nodeFromSearch.value === greatGrand.value);
                                                 if (greatGrandIsInSearchResults) return { ...greatGrand, className: '' };
+                                                // Hide the greatGrandChildren if they are not in the search results array.
                                                 return { ...greatGrand, className: 'hide' };
                                             });
-                                        const needsPlaceholder = shouldAddPlaceholder(
+                                        const needsPlaceholder = areChildrenPartial(
                                             existingGrandChild.count,
                                             existingGrandChild.children.concat(searchGrandChild.children)
                                         );
                                         if (needsPlaceholder) {
-                                            existingGrandChild.children.push({
-                                                isPlaceHolder: true,
-                                                label: "Child Placeholder",
-                                                value: `children_of_${existingGrandChild.value}`,
-                                                className: 'hide'
-                                            });
+                                            existingGrandChild.children = addPlaceholder(existingGrandChild.children, existingGrandChild.value);
                                         }
                                     }
                                 }
                                 else {
-                                    // or we're adding a new node.
+                                    // No existingChild to hide, just add it.
                                     acc[existingChildIndex].children.push(searchGrandChild);
                                 }
                             });
                     }
                     return acc;
                 }
-                // child added via search
-                if (shouldAddPlaceholder(searchChild.count, searchChild.children)) {
+                // searchChild is completely new, add it w/ a placeholder.
+                if (areChildrenPartial(searchChild.count, searchChild.children)) {
                     acc.push({
                         ...searchChild,
                         children: [
@@ -449,6 +464,7 @@ export const mergeChildren = (parentFromSearch, existingParent) => {
                         ]
                     });
                 }
+                // searchChild is completely new and fully populated with children, add it w/o a placeholder.
                 else {
                     acc.push({
                         ...searchChild,
@@ -478,6 +494,14 @@ export const mergeChildren = (parentFromSearch, existingParent) => {
     return [];
 };
 
+/**
+ * NOTE: This fn is only used to populate the checkbox tree w/ search results. It is not used to populate the tree from a dynamic expand from the user traversing the tree manually.
+ * @param tree an array of objects
+ * @param searchResults the code/value/id of the tree branch to populate
+ * @param traverseTreeByCodeFn a fn used to get any node in the tree by the code/value/id of the node
+ * @param sortNodes a fn used to sort the nodes after they've been added
+ * @returns a new array of objects with the newNodes appended to the right place
+*/
 export const addSearchResultsToTree = (
     tree,
     searchResults,
@@ -500,7 +524,15 @@ export const addSearchResultsToTree = (
         })
         .sort(sortNodes);
 };
-
+/**
+ * NOTE: This fn is only used to populate the checkbox tree on expand. It is not used to populate the tree with search results.
+ * @param tree an array of objects
+ * @param key the code/value/id of the tree branch to populate
+ * @param newNodes the branch/leaf nodes
+ * @param getHighestAncestorCode a fn used to get the highest ancestor of any node in the tree
+ * @param traverseTreeByCodeFn a fn used to get any node in the tree by the code/value/id of the node
+ * @returns a new array of objects with the newNodes appended to the right place
+*/
 export const populateBranchOrLeafLevelNodes = (
     tree,
     key = '',
@@ -564,18 +596,16 @@ export const populateBranchOrLeafLevelNodes = (
                     ? node.children
                         .map((child) => {
                             if (child.value === key) {
-                                debugger;
-                                const isPopulated = (
-                                    child.children.length === child.count &&
-                                    !child.children.some((grandChild) => grandChild.isPlaceHolder)
-                                );
-                                if (isPopulated) {
-                                    // we already have the child data for this particular child, don't overwrite it w/ a placeholder.
-                                    return child;
+                                if (areChildrenPartial(child.count, child.children)) {
+                                    return {
+                                        ...child,
+                                        children: data.children
+                                    };
                                 }
+                                // we already have the data for this child, don't overwrite it w/ a node that has placeholder children.
                                 return {
                                     ...child,
-                                    children: data.children
+                                    children: removePlaceHolders(child.children)
                                 };
                             }
                             const isParent = Object.keys(child).includes('children');
@@ -662,19 +692,11 @@ export const showAllNodes = (tree) => tree
         className: '',
         children: node.children
             ? node.children
-                .map((child) => {
-                    if (child.children && child.children.some((grand) => grand.className === 'hide')) {
-                        return {
-                            ...child,
-                            className: '',
-                            children: child.children.map((grand) => ({ ...grand, className: '' }))
-                        };
-                    }
-                    return {
-                        ...child,
-                        className: ''
-                    };
-                })
+                .map((child) => ({
+                    ...child,
+                    className: '',
+                    children: Object.keys(child).includes('children') ? showAllNodes(child.children) : []
+                }))
                 .sort(sortNodesByValue)
             : []
     }));

--- a/tests/containers/search/filters/naics/mockNaics_v2.js
+++ b/tests/containers/search/filters/naics/mockNaics_v2.js
@@ -115,6 +115,90 @@ export const treeWithPlaceholdersAndRealData = [
     }
 ];
 
+export const treeWithPlaceholdersAndRealDataPSCDepth = [
+    {
+        value: '11',
+        naics: '11',
+        naics_description: 'Agriculture, Forestry, Fishing and Hunting',
+        count: 64,
+        children: [
+            {
+                value: "1111",
+                naics: "1111",
+                naics_description: "Oilseed and Grain Farming",
+                count: 8,
+                children: [
+                    {
+                        naics: "111110",
+                        value: "111110",
+                        naics_description: "Soybean Farming",
+                        count: 0
+                    },
+                    {
+                        value: "111120",
+                        naics: "111120",
+                        naics_description: "Oilseed (except Soybean) Farming",
+                        count: 20,
+                        children: [
+                            {
+                                value: 'dont-overwrite-me',
+                                naics_description: 'real'
+                            },
+                            {
+                                value: 'children_of_111120',
+                                naics_description: 'psc-depth not realistic naics data',
+                                isPlaceHolder: true
+                            }
+                        ]
+                    },
+                    {
+                        naics: "111130",
+                        value: "111130",
+                        naics_description: "Dry Pea and Bean Farming",
+                        count: 0
+                    },
+                    {
+                        naics: "111140",
+                        value: "111140",
+                        naics_description: "Wheat Farming",
+                        count: 0
+                    },
+                    {
+                        naics: "111150",
+                        value: "111150",
+                        naics_description: "Corn Farming",
+                        count: 0
+                    },
+                    {
+                        naics: "111160",
+                        value: "111160",
+                        naics_description: "Rice Farming",
+                        count: 0
+                    },
+                    {
+                        naics: "111191",
+                        value: "111191",
+                        naics_description: "Oilseed and Grain Combination Farming",
+                        count: 0
+                    },
+                    {
+                        naics: "111199",
+                        value: "111199",
+                        naics_description: "All Other Grain Farming",
+                        count: 0
+                    }
+                ]
+            },
+            {
+                value: "children_of_11",
+                naics: "children_of_11",
+                isPlaceHolder: true,
+                count: 0
+            }
+        ]
+    }
+];
+
 export const reallyBigTree = [
     {
         naics: "11",
@@ -180,7 +264,6 @@ export const reallyBigTree = [
                         naics_description: "All Other Grain Farming",
                         count: 0
                     }
-     
                 ]
             },
             {

--- a/tests/containers/search/filters/naics/mockNaics_v2.js
+++ b/tests/containers/search/filters/naics/mockNaics_v2.js
@@ -106,8 +106,8 @@ export const treeWithPlaceholdersAndRealData = [
                 ]
             },
             {
-                value: "children_of_1112",
-                naics: "children_of_1112",
+                value: "children_of_11",
+                naics: "children_of_11",
                 isPlaceHolder: true,
                 count: 0
             }
@@ -138,7 +138,11 @@ export const reallyBigTree = [
                         naics: "111120",
                         value: "111120",
                         naics_description: "Oilseed (except Soybean) Farming",
-                        count: 0
+                        count: 1,
+                        children: [{
+                            value: 'great grandchild',
+                            naics_description: 'This will never happen with NAICS; its a test for PSC'
+                        }]
                     },
                     {
                         naics: "111130",

--- a/tests/containers/search/filters/naics/mockNaics_v2.js
+++ b/tests/containers/search/filters/naics/mockNaics_v2.js
@@ -141,10 +141,12 @@ export const treeWithPlaceholdersAndRealDataPSCDepth = [
                         count: 20,
                         children: [
                             {
+                                naics: 'dont-overwrite-me',
                                 value: 'dont-overwrite-me',
                                 naics_description: 'real'
                             },
                             {
+                                naics: 'children_of_111120',
                                 value: 'children_of_111120',
                                 naics_description: 'psc-depth not realistic naics data',
                                 isPlaceHolder: true
@@ -224,6 +226,7 @@ export const reallyBigTree = [
                         naics_description: "Oilseed (except Soybean) Farming",
                         count: 1,
                         children: [{
+                            naics: 'great grandchild',
                             value: 'great grandchild',
                             naics_description: 'This will never happen with NAICS; its a test for PSC'
                         }]

--- a/tests/containers/search/filters/naics/mockNaics_v2.js
+++ b/tests/containers/search/filters/naics/mockNaics_v2.js
@@ -154,39 +154,9 @@ export const treeWithPlaceholdersAndRealDataPSCDepth = [
                         ]
                     },
                     {
-                        naics: "111130",
-                        value: "111130",
-                        naics_description: "Dry Pea and Bean Farming",
-                        count: 0
-                    },
-                    {
-                        naics: "111140",
-                        value: "111140",
-                        naics_description: "Wheat Farming",
-                        count: 0
-                    },
-                    {
-                        naics: "111150",
-                        value: "111150",
-                        naics_description: "Corn Farming",
-                        count: 0
-                    },
-                    {
-                        naics: "111160",
-                        value: "111160",
-                        naics_description: "Rice Farming",
-                        count: 0
-                    },
-                    {
-                        naics: "111191",
-                        value: "111191",
-                        naics_description: "Oilseed and Grain Combination Farming",
-                        count: 0
-                    },
-                    {
-                        naics: "111199",
-                        value: "111199",
-                        naics_description: "All Other Grain Farming",
+                        value: "children_of_1111",
+                        naics: "children_of_1111",
+                        isPlaceHolder: true,
                         count: 0
                     }
                 ]
@@ -528,7 +498,8 @@ export const reallyBigTreePSCDepth = [
                         children: [{
                             naics: 'great grandchild',
                             value: 'great grandchild',
-                            naics_description: 'This will never happen with NAICS; its a test for PSC'
+                            naics_description: 'This will never happen with NAICS; its a test for PSC',
+                            className: 'hide'
                         }]
                     },
                     {

--- a/tests/containers/search/filters/naics/mockNaics_v2.js
+++ b/tests/containers/search/filters/naics/mockNaics_v2.js
@@ -224,6 +224,306 @@ export const reallyBigTree = [
                         naics: "111120",
                         value: "111120",
                         naics_description: "Oilseed (except Soybean) Farming",
+                        count: 0
+                    },
+                    {
+                        naics: "111130",
+                        value: "111130",
+                        naics_description: "Dry Pea and Bean Farming",
+                        count: 0
+                    },
+                    {
+                        naics: "111140",
+                        value: "111140",
+                        naics_description: "Wheat Farming",
+                        count: 0
+                    },
+                    {
+                        naics: "111150",
+                        value: "111150",
+                        naics_description: "Corn Farming",
+                        count: 0
+                    },
+                    {
+                        naics: "111160",
+                        value: "111160",
+                        naics_description: "Rice Farming",
+                        count: 0
+                    },
+                    {
+                        naics: "111191",
+                        value: "111191",
+                        naics_description: "Oilseed and Grain Combination Farming",
+                        count: 0
+                    },
+                    {
+                        naics: "111199",
+                        value: "111199",
+                        naics_description: "All Other Grain Farming",
+                        count: 0
+                    }
+                ]
+            },
+            {
+                naics: "1112",
+                value: "1112",
+                naics_description: "Vegetable and Melon Farming",
+                count: 2
+            },
+            {
+                naics: "1113",
+                value: "1113",
+                naics_description: "Fruit and Tree Nut Farming",
+                count: 9
+            },
+            {
+                naics: "1114",
+                value: "1114",
+                naics_description: "Greenhouse, Nursery, and Floriculture Production",
+                count: 4
+            },
+            {
+                naics: "1119",
+                value: "1119",
+                naics_description: "Other Crop Farming",
+                count: 7
+            },
+            {
+                naics: "1121",
+                value: "1121",
+                naics_description: "Cattle Ranching and Farming",
+                count: 4
+            },
+            {
+                naics: "1122",
+                value: "1122",
+                naics_description: "Hog and Pig Farming",
+                count: 1
+            },
+            {
+                naics: "1123",
+                value: "1123",
+                naics_description: "Poultry and Egg Production",
+                count: 5
+            },
+            {
+                naics: "1124",
+                value: "1124",
+                naics_description: "Sheep and Goat Farming",
+                count: 2
+            },
+            {
+                naics: "1125",
+                value: "1125",
+                naics_description: "Aquaculture",
+                count: 3
+            },
+            {
+                naics: "1129",
+                value: "1129",
+                naics_description: "Other Animal Production",
+                count: 4
+            },
+            {
+                naics: "1131",
+                value: "1131",
+                naics_description: "Timber Tract Operations",
+                count: 1
+            },
+            {
+                naics: "1132",
+                value: "1132",
+                naics_description: "Forest Nurseries and Gathering of Forest Products",
+                count: 1
+            },
+            {
+                naics: "1133",
+                value: "1133",
+                naics_description: "Logging",
+                count: 1
+            },
+            {
+                naics: "1141",
+                value: "1141",
+                naics_description: "Fishing",
+                count: 3
+            },
+            {
+                naics: "1142",
+                value: "1142",
+                naics_description: "Hunting and Trapping",
+                count: 1
+            },
+            {
+                naics: "1151",
+                value: "1151",
+                naics_description: "Support Activities for Crop Production",
+                count: 6
+            },
+            {
+                naics: "1152",
+                value: "1152",
+                naics_description: "Support Activities for Animal Production",
+                count: 1
+            },
+            {
+                naics: "1153",
+                value: "1153",
+                naics_description: "Support Activities for Forestry",
+                count: 1,
+                children: [
+                    {
+                        naics: "115310",
+                        value: "115310",
+                        naics_description: "Support Activities for Forestry",
+                        count: 0,
+                        className: 'hide'
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        naics: "21",
+        value: "21",
+        naics_description: "Mining, Quarrying, and Oil and Gas Extraction",
+        count: 32
+    },
+    {
+        naics: "22",
+        naics_description: "Utilities",
+        count: 15
+    },
+    {
+        naics: "23",
+        naics_description: "Construction",
+        count: 31
+    },
+    {
+        naics: "31",
+        naics_description: "Manufacturing",
+        count: 133
+    },
+    {
+        naics: "32",
+        naics_description: "Manufacturing",
+        count: 136
+    },
+    {
+        naics: "33",
+        naics_description: "Manufacturing",
+        count: 269
+    },
+    {
+        naics: "42",
+        naics_description: "Wholesale Trade",
+        count: 71
+    },
+    {
+        naics: "44",
+        naics_description: "Retail Trade",
+        count: 50
+    },
+    {
+        naics: "45",
+        naics_description: "Retail Trade",
+        count: 33
+    },
+    {
+        naics: "48",
+        naics_description: "Transportation and Warehousing",
+        count: 50
+    },
+    {
+        naics: "49",
+        naics_description: "Transportation and Warehousing",
+        count: 7
+    },
+    {
+        naics: "51",
+        naics_description: "Information",
+        count: 43
+    },
+    {
+        naics: "52",
+        naics_description: "Finance and Insurance",
+        count: 42
+    },
+    {
+        naics: "53",
+        naics_description: "Real Estate and Rental and Leasing",
+        count: 29
+    },
+    {
+        naics: "54",
+        naics_description: "Professional, Scientific, and Technical Services",
+        count: 52
+    },
+    {
+        naics: "55",
+        naics_description: "Management of Companies and Enterprises",
+        count: 3
+    },
+    {
+        naics: "56",
+        naics_description: "Administrative and Support and Waste Management and Remediation Services",
+        count: 45
+    },
+    {
+        naics: "61",
+        naics_description: "Educational Services",
+        count: 17
+    },
+    {
+        naics: "62",
+        naics_description: "Health Care and Social Assistance",
+        count: 39
+    },
+    {
+        naics: "71",
+        naics_description: "Arts, Entertainment, and Recreation",
+        count: 25
+    },
+    {
+        naics: "72",
+        naics_description: "Accommodation and Food Services",
+        count: 19
+    },
+    {
+        naics: "81",
+        naics_description: "Other Services (except Public Administration)",
+        count: 49
+    },
+    {
+        naics: "92",
+        naics_description: "Public Administration",
+        count: 29
+    }
+];
+
+export const reallyBigTreePSCDepth = [
+    {
+        naics: "11",
+        value: "11",
+        naics_description: "Agriculture, Forestry, Fishing and Hunting",
+        count: 64,
+        children: [
+            {
+                naics: "1111",
+                value: "1111",
+                naics_description: "Oilseed and Grain Farming",
+                count: 8,
+                children: [
+                    {
+                        naics: "111110",
+                        value: "111110",
+                        naics_description: "Soybean Farming",
+                        count: 0
+                    },
+                    {
+                        naics: "111120",
+                        value: "111120",
+                        naics_description: "Oilseed (except Soybean) Farming",
                         count: 1,
                         children: [{
                             naics: 'great grandchild',

--- a/tests/helpers/checkboxTreeHelper-test.js
+++ b/tests/helpers/checkboxTreeHelper-test.js
@@ -39,7 +39,7 @@ const mockSearchResults = [{
 describe('checkboxTree Helpers (using NAICS data)', () => {
     describe('getAllDescendants', () => {
         it('returns an array of lowest descendants in tree', () => {
-            const mock = mockData.reallyBigTree[0].children[0];
+            const mock = mockData.reallyBigTreePSCDepth[0].children[0];
             const result = getAllDescendants(mock);
             expect(result).toEqual([
                 "111110",
@@ -62,7 +62,7 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
             expect(grandChildrenWithSearch.length).toEqual(existingGrandChildren.length + 1);
         });
         it('adds the hide class to nodes not in search results', () => {
-            const existingNodes = mockData.reallyBigTree;
+            const existingNodes = mockData.reallyBigTreePSCDepth;
             const searchResult = addSearchResultsToTree(existingNodes, mockData.searchResults, getNaicsNodeFromTree);
             const existingGrandChildren = existingNodes[0].children[0].children;
             const grandChildrenWithSearch = searchResult
@@ -176,7 +176,7 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
         });
         it('at PSC Depth, children are not overwritten with placeholders when real data is present', () => {
             // Should be node 1111
-            const newNode = mockData.reallyBigTree
+            const newNode = mockData.reallyBigTreePSCDepth
                 .find((node) => node.value === '11')
                 .children
                 .find((node) => node.value === '1111');

--- a/tests/helpers/checkboxTreeHelper-test.js
+++ b/tests/helpers/checkboxTreeHelper-test.js
@@ -174,6 +174,31 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
             // node also has the new child
             expect(grandChildWasAdded).toEqual(true);
         });
+        it('at PSC Depth, children are not overwritten with placeholders when real data is present', () => {
+            // Should be node 1111
+            const newNode = mockData.reallyBigTree
+                .find((node) => node.value === '11')
+                .children
+                .find((node) => node.value === '1111');
+
+            const result = populateBranchOrLeafLevelNodes(
+                mockData.treeWithPlaceholdersAndRealDataPSCDepth,
+                '1111',
+                [newNode],
+                getHighestAncestorNaicsCode,
+                getNaicsNodeFromTree
+            );
+
+            const node = getNaicsNodeFromTree(result, '11');
+
+            const greatGrandChildWasNotOverwritten = node.children
+                .find((child) => child.value === '1111')
+                .children
+                .find((grand) => grand.value === '111120')
+                .children
+                .find((greatGrand) => greatGrand.value === 'dont-overwrite-me');
+            expect(greatGrandChildWasNotOverwritten.naics_description).toEqual('real');
+        });
     });
     describe('cleanTreeData', () => {
         it('object property mapping: (A) naics_description --> label & (B) naics --> value', () => {

--- a/tests/helpers/checkboxTreeHelper-test.js
+++ b/tests/helpers/checkboxTreeHelper-test.js
@@ -38,12 +38,12 @@ const mockSearchResults = [{
 
 describe('checkboxTree Helpers (using NAICS data)', () => {
     describe('getAllDescendants', () => {
-        it('returns an array of all nested values', () => {
+        it('returns an array of lowest descendants in tree', () => {
             const mock = mockData.reallyBigTree[0].children[0];
             const result = getAllDescendants(mock);
             expect(result).toEqual([
                 "111110",
-                "111120",
+                "great grandchild",
                 "111130",
                 "111140",
                 "111150",
@@ -53,7 +53,7 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
             ]);
         });
     });
-    describe('addSearchResultsToTree & mergeChildren & ', () => {
+    describe('addSearchResultsToTree & mergeChildren', () => {
         it('does NOT overwrite existing grand-children', () => {
             const existingNodes = mockData.treeWithPlaceholdersAndRealData;
             const [newChildren] = addSearchResultsToTree(existingNodes, mockSearchResults, getNaicsNodeFromTree);
@@ -61,7 +61,7 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
             const existingGrandChildren = existingNodes[0].children[0].children;
             expect(grandChildrenWithSearch.length).toEqual(existingGrandChildren.length + 1);
         });
-        it('adds a the hide class to nodes not in search results', () => {
+        it('adds the hide class to nodes not in search results', () => {
             const existingNodes = mockData.reallyBigTree;
             const searchResult = addSearchResultsToTree(existingNodes, mockData.searchResults, getNaicsNodeFromTree);
             const existingGrandChildren = existingNodes[0].children[0].children;
@@ -76,6 +76,13 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
             expect(hiddenNodes.length).toEqual(7);
             expect(visibleNodes.length).toEqual(1);
             expect(visibleNodes[0].naics_description).toEqual('Soybean Farming');
+            const greatGrandChild = hiddenNodes.find((node) => {
+                if (node.children) {
+                    return node.children.some((child) => child.value === 'great grandchild');
+                }
+                return false;
+            });
+            expect(greatGrandChild.className).toEqual('hide');
         });
         it('removes placeholder grandchildren for nodes with all grandchildren', () => {
             const existingNodes = mockData.placeholderNodes;

--- a/tests/helpers/checkboxTreeHelper-test.js
+++ b/tests/helpers/checkboxTreeHelper-test.js
@@ -61,7 +61,26 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
             const existingGrandChildren = existingNodes[0].children[0].children;
             expect(grandChildrenWithSearch.length).toEqual(existingGrandChildren.length + 1);
         });
-        it('adds the hide class to nodes not in search results', () => {
+        it('does NOT overwrite existing great-grand-children (PSC Depth)', () => {
+            const existingNodes = mockData.treeWithPlaceholdersAndRealDataPSCDepth;
+            const [newChildren] = addSearchResultsToTree(existingNodes, mockSearchResults, getNaicsNodeFromTree);
+            const preExistingGreatGrandChild = newChildren
+                .children
+                .find((node) => node.value === '1111')
+                .children
+                .find((node) => node.value === '111120')
+                .children
+                .find((node) => node.value === 'dont-overwrite-me');
+            const newGrandChild = newChildren
+                .children
+                .find((node) => node.value === '1111')
+                .children
+                .find((node) => node.value === 'pretend');
+
+            expect(preExistingGreatGrandChild.naics_description).toEqual('real');
+            expect(newGrandChild.value).toEqual('pretend');
+        });
+        it('adds the hide class to nodes not in search results (PSC Depth)', () => {
             const existingNodes = mockData.reallyBigTreePSCDepth;
             const searchResult = addSearchResultsToTree(existingNodes, mockData.searchResults, getNaicsNodeFromTree);
             const existingGrandChildren = existingNodes[0].children[0].children;
@@ -114,6 +133,35 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
             expect(grandPlaceHolderExists).toEqual(true);
             expect(childPlaceHolderExists).toEqual(true);
         });
+        it('keeps placeholder children/grandchildren for nodes without all children (PSC Depth)', () => {
+            const existingNodes = mockData.treeWithPlaceholdersAndRealDataPSCDepth;
+            const [searchResults] = addSearchResultsToTree(existingNodes, mockSearchResults, getNaicsNodeFromTree);
+            const childFromSearch = searchResults.children[0];
+            const childPlaceHolderExists = searchResults
+                .children
+                .some((child) => child.isPlaceHolder);
+
+            const grandPlaceHolderExists = childFromSearch
+                .children
+                .some((grand) => grand.isPlaceHolder);
+            
+            const greatGrandNotOverwritten = childFromSearch
+                .children
+                .find((grand) => grand.value === '111120')
+                .children
+                .some((greatGrand) => greatGrand.value === 'dont-overwrite-me');
+
+            const greatGrandPlaceholderNotOverwritten = childFromSearch
+                .children
+                .find((grand) => grand.value === '111120')
+                .children
+                .some((greatGrand) => greatGrand.isPlaceHolder === true);
+
+            expect(grandPlaceHolderExists).toEqual(true);
+            expect(childPlaceHolderExists).toEqual(true);
+            expect(greatGrandNotOverwritten).toEqual(true);
+            expect(greatGrandPlaceholderNotOverwritten).toEqual(true);
+        });
     });
     describe('expandNodeAndAllDescendantParents', () => {
         it('returns an array containing all values from tree', () => {
@@ -126,10 +174,10 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
             expect(result).toEqual(["11", "1111"]);
         });
     });
-    describe('showAllNodes', () => {
+    describe('showAllNodes (PSC Depth)', () => {
         it('removes the hide class from all nodes', () => {
-            const result = showAllNodes(mockData.reallyBigTree);
-            const nodeWithHideClass = getNaicsNodeFromTree(result, '115310', 'naics');
+            const result = showAllNodes(mockData.reallyBigTreePSCDepth);
+            const nodeWithHideClass = getNaicsNodeFromTree(result, '111120', 'naics').children[0];
             expect(nodeWithHideClass.className).toEqual('');
         });
     });
@@ -174,7 +222,7 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
             // node also has the new child
             expect(grandChildWasAdded).toEqual(true);
         });
-        it('at PSC Depth, children are not overwritten with placeholders when real data is present', () => {
+        it('keeps children when real data is present (PCS Depth)', () => {
             // Should be node 1111
             const newNode = mockData.reallyBigTreePSCDepth
                 .find((node) => node.value === '11')


### PR DESCRIPTION
**High level description:**
Fns used to incrementally populate the tree were not optimized to handle the four levels of PSC.


**Technical details:**
When performing a search, we populate the tree partially w/ the search results and placeholders. Then, when a user leaves search and expands down the tree, we complete that partial population. In order to preserve the proper checked state (full or half checked) we have to ensure that as we complete the tree population, we do not overwrite existing nodes from search.

We were doing this in PSC because we weren't anticipating 3 levels of children. **Now, we are via recursion**.

There is some added clean up to the logic as well by extracting some new helper fns outside the scope of the larger complex functions.

**JIRA Ticket:**
[DEV-4528](https://federal-spending-transparency.atlassian.net/browse/DEV-4528)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
