### PR TITLE
Change 'outlaid' to 'outlayed'

### DIFF
--- a/src/js/components/agency/visualizations/obligated/ObligatedVisualization.jsx
+++ b/src/js/components/agency/visualizations/obligated/ObligatedVisualization.jsx
@@ -135,7 +135,7 @@ export default class AgencyObligatedAmount extends React.Component {
                             obligatedText={formattedObligatedAmount}
                             legend={legend} />
                         <p className="outlay-text">
-                            ...and outlaid <span className="number number-bolder outlay">{formattedOutlayAmount}</span> in FY {this.props.activeFY}.
+                            ...and outlayed <span className="number number-bolder outlay">{formattedOutlayAmount}</span> in FY {this.props.activeFY}.
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
**High level description:**

Preterite and participle used for 'outlay' is 'outlayed', NOT 'outlaid'. Citation can be found in OMB's A-11: https://www.whitehouse.gov/wp-content/uploads/2018/06/a11.pdf 

Reviewer(s):

- [x] Code review complete
