### PR TITLE
[DEV-5242] Precise Lines for the Award Amounts Visualization

### DIFF
--- a/src/js/components/award/shared/awardAmountsSection/charts/NormalChart.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/charts/NormalChart.jsx
@@ -26,6 +26,13 @@ const emptyTooltipProps = {
     tooltipComponent: <p>Placeholder</p>
 };
 
+const offsets = {
+    current: 10,
+    obligated: 14,
+    fileCObligated: 18,
+    fileCOutlay: 22
+};
+
 const NormalChart = ({ awardType, awardAmounts }) => {
     const [isTooltipVisible, setIsTooltipVisible] = useState(false);
     const [activeTooltipProps, setActiveTooltipProps] = useState(emptyTooltipProps);
@@ -153,6 +160,7 @@ const NormalChart = ({ awardType, awardAmounts }) => {
                 }}
                 {...activeTooltipProps} />}
             <div
+                style={{ marginLeft: `${offsets.obligated / 2}px` }}
                 className="award-amounts-viz__desc-top"
                 role="button"
                 tabIndex="0"
@@ -164,7 +172,7 @@ const NormalChart = ({ awardType, awardAmounts }) => {
                 onClick={showObligatedTooltip}>
                 <strong>{awardAmounts.totalObligationAbbreviated}</strong><br />{isIdv ? "Combined Obligated Amounts" : "Obligated Amount"}
             </div>
-            <div className="award-amounts-viz__label obligated" style={absoluteWidths.obligated}>
+            <div className="award-amounts-viz__label obligated" style={{ marginLeft: `${offsets.obligated / 2}px`, width: `calc(${absoluteWidths.obligated.width} - ${offsets.obligated}px)` }}>
                 <div className={`award-amounts-viz__line-up${classNameForCovid}`} />
             </div>
             {isCaresReleased &&
@@ -172,6 +180,7 @@ const NormalChart = ({ awardType, awardAmounts }) => {
                     <div
                         role="button"
                         className="award-amounts-viz__desc-top file-c-obligated"
+                        style={{ marginLeft: `${offsets.fileCObligated / 2}px` }}
                         tabIndex="0"
                         onBlur={closeTooltip}
                         onFocus={showFileCObligatedTooltip}
@@ -181,7 +190,7 @@ const NormalChart = ({ awardType, awardAmounts }) => {
                         onClick={showFileCObligatedTooltip}>
                         <strong>{awardAmounts.fileCObligatedAbbreviated}</strong><br />COVID-19 Response Obligations Amount
                     </div>
-                    <div className="award-amounts-viz__label file-c-obligated" style={absoluteWidths.fileCObligated}>
+                    <div className="award-amounts-viz__label file-c-obligated" style={{ marginLeft: `${offsets.fileCObligated / 2}px`, width: `calc(${absoluteWidths.fileCObligated.width} - ${offsets.fileCObligated / 2}px)` }}>
                         <div className="award-amounts-viz__line-up file-c-obligated" />
                     </div>
                 </>
@@ -270,13 +279,14 @@ const NormalChart = ({ awardType, awardAmounts }) => {
             </div>
             {/* Even if outlay is 0, we want to show this so long as the obligated is > 0 */}
             {isCaresReleased &&
-                <div className="award-amounts-viz__label file-c-outlay">
-                    <div className="award-amounts-viz__line file-c-outlay" style={absoluteWidths.fileCOutlay} />
+                <div className="award-amounts-viz__label file-c-outlay" style={{ marginLeft: `${offsets.fileCOutlay / 2}px` }}>
+                    <div className="award-amounts-viz__line file-c-outlay" style={{ width: `calc(${absoluteWidths.fileCOutlay.width} - ${offsets.fileCOutlay / 2}px)` }} />
                     <div className="award-amounts-viz__desc">
                         <div
                             className="award-amounts-viz__desc-text"
                             role="button"
                             tabIndex="0"
+                            style={{ marginLeft: `${offsets.fileCOutlay / 2}px` }}
                             onBlur={closeTooltip}
                             onFocus={showFileCOutlayTooltip}
                             onKeyPress={showFileCOutlayTooltip}
@@ -289,10 +299,10 @@ const NormalChart = ({ awardType, awardAmounts }) => {
                     </div>
                 </div>
             }
-            <div className="award-amounts-viz__label" style={absoluteWidths.current}>
+            <div className="award-amounts-viz__label" style={{ marginLeft: `${offsets.current / 2}px`, width: `calc(${absoluteWidths.current.width} - ${offsets.current / 2}px)` }}>
                 <div
                     className={`award-amounts-viz__line current${classNameForCovid}`}
-                    style={{ backgroundColor: currentBarStyle.backgroundColor }} />
+                    style={currentBarStyle} />
                 <div className="award-amounts-viz__desc">
                     <div
                         className="award-amounts-viz__desc-text"

--- a/src/js/components/award/shared/awardAmountsSection/charts/NormalChart.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/charts/NormalChart.jsx
@@ -286,7 +286,6 @@ const NormalChart = ({ awardType, awardAmounts }) => {
                             className="award-amounts-viz__desc-text"
                             role="button"
                             tabIndex="0"
-                            style={{ marginLeft: `${offsets.fileCOutlay / 2}px` }}
                             onBlur={closeTooltip}
                             onFocus={showFileCOutlayTooltip}
                             onKeyPress={showFileCOutlayTooltip}


### PR DESCRIPTION
**High level description:**
- Lines under/above the award amounts visualization bars for each spending category we're not taking into account their padding and margin which made the lines a bit longer than the bar by like 5px.

**Technical details:**
Adjusts the width of the bar by the amount of padding of the relevant bar.

**JIRA Ticket:**
[DEV-5242](https://federal-spending-transparency.atlassian.net/browse/DEV-5242)

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A`[Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
`N/A`[API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete