### PR TITLE
DEV-5225 Remove "Total" from agency v2 tabs

### DIFF
--- a/src/js/components/agency/v2/accountSpending/AccountSpending.jsx
+++ b/src/js/components/agency/v2/accountSpending/AccountSpending.jsx
@@ -15,7 +15,7 @@ const propTypes = {
 const tabs = [
     {
         type: 'budget_function',
-        label: 'Total Budget Functions',
+        label: 'Budget Functions',
         description: 'What were the major categories of spending?',
         subHeading: 'Budget Sub-Functions',
         countField: 'budget_function_count',
@@ -23,19 +23,19 @@ const tabs = [
     },
     {
         type: 'program_activity',
-        label: 'Total Program Activities',
+        label: 'Program Activities',
         description: 'What were the purposes of this agency’s spending?',
         countField: 'program_activity_count'
     },
     {
         type: 'object_class',
-        label: 'Total Object Classes',
+        label: 'Object Classes',
         description: 'What types of things did this agency purchase?',
         countField: 'object_class_count'
     },
     {
         type: 'federal_account',
-        label: 'Total Federal Accounts',
+        label: 'Federal Accounts',
         description: 'What accounts funded this agency’s spending?',
         subHeading: 'Treasury Accounts',
         countField: 'federal_account_count',


### PR DESCRIPTION
**High level description:**

Design changed since the tabs were implemented in #1667 

**JIRA Ticket:**
[DEV-5225](https://federal-spending-transparency.atlassian.net/browse/DEV-5225)

**Mockup:**
https://bahdigital.invisionapp.com/share/2YIACOYGKF3#/296028021_Agency_Profile_V2_-_Mock_Mid-Fi

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
- [x] Code review complete