### PR TITLE
[DEV-4529] 3 Bugs, (a) adding search results, (b) counting selected nodes, (c) auto-adding checked nodes after search

### DIFF
--- a/src/js/containers/search/filters/naics/NAICSContainer.jsx
+++ b/src/js/containers/search/filters/naics/NAICSContainer.jsx
@@ -272,15 +272,21 @@ export class NAICSContainer extends React.Component {
                 const node = getNaicsNodeFromTree(nodes, expandedNode);
                 if (node.children) {
                     node.children.forEach((child) => {
-                        if (!child.children) this.props.addCheckedNaics(child.value);
+                        if (!child.children) {
+                            if (!this.props.unchecked.includes(child.value)) {
+                                this.props.addCheckedNaics(child.value);
+                            }
+                        }
                         if (child.children) {
                             child.children.forEach((grandChild) => {
-                                this.props.addCheckedNaics(grandChild.value);
+                                if (!this.props.unchecked.includes(grandChild.value)) {
+                                    this.props.addCheckedNaics(grandChild.value);
+                                }
                             });
                         }
                     });
                 }
-                else if (expandedNode.length === 6) {
+                else if (expandedNode.length === 6 && !this.props.unchecked.includes(expandedNode)) {
                     this.props.addCheckedNaics(node.value);
                 }
             });

--- a/src/js/helpers/apiRequest.js
+++ b/src/js/helpers/apiRequest.js
@@ -12,8 +12,7 @@ const localUrl = `http://localhost:8000/api/`;
 const getBaseUrl = (params) => {
     if (params.isMocked) return mockUrl;
     if (params.isLocal) return localUrl;
-    // return kGlobalConstants.API;
-    return `https://dev-api.usaspending.gov/api/`;
+    return kGlobalConstants.API;
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/js/helpers/apiRequest.js
+++ b/src/js/helpers/apiRequest.js
@@ -12,7 +12,8 @@ const localUrl = `http://localhost:8000/api/`;
 const getBaseUrl = (params) => {
     if (params.isMocked) return mockUrl;
     if (params.isLocal) return localUrl;
-    return kGlobalConstants.API;
+    // return kGlobalConstants.API;
+    return `https://dev-api.usaspending.gov/api/`;
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/js/helpers/apiRequest.js
+++ b/src/js/helpers/apiRequest.js
@@ -12,8 +12,7 @@ const localUrl = `http://localhost:8000/api/`;
 const getBaseUrl = (params) => {
     if (params.isMocked) return mockUrl;
     if (params.isLocal) return localUrl;
-    // return kGlobalConstants.API;
-    return 'https://dev-api.usaspending.gov/api/';
+    return kGlobalConstants.API;
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/js/helpers/apiRequest.js
+++ b/src/js/helpers/apiRequest.js
@@ -12,7 +12,8 @@ const localUrl = `http://localhost:8000/api/`;
 const getBaseUrl = (params) => {
     if (params.isMocked) return mockUrl;
     if (params.isLocal) return localUrl;
-    return kGlobalConstants.API;
+    // return kGlobalConstants.API;
+    return 'https://dev-api.usaspending.gov/api/';
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -427,21 +427,18 @@ export const mergeChildren = (parentFromSearch, existingParent) => {
                                         Object.keys(existingGrandChild).includes('children') &&
                                         existingGrandChild?.children?.length > 0
                                     );
+
                                     if (isParent) {
                                         existingGrandChild.children = existingGrandChild.children
-                                            .map((greatGrand) => {
-                                                const greatGrandIsInSearchResults = searchGrandChild.children
-                                                    .some((nodeFromSearch) => nodeFromSearch.value === greatGrand.value);
-                                                if (greatGrandIsInSearchResults) return { ...greatGrand, className: '' };
-                                                // Hide the greatGrandChildren if they are not in the search results array.
-                                                return { ...greatGrand, className: 'hide' };
-                                            });
+                                            .filter((grand) => !searchGrandChild.children.some((search) => search.value === grand.value))
+                                            .map((greatGrand) => ({ ...greatGrand, className: 'hide' }))
+                                            .concat(searchGrandChild.children);
                                         const needsPlaceholder = areChildrenPartial(
                                             existingGrandChild.count,
-                                            existingGrandChild.children.concat(searchGrandChild.children)
+                                            existingGrandChild.children
                                         );
                                         if (needsPlaceholder) {
-                                            existingGrandChild.children = addPlaceholder(existingGrandChild.children, existingGrandChild.value);
+                                            existingGrandChild.children = addPlaceholder(existingGrandChild.children, existingGrandChild.value, true);
                                         }
                                     }
                                 }

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -485,16 +485,7 @@ export const appendChildrenFromSearchResults = (parentFromSearch, existingParent
         };
     }
     else if (!doesNodeHaveGenuineChildren(existingParent) && doesNodeHaveGenuineChildren(parentFromSearch)) {
-        return parentFromSearch.children
-            .map((child) => {
-                if (doesNodeHaveGenuineChildren(child)) {
-                    return {
-                        ...child,
-                        children: addChildrenAndPossiblyPlaceholder(child.children, child, true)
-                    };
-                }
-                return child;
-            });
+        return addChildrenAndPossiblyPlaceholder(parentFromSearch.children, parentFromSearch);
     }
     return [];
 };

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -460,15 +460,6 @@ export const appendChildrenFromSearchResults = (parentFromSearch, existingParent
                     }]);
                 }
 
-                // child from search is completely new and fully populated, so add it w/o a placeholder
-                if (areChildrenPartial(searchChild.count, searchChild.children)) {
-                    return acc.concat([
-                        {
-                            ...searchChild,
-                            children: addPlaceholder(searchChild.children, searchChild.value, true)
-                        }
-                    ]);
-                }
                 return acc.concat([searchChild]);
             }, existingParent
                 .children

--- a/tests/containers/search/filters/psc/mockPSC.js
+++ b/tests/containers/search/filters/psc/mockPSC.js
@@ -1,3 +1,4 @@
+/* eslint-disable quote-props */
 import { cleanPscData } from "../../../../../src/js/helpers/pscHelper";
 
 export const mockPSC = {
@@ -853,7 +854,96 @@ export const reallyBigTree = cleanPscData([
                 ],
                 "description": "DEFENSE SYSTEMS R&D",
                 "count": 56,
-                "children": null
+                "children": [
+                    {
+                        "id": "AC2",
+                        "ancestors": [
+                            "Research and Development",
+                            "AC"
+                        ],
+                        "description": "R&D- DEFENSE SYSTEM: MISSILE/SPACE SYSTEMS",
+                        "count": 8,
+                        "children": [
+                            {
+                                "id": "AC21",
+                                "ancestors": [
+                                    "Research and Development",
+                                    "AC",
+                                    "AC2"
+                                ],
+                                "description": "R&D- DEFENSE SYSTEM: MISSILE/SPACE SYSTEMS (BASIC RESEARCH)",
+                                "count": 0,
+                                "children": []
+                            },
+                            {
+                                "id": "AC23",
+                                "ancestors": [
+                                    "Research and Development",
+                                    "AC",
+                                    "AC2"
+                                ],
+                                "description": "R&D- DEFENSE SYSTEM: MISSILE/SPACE SYSTEMS (ADVANCED DEVELOPMENT)",
+                                "count": 0,
+                                "children": []
+                            },
+                            {
+                                "id": "AC24",
+                                "ancestors": [
+                                    "Research and Development",
+                                    "AC",
+                                    "AC2"
+                                ],
+                                "description": "R&D- DEFENSE SYSTEM: MISSILE/SPACE SYSTEMS (ENGINEERING DEVELOPMENT)",
+                                "count": 0,
+                                "children": []
+                            },
+                            {
+                                "id": "AC25",
+                                "ancestors": [
+                                    "Research and Development",
+                                    "AC",
+                                    "AC2"
+                                ],
+                                "description": "R&D- DEFENSE SYSTEM: MISSILE/SPACE SYSTEMS (OPERATIONAL SYSTEMS DEVELOPMENT)",
+                                "count": 0,
+                                "children": []
+                            },
+                            {
+                                "id": "AC26",
+                                "ancestors": [
+                                    "Research and Development",
+                                    "AC",
+                                    "AC2"
+                                ],
+                                "description": "R&D- DEFENSE SYSTEM: MISSILE/SPACE SYSTEMS (MANAGEMENT/SUPPORT)",
+                                "count": 0,
+                                "children": []
+                            },
+                            {
+                                "id": "AC27",
+                                "ancestors": [
+                                    "Research and Development",
+                                    "AC",
+                                    "AC2"
+                                ],
+                                "description": "R&D- DEFENSE SYSTEM: MISSILE/SPACE SYSTEMS (COMMERCIALIZED)",
+                                "count": 0,
+                                "children": []
+                            },
+                            {
+                                "id": "AC20",
+                                "ancestors": [
+                                    "Research and Development",
+                                    "AC",
+                                    "AC2"
+                                ],
+                                "description": "R&D-MISSILE & SPACE SYS",
+                                "count": 0,
+                                "children": []
+                            }
+                        ]
+                    }
+                ]
             },
             {
                 "id": "AD",

--- a/tests/containers/search/filters/psc/mockPSC.js
+++ b/tests/containers/search/filters/psc/mockPSC.js
@@ -40,6 +40,7 @@ export const topTierResponse = {
     "results": [
         {
             "id": "Research and Development",
+            "value": "Research and Development",
             "ancestors": [],
             "description": "",
             "count": 815,
@@ -2300,5 +2301,4 @@ export const reallyBigTree = cleanPscData([
                 ]
             }
         ]
-    }]
-);
+    }]);

--- a/tests/helpers/checkboxTreeHelper-test.js
+++ b/tests/helpers/checkboxTreeHelper-test.js
@@ -20,7 +20,14 @@ import {
     shouldNaicsNodeHaveChildren
 } from 'helpers/naicsHelper';
 
+import {
+    getPscNodeFromTree,
+    getHighestPscAncestor,
+    getImmediatePscAncestor
+} from 'helpers/pscHelper';
+
 import * as mockData from '../containers/search/filters/naics/mockNaics_v2';
+import * as pscMockData from '../containers/search/filters/psc/mockPSC';
 
 // overwriting this because it makes life easier
 const mockSearchResults = [{
@@ -381,6 +388,19 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
             );
             expect(counts[0].count).toEqual(64);
         });
+        it('PSC Depth: when both parent and child placeholders are checked, only count the value of the parent', () => {
+            const [counts] = incrementCountAndUpdateUnchecked(
+                ["children_of_AC", "AC21", "children_of_AC2"],
+                [''],
+                [],
+                pscMockData.reallyBigTree,
+                [],
+                getPscNodeFromTree,
+                getImmediatePscAncestor,
+                getHighestPscAncestor
+            );
+            expect(counts[0].count).toEqual(57);
+        });
         it('checked place holders increment with an offset count when a descendent is also checked', async () => {
             const [counts] = incrementCountAndUpdateUnchecked(
                 ["111110", "111120", 'children_of_1111'],
@@ -395,6 +415,7 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
 
             expect(counts[0].count).toEqual(8);
         });
+
         it('removes items from unchecked array when all immediate children are checked', async () => {
             // ie, 1111 is unchecked, then all grand children underneath are checked.
             const allGrandchildrenOf1111 = mockData.reallyBigTree[0]


### PR DESCRIPTION
**High level description:**
Three issues addressed in this PR:

1. `counting checked nodes twice` when a placeholder was selected and then another placeholder under that was selected. (PSC Specific)
2. `Not removing the hide class` from nodes matching search results (PSC Specific)
3. `Adding nodes to checked from the unchecked array` after a search

**Technical details:**
1. Refactored the `incrementCount` helper function to allow for a placeholder to be counted by another placeholder.
2. Refactored the `mergeChildren` helper function, now called `appendSearchResultsToChild` such that it has no duplicate logic, utilizes more readable helper functions, and uses recursion.
3. Added simple conditional to container method `autoCheckAfterSearch`

Also added unit tests to prove all this works specifically with PSC.

**JIRA Ticket:**
[DEV-4529](https://federal-spending-transparency.atlassian.net/browse/DEV-4529)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
- [x] Smoke test in sandbox passed