### PR TITLE
Mod/dev 4176 add data dict color

### DIFF
--- a/src/_scss/pages/bulkDownload/dictionary/_dictionaryTable.scss
+++ b/src/_scss/pages/bulkDownload/dictionary/_dictionaryTable.scss
@@ -138,10 +138,10 @@ $dictionary-yellow: #FFF694;
         background-color: $dictionary-green;
     }
     .section-1 {
-        background-color: $dictionary-purple;
+        background-color: $dictionary-teal;
     }
     .section-2 {
-        background-color: $dictionary-teal;
+        background-color: $dictionary-purple;
     }
     .section-3 {
         background-color: $dictionary-orange;
@@ -151,10 +151,10 @@ $dictionary-yellow: #FFF694;
         background-color: $dictionary-green-light;
     }
     .section-1-col {
-        background-color: $dictionary-purple-light;
+        background-color: $dictionary-teal-light;
     }
     .section-2-col {
-        background-color: $dictionary-teal-light;
+        background-color: $dictionary-purple-light;
     }
     .section-3-col {
         background-color: $dictionary-orange-light;
@@ -164,10 +164,10 @@ $dictionary-yellow: #FFF694;
         background-color: $dictionary-green-lighter;
     }
     .section-1-cell {
-        background-color: $dictionary-purple-lighter;
+        background-color: $dictionary-teal-lighter;
     }
     .section-2-cell {
-        background-color: $dictionary-teal-lighter;
+        background-color: $dictionary-purple-lighter;
     }
     .section-3-cell {
         background-color: $dictionary-orange-lighter;

--- a/src/_scss/pages/bulkDownload/dictionary/_dictionaryTable.scss
+++ b/src/_scss/pages/bulkDownload/dictionary/_dictionaryTable.scss
@@ -1,15 +1,18 @@
 /* Section Headings */
 $dictionary-green: #D8E4BC;
+$dictionary-purple: #AD79E9;
 $dictionary-teal: #B7DEE8;
 $dictionary-orange: #FDE9D9;
 
 /* Column Headings */
 $dictionary-green-light: #E4ECD0;
+$dictionary-purple-light: #C39DEB;
 $dictionary-teal-light: #DBEEF3;
 $dictionary-orange-light: #FEF0E5;
 
 /* Table Cells */
 $dictionary-green-lighter: #F8FAF2;
+$dictionary-purple-lighter: #B699C6;
 $dictionary-teal-lighter: #F1F9FB;
 $dictionary-orange-lighter: #FFFBF8;
 
@@ -135,9 +138,12 @@ $dictionary-yellow: #FFF694;
         background-color: $dictionary-green;
     }
     .section-1 {
-        background-color: $dictionary-teal;
+        background-color: $dictionary-purple;
     }
     .section-2 {
+        background-color: $dictionary-teal;
+    }
+    .section-3 {
         background-color: $dictionary-orange;
     }
 
@@ -145,9 +151,12 @@ $dictionary-yellow: #FFF694;
         background-color: $dictionary-green-light;
     }
     .section-1-col {
-        background-color: $dictionary-teal-light;
+        background-color: $dictionary-purple-light;
     }
     .section-2-col {
+        background-color: $dictionary-teal-light;
+    }
+    .section-3-col {
         background-color: $dictionary-orange-light;
     }
 
@@ -155,9 +164,12 @@ $dictionary-yellow: #FFF694;
         background-color: $dictionary-green-lighter;
     }
     .section-1-cell {
-        background-color: $dictionary-teal-lighter;
+        background-color: $dictionary-purple-lighter;
     }
     .section-2-cell {
+        background-color: $dictionary-teal-lighter;
+    }
+    .section-3-cell {
         background-color: $dictionary-orange-lighter;
     }
 }

--- a/src/_scss/pages/bulkDownload/dictionary/_dictionaryTable.scss
+++ b/src/_scss/pages/bulkDownload/dictionary/_dictionaryTable.scss
@@ -1,18 +1,18 @@
 /* Section Headings */
 $dictionary-green: #D8E4BC;
-$dictionary-purple: #AD79E9;
+$dictionary-purple: #E2D8EB;
 $dictionary-teal: #B7DEE8;
 $dictionary-orange: #FDE9D9;
 
 /* Column Headings */
 $dictionary-green-light: #E4ECD0;
-$dictionary-purple-light: #C39DEB;
+$dictionary-purple-light: #ECE6F2;
 $dictionary-teal-light: #DBEEF3;
 $dictionary-orange-light: #FEF0E5;
 
 /* Table Cells */
 $dictionary-green-lighter: #F8FAF2;
-$dictionary-purple-lighter: #B699C6;
+$dictionary-purple-lighter: #F7F4FA;
 $dictionary-teal-lighter: #F1F9FB;
 $dictionary-orange-lighter: #FFFBF8;
 

--- a/src/_scss/pages/bulkDownload/dictionary/_dictionaryTable.scss
+++ b/src/_scss/pages/bulkDownload/dictionary/_dictionaryTable.scss
@@ -1,12 +1,12 @@
 /* Section Headings */
 $dictionary-green: #D8E4BC;
-$dictionary-purple: #E2D8EB;
+$dictionary-purple: #D5D3EA;
 $dictionary-teal: #B7DEE8;
 $dictionary-orange: #FDE9D9;
 
 /* Column Headings */
 $dictionary-green-light: #E4ECD0;
-$dictionary-purple-light: #ECE6F2;
+$dictionary-purple-light: #ECEAF5;
 $dictionary-teal-light: #DBEEF3;
 $dictionary-orange-light: #FEF0E5;
 

--- a/src/js/containers/bulkDownload/dictionary/DataDictionaryContainer.jsx
+++ b/src/js/containers/bulkDownload/dictionary/DataDictionaryContainer.jsx
@@ -95,7 +95,7 @@ export default class DataDictionaryContainer extends React.Component {
     changeSort(field, direction) {
         // Get the index of the column we are sorting by
         const index = this.state.columns.findIndex((col) => col.raw === field);
-
+        
         // Sort the rows based on their value at that index
         let rows = this.state.rows.sort((a, b) => a[index].localeCompare(b[index]));
 

--- a/src/js/containers/bulkDownload/dictionary/DataDictionaryContainer.jsx
+++ b/src/js/containers/bulkDownload/dictionary/DataDictionaryContainer.jsx
@@ -95,7 +95,7 @@ export default class DataDictionaryContainer extends React.Component {
     changeSort(field, direction) {
         // Get the index of the column we are sorting by
         const index = this.state.columns.findIndex((col) => col.raw === field);
-        
+
         // Sort the rows based on their value at that index
         let rows = this.state.rows.sort((a, b) => a[index].localeCompare(b[index]));
 

--- a/src/js/containers/bulkDownload/dictionary/DataDictionaryContainer.jsx
+++ b/src/js/containers/bulkDownload/dictionary/DataDictionaryContainer.jsx
@@ -93,7 +93,7 @@ export default class DataDictionaryContainer extends React.Component {
     }
 
     defaultSort() {
-        if(this.state.columns.length > 0){
+        if (this.state.columns.length > 0) {
             this.changeSort(this.state.columns[0].raw, 'asc');
         }
     }

--- a/src/js/containers/bulkDownload/dictionary/DataDictionaryContainer.jsx
+++ b/src/js/containers/bulkDownload/dictionary/DataDictionaryContainer.jsx
@@ -88,8 +88,14 @@ export default class DataDictionaryContainer extends React.Component {
             rows: parsedRows
         }, () => {
             // Default sort
-            this.changeSort(this.state.columns[0].raw, 'asc');
+            this.defaultSort();
         });
+    }
+
+    defaultSort() {
+        if(this.state.columns.length > 0){
+            this.changeSort(this.state.columns[0].raw, 'asc');
+        }
     }
 
     changeSort(field, direction) {

--- a/src/js/containers/bulkDownload/dictionary/DataDictionaryContainer.jsx
+++ b/src/js/containers/bulkDownload/dictionary/DataDictionaryContainer.jsx
@@ -88,7 +88,7 @@ export default class DataDictionaryContainer extends React.Component {
             rows: parsedRows
         }, () => {
             // Default sort
-            this.changeSort('element', 'asc');
+            this.changeSort(this.state.columns[0].raw, 'asc');
         });
     }
 


### PR DESCRIPTION
**High level description:**
Now that there is a new purple section to the data dictionary (and the order of sections has changed), add a new class to the scss to support purple boxes.

**Technical details:**

Technical details for the knowledge of other developers.

**JIRA Ticket:**
[DEV-4176](https://federal-spending-transparency.atlassian.net/browse/DEV-4176)

**Mockup:**
None, we didn't realize this was a new requirement until after work had started. I've been in touch with Ross directly, and the Excell Data Dictionary was used as a framework for the color change.

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [N/A ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [N/A ] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
- [N/A] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete