### PR TITLE
[DEV-4180] Share Icon: Hiding on Explorer Detail Page and Fixing Email Body Content

### DIFF
--- a/src/js/components/accountLanding/AccountLandingPage.jsx
+++ b/src/js/components/accountLanding/AccountLandingPage.jsx
@@ -36,7 +36,7 @@ export default class AccountLandingPage extends React.Component {
                             slug={slug}
                             email={{
                                 subject: emailSubject,
-                                body: `Search for different Federal Accounts on USAspending.gov: ${getBaseUrl(slug)}`
+                                body: `View all of the Federal Account Profiles on USAspending.gov: ${getBaseUrl(slug)}`
                             }} />
                     </div>
                 </StickyHeader>

--- a/src/js/components/agencyLanding/AgencyLandingPage.jsx
+++ b/src/js/components/agencyLanding/AgencyLandingPage.jsx
@@ -38,7 +38,7 @@ export default class AgencyLandingPage extends React.Component {
                             slug={slug}
                             email={{
                                 subject: emailSubject,
-                                body: `Search for different Federal Agencies on USAspending.gov: ${getBaseUrl(slug)}`
+                                body: `View all of the Agency Profiles on USAspending.gov: ${getBaseUrl(slug)}`
                             }} />
                     </div>
                 </StickyHeader>

--- a/src/js/components/explorer/ExplorerWrapperPage.jsx
+++ b/src/js/components/explorer/ExplorerWrapperPage.jsx
@@ -49,7 +49,6 @@ const ExplorerWrapperPage = (props) => (
                         body: `View the Spending Explorer on USAspending.gov: ${getBaseUrl(slug)}`
                     }} />
                 }
-                
             </div>
         </StickyHeader>
         <main

--- a/src/js/components/explorer/ExplorerWrapperPage.jsx
+++ b/src/js/components/explorer/ExplorerWrapperPage.jsx
@@ -17,7 +17,12 @@ import StickyHeader from 'components/sharedComponents/stickyHeader/StickyHeader'
 
 
 const propTypes = {
-    children: PropTypes.element
+    children: PropTypes.element,
+    showShareIcon: PropTypes.bool
+};
+
+const defaultProps = {
+    showShareIcon: false
 };
 
 require('pages/explorer/explorerPage.scss');
@@ -36,12 +41,15 @@ const ExplorerWrapperPage = (props) => (
                 </h1>
             </div>
             <div className="sticky-header__toolbar">
+                {props.showShareIcon &&
                 <ShareIcon
                     slug={slug}
                     email={{
                         subject: emailSubject,
                         body: `Explore Federal Spending on USAspending.gov: ${getBaseUrl(slug)}`
                     }} />
+                }
+                
             </div>
         </StickyHeader>
         <main
@@ -54,5 +62,6 @@ const ExplorerWrapperPage = (props) => (
 );
 
 ExplorerWrapperPage.propTypes = propTypes;
+ExplorerWrapperPage.defaultProps = defaultProps;
 
 export default ExplorerWrapperPage;

--- a/src/js/components/explorer/ExplorerWrapperPage.jsx
+++ b/src/js/components/explorer/ExplorerWrapperPage.jsx
@@ -46,7 +46,7 @@ const ExplorerWrapperPage = (props) => (
                     slug={slug}
                     email={{
                         subject: emailSubject,
-                        body: `Explore Federal Spending on USAspending.gov: ${getBaseUrl(slug)}`
+                        body: `View the Spending Explorer on USAspending.gov: ${getBaseUrl(slug)}`
                     }} />
                 }
                 

--- a/src/js/components/explorer/landing/ExplorerLanding.jsx
+++ b/src/js/components/explorer/landing/ExplorerLanding.jsx
@@ -51,7 +51,7 @@ export default class ExplorerLanding extends React.Component {
         }
 
         return (
-            <ExplorerWrapperPage>
+            <ExplorerWrapperPage showShareIcon>
                 <div className="explorer-landing">
                     <div className="explorer-landing__intro">
                         <h2

--- a/src/js/components/recipientLanding/RecipientLandingPage.jsx
+++ b/src/js/components/recipientLanding/RecipientLandingPage.jsx
@@ -38,7 +38,7 @@ export default class RecipientLandingPage extends React.Component {
                             slug={slug}
                             email={{
                                 subject: emailSubject,
-                                body: `Search for different Recipients of Federal funding on USAspending.gov: ${getBaseUrl(slug)}`
+                                body: `View all of the Recipient Profiles on USAspending.gov: ${getBaseUrl(slug)}`
                             }} />
                     </div>
                 </StickyHeader>

--- a/src/js/components/stateLanding/StateLandingPage.jsx
+++ b/src/js/components/stateLanding/StateLandingPage.jsx
@@ -38,7 +38,7 @@ export default class StateLandingPage extends React.Component {
                             slug={slug}
                             email={{
                                 subject: emailSubject,
-                                body: `Search for different State profiles on USAspending.gov: ${getBaseUrl(slug)}`
+                                body: `View all of the State Profiles on USAspending.gov: ${getBaseUrl(slug)}`
                             }} />
                     </div>
                 </StickyHeader>


### PR DESCRIPTION
**High level description:**
- Ensures Explorer Detail Page does not show Share Icon
- Fixes email body details for landing pages.

**Technical details:**
Minor updates.

**JIRA Ticket:**
[DEV-4180](https://federal-spending-transparency.atlassian.net/browse/DEV-4180)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
