### PR TITLE
[DEV-4469] Checkbox Trees Search Performance and Search Side Bar Title Update for PSC

### DIFF
--- a/src/js/components/search/SearchSidebar.jsx
+++ b/src/js/components/search/SearchSidebar.jsx
@@ -46,7 +46,7 @@ const filters = {
         'Award ID',
         'CFDA Program',
         'North American Industry Classification System (NAICS)',
-        'Product/Service Code (PSC)',
+        'Product or Service Code (PSC)',
         'Type of Contract Pricing',
         'Type of Set Aside',
         'Extent Competed'

--- a/src/js/containers/search/filters/naics/NAICSCheckboxTree.jsx
+++ b/src/js/containers/search/filters/naics/NAICSCheckboxTree.jsx
@@ -21,7 +21,10 @@ import {
     getHighestAncestorNaicsCode
 } from 'helpers/naicsHelper';
 
-import { getAllDescendants } from 'helpers/checkboxTreeHelper';
+import {
+    getAllDescendants,
+    doesMeetMinimumCharsRequiredForSearch
+} from 'helpers/checkboxTreeHelper';
 
 import { naicsRequest } from 'helpers/searchHelper';
 
@@ -235,18 +238,21 @@ export class NAICSCheckboxTree extends React.Component {
     };
 
     handleTextInputChange = (e) => {
+        e.persist();
         const text = e.target.value;
         if (!text) {
             return this.onClear();
         }
+        const shouldTriggerSearch = doesMeetMinimumCharsRequiredForSearch(text);
+        if (shouldTriggerSearch) {
+            return this.setState({
+                searchString: text,
+                isSearch: true,
+                isLoading: true
+            }, this.onSearchChange);
+        }
         return this.setState({
-            searchString: text,
-            isSearch: true,
-            isLoading: true
-        }, () => {
-            if (text.length >= 3) {
-                this.onSearchChange();
-            }
+            searchString: text
         });
     }
 

--- a/src/js/containers/search/filters/naics/NAICSCheckboxTree.jsx
+++ b/src/js/containers/search/filters/naics/NAICSCheckboxTree.jsx
@@ -239,7 +239,15 @@ export class NAICSCheckboxTree extends React.Component {
         if (!text) {
             return this.onClear();
         }
-        return this.setState({ searchString: text, isSearch: true, isLoading: true }, this.onSearchChange);
+        return this.setState({
+            searchString: text,
+            isSearch: true,
+            isLoading: true
+        }, () => {
+            if (text.length >= 3) {
+                this.onSearchChange();
+            }
+        });
     }
 
     autoCheckSearchedResultDescendants = (checked, expanded) => {

--- a/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
@@ -21,7 +21,8 @@ import {
     removePlaceholderString,
     getUniqueAncestorPaths,
     getAllDescendants,
-    trimCheckedToCommonAncestors
+    trimCheckedToCommonAncestors,
+    doesMeetMinimumCharsRequiredForSearch
 } from 'helpers/checkboxTreeHelper';
 import {
     setTasNodes,
@@ -326,18 +327,21 @@ export class TASCheckboxTree extends React.Component {
     }
 
     handleTextInputChange = (e) => {
+        e.persist();
         const text = e.target.value;
         if (!text) {
             return this.onClear();
         }
+        const shouldTriggerSearch = doesMeetMinimumCharsRequiredForSearch(text);
+        if (shouldTriggerSearch) {
+            return this.setState({
+                searchString: text,
+                isSearch: true,
+                isLoading: true
+            }, this.onSearchChange);
+        }
         return this.setState({
-            searchString: text,
-            isSearch: true,
-            isLoading: true
-        }, () => {
-            if (e.target.value.length >= 3) {
-                this.onSearchChange();
-            }
+            searchString: text
         });
     }
 

--- a/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
@@ -334,7 +334,11 @@ export class TASCheckboxTree extends React.Component {
             searchString: text,
             isSearch: true,
             isLoading: true
-        }, this.onSearchChange);
+        }, () => {
+            if (e.target.value.length >= 3) {
+                this.onSearchChange();
+            }
+        });
     }
 
     render() {

--- a/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
@@ -20,7 +20,8 @@ import {
     getAllDescendants,
     removePlaceholderString,
     getUniqueAncestorPaths,
-    trimCheckedToCommonAncestors
+    trimCheckedToCommonAncestors,
+    doesMeetMinimumCharsRequiredForSearch
 } from 'helpers/checkboxTreeHelper';
 
 import {
@@ -324,18 +325,21 @@ export class PSCCheckboxTreeContainer extends React.Component {
     }
 
     handleTextInputChange = (e) => {
+        e.persist();
         const text = e.target.value;
         if (!text) {
             return this.onClear();
         }
+        const shouldTriggerSearch = doesMeetMinimumCharsRequiredForSearch(text);
+        if (shouldTriggerSearch) {
+            return this.setState({
+                searchString: text,
+                isSearch: true,
+                isLoading: true
+            }, this.onSearchChange);
+        }
         return this.setState({
-            searchString: text,
-            isSearch: true,
-            isLoading: true
-        }, () => {
-            if (text.length >= 3) {
-                this.onSearchChange();
-            }
+            searchString: text
         });
     }
 

--- a/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
@@ -332,7 +332,11 @@ export class PSCCheckboxTreeContainer extends React.Component {
             searchString: text,
             isSearch: true,
             isLoading: true
-        }, this.onSearchChange);
+        }, () => {
+            if (text.length >= 3) {
+                this.onSearchChange();
+            }
+        });
     }
 
     render() {

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -5,6 +5,11 @@
 
 import { difference, cloneDeep, isEqual } from 'lodash';
 
+export const doesMeetMinimumCharsRequiredForSearch = (str = '', charMinimum = 3) => (
+    str &&
+    str.length >= charMinimum
+);
+
 const getChildren = (node, keyMap) => {
     if (!node.children && keyMap.isParent(node)) {
         const value = node[keyMap.value]

--- a/tests/containers/search/filters/naics/NAICSCheckboxTree-test.jsx
+++ b/tests/containers/search/filters/naics/NAICSCheckboxTree-test.jsx
@@ -120,4 +120,16 @@ describe('NAICS Search Filter Container', () => {
             expect(setUnchecked).toHaveBeenCalledWith([uncheckedNode.value]);
         });
     });
+    describe('handleTextInputChange', () => {
+        it('only calls onSearchChange if search string is greater than or equal to 3 chars', () => {
+            const mockFn = jest.fn();
+            const container = shallow(<NAICSCheckboxTree {...defaultProps} nodes={reallyBigTree} />);
+            container.instance().onSearchChange = mockFn;
+            container.instance().handleTextInputChange({ target: { value: 'a' } });
+            container.instance().handleTextInputChange({ target: { value: 'ab' } });
+            expect(mockFn).not.toHaveBeenCalled();
+            container.instance().handleTextInputChange({ target: { value: 'abc' } });
+            expect(mockFn).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/tests/containers/search/filters/naics/NAICSCheckboxTree-test.jsx
+++ b/tests/containers/search/filters/naics/NAICSCheckboxTree-test.jsx
@@ -125,10 +125,10 @@ describe('NAICS Search Filter Container', () => {
             const mockFn = jest.fn();
             const container = shallow(<NAICSCheckboxTree {...defaultProps} nodes={reallyBigTree} />);
             container.instance().onSearchChange = mockFn;
-            container.instance().handleTextInputChange({ target: { value: 'a' } });
-            container.instance().handleTextInputChange({ target: { value: 'ab' } });
+            container.instance().handleTextInputChange({ target: { value: 'a' }, persist: () => {} });
+            container.instance().handleTextInputChange({ target: { value: 'ab' }, persist: () => {} });
             expect(mockFn).not.toHaveBeenCalled();
-            container.instance().handleTextInputChange({ target: { value: 'abc' } });
+            container.instance().handleTextInputChange({ target: { value: 'abc' }, persist: () => {} });
             expect(mockFn).toHaveBeenCalledTimes(1);
         });
     });

--- a/tests/containers/search/filters/programSource/TASCheckboxContainer-test.jsx
+++ b/tests/containers/search/filters/programSource/TASCheckboxContainer-test.jsx
@@ -177,4 +177,21 @@ describe('TASCheckboxContainer', () => {
             expect(newChecked).toEqual([]);
         });
     });
+    describe('handleTextInputChange', () => {
+        it('only calls onSearchChange if search string is greater than or equal to 3 chars', () => {
+            const mockFn = jest.fn();
+            const container = shallow(<TASCheckboxTree
+                {...defaultProps}
+                setCheckedTas={mockFn}
+                nodes={treePopulatedToFederalAccountLevel}
+                checked={['012']} />);
+            
+            container.instance().onSearchChange = mockFn;
+            container.instance().handleTextInputChange({ target: { value: 'a' } });
+            container.instance().handleTextInputChange({ target: { value: 'ab' } });
+            expect(mockFn).not.toHaveBeenCalled();
+            container.instance().handleTextInputChange({ target: { value: 'abc' } });
+            expect(mockFn).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/tests/containers/search/filters/programSource/TASCheckboxContainer-test.jsx
+++ b/tests/containers/search/filters/programSource/TASCheckboxContainer-test.jsx
@@ -187,10 +187,10 @@ describe('TASCheckboxContainer', () => {
                 checked={['012']} />);
             
             container.instance().onSearchChange = mockFn;
-            container.instance().handleTextInputChange({ target: { value: 'a' } });
-            container.instance().handleTextInputChange({ target: { value: 'ab' } });
+            container.instance().handleTextInputChange({ target: { value: 'a' }, persist: () => {} });
+            container.instance().handleTextInputChange({ target: { value: 'ab' }, persist: () => {} });
             expect(mockFn).not.toHaveBeenCalled();
-            container.instance().handleTextInputChange({ target: { value: 'abc' } });
+            container.instance().handleTextInputChange({ target: { value: 'abc' }, persist: () => {} });
             expect(mockFn).toHaveBeenCalledTimes(1);
         });
     });

--- a/tests/containers/search/filters/psc/PSCCheckboxTreeContainer-test.jsx
+++ b/tests/containers/search/filters/psc/PSCCheckboxTreeContainer-test.jsx
@@ -279,4 +279,16 @@ describe('PscCheckboxTreeContainer', () => {
             expect(mockSetCheckedPsc).toHaveBeenCalledWith(checkedNodes);
         });
     });
+    describe('handleTextInputChange', () => {
+        it('only calls onSearchChange if search string is greater than or equal to 3 chars', () => {
+            const mockFn = jest.fn();
+            const container = shallow(<PSCCheckboxTreeContainer {...defaultProps} nodes={reallyBigTree} />);
+            container.instance().onSearchChange = mockFn;
+            container.instance().handleTextInputChange({ target: { value: 'a' } });
+            container.instance().handleTextInputChange({ target: { value: 'ab' } });
+            expect(mockFn).not.toHaveBeenCalled();
+            container.instance().handleTextInputChange({ target: { value: 'abc' } });
+            expect(mockFn).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/tests/containers/search/filters/psc/PSCCheckboxTreeContainer-test.jsx
+++ b/tests/containers/search/filters/psc/PSCCheckboxTreeContainer-test.jsx
@@ -284,10 +284,10 @@ describe('PscCheckboxTreeContainer', () => {
             const mockFn = jest.fn();
             const container = shallow(<PSCCheckboxTreeContainer {...defaultProps} nodes={reallyBigTree} />);
             container.instance().onSearchChange = mockFn;
-            container.instance().handleTextInputChange({ target: { value: 'a' } });
-            container.instance().handleTextInputChange({ target: { value: 'ab' } });
+            container.instance().handleTextInputChange({ target: { value: 'a' }, persist: () => {} });
+            container.instance().handleTextInputChange({ target: { value: 'ab' }, persist: () => {} });
             expect(mockFn).not.toHaveBeenCalled();
-            container.instance().handleTextInputChange({ target: { value: 'abc' } });
+            container.instance().handleTextInputChange({ target: { value: 'abc' }, persist: () => {} });
             expect(mockFn).toHaveBeenCalledTimes(1);
         });
     });

--- a/tests/helpers/checkboxTreeHelper-test.js
+++ b/tests/helpers/checkboxTreeHelper-test.js
@@ -15,7 +15,8 @@ import {
     addChildrenAndPossiblyPlaceholder,
     areChildrenPartial,
     getUniqueAncestorPaths,
-    trimCheckedToCommonAncestors
+    trimCheckedToCommonAncestors,
+    doesMeetMinimumCharsRequiredForSearch
 } from 'helpers/checkboxTreeHelper';
 import {
     getHighestAncestorNaicsCode,
@@ -863,5 +864,11 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
             expect(leanArray.length).toEqual(1);
             expect(leanArray).toEqual([['Research and Development']]);
         });
+    });
+    describe('doesMeetMinimumCharsRequiredForSearch', () => {
+        const mockFalse = doesMeetMinimumCharsRequiredForSearch('ab');
+        const mockTrue = doesMeetMinimumCharsRequiredForSearch('abc');
+        expect(mockFalse).toEqual(false);
+        expect(mockTrue).toEqual(true);
     });
 });


### PR DESCRIPTION
**High level description:**
Only search for NAICS/TAS/PSC if the input is greater than or equal to three chars.
Also, corrected the search side bar title for PSC per https://federal-spending-transparency.atlassian.net/browse/DEV-5119.

**Technical details:**
Adds conditional to `handleInputChange` on all trees and adds identical test for each.


**JIRA Ticket:**
[DEV-4469](https://federal-spending-transparency.atlassian.net/browse/DEV-4469)
[DEV-5119](https://federal-spending-transparency.atlassian.net/browse/DEV-5119)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
