### PR TITLE
add package lock to docker folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM node:10
 
 RUN mkdir /node-workspace
 COPY package.json /node-workspace 
+COPY package-lock.json /node-workspace 
 
 WORKDIR /node-workspace
 


### PR DESCRIPTION
**High level description:**

> • Add package-lock.json to docker folder so the `npm ci` command knows what to install.


- [x] Code review complete
