### PR TITLE
[DEV-5417] Fix bugs on Federal Account page filter

### DIFF
--- a/src/js/components/account/SearchSidebar.jsx
+++ b/src/js/components/account/SearchSidebar.jsx
@@ -15,10 +15,10 @@ import AccountProgramActivityContainer
 
 const filters = {
     options: [
-        'Time Period',
-        'Object Class',
-        'Program Activity',
-        'Treasury Account Symbol (TAS)'
+        { title: 'Time Period' },
+        { title: 'Object Class' },
+        { title: 'Program Activity' },
+        { title: 'Treasury Account Symbol (TAS)' }
     ],
     components: [
         AccountTimePeriodContainer,

--- a/src/js/models/account/queries/queryBuilders/_programActivityTranslator.js
+++ b/src/js/models/account/queries/queryBuilders/_programActivityTranslator.js
@@ -11,10 +11,10 @@ const exchangeTemplate = {
     frontendToAPI: {}
 };
 
-let _frontendAPIExchange = Object.assign({}, exchangeTemplate);
+let _frontendAPIExchange = JSON.parse(JSON.stringify(exchangeTemplate));
 
 export const _resetExchange = () => {
-    _frontendAPIExchange = Object.assign({}, exchangeTemplate);
+    _frontendAPIExchange = JSON.parse(JSON.stringify(exchangeTemplate));
 };
 
 const _exchangeForAPIValue = (frontendId) => _frontendAPIExchange.frontendToAPI[frontendId] || [];


### PR DESCRIPTION
**High level description:**

The issue was found where filter titles are not displaying on Federal Account page and the PSC filter does not display checkboxes after closing and re-opening the filter.

**Technical details:**

![Screen Shot 2020-06-15 at 6 32 57 PM](https://user-images.githubusercontent.com/40359517/84721932-b6e86600-af36-11ea-9f39-696501b57b34.png)


The issue with Federal Account filter titles was simply a bit of code that was updated to support an object, but the titles for the filters were not. 

The issue of the PSC filter not populating after closing is due to the `_resetExchange()` function not working as expected. Simply put, Object.assign() can be used to create a shallow copy of an object where there are no nested objects, but this will not work for a deep copy. Explanation and solution are explained in much more detail here: https://scotch.io/bar-talk/copying-objects-in-javascript

**JIRA Ticket:**
[DEV-5417](https://federal-spending-transparency.atlassian.net/browse/DEV-5417)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [X] Linked to this PR in JIRA ticket
- N/A]Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [X] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [X] Verified mobile/tablet/desktop/monitor responsiveness
- [X] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- N/A Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- N/A All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- N/A [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- N/A [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- N/A Design review complete `if applicable`
- N/A [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
