### PR TITLE
[DEV-5434] Removing Front End Mock Data Logic for Award Amounts Viz

### DIFF
--- a/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
@@ -1,15 +1,12 @@
 $grants-line-color: #47AAA7;
 $loans-line-color: #F5A623;
-$file-c-current: #558EC6;
-$new-potential: #AAC6E2;
+
+$obligated: #0A2F5A;
+$current: #558EC6;
+$potential: #AAC6E2;
+
 $file-c-outlay: #6E338E;
 $file-c-obligation: #B699C6;
-
-$old-obligated: $color-cool-blue-light;
-
-$new-obligated: #0A2F5A;
-$new-current: #558EC6;
-$new-potential: #AAC6E2;
 
 %award-amounts-viz__line-indicator {
     content: "";
@@ -63,8 +60,8 @@ $new-potential: #AAC6E2;
                 border-bottom: .4rem solid $color-gray-lightest;
                 background: repeating-linear-gradient(45deg,#4773aa,#4773aa .8rem,#fdb81e 0,#fdb81e 1rem);
                 &.covid {
-                    border-top: .4rem solid $new-potential;
-                    border-bottom: .4rem solid $new-potential;
+                    border-top: .4rem solid $potential;
+                    border-bottom: .4rem solid $potential;
                 }
             }
             .award-amounts-viz__bar-wrapper {
@@ -80,7 +77,7 @@ $new-potential: #AAC6E2;
                         }
                         &.covid.contract-extreme-overspending-current,
                         &.covid.idv-extreme-overspending-current {
-                            border: solid 0.4rem $new-current;
+                            border: solid 0.4rem $current;
                         }
                         &.contract-extreme-overspending-potential,
                         &.idv-extreme-overspending-potential {
@@ -223,10 +220,10 @@ $new-potential: #AAC6E2;
                     }
                     &.covid::before,
                     &.covid::after {
-                        border-left: rem(1) solid $new-obligated;
+                        border-left: rem(1) solid $obligated;
                     }
                     &.covid {
-                        border-bottom: rem(1) solid $new-obligated;
+                        border-bottom: rem(1) solid $obligated;
                     }
                     &.idv-file-c-obligated,
                     &.contract-file-c-obligated,
@@ -299,7 +296,7 @@ $new-potential: #AAC6E2;
                         &.idv-overspending-current,
                         &.contract-extreme-overspending-current,
                         &.idv-extreme-overspending-current {
-                            border-right: 5px solid $new-current;
+                            border-right: 5px solid $current;
                         }
                         &.idv-potential,
                         &.contract-potential,
@@ -307,7 +304,7 @@ $new-potential: #AAC6E2;
                         &.contract-overspending-potential,
                         &.idv-extreme-overspending-potential,
                         &.contract-extreme-overspending-potential {
-                            border-right: 5px solid $new-potential;
+                            border-right: 5px solid $potential;
                         }
                     }
                     .award-amounts-viz__desc-text {
@@ -393,18 +390,18 @@ $new-potential: #AAC6E2;
                         }
                     }
                     &.covid.contract-current {
-                        border-bottom: rem(1) solid $file-c-current;
+                        border-bottom: rem(1) solid $current;
                         &::after,
                         &::before {
-                            border-left: rem(1) solid $file-c-current;
+                            border-left: rem(1) solid $current;
                         }
                     }
                     &.covid.idv-potential,
                     &.covid.contract-potential {
-                        border-bottom: rem(1) solid $new-potential;
+                        border-bottom: rem(1) solid $potential;
                         &::before,
                         &::after {
-                            border-left: rem(1) solid $new-potential;
+                            border-left: rem(1) solid $potential;
                         }
                     }
                     &.contract-file-c-outlay,

--- a/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
@@ -52,7 +52,7 @@
     }
 
     .award-amounts__current {
-        background-color: rgb(85, 142, 198);
+        background-color: #558EC6;
     }
 
     .award-amounts__obligated {

--- a/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
@@ -47,18 +47,17 @@
         border: rem(2) solid #6E338E;
     }
 
-    // [DEV-5309] update colors for post cares act release
-    // .award-amounts__potential {
-    //     background-color: rgb(170, 198, 226);
-    // }
+    .award-amounts__potential {
+        background-color:#AAC6E2;
+    }
 
-    // .award-amounts__current {
-    //     background-color: rgb(85, 142, 198);
-    // }
+    .award-amounts__current {
+        background-color: rgb(85, 142, 198);
+    }
 
-    // .award-amounts__obligated {
-    //     background-color: #4773aa;
-    // }
+    .award-amounts__obligated {
+        background-color: #0A2F5A;
+    }
 
     .award-amounts__file-c-obligations {
         background-color: #B699C6;

--- a/src/js/components/award/idv/amounts/AggregatedAwardAmounts.jsx
+++ b/src/js/components/award/idv/amounts/AggregatedAwardAmounts.jsx
@@ -86,7 +86,10 @@ export default class AggregatedAwardAmounts extends React.Component {
                     icon="table" />
                 <AwardAmountsTable
                     awardAmountType="idv_aggregated"
-                    showFileC={showCaresActViz}
+                    showFileC={(
+                        showCaresActViz &&
+                        awardAmounts.__fileCObligated > 0
+                    )}
                     awardData={awardAmounts}
                     spendingScenario={spendingScenario} />
             </div>

--- a/src/js/components/award/idv/amounts/AggregatedAwardAmounts.jsx
+++ b/src/js/components/award/idv/amounts/AggregatedAwardAmounts.jsx
@@ -88,7 +88,7 @@ export default class AggregatedAwardAmounts extends React.Component {
                     awardAmountType="idv_aggregated"
                     showFileC={(
                         showCaresActViz &&
-                        awardAmounts.__fileCObligated > 0
+                        awardAmounts._fileCObligated > 0
                     )}
                     awardData={awardAmounts}
                     spendingScenario={spendingScenario} />

--- a/src/js/components/award/idv/amounts/AggregatedAwardAmounts.jsx
+++ b/src/js/components/award/idv/amounts/AggregatedAwardAmounts.jsx
@@ -52,7 +52,6 @@ export default class AggregatedAwardAmounts extends React.Component {
 
         const { awardAmounts } = this.props;
         const showCaresActViz = (
-            awardAmounts._showFileC &&
             GlobalConstants.CARES_ACT_RELEASED
         );
         const spendingScenario = determineSpendingScenarioByAwardType("idv", awardAmounts);

--- a/src/js/components/award/idv/amounts/AwardAmounts.jsx
+++ b/src/js/components/award/idv/amounts/AwardAmounts.jsx
@@ -57,7 +57,10 @@ export default class AwardAmounts extends React.Component {
                 jumpToSection={this.props.jumpToSection} />
         ) : (
             <AwardAmountsTable
-                showFileC={(GlobalConstants.CARES_ACT_RELEASED)}
+                showFileC={(
+                    GlobalConstants.CARES_ACT_RELEASED &&
+                    awards._fileCObligated > 0
+                )}
                 awardData={awards}
                 awardAmountType="idv"
                 spendingScenario={determineSpendingScenarioByAwardType("idv", awards)} />

--- a/src/js/components/award/idv/amounts/AwardAmounts.jsx
+++ b/src/js/components/award/idv/amounts/AwardAmounts.jsx
@@ -57,7 +57,7 @@ export default class AwardAmounts extends React.Component {
                 jumpToSection={this.props.jumpToSection} />
         ) : (
             <AwardAmountsTable
-                showFileC={(GlobalConstants.CARES_ACT_RELEASED && awards._showFileC)}
+                showFileC={(GlobalConstants.CARES_ACT_RELEASED)}
                 awardData={awards}
                 awardAmountType="idv"
                 spendingScenario={determineSpendingScenarioByAwardType("idv", awards)} />

--- a/src/js/components/award/shared/awardAmountsSection/AwardAmountsSection.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/AwardAmountsSection.jsx
@@ -38,7 +38,10 @@ const AwardAmountsSection = ({
                         showCaresActViz={showCaresActViz}
                         spendingScenario={spendingScenario} />
                     <AwardAmountsTable
-                        showFileC={showCaresActViz}
+                        showFileC={(
+                            showCaresActViz &&
+                            awardOverview._fileCObligated > 0
+                        )}
                         awardData={awardOverview}
                         awardAmountType={awardType}
                         spendingScenario={spendingScenario} />

--- a/src/js/components/award/shared/awardAmountsSection/AwardAmountsSection.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/AwardAmountsSection.jsx
@@ -25,7 +25,6 @@ const AwardAmountsSection = ({
     const spendingScenario = determineSpendingScenarioByAwardType(awardType, awardOverview);
     const tooltip = getToolTipBySectionAndAwardType('awardAmounts', awardType);
     const showCaresActViz = (
-        awardOverview._showFileC &&
         GlobalConstants.CARES_ACT_RELEASED
     );
     return (

--- a/src/js/dataMapping/award/awardAmountsSection.js
+++ b/src/js/dataMapping/award/awardAmountsSection.js
@@ -18,26 +18,6 @@ export const caresActSpendingCategories = [
     'fileCOutlayFormatted'
 ];
 
-// TODO: [DEV-5434] Remove White Listed Award IDs for Mock Award Amount Data
-export const mockAwardIdsForCaresAct = [
-    // contract
-    'CONT_AWD_N0001917C0001_9700_-NONE-_-NONE-',
-    // exceeds current contract
-    'CONT_AWD_W91QVN04P2195_9700_-NONE-_-NONE-',
-    // exceeds potential contract
-    'CONT_AWD_WCO00200110D68R80201_6800_-NONE-_-NONE-',
-    // IDV
-    'CONT_IDV_EDFSA09D0012_9100',
-    // Exceeds Current IDV
-    'CONT_IDV_SLMAQM01D0074_1900',
-    // Exceeds Potential IDV
-    'CONT_IDV_GS10F0287L_4730',
-    // grant
-    'ASST_NON_1905CA5MAP_7530',
-    // loan
-    'ASST_NON_13789835_12D2'
-];
-
 export const formattedSpendingCategoriesByAwardType = {
     contract: [
         'fileCOutlayFormatted',

--- a/src/js/dataMapping/award/awardAmountsSection.js
+++ b/src/js/dataMapping/award/awardAmountsSection.js
@@ -56,19 +56,12 @@ export const formattedSpendingCategoriesByAwardType = {
 };
 
 export const awardTableClassMap = {
-    "Combined Obligated Amounts": "award-amounts__data-icon_blue",
-    "Combined Current Amounts": "award-amounts__data-icon_gray",
-    "Combined Potential Amounts": "award-amounts__data-icon_transparent",
-    "Obligated Amount": "award-amounts__data-icon_blue",
-    "Current Amount": "award-amounts__data-icon_gray",
-    "Potential Amount": "award-amounts__data-icon_transparent",
-    // TODO: [DEV-5309] update colors for post cares act release
-    // "Combined Obligated Amounts": "award-amounts__obligated",
-    // "Combined Current Amounts": "award-amounts__current",
-    // "Combined Potential Amounts": "award-amounts__potential",
-    // "Obligated Amount": "award-amounts__obligated",
-    // "Current Amount": "award-amounts__current",
-    // "Potential Amount": "award-amounts__potential",
+    "Combined Obligated Amounts": "award-amounts__obligated",
+    "Combined Current Amounts": "award-amounts__current",
+    "Combined Potential Amounts": "award-amounts__potential",
+    "Obligated Amount": "award-amounts__obligated",
+    "Current Amount": "award-amounts__current",
+    "Potential Amount": "award-amounts__potential",
     "Non-Federal Funding": "award-amounts__data-icon_green",
     "Total Funding": "award-amounts__data-icon_gray",
     "Face Value of Direct Loan": "award-amounts__data-icon_transparent",

--- a/src/js/dataMapping/award/awardAmountsSection.js
+++ b/src/js/dataMapping/award/awardAmountsSection.js
@@ -34,8 +34,8 @@ export const formattedSpendingCategoriesByAwardType = {
         'baseAndAllOptionsFormatted'
     ],
     idv_aggregated: [
-        'fileCObligatedFormatted',
         'fileCOutlayFormatted',
+        'fileCObligatedFormatted',
         'totalObligationFormatted',
         'baseExercisedOptionsFormatted',
         'baseAndAllOptionsFormatted'

--- a/src/js/models/v2/award/BaseAwardAmounts.js
+++ b/src/js/models/v2/award/BaseAwardAmounts.js
@@ -5,14 +5,13 @@
 
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 import { defCodes } from 'dataMapping/covid19/covid19';
-import { mockAwardIdsForCaresAct } from 'dataMapping/award/awardAmountsSection';
 
 const getCovid19Totals = (arr) => arr
     .filter((obj) => defCodes.includes(obj.code))
     .reduce((acc, obj) => acc + obj.amount, 0);
 
 const BaseAwardAmounts = {
-    populateBase(data, awardType) {
+    populateBase(data) {
         this.id = (data.award_id && `${data.award_id}`) || '';
         if (data.generatedId) {
             this.generatedId = encodeURIComponent(`${data.generatedId}`);
@@ -20,13 +19,6 @@ const BaseAwardAmounts = {
         this.generatedId = data.generated_unique_award_id
             ? encodeURIComponent(`${data.generated_unique_award_id}`)
             : '';
-        this._denominator = awardType === 'loan' ? '_subsidy' : '_totalObligation';
-        this._showFileC = (
-            // will be passed as data.fileC
-            mockAwardIdsForCaresAct.includes(data?.generatedId) ||
-            // eslint-disable-next-line camelcase
-            mockAwardIdsForCaresAct.includes(data?.generated_unique_award_id)
-        );
     },
     populateAggIdv(data) {
         this.childIDVCount = data.child_idv_count || 0;
@@ -41,55 +33,35 @@ const BaseAwardAmounts = {
         this._baseExercisedOptions = parseFloat(
             data.child_award_base_exercised_options_val + data.grandchild_award_base_exercised_options_val
         ) || 0;
-        this._fileCOutlay = this._showFileC
-            ? getCovid19Totals([{ amount: this[this._denominator] * 0.25, code: 'L' }])
-            : getCovid19Totals(data.child_account_obligations_by_defc);
-        this._fileCObligated = this._showFileC
-            ? getCovid19Totals([{ amount: this[this._denominator] * 0.5, code: 'L' }])
-            : getCovid19Totals(data.child_account_obligations_by_defc);
+        this._fileCOutlay = getCovid19Totals(data.child_account_obligations_by_defc);
+        this._fileCObligated = getCovid19Totals(data.child_account_obligations_by_defc);
     },
     populateIdv(data) {
         this._totalObligation = data._totalObligation;
         this._baseExercisedOptions = data._baseExercisedOptions;
         this._baseAndAllOptions = data._baseAndAllOptions;
-        this._fileCOutlay = this._showFileC
-            ? getCovid19Totals([{ amount: this[this._denominator] * 0.25, code: 'L' }])
-            : getCovid19Totals(data.fileC.outlays);
-        this._fileCObligated = this._showFileC
-            ? getCovid19Totals([{ amount: this[this._denominator] * 0.5, code: 'L' }])
-            : getCovid19Totals(data.fileC.obligations);
+        this._fileCOutlay = getCovid19Totals(data.fileC.outlays);
+        this._fileCObligated = getCovid19Totals(data.fileC.obligations);
     },
     populateLoan(data) {
         this._subsidy = data._subsidy;
         this._faceValue = data._faceValue;
-        this._fileCOutlay = this._showFileC
-            ? getCovid19Totals([{ amount: this[this._denominator] * 0.25, code: 'L' }])
-            : getCovid19Totals(data.fileC.outlays);
-        this._fileCObligated = this._showFileC
-            ? getCovid19Totals([{ amount: this[this._denominator] * 0.5, code: 'L' }])
-            : getCovid19Totals(data.fileC.obligations);
+        this._fileCOutlay = getCovid19Totals(data.fileC.outlays);
+        this._fileCObligated = getCovid19Totals(data.fileC.obligations);
     },
     populateAsst(data) {
         this._totalObligation = data._totalObligation;
         this._totalFunding = data._totalFunding;
         this._nonFederalFunding = data._nonFederalFunding;
-        this._fileCOutlay = this._showFileC
-            ? getCovid19Totals([{ amount: this[this._denominator] * 0.25, code: 'L' }])
-            : getCovid19Totals(data.fileC.outlays);
-        this._fileCObligated = this._showFileC
-            ? getCovid19Totals([{ amount: this[this._denominator] * 0.5, code: 'L' }])
-            : getCovid19Totals(data.fileC.obligations);
+        this._fileCOutlay = getCovid19Totals(data.fileC.outlays);
+        this._fileCObligated = getCovid19Totals(data.fileC.obligations);
     },
     populateContract(data) {
         this._totalObligation = data._totalObligation;
         this._baseExercisedOptions = data._baseExercisedOptions;
         this._baseAndAllOptions = data._baseAndAllOptions;
-        this._fileCOutlay = this._showFileC
-            ? getCovid19Totals([{ amount: this[this._denominator] * 0.25, code: 'L' }])
-            : getCovid19Totals(data.fileC.outlays);
-        this._fileCObligated = this._showFileC
-            ? getCovid19Totals([{ amount: this[this._denominator] * 0.5, code: 'L' }])
-            : getCovid19Totals(data.fileC.obligations);
+        this._fileCOutlay = getCovid19Totals(data.fileC.outlays);
+        this._fileCObligated = getCovid19Totals(data.fileC.obligations);
     },
     populate(data, awardAmountType) {
         this.populateBase(data, awardAmountType);

--- a/src/js/models/v2/award/BaseContract.js
+++ b/src/js/models/v2/award/BaseContract.js
@@ -5,7 +5,6 @@
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 import * as pscHelper from 'helpers/pscHelper';
 import CoreLocation from 'models/v2/CoreLocation';
-import { mockAwardIdsForCaresAct } from 'dataMapping/award/awardAmountsSection';
 
 import BaseAwardRecipient from './BaseAwardRecipient';
 import BaseParentAwardDetails from './BaseParentAwardDetails';
@@ -39,9 +38,7 @@ BaseContract.populate = function populate(data) {
             obligations: data.account_obligations_by_defc,
             outlays: data.account_outlays_by_defc
         },
-        defCodes: mockAwardIdsForCaresAct.includes(data.generated_unique_award_id)
-            ? ["L", "M", "N"]
-            : data.disaster_emergency_fund_codes
+        defCodes: data.disaster_emergency_fund_codes
     };
     this.populateCore(coreData);
 

--- a/src/js/models/v2/award/BaseFinancialAssistance.js
+++ b/src/js/models/v2/award/BaseFinancialAssistance.js
@@ -4,7 +4,6 @@
  */
 
 import CoreLocation from 'models/v2/CoreLocation';
-import { mockAwardIdsForCaresAct } from 'dataMapping/award/awardAmountsSection';
 
 import BaseAwardRecipient from './BaseAwardRecipient';
 import CoreAwardAgency from './CoreAwardAgency';
@@ -43,14 +42,10 @@ BaseFinancialAssistance.populate = function populate(data) {
         baseExercisedOptions: data.base_exercised_options,
         dateSigned: data.date_signed,
         fileC: {
-            obligations: mockAwardIdsForCaresAct.includes(data.generated_unique_award_id)
-                ? [{ code: 'L', amount: 5 }, { code: 'M', amount: 6 }]
-                : data.account_obligations_by_defc,
+            obligations: data.account_obligations_by_defc,
             outlays: data.account_outlays_by_defc
         },
-        defCodes: mockAwardIdsForCaresAct.includes(data.generated_unique_award_id)
-            ? ["L", "M", "N"]
-            : data.disaster_emergency_fund_codes
+        defCodes: data.disaster_emergency_fund_codes
     };
     this.populateCore(coreData);
     if (data.cfda_info && data.cfda_info.length) {

--- a/src/js/models/v2/award/BaseIdv.js
+++ b/src/js/models/v2/award/BaseIdv.js
@@ -4,7 +4,6 @@
  */
 
 import * as pscHelper from 'helpers/pscHelper';
-import { mockAwardIdsForCaresAct } from 'dataMapping/award/awardAmountsSection';
 import CoreLocation from 'models/v2/CoreLocation';
 import CoreAward from './CoreAward';
 import CoreAwardAgency from './CoreAwardAgency';
@@ -37,9 +36,7 @@ BaseIdv.populate = function populate(data) {
             obligations: data.account_obligations_by_defc,
             outlays: data.account_outlays_by_defc
         },
-        defCodes: mockAwardIdsForCaresAct.includes(data.generated_unique_award_id)
-            ? ["L", "M", "N"]
-            : data.disaster_emergency_fund_codes
+        defCodes: data.disaster_emergency_fund_codes
     };
 
     this.populateCore(coreData);

--- a/src/js/propTypes/index.js
+++ b/src/js/propTypes/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 export const AWARD_OVERVIEW_PROPS = PropTypes.shape({
     _category: PropTypes.string,
-    id: PropTypes.string,
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     generatedId: PropTypes.string,
     type: PropTypes.string,
     typeDescription: PropTypes.string,
@@ -44,7 +44,7 @@ export const TOOLTIP_PROPS = PropTypes.shape({
 
 export const AWARD_SECTION_PROPS = {
     type: PropTypes.oneOf(["row", "column"]),
-    id: PropTypes.string,
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     children: PropTypes.node
 };
 
@@ -78,7 +78,7 @@ const awardOverviewAwardAmountsSectionBase = {
     extremeOverspendingAbbreviated: PropTypes.string,
     extremeOverspendingFormatted: PropTypes.string,
     generatedId: PropTypes.string,
-    id: PropTypes.string,
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     nonFederalFundingAbbreviated: PropTypes.string,
     nonFederalFundingFormatted: PropTypes.string,
     overspendingAbbreviated: PropTypes.string,

--- a/tests/models/award/BaseAwardAmounts-test.js
+++ b/tests/models/award/BaseAwardAmounts-test.js
@@ -228,62 +228,26 @@ describe('BaseAwardAmounts', () => {
             expect(loanAwardAmounts.faceValueAbbreviated).toEqual("$2.5 B");
         });
     });
-    describe('Mock Awards for Cares Act Release', () => {
-        it.each([
-            ['contract', 'CONT_AWD_N0001917C0001_9700_-NONE-_-NONE-', mockContract, '_totalObligation', 100],
-            ['idv', 'CONT_IDV_EDFSA09D0012_9100', mockIdv, '_totalObligation', 100],
-            ['grant', 'ASST_NON_1905CA5MAP_7530', mockGrant, '_totalObligation', 100],
-            ['loan', 'ASST_NON_13789835_12D2', mockLoan, '_subsidy', 100]
-        ])('For %s awards, with whitelisted award id %s it adds mock file c data', (
-            awardType,
-            id,
-            mockAward,
-            denominatorKey,
-            denominatorValue
-        ) => {
-            const mockAwardAmount = Object.create(BaseAwardAmounts);
-            mockAwardAmount.populate({ ...mockAward, generatedId: id, [denominatorKey]: denominatorValue }, awardType);
-            expect(mockAwardAmount._showFileC).toEqual(true);
-            expect(mockAwardAmount._fileCObligated > 0).toEqual(true);
-            expect(mockAwardAmount._fileCOutlay > 0).toEqual(true);
-            expect(mockAwardAmount._fileCOutlay < mockAwardAmount._fileCObligated).toEqual(true);
-        });
-        it.each([
-            ['contract', 'CONT_AWD_N0001917C0001_9700_-NONE-_-NONE-z', mockContract, '_totalObligation', 100],
-            ['idv', 'CONT_IDV_EDFSA09D0012_9100-z', mockIdv, '_totalObligation', 100],
-            ['grant', 'ASST_NON_1905CA5MAP_7530-z', mockGrant, '_totalObligation', 100],
-            ['loan', 'ASST_NON_13789835_12D2-z', mockLoan, '_subsidy', 100]
-        ])('For %s awards not whitelisted (%s) it does not add the mock file c data', (
-            awardType,
-            id,
-            mockAward,
-            denominatorKey,
-            denominatorValue
-        ) => {
-            const mockAwardAmount = Object.create(BaseAwardAmounts);
-            mockAwardAmount.populate({ ...mockAward, generatedId: id, [denominatorKey]: denominatorValue }, awardType);
-            expect(mockAwardAmount._showFileC).toEqual(false);
-            expect(mockAwardAmount._fileCObligated > 0).toEqual(false);
-            expect(mockAwardAmount._fileCOutlay > 0).toEqual(false);
-            expect(mockAwardAmount._fileCOutlay < mockAwardAmount._fileCObligated).toEqual(false);
-        });
-    });
     describe('fileC getters', () => {
+        const addCovidSpending = (obj, obligated, outlayed) => ({
+            ...obj,
+            fileC: {
+                obligations: [{ amount: 1, code: 'not-covid' }, { amount: obligated, code: 'M' }],
+                outlays: [{ amount: 1, code: 'not-covid' }, { amount: outlayed, code: 'M' }]
+            }
+        });
         it.each([
-            ['contract', 'CONT_AWD_N0001917C0001_9700_-NONE-_-NONE-', mockContract, '_totalObligation', 10000000],
-            ['idv', 'CONT_IDV_EDFSA09D0012_9100', mockIdv, '_totalObligation', 10000000],
-            ['grant', 'ASST_NON_1905CA5MAP_7530', mockGrant, '_totalObligation', 10000000],
-            ['loan', 'ASST_NON_13789835_12D2', mockLoan, '_subsidy', 10000000]
+            ['contract', 'CONT_AWD_N0001917C0001_9700_-NONE-_-NONE-', addCovidSpending(mockContract, 5000000, 2500000)],
+            ['idv', 'CONT_IDV_EDFSA09D0012_9100', addCovidSpending(mockIdv, 5000000, 2500000)],
+            ['grant', 'ASST_NON_1905CA5MAP_7530', addCovidSpending(mockGrant, 5000000, 2500000)],
+            ['loan', 'ASST_NON_13789835_12D2', addCovidSpending(mockLoan, 5000000, 2500000)]
         ])('For %s awards, get formatted and get abbreviated file c data returns as expected', (
             awardType,
             id,
-            mockAward,
-            denominatorKey,
-            denominatorValue
+            mockAward
         ) => {
             const mockAwardAmount = Object.create(BaseAwardAmounts);
-            mockAwardAmount.populate({ ...mockAward, generatedId: id, [denominatorKey]: denominatorValue }, awardType);
-            expect(mockAwardAmount._showFileC).toEqual(true);
+            mockAwardAmount.populate({ ...mockAward, generatedId: id }, awardType);
             expect(mockAwardAmount.fileCObligatedFormatted).toEqual("$5,000,000.00");
             expect(mockAwardAmount.fileCObligatedAbbreviated).toEqual("$5.0 M");
 


### PR DESCRIPTION
**High level description:**
We were mocking award amounts data to populate the award amounts viz. Now that the API is returning this data, we don't have to do this anymore.

**Technical details:**
- Remove white list of award ids to populate mock data for
- Update Tests to no longer confirm these white listed award are being mocked
- Remove obsolete properties on the AwardAmounts model
- Show new colors for award amounts table (DEV-5477)
- Only show award amounts table covid data when it is non-zero (DEV-5477)
- Fixing order of legend so outlayed proceeds obligated.

**JIRA Ticket:**
[DEV-5434](https://federal-spending-transparency.atlassian.net/browse/DEV-5434)

The following are ALL required for the PR to be merged:

Author:
- [X] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [X] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
