### PR TITLE
[DEV-5119] Update some titles and links

### DIFF
--- a/src/js/components/about/DataSources.jsx
+++ b/src/js/components/about/DataSources.jsx
@@ -32,7 +32,7 @@ export default class DataSources extends React.Component {
                             rel="noopener noreferrer">
                             Federal Procurement Data System Next Generation (FPDS-NG)
                         </a>, which is the system of record for federal procurement data;
-                        Financial Assistance award data is loaded in from the Federal Assistance
+                        Financial Assistance award data is loaded in from the Financial Assistance
                         Broker Submission system (FABS). In the end, more than 400 points of data
                         are collected.
                     </p>

--- a/src/js/components/award/shared/description/AwardDescription.jsx
+++ b/src/js/components/award/shared/description/AwardDescription.jsx
@@ -58,8 +58,8 @@ const AwardDescription = ({
                                     <span>
                                         {/* last word of heading inside the span to prevent the glossary icon from going to its own line by itself */}
                                         (PSC)
-                                        <a href={`#/award/${awardId}/?glossary=productservice-code-psc`}>
-                                            <Glossary alt="View glossary definition of Product/Service Code (PSC)" />
+                                        <a href={`#/award/${awardId}/?glossary=product-or-service-code-psc`}>
+                                            <Glossary alt="View glossary definition of Product or Service Code (PSC)" />
                                         </a>
                                     </span>
                                 </div>

--- a/src/js/components/search/SearchSidebar.jsx
+++ b/src/js/components/search/SearchSidebar.jsx
@@ -46,7 +46,7 @@ const filters = {
         'Award ID',
         'CFDA Program',
         'North American Industry Classification System (NAICS)',
-        'Product/Service Code (PSC)',
+        'Product or Service Code (PSC)',
         'Type of Contract Pricing',
         'Type of Set Aside',
         'Extent Competed'
@@ -99,7 +99,7 @@ const filters = {
         null,
         null,
         null,
-        'productservice-code-psc',
+        'product-or-service-code-psc',
         null,
         null
     ]

--- a/src/js/containers/search/helpers/searchAnalytics.js
+++ b/src/js/containers/search/helpers/searchAnalytics.js
@@ -176,7 +176,7 @@ export const convertFilter = (type, value) => {
         case 'selectedPSC':
             return convertReducibleValue(
                 value,
-                'Product/Service Code (PSC)',
+                'Product or Service Code (PSC)',
                 (psc) => `${psc.product_or_service_code} - ${psc.psc_description}`
             );
         case 'pricingType':

--- a/src/js/helpers/sidebarHelper.js
+++ b/src/js/helpers/sidebarHelper.js
@@ -61,7 +61,7 @@ export const filterHasSelections = (reduxFilters, filter) => {
             return false;
         case 'North American Industry Classification System (NAICS)':
             return (reduxFilters.naicsCodes.toObject().require.length > 0);
-        case 'Product/Service Code (PSC)':
+        case 'Product or Service Code (PSC)':
             if (reduxFilters.selectedPSC.toArray().length > 0) {
                 return true;
             }

--- a/tests/models/awards/additionalDetails/BaseContractAdditionalDetails-test.js
+++ b/tests/models/awards/additionalDetails/BaseContractAdditionalDetails-test.js
@@ -11,7 +11,7 @@ details.populate(mockContractApi.latest_transaction.contract_data);
 
 describe('BaseContractAdditionalDetails', () => {
     it('should format psc code', () => {
-        expect(details.pscCode).toEqual('psc: product/service description');
+        expect(details.pscCode).toEqual('psc: product or service description');
     });
     it('should format naics code', () => {
         expect(details.naicsCode).toEqual('naics');

--- a/tests/models/awards/mockAwardApi.js
+++ b/tests/models/awards/mockAwardApi.js
@@ -21,7 +21,7 @@ export const mockContractApi = {
             contract_award_type_desc: 'mock contract type',
             awarding_office_name: 'Office of Cheesesteak',
             product_or_service_code: 'psc',
-            product_or_service_co_desc: 'product/service description',
+            product_or_service_co_desc: 'product or service description',
             naics: 'naics',
             naics_description: null,
             clinger_cohen_act_planning: null,


### PR DESCRIPTION
**High level description:**

- Updated incorrect definition for FABS in About Us -> Data Sources
- Fixed a broken link caused by a glossary change
- Replaced "Product/Service" with "Product or Service" wherever it was found

That's about it.  EZPZ.  Hopefully I didn't break anything.

[There is a matching back end ticket](https://github.com/fedspendingtransparency/usaspending-api/pull/2496), but it isn't strictly necessary to merge them together.  A glossary link won't work until they're both merged, but nothing should burst into flames.