### PR TITLE
[DEV-4794] Load tree from URL on back button select from award page

### DIFF
--- a/src/js/containers/search/filters/naics/NAICSContainer.jsx
+++ b/src/js/containers/search/filters/naics/NAICSContainer.jsx
@@ -146,6 +146,9 @@ export class NAICSContainer extends React.Component {
                             });
                         });
                 }
+                if (this.props.nodes.length > 0) {
+                    this.props.showNaicsTree();
+                }
                 // consistent return.
                 return Promise.resolve();
             })

--- a/src/js/containers/search/filters/naics/NAICSContainer.jsx
+++ b/src/js/containers/search/filters/naics/NAICSContainer.jsx
@@ -128,7 +128,7 @@ export class NAICSContainer extends React.Component {
                                 }, []);
                             const [newCounts, newUnchecked] = incrementNaicsCountAndUpdateUnchecked(
                                 newChecked,
-                                this.props.checked,
+                                [],
                                 uncheckedFromHash,
                                 this.props.nodes,
                                 this.state.stagedNaicsFilters

--- a/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
@@ -154,6 +154,9 @@ export class TASCheckboxTree extends React.Component {
                     return Promise.resolve();
                 });
         }
+        if (this.props.nodes.length > 0) {
+            this.props.showTasTree();
+        }
         return Promise.resolve();
     }
 

--- a/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
@@ -87,77 +87,75 @@ export class TASCheckboxTree extends React.Component {
             checkedFromHash,
             uncheckedFromHash
         } = this.props;
-        if (this.props.nodes.length === 0) {
-            return this.fetchTas('')
-                .then(() => {
-                    if (checkedFromHash.length > 0) {
-                        const checkedNodesByAgencyId = groupBy(checkedFromHash, (ancestryPath) => ancestryPath[0]);
-                        return Object.keys(checkedNodesByAgencyId)
-                            .reduce((prevPromise, agency) => prevPromise
-                                // fetch the agency
-                                .then(() => this.fetchTas(agency)), Promise.resolve([])
-                            )
-                            .then(() => Object.entries(checkedNodesByAgencyId)
-                                .reduce((prevPromise, [, selectedTwoDArray]) => prevPromise
-                                    .then(() => {
-                                        const selectedTasUnderAgency = selectedTwoDArray.filter((selectedArray) => selectedArray.length === 3);
-                                        if (selectedTasUnderAgency.length !== 0) {
-                                            // fetch the federal account for the TAS, if any
-                                            return Promise.all([
-                                                // no duplicate federal accounts in this array, we only need to fetch each federal account once.
-                                                ...Object.keys(groupBy(selectedTasUnderAgency, (arr) => `${arr[0]}/${arr[1]}`))
-                                                    .map((uniqueFederalAccount) => this.fetchTas(uniqueFederalAccount))
-                                            ]);
-                                        }
-                                        return Promise.resolve();
-                                    }), Promise.resolve())
-                            )
-                            .then(() => {
-                                // the tree is now guaranteed to be populated adequately such that we can register counts and full/half check the tree.
-                                const selectedNodesByTreeLevel = groupBy(checkedFromHash, (ancestryPath) => {
-                                    if (ancestryPath.length === 2) return 'branch';
-                                    return 'leaf';
-                                });
-                                const newChecked = Object.entries(selectedNodesByTreeLevel)
-                                    .reduce((acc, [location, array]) => {
-                                        if (location === 'branch') {
-                                            return [
-                                                ...acc,
-                                                ...array
-                                                    .map((ancestryPath) => ancestryPath[1])
-                                                    .reduce((grandChildren, node) => {
-                                                        if (this.props.nodes.length === 0) return grandChildren;
-                                                        const newGrandChildren = getTasNodeFromTree(this.props.nodes, node)
-                                                            .children
-                                                            .map((child) => child.value);
-                                                        return [...grandChildren, ...newGrandChildren];
-                                                    }, acc)
-                                            ];
-                                        }
+        if (this.props.nodes.length !== 0 && !checkedFromHash && !uncheckedFromHash) {
+            this.props.showTasTree();
+            return Promise.resolve();
+        }
+        return this.fetchTas('')
+            .then(() => {
+                if (checkedFromHash.length > 0) {
+                    const checkedNodesByAgencyId = groupBy(checkedFromHash, (ancestryPath) => ancestryPath[0]);
+                    return Object.keys(checkedNodesByAgencyId)
+                        .reduce((prevPromise, agency) => prevPromise
+                            // fetch the agency
+                            .then(() => this.fetchTas(agency)), Promise.resolve([])
+                        )
+                        .then(() => Object.entries(checkedNodesByAgencyId)
+                            .reduce((prevPromise, [, selectedTwoDArray]) => prevPromise
+                                .then(() => {
+                                    const selectedTasUnderAgency = selectedTwoDArray.filter((selectedArray) => selectedArray.length === 3);
+                                    if (selectedTasUnderAgency.length !== 0) {
+                                        // fetch the federal account for the TAS, if any
+                                        return Promise.all([
+                                            // no duplicate federal accounts in this array, we only need to fetch each federal account once.
+                                            ...Object.keys(groupBy(selectedTasUnderAgency, (arr) => `${arr[0]}/${arr[1]}`))
+                                                .map((uniqueFederalAccount) => this.fetchTas(uniqueFederalAccount))
+                                        ]);
+                                    }
+                                    return Promise.resolve();
+                                }), Promise.resolve())
+                        )
+                        .then(() => {
+                            // the tree is now guaranteed to be populated adequately such that we can register counts and full/half check the tree.
+                            const selectedNodesByTreeLevel = groupBy(checkedFromHash, (ancestryPath) => {
+                                if (ancestryPath.length === 2) return 'branch';
+                                return 'leaf';
+                            });
+                            const newChecked = Object.entries(selectedNodesByTreeLevel)
+                                .reduce((acc, [location, array]) => {
+                                    if (location === 'branch') {
                                         return [
                                             ...acc,
                                             ...array
-                                                .map((ancestryPath) => ancestryPath[2])
+                                                .map((ancestryPath) => ancestryPath[1])
+                                                .reduce((grandChildren, node) => {
+                                                    if (this.props.nodes.length === 0) return grandChildren;
+                                                    const newGrandChildren = getTasNodeFromTree(this.props.nodes, node)
+                                                        .children
+                                                        .map((child) => child.value);
+                                                    return [...grandChildren, ...newGrandChildren];
+                                                }, acc)
                                         ];
-                                    }, [])
-                                    .filter((checked) => {
-                                        const inUncheckedArray = uncheckedFromHash.some((arr) => arr[arr.length - 1] === checked);
-                                        if (inUncheckedArray) return false;
-                                        return true;
-                                    });
+                                    }
+                                    return [
+                                        ...acc,
+                                        ...array
+                                            .map((ancestryPath) => ancestryPath[2])
+                                    ];
+                                }, [])
+                                .filter((checked) => {
+                                    const inUncheckedArray = uncheckedFromHash.some((arr) => arr[arr.length - 1] === checked);
+                                    if (inUncheckedArray) return false;
+                                    return true;
+                                });
 
-                                this.setCheckedStateFromUrlHash(newChecked);
-                                this.props.setExpandedTas(checkedFromHash.map((ancestryPath) => ancestryPath[0]));
-                            });
-                    }
-                    // just do this for consistent return.
-                    return Promise.resolve();
-                });
-        }
-        if (this.props.nodes.length > 0) {
-            this.props.showTasTree();
-        }
-        return Promise.resolve();
+                            this.setCheckedStateFromUrlHash(newChecked);
+                            this.props.setExpandedTas(checkedFromHash.map((ancestryPath) => ancestryPath[0]));
+                        });
+                }
+                // just do this for consistent return.
+                return Promise.resolve();
+            });
     }
 
     onExpand = (expandedValue, newExpandedArray, shouldFetchChildren, selectedNode) => {

--- a/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
@@ -250,7 +250,7 @@ export class TASCheckboxTree extends React.Component {
         if (this.props.nodes.length > 0) {
             const [counts, unchecked] = incrementTasCountAndUpdateUnchecked(
                 newChecked,
-                this.props.checked,
+                [],
                 this.props.unchecked,
                 this.props.nodes,
                 this.props.counts


### PR DESCRIPTION
**High level description:**
Two things:
(1) Nav from search --> award --> back to search breaks the ability to load the tree from hash

**Technical details:**
Passing empty array rather than `this.props` and changing conditions for invoking `fetchTas`

**JIRA Ticket:**
[DEV-4794](https://federal-spending-transparency.atlassian.net/browse/DEV-4794)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
