### PR TITLE
[DEV-4469] Release Checkbox Trees TAS/NAICS/PSC

### DIFF
--- a/src/js/components/search/SearchSidebar.jsx
+++ b/src/js/components/search/SearchSidebar.jsx
@@ -21,7 +21,6 @@ import AwardAmountSearchContainer from
     'containers/search/filters/awardAmount/AwardAmountSearchContainer';
 import CFDASearchContainer from 'containers/search/filters/cfda/CFDASearchContainer';
 import NAICSCheckboxTree from 'containers/search/filters/naics/NAICSCheckboxTree';
-import PSCSearchContainer from 'containers/search/filters/psc/PSCSearchContainer';
 import PSCCheckboxTreeContainer from 'containers/search/filters/psc/PSCCheckboxTreeContainer';
 import PricingTypeContainer from 'containers/search/filters/PricingTypeContainer';
 import SetAsideContainer from 'containers/search/filters/SetAsideContainer';
@@ -32,10 +31,6 @@ import KeywordHover from 'components/search/filters/keyword/KeywordHover';
 import { Filter as FilterIcon } from 'components/sharedComponents/icons/Icons';
 import FilterSidebar from 'components/sharedComponents/filterSidebar/FilterSidebar';
 import * as SidebarHelper from 'helpers/sidebarHelper';
-
-import kGlobalConstants from 'GlobalConstants';
-
-const PscComponent = kGlobalConstants.DEV ? PSCCheckboxTreeContainer : PSCSearchContainer;
 
 const filters = {
     options: [
@@ -69,7 +64,7 @@ const filters = {
         AwardIDSearchContainer,
         CFDASearchContainer,
         NAICSCheckboxTree,
-        PscComponent,
+        PSCCheckboxTreeContainer,
         PricingTypeContainer,
         SetAsideContainer,
         ExtentCompetedContainer

--- a/src/js/components/search/SearchSidebar.jsx
+++ b/src/js/components/search/SearchSidebar.jsx
@@ -36,7 +36,6 @@ import * as SidebarHelper from 'helpers/sidebarHelper';
 import kGlobalConstants from 'GlobalConstants';
 
 const PscComponent = kGlobalConstants.DEV ? PSCCheckboxTreeContainer : PSCSearchContainer;
-const tasTitle = kGlobalConstants.DEV ? 'Treasury Account Symbol (TAS)' : 'Program Source (TAS)';
 
 const filters = {
     options: [
@@ -44,7 +43,7 @@ const filters = {
         'Time Period',
         'Award Type',
         'Agency',
-        tasTitle,
+        'Treasury Account Symbol (TAS)',
         'Location',
         'Recipient',
         'Recipient Type',

--- a/src/js/components/search/filters/programSource/ProgramSourceSection.jsx
+++ b/src/js/components/search/filters/programSource/ProgramSourceSection.jsx
@@ -183,8 +183,6 @@ export default class ProgramSourceSection extends React.Component {
             </React.Fragment>
         );
 
-        const tab2Title = 'TAS Components';
-
         return (
             <div className="program-source-filter search-filter">
                 <ul
@@ -211,7 +209,7 @@ export default class ProgramSourceSection extends React.Component {
                             title="Federal Account"
                             aria-label="Federal Account"
                             onClick={this.toggleTab}>
-                            {tab2Title}
+                            TAS Components
                         </button>
                     </li>
                 </ul>

--- a/src/js/components/search/filters/programSource/ProgramSourceSection.jsx
+++ b/src/js/components/search/filters/programSource/ProgramSourceSection.jsx
@@ -6,7 +6,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import kGlobalConstants from 'GlobalConstants';
 import SubmitHint from 'components/sharedComponents/filterSidebar/SubmitHint';
 import TreasuryAccountFilters from './TreasuryAccountFilters';
 import SelectedSources from './SelectedSources';
@@ -19,8 +18,6 @@ const propTypes = {
     updateTreasuryAccountComponents: PropTypes.func,
     dirtyFilters: PropTypes.symbol
 };
-
-const isDev = kGlobalConstants.DEV;
 
 export default class ProgramSourceSection extends React.Component {
     constructor(props) {
@@ -158,17 +155,7 @@ export default class ProgramSourceSection extends React.Component {
         );
 
         let selectedSources = null;
-        if (!isDev && activeTab === 2 && this.props.selectedFederalComponents) {
-            selectedSources = (
-                <SelectedSources
-                    removeSource={this.removeFilter}
-                    label="FA #"
-                    selectedSources={this.props.selectedFederalComponents} />);
-        }
-        else if (
-            (isDev && activeTab === 2 && this.props.selectedFederalComponents) ||
-            (!isDev && activeTab === 1 && this.props.selectedTreasuryComponents)
-        ) {
+        if (activeTab === 2 && this.props.selectedFederalComponents) {
             selectedSources = (
                 <SelectedSources
                     removeSource={this.removeFilter}
@@ -196,7 +183,7 @@ export default class ProgramSourceSection extends React.Component {
             </React.Fragment>
         );
 
-        const tab2Title = isDev ? 'TAS Components' : 'Federal Account';
+        const tab2Title = 'TAS Components';
 
         return (
             <div className="program-source-filter search-filter">

--- a/src/js/components/search/filters/programSource/TreasuryAccountFilters.jsx
+++ b/src/js/components/search/filters/programSource/TreasuryAccountFilters.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import EntityWarning from 'components/search/filters/location/EntityWarning';
-import kGlobalConstants from 'GlobalConstants';
 import ProgramSourceAutocompleteContainer from 'containers/search/filters/programSource/ProgramSourceAutocompleteContainer';
 import TASCheckboxTree from 'containers/search/filters/programSource/TASCheckboxTreeContainer';
 import { treasuryAccountComponents, federalAccountComponents } from 'dataMapping/search/programSourceComponents';
@@ -20,8 +19,6 @@ const propTypes = {
     clearSelection: PropTypes.func,
     activeTab: PropTypes.number
 };
-
-const isDev = kGlobalConstants.DEV;
 
 export default class TreasuryAccountFilters extends React.Component {
     constructor(props) {
@@ -49,33 +46,11 @@ export default class TreasuryAccountFilters extends React.Component {
 
     generateFilters() {
         if (this.props.activeTab === 1) {
-            if (isDev) {
-                return (
-                    <TASCheckboxTree />
-                );
-            }
-            return treasuryAccountComponents.map((option) => (
-                <ProgramSourceAutocompleteContainer
-                    dirtyFilters={this.props.dirtyFilters}
-                    key={option.code}
-                    component={option}
-                    selectedSources={this.props.components}
-                    updateComponent={this.props.updateComponent}
-                    clearSelection={this.props.clearSelection} />
-            ));
+            return (
+                <TASCheckboxTree />
+            );
         }
-        if (isDev) {
-            return treasuryAccountComponents.map((option) => (
-                <ProgramSourceAutocompleteContainer
-                    dirtyFilters={this.props.dirtyFilters}
-                    key={option.code}
-                    component={option}
-                    selectedSources={this.props.components}
-                    updateComponent={this.props.updateComponent}
-                    clearSelection={this.props.clearSelection} />
-            ));
-        }
-        return federalAccountComponents.map((option) => (
+        return treasuryAccountComponents.map((option) => (
             <ProgramSourceAutocompleteContainer
                 dirtyFilters={this.props.dirtyFilters}
                 key={option.code}
@@ -98,21 +73,12 @@ export default class TreasuryAccountFilters extends React.Component {
             message = "Enter value for AID";
         }
 
-        const heading = activeTab === 1
-            ? 'Treasury'
-            : 'Federal';
-
         return (
             <div className="program-source-tab">
                 <form className="program-source-components">
-                    {isDev && activeTab === 2 && (
+                    {activeTab === 2 && (
                         <div className="program-source-components__heading">
                             Treasury Account Components
-                        </div>
-                    )}
-                    {!isDev && (
-                        <div className="program-source-components__heading">
-                            {heading} Account Components
                         </div>
                     )}
                     {this.generateFilters()}
@@ -122,7 +88,7 @@ export default class TreasuryAccountFilters extends React.Component {
                         onMouseEnter={this.showWarning}
                         onBlur={this.hideWarning}
                         onMouseLeave={this.hideWarning}>
-                        {(!isDev || (isDev && activeTab === 2)) && (
+                        {activeTab === 2 && (
                             <button
                                 disabled={!enabled}
                                 onClick={this.props.applyFilter}

--- a/src/js/components/search/filters/programSource/TreasuryAccountFilters.jsx
+++ b/src/js/components/search/filters/programSource/TreasuryAccountFilters.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import EntityWarning from 'components/search/filters/location/EntityWarning';
 import ProgramSourceAutocompleteContainer from 'containers/search/filters/programSource/ProgramSourceAutocompleteContainer';
 import TASCheckboxTree from 'containers/search/filters/programSource/TASCheckboxTreeContainer';
-import { treasuryAccountComponents, federalAccountComponents } from 'dataMapping/search/programSourceComponents';
+import { treasuryAccountComponents } from 'dataMapping/search/programSourceComponents';
 
 const propTypes = {
     updateComponent: PropTypes.func,


### PR DESCRIPTION
**High level description:**
Release the checkbox trees.

**Technical details:**
Removes the dark release logic in the search sidebar component and, for tas, elsewhere.

**JIRA Ticket:**
[DEV-4469](https://federal-spending-transparency.atlassian.net/browse/DEV-4469)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
`N/A` Design review complete `if applicable`
- [x] [API #2481](https://github.com/fedspendingtransparency/usaspending-api/pull/2481) merged concurrently `if applicable`
- [x] PSC Submit & Follow Up Tech Debt Polish PR merged #1683 
- [x] Code review complete
