### PR TITLE
[DEV-5136] fixing expected idv_agg response object shape

### DIFF
--- a/src/js/components/award/idv/amounts/AwardAmounts.jsx
+++ b/src/js/components/award/idv/amounts/AwardAmounts.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { TooltipWrapper } from 'data-transparency-ui';
 
 import { determineSpendingScenarioByAwardType } from 'helpers/awardAmountHelper';
+import GlobalConstants from 'GlobalConstants';
 import BaseAwardAmounts from 'models/v2/award/BaseAwardAmounts';
 import IdvAwardAmountsSectionContainer from 'containers/award/idv/IdvAwardAmountsSectionContainer';
 import ResultsTableTabs from 'components/search/table/ResultsTableTabs';
@@ -56,6 +57,7 @@ export default class AwardAmounts extends React.Component {
                 jumpToSection={this.props.jumpToSection} />
         ) : (
             <AwardAmountsTable
+                showFileC={(GlobalConstants.CARES_ACT_RELEASED && awards._showFileC)}
                 awardData={awards}
                 awardAmountType="idv"
                 spendingScenario={determineSpendingScenarioByAwardType("idv", awards)} />

--- a/src/js/dataMapping/award/awardAmountsSection.js
+++ b/src/js/dataMapping/award/awardAmountsSection.js
@@ -93,8 +93,8 @@ export const awardTableClassMap = {
     "Total Funding": "award-amounts__data-icon_gray",
     "Face Value of Direct Loan": "award-amounts__data-icon_transparent",
     "Original Subsidy Cost": "award-amounts__data-icon_yellow",
-    "COVID-19 Related Obligations Amount": "award-amounts__file-c-obligations",
-    "COVID-19 Related Outlays Amount": "award-amounts__file-c-outlays"
+    "COVID-19 Response Obligated Amount": "award-amounts__file-c-obligations",
+    "COVID-19 Response Outlayed Amount": "award-amounts__file-c-outlays"
 };
 
 export const tableTitlesBySpendingCategoryAndAwardType = {
@@ -102,35 +102,35 @@ export const tableTitlesBySpendingCategoryAndAwardType = {
         totalFundingFormatted: 'Total Funding',
         nonFederalFundingFormatted: 'Non-Federal Funding',
         totalObligationFormatted: 'Obligated Amount',
-        fileCOutlayFormatted: 'COVID-19 Related Outlays Amount',
-        fileCObligatedFormatted: 'COVID-19 Related Obligations Amount'
+        fileCOutlayFormatted: 'COVID-19 Response Outlayed Amount',
+        fileCObligatedFormatted: 'COVID-19 Response Obligated Amount'
     },
     idv_aggregated: {
         baseExercisedOptionsFormatted: 'Combined Current Amounts',
         baseAndAllOptionsFormatted: 'Combined Potential Amounts',
         totalObligationFormatted: 'Combined Obligated Amounts',
-        fileCOutlayFormatted: 'COVID-19 Related Outlays Amount',
-        fileCObligatedFormatted: 'COVID-19 Related Obligations Amount'
+        fileCOutlayFormatted: 'COVID-19 Response Outlayed Amount',
+        fileCObligatedFormatted: 'COVID-19 Response Obligated Amount'
     },
     contract: {
         baseExercisedOptionsFormatted: 'Current Amount',
         baseAndAllOptionsFormatted: 'Potential Amount',
         totalObligationFormatted: 'Obligated Amount',
-        fileCOutlayFormatted: 'COVID-19 Related Outlays Amount',
-        fileCObligatedFormatted: 'COVID-19 Related Obligations Amount'
+        fileCOutlayFormatted: 'COVID-19 Response Outlayed Amount',
+        fileCObligatedFormatted: 'COVID-19 Response Obligated Amount'
     },
     idv: {
         baseExercisedOptionsFormatted: 'Current Amount',
         baseAndAllOptionsFormatted: 'Potential Amount',
         totalObligationFormatted: 'Obligated Amount',
-        fileCOutlayFormatted: 'COVID-19 Related Outlays Amount',
-        fileCObligatedFormatted: 'COVID-19 Related Obligations Amount'
+        fileCOutlayFormatted: 'COVID-19 Response Outlayed Amount',
+        fileCObligatedFormatted: 'COVID-19 Response Obligated Amount'
     },
     loan: {
         subsidyFormatted: 'Original Subsidy Cost',
         faceValueFormatted: 'Face Value of Direct Loan',
-        fileCOutlayFormatted: 'COVID-19 Related Outlays Amount',
-        fileCObligatedFormatted: 'COVID-19 Related Obligations Amount'
+        fileCOutlayFormatted: 'COVID-19 Response Outlayed Amount',
+        fileCObligatedFormatted: 'COVID-19 Response Obligated Amount'
     }
 };
 

--- a/src/js/models/v2/award/BaseAwardAmounts.js
+++ b/src/js/models/v2/award/BaseAwardAmounts.js
@@ -43,10 +43,10 @@ const BaseAwardAmounts = {
         ) || 0;
         this._fileCOutlay = this._showFileC
             ? getCovid19Totals([{ amount: this[this._denominator] * 0.25, code: 'L' }])
-            : getCovid19Totals(data.account_outlays_by_defc);
+            : getCovid19Totals(data.child_account_obligations_by_defc);
         this._fileCObligated = this._showFileC
             ? getCovid19Totals([{ amount: this[this._denominator] * 0.5, code: 'L' }])
-            : getCovid19Totals(data.account_obligations_by_defc);
+            : getCovid19Totals(data.child_account_obligations_by_defc);
     },
     populateIdv(data) {
         this._totalObligation = data._totalObligation;

--- a/tests/models/award/BaseAwardAmounts-test.js
+++ b/tests/models/award/BaseAwardAmounts-test.js
@@ -32,16 +32,16 @@ awardAmounts.populate(mockAwardAmounts, "idv_aggregated");
 
 const awardAmountsNeg = Object.create(BaseAwardAmounts);
 const negativeObligationAgg = {
-    account_obligations_by_defc: [],
-    account_outlays_by_defc: [],
+    child_account_obligations_by_defc: [],
+    child_account_outlays_by_defc: [],
     child_award_total_obligation: -811660.51,
     grandchild_award_total_obligation: -811660.51
 };
 
 const awardAmountsOverspent = Object.create(BaseAwardAmounts);
 const overspendingAgg = {
-    account_obligations_by_defc: [],
-    account_outlays_by_defc: [],
+    child_account_obligations_by_defc: [],
+    child_account_outlays_by_defc: [],
     child_award_base_exercised_options_val: 2500000,
     grandchild_award_base_exercised_options_val: 2500000,
     child_award_base_and_all_options_value: 5000000,
@@ -52,8 +52,8 @@ const overspendingAgg = {
 
 const awardAmountsExtremeOverspent = Object.create(BaseAwardAmounts);
 const extremeOverspendingAgg = {
-    account_obligations_by_defc: [],
-    account_outlays_by_defc: [],
+    child_account_obligations_by_defc: [],
+    child_account_outlays_by_defc: [],
     child_award_base_exercised_options_val: 1250000,
     grandchild_award_base_exercised_options_val: 1250000,
     child_award_base_and_all_options_value: 2500000,

--- a/tests/models/award/mockAwardApi.js
+++ b/tests/models/award/mockAwardApi.js
@@ -446,8 +446,8 @@ export const mockAwardAmounts = {
     grandchild_award_base_and_all_options_value: 53493660.55,
     child_award_total_obligation: 811660.51,
     grandchild_award_total_obligation: 811660.51,
-    account_obligations_by_defc: [],
-    account_outlays_by_defc: []
+    child_account_obligations_by_defc: [],
+    child_account_outlays_by_defc: []
 };
 
 export const mockReferencedAwards = {


### PR DESCRIPTION
**High level description:**
Fixing undefined error in DEV.

**Technical details:**

- [The response object for this endpoint](https://dev-api.usaspending.gov/api/v2/idvs/amounts/CONT_IDV_EDFSA09D0012_9100/) was wrong.
- Was not passing the `showFileC` to the AwardAmountsTable component in one context for idvs
- Fixes the Table Label per [this ticket](https://federal-spending-transparency.atlassian.net/browse/DEV-5477)

**JIRA Ticket:**
[DEV-5136](https://federal-spending-transparency.atlassian.net/browse/DEV-5136)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
