### PR TITLE
[DEV-5310] Adding def_codes to request object for the spending_by_award endpoint

### DIFF
--- a/src/js/dataMapping/search/awardsOperationKeys.js
+++ b/src/js/dataMapping/search/awardsOperationKeys.js
@@ -21,6 +21,7 @@ export const rootKeys = {
     cfda: 'program_numbers',
     naics: 'naics_codes',
     psc: 'psc_codes',
+    defCodes: 'def_codes',
     contractPricing: 'contract_pricing_type_codes',
     setAsideType: 'set_aside_type_codes',
     extentCompeted: 'extent_competed_type_codes'

--- a/src/js/models/search/SearchAwardsOperation.js
+++ b/src/js/models/search/SearchAwardsOperation.js
@@ -44,6 +44,7 @@ class SearchAwardsOperation {
         this.selectedCFDA = [];
         this.naicsCodes = checkboxTreeKeys;
         this.pscCheckbox = checkboxTreeKeys;
+        this.defCodes = checkboxTreeKeys;
         this.pricingType = [];
         this.setAside = [];
         this.extentCompeted = [];
@@ -91,6 +92,10 @@ class SearchAwardsOperation {
         this.pscCheckbox = {
             require: state.pscCodes.toObject().require,
             exclude: state.pscCodes.toObject().exclude
+        };
+        this.defCodes = {
+            require: state.defCodes.toObject().require,
+            exclude: state.defCodes.toObject().exclude
         };
 
         this.pricingType = state.pricingType.toArray();
@@ -331,6 +336,15 @@ class SearchAwardsOperation {
         // Add Extent Competed
         if (this.extentCompeted.length > 0) {
             filters[rootKeys.extentCompeted] = this.extentCompeted;
+        }
+
+        // Add Def Codes
+        if (this.defCodes.require.length > 0) {
+            filters[rootKeys.defCodes] = { require: this.defCodes.require };
+            // at the moment, this will never be added unless we introduce some hierarchy.
+            if (this.defCodes.exclude.length > 0) {
+                filters[rootKeys.defCodes].exclude = this.defCodes.exclude;
+            }
         }
 
         return filters;

--- a/tests/models/search/SearchAwardsOperation-test.js
+++ b/tests/models/search/SearchAwardsOperation-test.js
@@ -10,7 +10,7 @@ describe('SearchAwardsOperation', () => {
     describe('building the request object with toParams', () => {
         // we have two kinds of tas properties on the request object; one for the checkbox
         // tree selections; the other for the non-checkbox tree selections
-        it('does not put an empty exclude array for tas_components property when tas-checbox tree items are selected', () => {
+        it('does not put an empty exclude or count array for tas_codes property when tas-checkbox tree items are selected', () => {
             const model = new SearchAwardsOperation();
             model.fromState({
                 ...initialState,
@@ -25,7 +25,7 @@ describe('SearchAwardsOperation', () => {
             expect(Object.keys(requestObject)).toEqual(['time_period', 'tas_codes']);
             expect(requestObject.tas_codes.counts).toBeFalsy();
         });
-        it('does not put an empty exclude array for def_codes property when tas-checbox tree items are selected', () => {
+        it('does not put an empty exclude or count array for def_codes property when defcode-checkbox tree items are selected', () => {
             const model = new SearchAwardsOperation();
             model.fromState({
                 ...initialState,

--- a/tests/models/search/SearchAwardsOperation-test.js
+++ b/tests/models/search/SearchAwardsOperation-test.js
@@ -10,7 +10,7 @@ describe('SearchAwardsOperation', () => {
     describe('building the request object with toParams', () => {
         // we have two kinds of tas properties on the request object; one for the checkbox
         // tree selections; the other for the non-checkbox tree selections
-        it('does not put an empty array for tas_components property when tas-checbox tree items are selected', () => {
+        it('does not put an empty exclude array for tas_components property when tas-checbox tree items are selected', () => {
             const model = new SearchAwardsOperation();
             model.fromState({
                 ...initialState,
@@ -23,6 +23,22 @@ describe('SearchAwardsOperation', () => {
             const requestObject = model.toParams();
             expect(Object.keys(requestObject).includes('tas_codes')).toEqual(true);
             expect(Object.keys(requestObject)).toEqual(['time_period', 'tas_codes']);
+            expect(requestObject.tas_codes.counts).toBeFalsy();
+        });
+        it('does not put an empty exclude array for def_codes property when tas-checbox tree items are selected', () => {
+            const model = new SearchAwardsOperation();
+            model.fromState({
+                ...initialState,
+                defCodes: new CheckboxTreeSelections({
+                    require: ["M"],
+                    exclude: [],
+                    counts: [{ count: 1 }]
+                })
+            });
+            const requestObject = model.toParams();
+            expect(Object.keys(requestObject).includes('def_codes')).toEqual(true);
+            expect(Object.keys(requestObject)).toEqual(['time_period', 'def_codes']);
+            expect(requestObject.def_codes.counts).toBeFalsy();
         });
     });
 });

--- a/tests/testResources/defaultReduxFilters.js
+++ b/tests/testResources/defaultReduxFilters.js
@@ -38,7 +38,8 @@ export const defaultFilters = {
     selectedPSC: new OrderedMap(),
     pricingType: new Set(),
     setAside: new Set(),
-    extentCompeted: new Set()
+    extentCompeted: new Set(),
+    defCodes: new CheckboxTreeSelections()
 };
 
 export const defaultResultsMeta = {


### PR DESCRIPTION
**High level description:**
Adds def_codes property to `spending_by_award` request object.

**Technical details:**
This doesnt break the API so we can just add it before the API is ready.

Adds test to confirm the request object shape is right.

**JIRA Ticket:**
[DEV-5310](https://federal-spending-transparency.atlassian.net/browse/DEV-5310)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
