### PR TITLE
[DEV-3140] Link to recipient page from spending explorer

### DIFF
--- a/src/js/components/explorer/detail/header/DetailHeader.jsx
+++ b/src/js/components/explorer/detail/header/DetailHeader.jsx
@@ -95,6 +95,20 @@ const heading = (type, title, id) => {
             </h2>
         );
     }
+    else if (type === 'Recipient') {
+        return (
+            <h2 className="detail-header__title">
+                <a
+                    href={`/#/recipient/${id}/latest`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="detail-header__title-link"
+                    onClick={exitExplorer.bind(null, `/recipient/${id}/latest`)}>
+                    {title}
+                </a>
+            </h2>
+        );
+    }
     return (
         <h2 className="detail-header__title">
             {title}


### PR DESCRIPTION
**High level description:**

The recipinet name on spending explorer now links to the recipient page.

**Technical details:**

Current PR for API returns the recipient hash as the `id` so that the recipient name can link to the recipient page in a new tab per the AC.

**JIRA Ticket:**
[DEV-3140](https://federal-spending-transparency.atlassian.net/browse/DEV-3140)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [X] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [X] Verified cross-browser compatibility
- [X] Verified mobile/tablet/desktop/monitor responsiveness
- [X] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [ ] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [X] [API #2482](https://github.com/fedspendingtransparency/usaspending-api/pull/2482) merged concurrently `if applicable`
- [x] Code review complete
