### PR TITLE
[DEV-4527] Expand Collapse Overwrites Nodes from Search Results

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM node:10
 
 RUN mkdir /node-workspace
 COPY package.json /node-workspace 
-COPY package-lock.json /node-workspace 
+COPY package-lock.json /node-workspace --no-cache
 
 WORKDIR /node-workspace
 
-RUN npm ci
+RUN npm ci --no-cache
 
 COPY . /node-workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM node:10
 
 RUN mkdir /node-workspace
 COPY package.json /node-workspace 
-COPY package-lock.json /node-workspace --no-cache
+COPY package-lock.json /node-workspace
 
 WORKDIR /node-workspace
 
-RUN npm ci --no-cache
+RUN npm ci
 
 COPY . /node-workspace
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13479,9 +13479,9 @@
             "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
         },
         "nanoid": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.5.tgz",
-            "integrity": "sha512-77yYm8wPy8igTpUQv9fA0VzEb5Ohxt5naC3zTK1oAb+u1MiyITtx0jpYrYRFfgJlefwJy2SkCaojZvxSYq6toA=="
+            "version": "2.1.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+            "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
         },
         "nanomatch": {
             "version": "1.2.13",
@@ -16660,12 +16660,13 @@
             }
         },
         "react-checkbox-tree": {
-            "version": "github:maxwellkendall/react-checkbox-tree#647f81fb237458a674ac83a029328dbe51f302ce",
-            "from": "github:maxwellkendall/react-checkbox-tree#bugfix/v1",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/react-checkbox-tree/-/react-checkbox-tree-1.5.0.tgz",
+            "integrity": "sha512-AsoTYxWF9o9mwcbLJPR4Svdqo+41AMb7tck3rcnrzsW4/7u4FQdfPmnYDIJG4IsEW8EC+pzefTMuqJzvpwWJfg==",
             "requires": {
                 "classnames": "^2.2.5",
                 "lodash": "^4.17.10",
-                "nanoid": "^3.0.0",
+                "nanoid": "^2.0.0",
                 "prop-types": "^15.5.8"
             }
         },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "test": "./node_modules/.bin/jest; exit 0;",
         "lint": "./node_modules/.bin/eslint --config .eslintrc --ext .jsx,.js \"src/js/**\"; exit 0;",
         "errors": "./node_modules/.bin/eslint --config .eslintrc --ext .jsx,.js \"src/js/**\" --quiet; exit 0;",
-        "dev": "node ./scripts/buildSitemap.js && webpack --progress --config ./webpack/webpack.dev.config.js",
+        "dev": "node ./scripts/buildSitemap.js && webpack --progress --config ./webpack/webpack.prod.config.js",
         "prod": "node ./scripts/buildSitemap.js && webpack --progress --config ./webpack/webpack.prod.config.js",
         "travis": "./node_modules/.bin/eslint --config .eslintrc --ext .jsx,.js \"src/js/**\" && ./node_modules/.bin/jest --runInBand;"
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "repository": "fedspendingtransparency/usaspending-website",
     "main": "src/index.js",
     "scripts": {
-        "start": "webpack-dev-server --open --progress --config ./webpack/webpack.dev.config.js",
+        "start": "webpack-dev-server --open --progress --config ./webpack/webpack.prod.config.js",
         "sass": "webpack-dev-server --open --progress --config ./webpack/webpack.sass.config.js",
         "test": "./node_modules/.bin/jest; exit 0;",
         "lint": "./node_modules/.bin/eslint --config .eslintrc --ext .jsx,.js \"src/js/**\"; exit 0;",
@@ -100,7 +100,7 @@
         "react": "^16.8.6",
         "react-addons-perf": "15.4.2",
         "react-aria-modal": "^2.7.0",
-        "react-checkbox-tree": "github:maxwellkendall/react-checkbox-tree#bugfix/v1",
+        "react-checkbox-tree": "^1.5.0",
         "react-copy-to-clipboard": "^5.0.1",
         "react-custom-scrollbars": "^4.1.2",
         "react-day-picker": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
     "repository": "fedspendingtransparency/usaspending-website",
     "main": "src/index.js",
     "scripts": {
-        "start": "webpack-dev-server --open --progress --config ./webpack/webpack.prod.config.js",
+        "start": "webpack-dev-server --open --progress --config ./webpack/webpack.dev.config.js",
         "sass": "webpack-dev-server --open --progress --config ./webpack/webpack.sass.config.js",
         "test": "./node_modules/.bin/jest; exit 0;",
         "lint": "./node_modules/.bin/eslint --config .eslintrc --ext .jsx,.js \"src/js/**\"; exit 0;",
         "errors": "./node_modules/.bin/eslint --config .eslintrc --ext .jsx,.js \"src/js/**\" --quiet; exit 0;",
-        "dev": "node ./scripts/buildSitemap.js && webpack --progress --config ./webpack/webpack.prod.config.js",
+        "dev": "node ./scripts/buildSitemap.js && webpack --progress --config ./webpack/webpack.dev.config.js",
         "prod": "node ./scripts/buildSitemap.js && webpack --progress --config ./webpack/webpack.prod.config.js",
         "travis": "./node_modules/.bin/eslint --config .eslintrc --ext .jsx,.js \"src/js/**\" && ./node_modules/.bin/jest --runInBand;"
     },

--- a/src/js/helpers/apiRequest.js
+++ b/src/js/helpers/apiRequest.js
@@ -12,8 +12,7 @@ const localUrl = `http://localhost:8000/api/`;
 const getBaseUrl = (params) => {
     if (params.isMocked) return mockUrl;
     if (params.isLocal) return localUrl;
-    // return kGlobalConstants.API;
-    return 'https://dev-api.usaspending.gov/api/';
+    return kGlobalConstants.API;
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/js/helpers/apiRequest.js
+++ b/src/js/helpers/apiRequest.js
@@ -12,7 +12,8 @@ const localUrl = `http://localhost:8000/api/`;
 const getBaseUrl = (params) => {
     if (params.isMocked) return mockUrl;
     if (params.isLocal) return localUrl;
-    return kGlobalConstants.API;
+    // return kGlobalConstants.API;
+    return 'https://dev-api.usaspending.gov/api/';
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -541,8 +541,12 @@ export const populateBranchOrLeafLevelNodes = (
     // 1. add nodes to either branch or leaf level of tree
     // 2. when adding nodes, don't remove placeholders if we're adding a partial child and don't remove any existing children
     const nodeWithNewChildren = key ? traverseTreeByCodeFn(tree, key) : '';
-    const immediateAncestorCode = getImmediateAncestorCode(nodeWithNewChildren);
-    const highestAncestorCode = getHighestAncestorCode(nodeWithNewChildren);
+    const immediateAncestorCode = nodeWithNewChildren
+        ? getImmediateAncestorCode(nodeWithNewChildren)
+        : getImmediateAncestorCode(key);
+    const highestAncestorCode = nodeWithNewChildren
+        ? getHighestAncestorCode(nodeWithNewChildren)
+        : getHighestAncestorCode(key);
     return tree.map((node) => {
         const [data] = newNodes;
         const shouldPopulateChildren = node.value === key;
@@ -569,8 +573,10 @@ export const populateBranchOrLeafLevelNodes = (
                             return {
                                 ...child,
                                 children: existingChild.children
-                                    .map((grand) => ({ ...grand, className: '' }))
-                                    .sort(sortNodesByValue)
+                                    ? existingChild.children
+                                        .map((grand) => ({ ...grand, className: '' }))
+                                        .sort(sortNodesByValue)
+                                    : []
                             };
                         }
                         if (weHaveAtLeastOneGrandChild) {

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -529,7 +529,7 @@ export const addSearchResultsToTree = (
  * @param traverseTreeByCodeFn a fn used to get any node in the tree by the code/value/id of the node
  * @returns a new array of objects with the newNodes appended to the right place
 */
-export const populateBranchOrLeafLevelNodes = (
+export const populateChildNodes = (
     tree,
     key = '',
     newNodes = [],
@@ -537,9 +537,8 @@ export const populateBranchOrLeafLevelNodes = (
     getImmediateAncestorCode,
     traverseTreeByCodeFn
 ) => {
-    // debugger;
-    // 1. add nodes to either branch or leaf level of tree
-    // 2. when adding nodes, don't remove placeholders if we're adding a partial child and don't remove any existing children
+    // 1. add nodes to either branch (recursive) or leaf level of tree
+    // 2. when adding nodes, don't remove any existing children that aren't placeholders as they are assumed to have and likely do have children of their own from search.
     const nodeWithNewChildren = key ? traverseTreeByCodeFn(tree, key) : '';
     const immediateAncestorCode = nodeWithNewChildren
         ? getImmediateAncestorCode(nodeWithNewChildren)
@@ -596,7 +595,7 @@ export const populateBranchOrLeafLevelNodes = (
             return {
                 ...node,
                 className: '',
-                children: populateBranchOrLeafLevelNodes(
+                children: populateChildNodes(
                     node.children,
                     key,
                     newNodes,

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -370,8 +370,7 @@ const removePlaceHolders = (children) => children.filter((child) => !child.isPla
 
 const areChildrenPartial = (count, children) => {
     if (!children) return false;
-    const sumOfAllChildren = children
-        .filter((child) => !child.isPlaceHolder)
+    const sumOfAllChildren = removePlaceHolders(children)
         .reduce((acc, child) => {
             const childCount = child.count || 1;
             return acc + childCount;

--- a/src/js/redux/reducers/search/naicsReducer.js
+++ b/src/js/redux/reducers/search/naicsReducer.js
@@ -5,7 +5,7 @@
 
 import { List } from 'immutable';
 
-import { addSearchResultsToTree, populateBranchOrLeafLevelNodes, showAllNodes } from 'helpers/checkboxTreeHelper';
+import { addSearchResultsToTree, populateChildNodes, showAllNodes } from 'helpers/checkboxTreeHelper';
 import { getHighestAncestorNaicsCode, getNaicsNodeFromTree, getImmediateAncestorNaicsCode } from 'helpers/naicsHelper';
 
 export const initialState = {
@@ -16,7 +16,7 @@ export const initialState = {
     unchecked: new List()
 };
 
-const populateNaicsBranchOrLeafNodes = (nodes, key, newNodes) => populateBranchOrLeafLevelNodes(
+const populateNaicsBranchOrLeafNodes = (nodes, key, newNodes) => populateChildNodes(
     nodes,
     key,
     newNodes,

--- a/src/js/redux/reducers/search/naicsReducer.js
+++ b/src/js/redux/reducers/search/naicsReducer.js
@@ -6,7 +6,7 @@
 import { List } from 'immutable';
 
 import { addSearchResultsToTree, populateBranchOrLeafLevelNodes, showAllNodes } from 'helpers/checkboxTreeHelper';
-import { getHighestAncestorNaicsCode, getNaicsNodeFromTree } from 'helpers/naicsHelper';
+import { getHighestAncestorNaicsCode, getNaicsNodeFromTree, getImmediateAncestorNaicsCode } from 'helpers/naicsHelper';
 
 export const initialState = {
     naics: new List(),
@@ -21,6 +21,7 @@ const populateNaicsBranchOrLeafNodes = (nodes, key, newNodes) => populateBranchO
     key,
     newNodes,
     getHighestAncestorNaicsCode,
+    getImmediateAncestorNaicsCode,
     getNaicsNodeFromTree
 );
 

--- a/src/js/redux/reducers/search/pscReducer.js
+++ b/src/js/redux/reducers/search/pscReducer.js
@@ -5,7 +5,7 @@
 
 import { List } from 'immutable';
 
-import { addSearchResultsToTree, populateBranchOrLeafLevelNodes, showAllNodes } from 'helpers/checkboxTreeHelper';
+import { addSearchResultsToTree, populateChildNodes, showAllNodes } from 'helpers/checkboxTreeHelper';
 import { getHighestPscAncestor, getImmediatePscAncestor, getPscNodeFromTree } from 'helpers/pscHelper';
 
 export const initialState = {
@@ -17,7 +17,7 @@ export const initialState = {
     counts: new List()
 };
 
-const populatePscBranchOrLeafNodes = (nodes, key, newNodes) => populateBranchOrLeafLevelNodes(
+const populatePscBranchOrLeafNodes = (nodes, key, newNodes) => populateChildNodes(
     nodes,
     key,
     newNodes,

--- a/src/js/redux/reducers/search/pscReducer.js
+++ b/src/js/redux/reducers/search/pscReducer.js
@@ -6,7 +6,7 @@
 import { List } from 'immutable';
 
 import { addSearchResultsToTree, populateBranchOrLeafLevelNodes, showAllNodes } from 'helpers/checkboxTreeHelper';
-import { getHighestPscAncestor, getPscNodeFromTree } from 'helpers/pscHelper';
+import { getHighestPscAncestor, getImmediatePscAncestor, getPscNodeFromTree } from 'helpers/pscHelper';
 
 export const initialState = {
     psc: new List(),
@@ -22,6 +22,7 @@ const populatePscBranchOrLeafNodes = (nodes, key, newNodes) => populateBranchOrL
     key,
     newNodes,
     getHighestPscAncestor,
+    getImmediatePscAncestor,
     getPscNodeFromTree
 );
 

--- a/src/js/redux/reducers/search/tasReducer.js
+++ b/src/js/redux/reducers/search/tasReducer.js
@@ -1,6 +1,6 @@
 import { List } from 'immutable';
 
-import { addSearchResultsToTree, populateBranchOrLeafLevelNodes, showAllNodes } from 'helpers/checkboxTreeHelper';
+import { addSearchResultsToTree, populateChildNodes, showAllNodes } from 'helpers/checkboxTreeHelper';
 import {
     getTasNodeFromTree,
     getHighestTasAncestorCode,
@@ -9,7 +9,7 @@ import {
 } from 'helpers/tasHelper';
 
 
-const populateTasBranchOrLeafLevelNodes = (nodes, key, newNodes) => populateBranchOrLeafLevelNodes(
+const populateTasBranchOrLeafLevelNodes = (nodes, key, newNodes) => populateChildNodes(
     nodes,
     key,
     newNodes,

--- a/src/js/redux/reducers/search/tasReducer.js
+++ b/src/js/redux/reducers/search/tasReducer.js
@@ -4,6 +4,7 @@ import { addSearchResultsToTree, populateBranchOrLeafLevelNodes, showAllNodes } 
 import {
     getTasNodeFromTree,
     getHighestTasAncestorCode,
+    getImmediateTasAncestorCode,
     tasSortFn
 } from 'helpers/tasHelper';
 
@@ -13,6 +14,7 @@ const populateTasBranchOrLeafLevelNodes = (nodes, key, newNodes) => populateBran
     key,
     newNodes,
     getHighestTasAncestorCode,
+    getImmediateTasAncestorCode,
     getTasNodeFromTree
 );
 

--- a/tests/helpers/checkboxTreeHelper-test.js
+++ b/tests/helpers/checkboxTreeHelper-test.js
@@ -1,7 +1,7 @@
 import {
     addSearchResultsToTree,
     expandNodeAndAllDescendantParents,
-    populateBranchOrLeafLevelNodes,
+    populateChildNodes,
     cleanTreeData,
     removePlaceholderString,
     removeStagedFilter,
@@ -181,9 +181,9 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
             expect(nodeWithHideClass.className).toEqual('');
         });
     });
-    describe('populateBranchOrLeafLevelNodes', () => {
+    describe('populateChildNodes', () => {
         it('adds new children and removes the loading placeholder if we have all the nodes', () => {
-            const result = populateBranchOrLeafLevelNodes(
+            const result = populateChildNodes(
                 mockData.placeholderNodes,
                 '11',
                 [mockData.reallyBigTree[0]],
@@ -202,7 +202,7 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
                 .children
                 .find((node) => node.value === '1111');
 
-            const result = populateBranchOrLeafLevelNodes(
+            const result = populateChildNodes(
                 mockData.treeWithPlaceholdersAndRealData,
                 '1111',
                 [newNode],
@@ -231,7 +231,7 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
                 .children
                 .find((node) => node.value === '1111');
 
-            const result = populateBranchOrLeafLevelNodes(
+            const result = populateChildNodes(
                 mockData.treeWithPlaceholdersAndRealDataPSCDepth,
                 '1111',
                 [newNode],

--- a/tests/helpers/checkboxTreeHelper-test.js
+++ b/tests/helpers/checkboxTreeHelper-test.js
@@ -188,6 +188,7 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
                 '11',
                 [mockData.reallyBigTree[0]],
                 getHighestAncestorNaicsCode,
+                getImmediateAncestorNaicsCode,
                 getNaicsNodeFromTree
             );
             const lengthWithoutPlaceholderNodes = mockData.reallyBigTree[0].children.length;
@@ -206,6 +207,7 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
                 '1111',
                 [newNode],
                 getHighestAncestorNaicsCode,
+                getImmediateAncestorNaicsCode,
                 getNaicsNodeFromTree
             );
 
@@ -234,6 +236,7 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
                 '1111',
                 [newNode],
                 getHighestAncestorNaicsCode,
+                getImmediateAncestorNaicsCode,
                 getNaicsNodeFromTree
             );
 


### PR DESCRIPTION
**High level description:**
Search populates the tree to the `nth` level, but only partially. This means toggling back to the expand/collapse view, down to the parent of a node that was returned from search, we need to ensure we do not replace that parent that is `less populated` than the existing node.

**Technical details:**
Made the function that handles populating the tree on expand/collapse recursive. This simplifies the logic and really helps w/ PSC as there are three levels of children compared to just two with TAS and NAICS

**JIRA Ticket:**
[DEV-4527](https://federal-spending-transparency.atlassian.net/browse/DEV-4527)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
