### PR TITLE
[DEV-3986] add awarding agency links

### DIFF
--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -96,7 +96,12 @@ export default class ResultsTable extends React.Component {
             // for Sub-Awards
             cellClass = ResultsTableLinkCell;
             props.id = this.props.results[rowIndex].prime_award_recipient_id;
-            props.column = 'recipient';
+            props.column = 'award';
+        }
+        else if (column.columnName === 'Awarding Agency' && this.props.results[rowIndex].awarding_agency_id) {
+            cellClass = ResultsTableLinkCell;
+            props.id = this.props.results[rowIndex].awarding_agency_id;
+            props.column = 'agency';
         }
         else if (column.columnName === 'Prime Award ID') {
             const primeAwardId = this.props.results[rowIndex].prime_award_generated_internal_id;


### PR DESCRIPTION
**High level description:**

Adds links to the Agency profile page under the "Awarding Agency" column on the advanced search page

**Technical details:**
API will now provide a new field "awarding_agency_id", which will allow linking to the agency profile page.


**JIRA Ticket:**
[DEV-3986](https://federal-spending-transparency.atlassian.net/browse/DEV-3986)

The following are ALL required for the PR to be merged:

Author:
- [X] Linked to this PR in JIRA ticket
- [X] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [X] Verified cross-browser compatibility
- [X] Verified mobile/tablet/desktop/monitor responsiveness
- [X] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [X] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)

Reviewer(s):
- [x] [API #2478](https://github.com/fedspendingtransparency/usaspending-api/pull/2478) merged concurrently 
- [x] Code review complete
