### PR TITLE
[DEV-5198 & 5166] Warmfix IE Tooltip Bugs - Nested tooltips inside buttons

### DIFF
--- a/src/_scss/pages/award/idv/_referencedAwards.scss
+++ b/src/_scss/pages/award/idv/_referencedAwards.scss
@@ -4,7 +4,7 @@
         @import 'pages/search/results/table/tableTypes';
         .table-types {
             width: 100%;
-            button.table-type-toggle {
+            .table-type-toggle {
                 margin-top: 0;
             }
         }

--- a/src/_scss/pages/award/shared/_awardHistorySection.scss
+++ b/src/_scss/pages/award/shared/_awardHistorySection.scss
@@ -3,7 +3,7 @@
     width: 100%; 
     @import "./table/_tablesSection";
     .table-types {
-      button.table-type-toggle {
+      .table-type-toggle {
         margin-top: 0;
       }
     }

--- a/src/_scss/pages/recipientLanding/recipientLandingPage.scss
+++ b/src/_scss/pages/recipientLanding/recipientLandingPage.scss
@@ -81,7 +81,7 @@
 
     .table-types {
         margin-top: rem(5);
-        button.table-type-toggle {
+        .table-type-toggle {
             .tab-content {
                 .tab-label {
                     margin-right: 0;

--- a/src/_scss/pages/search/_tooltips.scss
+++ b/src/_scss/pages/search/_tooltips.scss
@@ -10,6 +10,7 @@ $letter-color: #323A45;
         @include justify-content(center);
         @include align-items(center);
         @include flex-direction(column);
+        width: 100%;
         // tooltip header styles
         h3 {
             margin: 0;

--- a/src/_scss/pages/search/results/table/_resultsTablePicker.scss
+++ b/src/_scss/pages/search/results/table/_resultsTablePicker.scss
@@ -8,7 +8,7 @@
   .field-list {
     width: rem(220);
   }
-  button.table-type-toggle.coming-soon {
+  .table-type-toggle.coming-soon {
     .coming-soon-container {
       text-align: right;
       float: right;

--- a/src/_scss/pages/search/results/table/_tableTypes.scss
+++ b/src/_scss/pages/search/results/table/_tableTypes.scss
@@ -3,9 +3,9 @@
     padding-left: rem(15);
     display: none;
     @include media($tablet-screen) {
-        display: block;
+        @include display(flex);
     }
-    button.table-type-toggle {
+    .table-type-toggle {
         border: 1px solid transparent;
         border-bottom: 1px solid $color-gray-light;
         color: $color-gray-dark;
@@ -17,6 +17,7 @@
         height: rem(50);
         vertical-align: middle;
         margin-bottom: -0.1rem;
+        width: auto;
         @include media($large-screen) {
             padding: rem(15);
         }

--- a/src/_scss/pages/state/topFive/_topFive.scss
+++ b/src/_scss/pages/state/topFive/_topFive.scss
@@ -2,7 +2,7 @@
     @import "pages/search/results/table/_tableTypes";
 
     .table-types {
-        button.table-type-toggle {
+        .table-type-toggle {
             .tab-content {
                 .tab-label {
                     margin-right: 0;

--- a/src/js/components/award/table/DetailsTabItem.jsx
+++ b/src/js/components/award/table/DetailsTabItem.jsx
@@ -72,7 +72,9 @@ export default class DetailsTabItem extends React.Component {
         }
 
         return (
-            <button
+            <div
+                role="button"
+                onKeyDown={this.clickedButton}
                 className={`table-type-toggle ${activeClass}${status}`}
                 onClick={this.clickedButton}
                 title={`Show ${this.props.label}`}
@@ -83,7 +85,7 @@ export default class DetailsTabItem extends React.Component {
                     {count}
                 </div>
                 {infoTooltip}
-            </button>
+            </div>
         );
     }
 }

--- a/src/js/components/search/table/ResultsTableTabItem.jsx
+++ b/src/js/components/search/table/ResultsTableTabItem.jsx
@@ -59,9 +59,10 @@ export default class ResultsTableTabItem extends React.Component {
         }
         const className = `table-type-toggle${activeClass} ${this.props.className}`;
         return (
-            <button
+            <div
                 className={className}
                 onClick={this.clickedTab}
+                onKeyDown={this.clickedTab}
                 role="menuitemradio"
                 aria-checked={this.props.active}
                 title={`Show ${this.props.label}`}
@@ -74,7 +75,7 @@ export default class ResultsTableTabItem extends React.Component {
                     {count}
                     {this.props.tooltip}
                 </div>
-            </button>
+            </div>
         );
     }
 }

--- a/src/js/components/sharedComponents/filterSidebar/FilterExpandButton.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterExpandButton.jsx
@@ -84,9 +84,11 @@ export default class FilterExpandButton extends React.Component {
         const filterClassName = this.props.className ? ` ${this.props.className}` : '';
         return (
             <div className="filter-toggle">
-                <button
+                <div
+                    role="button"
                     className={`filter-toggle__button ${hiddenClass}`}
                     onClick={this.props.toggleFilter}
+                    onKeyDown={this.props.toggleFilter}
                     disabled={this.props.disabled}
                     title={this.props.name}
                     aria-label={this.props.name}
@@ -97,7 +99,7 @@ export default class FilterExpandButton extends React.Component {
                         <span>{this.props.name}</span>
                         {this.props.tooltip && <this.props.tooltip />}
                     </div>
-                </button>
+                </div>
                 {glossaryLink}
                 <div className="filter-toggle__accessory">
                     {this.props.accessory && (


### PR DESCRIPTION
**High level description:**
Tooltips are not triggering when they're nested under buttons.

**Technical details:**
Changes button elements to divs, with the role set to button.

**JIRA Ticket:**
https://federal-spending-transparency.atlassian.net/browse/DEV-5198
https://federal-spending-transparency.atlassian.net/browse/DEV-5166

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, and helper functions `if applicable`
`N/A` All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A`  Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
