### PR TITLE
[DEV-5318] Correction of Dark Release Logic for Award Amounts Viz

### DIFF
--- a/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
@@ -61,7 +61,7 @@ const buildNormalProps = (awardType, data, hasFileC) => {
             ]
         }
     };
-    if (!hasFileC) return chartProps;
+    if (!hasFileC || !isCaresActReleased) return chartProps;
     return {
         ...chartProps,
         // eslint-disable-next-line no-multi-assign
@@ -171,7 +171,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
             tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'exceedsCurrent', data)
         }
     };
-    if (!showCares) return chartProps;
+    if (!hasFileC || !isCaresActReleased) return chartProps;
     return {
         ...chartProps,
         // eslint-disable-next-line no-multi-assign
@@ -314,7 +314,7 @@ const buildExceedsPotentialProps = (awardType, data, hasFileC) => {
             tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'exceedsPotential', data)
         }
     };
-    if (!hasFileC) return chartProps;
+    if (!hasFileC || !isCaresActReleased) return chartProps;
     return {
         ...chartProps,
         // eslint-disable-next-line no-multi-assign
@@ -398,7 +398,7 @@ const AwardAmountsChart = ({ awardType, awardOverview, spendingScenario }) => {
     const renderChartByAwardType = (awardAmounts = awardOverview, type = awardType, scenario = spendingScenario) => {
         const isNormal = scenario === 'normal';
         if (asstAwardTypesWithSimilarAwardAmountData.includes(type) && isNormal) {
-            const showFileC = awardAmounts._fileCObligated > 0 && GlobalConstants.CARES_ACT_RELEASED;
+            const showFileC = awardAmounts._fileCObligated > 0 && isCaresActReleased;
             const chartProps = {
                 denominator: {
                     labelPosition: 'bottom',
@@ -471,7 +471,7 @@ const AwardAmountsChart = ({ awardType, awardOverview, spendingScenario }) => {
             );
         }
         else if (type === 'loan' && isNormal) {
-            const hasFileC = awardAmounts._fileCObligated > 0;
+            const showFileC = awardAmounts._fileCObligated > 0 && isCaresActReleased;
             const propsWithoutFileC = {
                 numerator: {
                     labelPosition: 'top',
@@ -494,7 +494,7 @@ const AwardAmountsChart = ({ awardType, awardOverview, spendingScenario }) => {
                     color: '#fff'
                 }
             };
-            const props = hasFileC
+            const props = showFileC
                 ? {
                     ...propsWithoutFileC,
                     numerator: {


### PR DESCRIPTION
**High level description:**
Only condition that was used for showing covid mock data was if it exists. Adding dual condition for `isCaresActReleased`

**Technical details:**

Adding new conditional

**JIRA Ticket:**
[DEV-5318](https://federal-spending-transparency.atlassian.net/browse/DEV-5318)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
