### PR TITLE
DEV-5458 COVID profile CFDA section award type tabs

### DIFF
--- a/src/_scss/pages/covid19/assistanceListing/_assistanceListing.scss
+++ b/src/_scss/pages/covid19/assistanceListing/_assistanceListing.scss
@@ -9,6 +9,7 @@
                     &:first-of-type {
                         .table-header__label {
                             text-align: left; // Align the CFDA column to the left
+                            width: auto;
                         }
                     }
                     .table-header__label {

--- a/src/_scss/pages/covid19/assistanceListing/_assistanceListing.scss
+++ b/src/_scss/pages/covid19/assistanceListing/_assistanceListing.scss
@@ -1,4 +1,5 @@
 .assistance-listing {
+    @import 'components/moreOptionsTabs';
     .table-wrapper {
         overflow-x: auto;
         .usda-table {

--- a/src/_scss/pages/covid19/spendingOverTime/_awardSpendingOverTime.scss
+++ b/src/_scss/pages/covid19/spendingOverTime/_awardSpendingOverTime.scss
@@ -27,6 +27,7 @@
                     &:first-of-type {
                         .table-header__label {
                             text-align: left; // Align the Month column to the left
+                            width: auto;
                         }
                     }
                     .table-header__label {

--- a/src/_scss/pages/search/results/table/_tableTypes.scss
+++ b/src/_scss/pages/search/results/table/_tableTypes.scss
@@ -24,6 +24,7 @@
         &:hover{
             @include transition(all 0.3s ease-in-out);
             background-color: darken($color-gray-lightest, 5%);
+            cursor: pointer;
         }
         &.active {
             background-color: $color-white;
@@ -52,7 +53,7 @@
                 padding: rem(0) rem(5);
 
                 &.active {
-                    background-color: $color-gold;    
+                    background-color: $color-gold;
                 }
             }
               .tooltip-wrapper {
@@ -65,7 +66,7 @@
                 .tooltip__text:last-child {
                   padding: 2rem;
                 }
-              } 
+              }
         }
 
         &[disabled] {

--- a/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
+++ b/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
@@ -19,15 +19,13 @@ const SpendingByCFDA = () => {
     const [activeTab, setActiveTab] = useState(financialAssistanceTabs[0].internal);
     const defCodes = useSelector((state) => state.covid19.defCodes);
 
-    const defaultTabCounts = {
+    const [tabCounts, setTabCounts] = useState({
         all: null,
         grants: null,
         direct_payments: null,
         loans: null,
         other: null
-    };
-
-    const [tabCounts, setTabCounts] = useState(defaultTabCounts);
+    });
 
     const onRedirectModalClick = (e) => {
         setRedirectModalURL(e.currentTarget.value);
@@ -45,19 +43,19 @@ const SpendingByCFDA = () => {
     };
 
     useEffect(() => {
-        const promises = [];
         // Make an API request for the count of CFDA for each award type
         // Post-MVP this should be updated to use a new endpoint that returns all the counts
-        financialAssistanceTabs.forEach((awardType) => {
+        const promises = financialAssistanceTabs.map((awardType) => {
             const params = {
                 filter: {
                     def_codes: defCodes.map((defc) => defc.code)
                 }
             };
             if (awardType.internal !== 'all') {
+                // Endpoint defaults to all financial assistance types if award_type_codes is not provided
                 params.filter.award_type_codes = awardTypeGroups[awardType.internal];
             }
-            promises.push(fetchCfdaCount(params).promise);
+            return fetchCfdaCount(params).promise;
         });
         // Wait for all the requests to complete and then store the results in state
         Promise.all(promises)

--- a/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
+++ b/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
@@ -54,7 +54,9 @@ const SpendingByCFDA = () => {
                 pickerLabel="More Award Types"
                 changeActiveTab={changeActiveTab} />
             <SummaryInsightsContainer activeTab={activeTab} />
-            <SpendingByCFDAContainer onRedirectModalClick={onRedirectModalClick} />
+            <SpendingByCFDAContainer
+                onRedirectModalClick={onRedirectModalClick}
+                activeTab={activeTab} />
             <RedirectModal
                 mounted={isRedirectModalMounted}
                 hideModal={closeRedirectModal}

--- a/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
+++ b/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
@@ -13,7 +13,7 @@ import SpendingByCFDAContainer from 'containers/covid19/assistanceListing/Spendi
 const SpendingByCFDA = () => {
     const [isRedirectModalMounted, setIsRedirectModalMounted] = useState(false);
     const [redirectModalURL, setRedirectModalURL] = useState('');
-    const [activeTab, setActiveTab] = useState(financialAssistanceTabs[0].label);
+    const [activeTab, setActiveTab] = useState(financialAssistanceTabs[0].internal);
 
     const onRedirectModalClick = (e) => {
         setRedirectModalURL(e.currentTarget.value);
@@ -36,7 +36,7 @@ const SpendingByCFDA = () => {
     };
 
     const changeActiveTab = (tab) => {
-        const selectedTab = financialAssistanceTabs.filter((item) => item.internal === tab)[0].label;
+        const selectedTab = financialAssistanceTabs.filter((item) => item.internal === tab)[0].internal;
         setActiveTab(selectedTab);
     };
 

--- a/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
+++ b/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
@@ -4,13 +4,16 @@
  */
 
 import React, { useState } from 'react';
+import { financialAssistanceTabs } from 'dataMapping/covid19/covid19';
 import RedirectModal from 'components/sharedComponents/RedirectModal';
+import MoreOptionsTabs from 'components/sharedComponents/moreOptionsTabs/MoreOptionsTabs';
 import SummaryInsightsContainer from 'containers/covid19/assistanceListing/SummaryInsightsContainer';
 import SpendingByCFDAContainer from 'containers/covid19/assistanceListing/SpendingByCFDAContainer';
 
 const SpendingByCFDA = () => {
     const [isRedirectModalMounted, setIsRedirectModalMounted] = useState(false);
     const [redirectModalURL, setRedirectModalURL] = useState('');
+    const [activeTab, setActiveTab] = useState(financialAssistanceTabs[0].label);
 
     const onRedirectModalClick = (e) => {
         setRedirectModalURL(e.currentTarget.value);
@@ -22,6 +25,21 @@ const SpendingByCFDA = () => {
         setIsRedirectModalMounted(false);
     };
 
+    // TODO - Remove mock counts and replace with API call for counts
+    const mockCounts = {
+        all: 123123123,
+        contracts: 2856942,
+        idvs: 65718,
+        grants: 262180,
+        direct_payments: 3173522,
+        loans: 955562
+    };
+
+    const changeActiveTab = (tab) => {
+        const selectedTab = financialAssistanceTabs.filter((item) => item.internal === tab)[0].label;
+        setActiveTab(selectedTab);
+    };
+
     return (
         <div className="body__content assistance-listing">
             <h3 className="body__narrative">
@@ -30,7 +48,12 @@ const SpendingByCFDA = () => {
             <p className="body__narrative-description">
                 The total federal spending for the COVID-19 Response can be divided into different budget categories, including the different agencies that spent funds, the Federal Spending bills and Federal Accounts that funded the Response, and the different types of items and services that were purchased.
             </p>
-            <SummaryInsightsContainer />
+            <MoreOptionsTabs
+                tabs={financialAssistanceTabs}
+                tabCounts={mockCounts}
+                pickerLabel="More Award Types"
+                changeActiveTab={changeActiveTab} />
+            <SummaryInsightsContainer activeTab={activeTab} />
             <SpendingByCFDAContainer onRedirectModalClick={onRedirectModalClick} />
             <RedirectModal
                 mounted={isRedirectModalMounted}

--- a/src/js/containers/covid19/assistanceListing/SpendingByCFDAContainer.jsx
+++ b/src/js/containers/covid19/assistanceListing/SpendingByCFDAContainer.jsx
@@ -43,6 +43,8 @@ const columns = [
     }
 ];
 
+// TODO - add Face Value of Loans column when Loans is the active tab (pending API contract)
+
 export const parseRows = (rows, onRedirectModalClick) => (
     rows.map((row) => {
         const rowData = Object.create(BaseSpendingByCfdaRow);

--- a/src/js/containers/covid19/assistanceListing/SpendingByCFDAContainer.jsx
+++ b/src/js/containers/covid19/assistanceListing/SpendingByCFDAContainer.jsx
@@ -9,6 +9,7 @@ import { useSelector } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Table, Pagination } from 'data-transparency-ui';
 import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
+import { awardTypeGroups } from 'dataMapping/search/awardType';
 import BaseSpendingByCfdaRow from 'models/v2/covid19/BaseSpendingByCfdaRow';
 import { cfdaSortFields } from 'dataMapping/covid19/covid19';
 import { fetchSpendingByCfda } from 'helpers/disasterHelper';
@@ -16,7 +17,8 @@ import ResultsTableLoadingMessage from 'components/search/table/ResultsTableLoad
 import ResultsTableErrorMessage from 'components/search/table/ResultsTableErrorMessage';
 
 const propTypes = {
-    onRedirectModalClick: PropTypes.func.isRequired
+    onRedirectModalClick: PropTypes.func.isRequired,
+    activeTab: PropTypes.string.isRequired
 };
 
 const columns = [
@@ -65,7 +67,7 @@ export const parseRows = (rows, onRedirectModalClick) => (
     })
 );
 
-const SpendingByCFDAContainer = ({ onRedirectModalClick }) => {
+const SpendingByCFDAContainer = ({ onRedirectModalClick, activeTab }) => {
     const [currentPage, changeCurrentPage] = useState(1);
     const [pageSize, changePageSize] = useState(10);
     const [totalItems, setTotalItems] = useState(0);
@@ -85,7 +87,6 @@ const SpendingByCFDAContainer = ({ onRedirectModalClick }) => {
         const params = {
             filter: {
                 def_codes: defCodes.map((defc) => defc.code)
-                // TODO - add award type codes based on active tab
             },
             spending_type: 'award',
             pagination: {
@@ -95,6 +96,9 @@ const SpendingByCFDAContainer = ({ onRedirectModalClick }) => {
                 order
             }
         };
+        if (activeTab !== 'all') {
+            params.filter.award_type_codes = awardTypeGroups[activeTab];
+        }
         const request = fetchSpendingByCfda(params);
         request.promise
             .then((res) => {
@@ -114,7 +118,7 @@ const SpendingByCFDAContainer = ({ onRedirectModalClick }) => {
         // Reset to the first page
         changeCurrentPage(1);
         fetchSpendingByCfdaCallback();
-    }, [pageSize, defCodes, sort, order]);
+    }, [pageSize, defCodes, sort, order, activeTab]);
 
     useEffect(() => {
         fetchSpendingByCfdaCallback();

--- a/src/js/containers/covid19/assistanceListing/SummaryInsightsContainer.jsx
+++ b/src/js/containers/covid19/assistanceListing/SummaryInsightsContainer.jsx
@@ -7,11 +7,12 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { awardTypeGroups, awardTypeGroupLabels } from 'dataMapping/search/awardType';
-import { fetchCfdaCount, fetchAwardAmounts, fetchAwardCount } from 'helpers/disasterHelper';
+import { fetchAwardAmounts, fetchAwardCount } from 'helpers/disasterHelper';
 import OverviewData from 'components/covid19/OverviewData';
 
 const propTypes = {
-    activeTab: PropTypes.string
+    activeTab: PropTypes.string,
+    cfdaCount: PropTypes.number
 };
 
 const overviewData = [
@@ -35,8 +36,7 @@ const overviewData = [
     }
 ];
 
-const SummaryInsightsContainer = ({ activeTab }) => {
-    const [cfdaCount, setCfdaCount] = useState(null);
+const SummaryInsightsContainer = ({ activeTab, cfdaCount }) => {
     const [awardOutlays, setAwardOutlays] = useState(null);
     const [awardObligations, setAwardObligations] = useState(null);
     const [numberOfAwards, setNumberOfAwards] = useState(null);
@@ -44,7 +44,6 @@ const SummaryInsightsContainer = ({ activeTab }) => {
 
     useEffect(() => {
         // Reset any existing counts
-        setCfdaCount(null);
         setAwardOutlays(null);
         setAwardObligations(null);
         setNumberOfAwards(null);
@@ -57,10 +56,6 @@ const SummaryInsightsContainer = ({ activeTab }) => {
         if (activeTab !== 'all') {
             params.filter.award_type_codes = awardTypeGroups[activeTab];
         }
-        fetchCfdaCount(params).promise
-            .then((res) => {
-                setCfdaCount(res.data.count);
-            });
         fetchAwardAmounts(params).promise
             .then((res) => {
                 setAwardObligations(res.data.obligation);

--- a/src/js/containers/covid19/assistanceListing/SummaryInsightsContainer.jsx
+++ b/src/js/containers/covid19/assistanceListing/SummaryInsightsContainer.jsx
@@ -4,9 +4,14 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { fetchCfdaCount, fetchAwardAmounts, fetchAwardCount } from 'helpers/disasterHelper';
 import OverviewData from 'components/covid19/OverviewData';
+
+const propTypes = {
+    activeTab: PropTypes.string
+};
 
 const overviewData = [
     {
@@ -29,7 +34,7 @@ const overviewData = [
     }
 ];
 
-const SummaryInsightsContainer = () => {
+const SummaryInsightsContainer = ({ activeTab }) => {
     const [cfdaCount, setCfdaCount] = useState(null);
     const [awardOutlays, setAwardOutlays] = useState(null);
     const [awardObligations, setAwardObligations] = useState(null);
@@ -71,12 +76,12 @@ const SummaryInsightsContainer = () => {
                 <OverviewData
                     key={data.label}
                     {...data}
-                    // TODO - use the active award type in the subtitle
-                    subtitle="for all awards"
+                    subtitle={`for ${activeTab.toLowerCase()}`}
                     amount={amounts[data.type]} />
             ))}
         </div>
     );
 };
 
+SummaryInsightsContainer.propTypes = propTypes;
 export default SummaryInsightsContainer;

--- a/src/js/containers/covid19/assistanceListing/SummaryInsightsContainer.jsx
+++ b/src/js/containers/covid19/assistanceListing/SummaryInsightsContainer.jsx
@@ -6,6 +6,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
+import { awardTypeGroups, awardTypeGroupLabels } from 'dataMapping/search/awardType';
 import { fetchCfdaCount, fetchAwardAmounts, fetchAwardCount } from 'helpers/disasterHelper';
 import OverviewData from 'components/covid19/OverviewData';
 
@@ -42,12 +43,20 @@ const SummaryInsightsContainer = ({ activeTab }) => {
     const defCodes = useSelector((state) => state.covid19.defCodes);
 
     useEffect(() => {
+        // Reset any existing counts
+        setCfdaCount(null);
+        setAwardOutlays(null);
+        setAwardObligations(null);
+        setNumberOfAwards(null);
+
         const params = {
             filter: {
                 def_codes: defCodes.map((defc) => defc.code)
-                // TODO - add award type codes
             }
         };
+        if (activeTab !== 'all') {
+            params.filter.award_type_codes = awardTypeGroups[activeTab];
+        }
         fetchCfdaCount(params).promise
             .then((res) => {
                 setCfdaCount(res.data.count);
@@ -61,7 +70,7 @@ const SummaryInsightsContainer = ({ activeTab }) => {
             .then((res) => {
                 setNumberOfAwards(res.data.count);
             });
-    }, [defCodes]);
+    }, [defCodes, activeTab]);
 
     const amounts = {
         cfdaCount,
@@ -76,7 +85,7 @@ const SummaryInsightsContainer = ({ activeTab }) => {
                 <OverviewData
                     key={data.label}
                     {...data}
-                    subtitle={`for ${activeTab.toLowerCase()}`}
+                    subtitle={`for all ${(awardTypeGroupLabels[activeTab] || 'awards').toLowerCase()}`}
                     amount={amounts[data.type]} />
             ))}
         </div>

--- a/src/js/dataMapping/covid19/covid19.js
+++ b/src/js/dataMapping/covid19/covid19.js
@@ -25,3 +25,31 @@ export const cfdaSortFields = {
     count: 'count',
     name: 'description'
 };
+
+export const financialAssistanceTabs = [
+    {
+        enabled: true,
+        internal: 'all',
+        label: 'All Awards'
+    },
+    {
+        enabled: true,
+        internal: 'grants',
+        label: 'Grants'
+    },
+    {
+        enabled: true,
+        internal: 'direct_payments',
+        label: 'Direct Payments'
+    },
+    {
+        enabled: true,
+        internal: 'loans',
+        label: 'Loans'
+    },
+    {
+        enabled: true,
+        internal: 'other',
+        label: 'Other'
+    }
+];


### PR DESCRIPTION
**High level description:**

Implements award type tabs in the Spending by CFDA Program (Assistance Listing) section of the COVID-19 profile page.

**Technical details:**

- Relies on the mock API (endpoints and API integration will be completed in a future sprint)

**JIRA Ticket:**
[DEV-5458](https://federal-spending-transparency.atlassian.net/browse/DEV-5458), subtask of [DEV-5299](https://federal-spending-transparency.atlassian.net/browse/DEV-5299)

**Mockup:**
https://bahdigital.invisionapp.com/share/NGIAE7D7H6S#/296040947_COVID-19_Profile_-_Tab_Rework

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- N/A Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR - demo when final subtasks are complete
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Design review complete
- [x] Code review complete
- [x] #1774 merged / conflicts resolved