### PR TITLE
[DEV-4180] onHover, ensuring copy link doesn't wrap into two lines

### DIFF
--- a/src/_scss/layouts/default/stickyHeader/_toolbar.scss
+++ b/src/_scss/layouts/default/stickyHeader/_toolbar.scss
@@ -10,6 +10,9 @@
             .usa-dt-picker__list {
                 width: rem(140);
                 z-index: 1;
+                .usa-dt-picker__item {
+                    padding-right: rem(10);
+                }
                 span {
                     margin-left: rem(10);
                 }


### PR DESCRIPTION
**High level description:**
Removes 5px of padding

**Technical details:**
Prevents the Copy Link drop down item from wrapping into two lines in IE

**JIRA Ticket:**
[DEV-4180](https://federal-spending-transparency.atlassian.net/browse/DEV-4180)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
