### PR TITLE
added purple to dictionary colors

### DIFF
--- a/src/_scss/pages/bulkDownload/dictionary/_dictionaryTable.scss
+++ b/src/_scss/pages/bulkDownload/dictionary/_dictionaryTable.scss
@@ -138,10 +138,10 @@ $dictionary-yellow: #FFF694;
         background-color: $dictionary-green;
     }
     .section-1 {
-        background-color: $dictionary-purple;
+        background-color: $dictionary-teal;
     }
     .section-2 {
-        background-color: $dictionary-teal;
+        background-color: $dictionary-purple;
     }
     .section-3 {
         background-color: $dictionary-orange;
@@ -151,10 +151,10 @@ $dictionary-yellow: #FFF694;
         background-color: $dictionary-green-light;
     }
     .section-1-col {
-        background-color: $dictionary-purple-light;
+        background-color: $dictionary-teal-light;
     }
     .section-2-col {
-        background-color: $dictionary-teal-light;
+        background-color: $dictionary-purple-light;
     }
     .section-3-col {
         background-color: $dictionary-orange-light;
@@ -164,10 +164,10 @@ $dictionary-yellow: #FFF694;
         background-color: $dictionary-green-lighter;
     }
     .section-1-cell {
-        background-color: $dictionary-purple-lighter;
+        background-color: $dictionary-teal-lighter;
     }
     .section-2-cell {
-        background-color: $dictionary-teal-lighter;
+        background-color: $dictionary-purple-lighter;
     }
     .section-3-cell {
         background-color: $dictionary-orange-lighter;

--- a/src/_scss/pages/bulkDownload/dictionary/_dictionaryTable.scss
+++ b/src/_scss/pages/bulkDownload/dictionary/_dictionaryTable.scss
@@ -1,15 +1,18 @@
 /* Section Headings */
 $dictionary-green: #D8E4BC;
+$dictionary-purple: #AD79E9;
 $dictionary-teal: #B7DEE8;
 $dictionary-orange: #FDE9D9;
 
 /* Column Headings */
 $dictionary-green-light: #E4ECD0;
+$dictionary-purple-light: #C39DEB;
 $dictionary-teal-light: #DBEEF3;
 $dictionary-orange-light: #FEF0E5;
 
 /* Table Cells */
 $dictionary-green-lighter: #F8FAF2;
+$dictionary-purple-lighter: #B699C6;
 $dictionary-teal-lighter: #F1F9FB;
 $dictionary-orange-lighter: #FFFBF8;
 
@@ -135,9 +138,12 @@ $dictionary-yellow: #FFF694;
         background-color: $dictionary-green;
     }
     .section-1 {
-        background-color: $dictionary-teal;
+        background-color: $dictionary-purple;
     }
     .section-2 {
+        background-color: $dictionary-teal;
+    }
+    .section-3 {
         background-color: $dictionary-orange;
     }
 
@@ -145,9 +151,12 @@ $dictionary-yellow: #FFF694;
         background-color: $dictionary-green-light;
     }
     .section-1-col {
-        background-color: $dictionary-teal-light;
+        background-color: $dictionary-purple-light;
     }
     .section-2-col {
+        background-color: $dictionary-teal-light;
+    }
+    .section-3-col {
         background-color: $dictionary-orange-light;
     }
 
@@ -155,9 +164,12 @@ $dictionary-yellow: #FFF694;
         background-color: $dictionary-green-lighter;
     }
     .section-1-cell {
-        background-color: $dictionary-teal-lighter;
+        background-color: $dictionary-purple-lighter;
     }
     .section-2-cell {
+        background-color: $dictionary-teal-lighter;
+    }
+    .section-3-cell {
         background-color: $dictionary-orange-lighter;
     }
 }

--- a/src/js/components/about/DataSources.jsx
+++ b/src/js/components/about/DataSources.jsx
@@ -32,7 +32,7 @@ export default class DataSources extends React.Component {
                             rel="noopener noreferrer">
                             Federal Procurement Data System Next Generation (FPDS-NG)
                         </a>, which is the system of record for federal procurement data;
-                        Financial Assistance award data is loaded in from the Federal Assistance
+                        Financial Assistance award data is loaded in from the Financial Assistance
                         Broker Submission system (FABS). In the end, more than 400 points of data
                         are collected.
                     </p>

--- a/src/js/components/agency/v2/accountSpending/AccountSpending.jsx
+++ b/src/js/components/agency/v2/accountSpending/AccountSpending.jsx
@@ -15,7 +15,7 @@ const propTypes = {
 const tabs = [
     {
         type: 'budget_function',
-        label: 'Total Budget Functions',
+        label: 'Budget Functions',
         description: 'What were the major categories of spending?',
         subHeading: 'Budget Sub-Functions',
         countField: 'budget_function_count',
@@ -23,19 +23,19 @@ const tabs = [
     },
     {
         type: 'program_activity',
-        label: 'Total Program Activities',
+        label: 'Program Activities',
         description: 'What were the purposes of this agency’s spending?',
         countField: 'program_activity_count'
     },
     {
         type: 'object_class',
-        label: 'Total Object Classes',
+        label: 'Object Classes',
         description: 'What types of things did this agency purchase?',
         countField: 'object_class_count'
     },
     {
         type: 'federal_account',
-        label: 'Total Federal Accounts',
+        label: 'Federal Accounts',
         description: 'What accounts funded this agency’s spending?',
         subHeading: 'Treasury Accounts',
         countField: 'federal_account_count',

--- a/src/js/components/award/shared/description/AwardDescription.jsx
+++ b/src/js/components/award/shared/description/AwardDescription.jsx
@@ -58,8 +58,8 @@ const AwardDescription = ({
                                     <span>
                                         {/* last word of heading inside the span to prevent the glossary icon from going to its own line by itself */}
                                         (PSC)
-                                        <a href={`#/award/${awardId}/?glossary=productservice-code-psc`}>
-                                            <Glossary alt="View glossary definition of Product/Service Code (PSC)" />
+                                        <a href={`#/award/${awardId}/?glossary=product-or-service-code-psc`}>
+                                            <Glossary alt="View glossary definition of Product or Service Code (PSC)" />
                                         </a>
                                     </span>
                                 </div>

--- a/src/js/components/search/SearchSidebar.jsx
+++ b/src/js/components/search/SearchSidebar.jsx
@@ -46,7 +46,7 @@ const filters = {
         'Award ID',
         'CFDA Program',
         'North American Industry Classification System (NAICS)',
-        'Product/Service Code (PSC)',
+        'Product or Service Code (PSC)',
         'Type of Contract Pricing',
         'Type of Set Aside',
         'Extent Competed'
@@ -99,7 +99,7 @@ const filters = {
         null,
         null,
         null,
-        'productservice-code-psc',
+        'product-or-service-code-psc',
         null,
         null
     ]

--- a/src/js/containers/bulkDownload/dictionary/DataDictionaryContainer.jsx
+++ b/src/js/containers/bulkDownload/dictionary/DataDictionaryContainer.jsx
@@ -95,7 +95,7 @@ export default class DataDictionaryContainer extends React.Component {
     changeSort(field, direction) {
         // Get the index of the column we are sorting by
         const index = this.state.columns.findIndex((col) => col.raw === field);
-
+        
         // Sort the rows based on their value at that index
         let rows = this.state.rows.sort((a, b) => a[index].localeCompare(b[index]));
 

--- a/src/js/containers/bulkDownload/dictionary/DataDictionaryContainer.jsx
+++ b/src/js/containers/bulkDownload/dictionary/DataDictionaryContainer.jsx
@@ -95,7 +95,7 @@ export default class DataDictionaryContainer extends React.Component {
     changeSort(field, direction) {
         // Get the index of the column we are sorting by
         const index = this.state.columns.findIndex((col) => col.raw === field);
-        
+
         // Sort the rows based on their value at that index
         let rows = this.state.rows.sort((a, b) => a[index].localeCompare(b[index]));
 

--- a/src/js/containers/search/helpers/searchAnalytics.js
+++ b/src/js/containers/search/helpers/searchAnalytics.js
@@ -176,7 +176,7 @@ export const convertFilter = (type, value) => {
         case 'selectedPSC':
             return convertReducibleValue(
                 value,
-                'Product/Service Code (PSC)',
+                'Product or Service Code (PSC)',
                 (psc) => `${psc.product_or_service_code} - ${psc.psc_description}`
             );
         case 'pricingType':

--- a/src/js/helpers/sidebarHelper.js
+++ b/src/js/helpers/sidebarHelper.js
@@ -61,7 +61,7 @@ export const filterHasSelections = (reduxFilters, filter) => {
             return false;
         case 'North American Industry Classification System (NAICS)':
             return (reduxFilters.naicsCodes.toObject().require.length > 0);
-        case 'Product/Service Code (PSC)':
+        case 'Product or Service Code (PSC)':
             if (reduxFilters.selectedPSC.toArray().length > 0) {
                 return true;
             }

--- a/tests/models/awards/additionalDetails/BaseContractAdditionalDetails-test.js
+++ b/tests/models/awards/additionalDetails/BaseContractAdditionalDetails-test.js
@@ -11,7 +11,7 @@ details.populate(mockContractApi.latest_transaction.contract_data);
 
 describe('BaseContractAdditionalDetails', () => {
     it('should format psc code', () => {
-        expect(details.pscCode).toEqual('psc: product/service description');
+        expect(details.pscCode).toEqual('psc: product or service description');
     });
     it('should format naics code', () => {
         expect(details.naicsCode).toEqual('naics');

--- a/tests/models/awards/mockAwardApi.js
+++ b/tests/models/awards/mockAwardApi.js
@@ -21,7 +21,7 @@ export const mockContractApi = {
             contract_award_type_desc: 'mock contract type',
             awarding_office_name: 'Office of Cheesesteak',
             product_or_service_code: 'psc',
-            product_or_service_co_desc: 'product/service description',
+            product_or_service_co_desc: 'product or service description',
             naics: 'naics',
             naics_description: null,
             clinger_cohen_act_planning: null,


### PR DESCRIPTION
**High level description:**
Now that there is a new purple section to the data dictionary (and the order of sections has changed), add a new class to the scss to support purple boxes.

**Technical details:**

Technical details for the knowledge of other developers.

**JIRA Ticket:**
[DEV-4176](https://federal-spending-transparency.atlassian.net/browse/DEV-4176)

**Mockup:**
None, we didn't realize this was a new requirement until after work had started. I've been in touch with Ross directly, and the Excell Data Dictionary was used as a framework for the color change.

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [N/A] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
