### PR TITLE
[DEV-5120] Updating the Active Filter Tag Title

### DIFF
--- a/src/js/components/search/topFilterBar/filterGroups/ProgramSourceFilterGroup.jsx
+++ b/src/js/components/search/topFilterBar/filterGroups/ProgramSourceFilterGroup.jsx
@@ -47,9 +47,9 @@ export default class ProgramSourceFilterGroup extends React.Component {
         return this.props.filter.values.map((tas) => {
             const title = tas.isV2
                 ? tas.tas_description
-                : `${label} | ${tas.value}`;
+                : `${label} | ${tas}`;
             return {
-                value: tas.value,
+                value: tas,
                 title,
                 isSpecial: false,
                 removeFilter: this.removeFilter


### PR DESCRIPTION
**High level description:**
TAS active filters, from older filter, are showing as undefined.

**Technical details:**
This is because in the relevant `.map` over the filter values, I was referencincing `tas.value` when I should've done just `tas`

**JIRA Ticket:**
[DEV-5120](https://federal-spending-transparency.atlassian.net/browse/DEV-5120)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A`  Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
