### PR TITLE
[DEV-5537 & DEV-5491] Hooking up DEFC Filter to API and loading it from Hash

### DIFF
--- a/src/js/components/search/SearchSidebar.jsx
+++ b/src/js/components/search/SearchSidebar.jsx
@@ -78,7 +78,7 @@ const staticFilters = {
             title: 'CFDA Program'
         },
         {
-            title: 'Disaster and Emergency Fund (DEF) Code',
+            title: 'Disaster Emergency Fund (DEF) Code',
             tooltip: withAdvancedSearchTooltip({
                 icon: 'info',
                 tooltipComponent: <DEFTooltip />

--- a/src/js/components/search/filters/tooltips/AdvancedSearchTooltip.jsx
+++ b/src/js/components/search/filters/tooltips/AdvancedSearchTooltip.jsx
@@ -36,11 +36,11 @@ export const KeyWordTooltip = () => (
 export const DEFTooltip = () => (
     <div className="advanced-search-tt">
         <h3 className="advanced-search-tt__header">
-           Disaster and Emergency Fund (DEF) Code
+           Disaster Emergency Fund (DEF) Code
         </h3>
         <div className="advanced-search-tt__body">
             <p>
-                Disaster Emergency Fund Code (DEF Code) is an accounting attribute used to track the spending of supplemental funding targeting disasters and emergencies.
+                <strong>Disaster Emergency Fund (DEF) Code</strong> is an accounting attribute used to track the spending of supplemental funding targeting disasters and emergencies.
             </p>
         </div>
     </div>

--- a/src/js/containers/search/filters/def/DEFCheckboxTree.jsx
+++ b/src/js/containers/search/filters/def/DEFCheckboxTree.jsx
@@ -110,9 +110,9 @@ export class DEFCheckboxTree extends React.Component {
                     checked={this.props.checked}
                     expanded={defaultExpanded}
                     data={this.state.nodes}
-                    isError={false}
-                    errorMessage={null}
-                    isLoading={false}
+                    isError={this.state.isError}
+                    errorMessage={this.state.errorMessage}
+                    isLoading={this.state.isLoading}
                     searchText=""
                     noResults={false}
                     onUncheck={this.stageFilter}

--- a/src/js/containers/search/filters/def/DEFCheckboxTree.jsx
+++ b/src/js/containers/search/filters/def/DEFCheckboxTree.jsx
@@ -1,9 +1,11 @@
-import React, { useState, useRef } from 'react';
+import React from 'react';
+import { isCancel } from 'axios';
 import PropTypes from "prop-types";
 import { connect } from 'react-redux';
-import { uniqueId } from 'lodash';
+import { uniqueId, get } from 'lodash';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
+import { fetchDEFCodes } from 'helpers/disasterHelper';
 import CheckboxTree from 'components/sharedComponents/CheckboxTree';
 import { updateDefCodes } from 'redux/actions/search/searchFilterActions';
 import SubmitHint from 'components/sharedComponents/filterSidebar/SubmitHint';
@@ -12,64 +14,56 @@ export const NewBadge = () => (
     <div className="advanced-search-filter-accessory__new-badge">NEW</div>
 );
 
-const mockData = {
+const covidParentNode = {
     label: "COVID-19 Response",
     value: "COVID",
     className: "def-checkbox-label--covid",
     isSearchable: false,
     expandDisabled: true,
     showNodeIcon: false,
-    children: [
-        {
-            label: "Some Description with placeholder content...",
-            value: "L",
-            expandDisabled: true
-        },
-        {
-            label: "Some Description with placeholder content...",
-            value: "M",
-            expandDisabled: true
-        },
-        {
-            label: "Some Description with placeholder content...",
-            value: "N",
-            expandDisabled: true
-        },
-        {
-            value: "O",
-            label: "Some Description with placeholder content..."
-        },
-        {
-            value: "P",
-            label: "Some Description with placeholder content...",
-            expandDisabled: true
-        }
-    ]
+    children: []
 };
 
+const parseCovidCodes = (codes) => codes.filter((code) => code.disaster === 'covid_19')
+    .reduce((acc, covidCode) => ({
+        ...acc,
+        children: acc.children.concat([{
+            label: covidCode.title,
+            value: covidCode.code,
+            expandDisabled: true
+        }])
+    }), covidParentNode);
+
 const defaultExpanded = ['COVID'];
-const nodes = [mockData];
 const countLabel = { value: 'COVID-19', count: 0, label: 'COVID-19 Response' };
 
-const DEFCheckboxTree = ({
-    counts,
-    stageDef
-}) => {
-    const hint = useRef();
-    const [checked, setChecked] = useState([]);
+export class DEFCheckboxTree extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            nodes: [],
+            isLoading: false,
+            isError: false,
+            errorMessage: null
+        };
+        this.request = null;
+    }
 
-    const stageFilter = (newChecked) => {
-        setChecked(newChecked);
+    componentDidMount() {
+        this.fetchCodes();
+    }
+
+    stageFilter = (newChecked) => {
         const newCount = newChecked.reduce((acc) => acc + 1, 0);
         if (newCount > 0) {
-            stageDef(
+            this.props.stageDef(
                 newChecked,
                 [],
                 [{ ...countLabel, count: newCount }]
             );
         }
         else {
-            stageDef(
+            this.props.stageDef(
                 [],
                 [],
                 []
@@ -77,61 +71,92 @@ const DEFCheckboxTree = ({
         }
     };
 
-    const removeSelectedFilter = (e) => {
-        e.preventDefault();
-        stageDef([], [], []);
-        setChecked([]);
+    fetchCodes = async () => {
+        if (this.request) {
+            this.request.cancel();
+        }
+        this.request = fetchDEFCodes();
+        this.setState({ isLoading: true });
+        try {
+            const { data: { codes: allDisasterCodes } } = await this.request.promise;
+            const covidCodes = parseCovidCodes(allDisasterCodes);
+            this.setState({
+                nodes: [covidCodes],
+                isLoading: false
+            });
+        }
+        catch (e) {
+            console.log('Error fetching Def Codes ', e);
+            if (!isCancel(e)) {
+                this.setState({
+                    isLoading: false,
+                    isError: true,
+                    errorMessage: get(e, 'message', 'There was an error, please refresh the browser.')
+                });
+            }
+        }
     };
 
-    return (
-        <div className="def-code-filter">
-            <CheckboxTree
-                className="def-checkbox-tree"
-                checked={checked}
-                expanded={defaultExpanded}
-                data={nodes}
-                isError={false}
-                errorMessage={null}
-                isLoading={false}
-                searchText=""
-                noResults={false}
-                onUncheck={stageFilter}
-                onCheck={stageFilter} />
-            {counts.length > 0 && (
-                <div
-                    className="selected-filters"
-                    role="status">
-                    {counts.map((node) => {
-                        const label = `${node.value} - ${node.label} (${node.count})`;
-                        return (
-                            <button
-                                key={uniqueId()}
-                                className="shown-filter-button"
-                                value={label}
-                                onClick={(e) => removeSelectedFilter(e, node)}
-                                title="Click to remove."
-                                aria-label={`Applied filter: ${label}`}>
-                                {label}
-                                <span className="close">
-                                    <FontAwesomeIcon icon="times" />
-                                </span>
-                            </button>
-                        );
-                    })}
-                </div>
-            )}
-            <SubmitHint ref={hint} />
-        </div>
-    );
+    removeSelectedFilter = (e) => {
+        e.preventDefault();
+        this.props.stageDef([], [], []);
+    };
+
+    render() {
+        return (
+            <div className="def-code-filter">
+                <CheckboxTree
+                    className="def-checkbox-tree"
+                    checked={this.props.checked}
+                    expanded={defaultExpanded}
+                    data={this.state.nodes}
+                    isError={false}
+                    errorMessage={null}
+                    isLoading={false}
+                    searchText=""
+                    noResults={false}
+                    onUncheck={this.stageFilter}
+                    onCheck={this.stageFilter} />
+                {this.props.counts.length > 0 && (
+                    <div
+                        className="selected-filters"
+                        role="status">
+                        {this.props.counts.map((node) => {
+                            const label = `${node.value} - ${node.label} (${node.count})`;
+                            return (
+                                <button
+                                    key={uniqueId()}
+                                    className="shown-filter-button"
+                                    value={label}
+                                    onClick={(e) => this.removeSelectedFilter(e, node)}
+                                    title="Click to remove."
+                                    aria-label={`Applied filter: ${label}`}>
+                                    {label}
+                                    <span className="close">
+                                        <FontAwesomeIcon icon="times" />
+                                    </span>
+                                </button>
+                            );
+                        })}
+                    </div>
+                )}
+                <SubmitHint ref={(component) => {
+                    this.hint = component;
+                }} />
+            </div>
+        );
+    }
 };
 
 DEFCheckboxTree.propTypes = {
     counts: PropTypes.arrayOf(PropTypes.shape({})),
+    checked: PropTypes.arrayOf(PropTypes.string),
     stageDef: PropTypes.func
 };
 
 const mapStateToProps = (state) => ({
-    counts: state.filters.defCodes.toObject().counts
+    counts: state.filters.defCodes.toObject().counts,
+    checked: state.filters.defCodes.toObject().require
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/js/helpers/sidebarHelper.js
+++ b/src/js/helpers/sidebarHelper.js
@@ -4,7 +4,7 @@
 
 // eslint-disable-next-line import/prefer-default-export
 export const filterHasSelections = (reduxFilters, filter) => {
-    switch (filter) {
+    switch (filter.title) {
         case 'Time Period':
             if (reduxFilters.timePeriodFY.toArray().length > 0
                 || (reduxFilters.timePeriodRange
@@ -54,18 +54,10 @@ export const filterHasSelections = (reduxFilters, filter) => {
                 return true;
             }
             return false;
-        case 'NAICS Code':
-            if (reduxFilters.selectedNAICS.toArray().length > 0) {
-                return true;
-            }
-            return false;
         case 'North American Industry Classification System (NAICS)':
             return (reduxFilters.naicsCodes.toObject().require.length > 0);
         case 'Product or Service Code (PSC)':
-            if (reduxFilters.selectedPSC.toArray().length > 0) {
-                return true;
-            }
-            else if (reduxFilters.pscCodes.toObject().require.length > 0) {
+            if (reduxFilters.pscCodes.toObject().require.length > 0) {
                 return true;
             }
             return false;
@@ -86,6 +78,9 @@ export const filterHasSelections = (reduxFilters, filter) => {
             return false;
         case 'Treasury Account Symbol (TAS)':
             if (reduxFilters.tasCodes.toObject().require.length > 0) return true;
+            return false;
+        case 'Disaster Emergency Fund (DEF) Code':
+            if (reduxFilters.defCodes.toObject().require.length > 0) return true;
             return false;
         default:
             return false;

--- a/tests/containers/search/filters/DEFCheckboxxTree-test.jsx
+++ b/tests/containers/search/filters/DEFCheckboxxTree-test.jsx
@@ -1,0 +1,38 @@
+/**
+ * Created by Max Kendall
+ * 03/25/2020
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { fetchDEFCodes } from "helpers/disasterHelper";
+import { DEFCheckboxTree } from "../../../../src/js/containers/search/filters/def/DEFCheckboxTree";
+
+jest.mock("helpers/disasterHelper", () => ({
+    fetchDEFCodes: jest.fn()
+}));
+
+const defaultProps = {
+    counts: [{}],
+    stageDef: () => {}
+};
+
+describe('DEFCheckboxTree', () => {
+    it('fetchCodes on mount and only sets the nodes to the covid codes', async () => {
+        fetchDEFCodes.mockImplementation(() => ({
+            promise: Promise.resolve({
+                data: {
+                    codes: [
+                        { disaster: 'covid_19', code: 'L', title: 'test' },
+                        { disaster: 'non-covid_19', code: 'M', title: 'test' }
+                    ]
+                }
+            })
+        }));
+        const container = shallow(<DEFCheckboxTree {...defaultProps} />);
+        await container.instance().componentDidMount();
+
+        expect(container.instance().state.nodes[0].children.some((node) => node.value === 'L')).toEqual(true);
+        expect(container.instance().state.nodes[0].children.some((node) => node.value === 'M')).toEqual(false);
+    });
+});


### PR DESCRIPTION
**High level description:**
Hooks up the DEFC Filter to the API and cleans up some bugs. Also adds a test.

**Technical details:**
Previously this checkbox tree was...
- Using Mock Data
- Using local state rather than redux state for the checked state of the tree (**root cause for why it wasnt loading from hash**)

Switch Statement clean up for detecting expanded state of the search side bar 👇 ,
- Deleted dead code in the switch statement for the sidebar (for NAICS/PSC)
- Switch statement now switches on the `filter.title` property
- Adds new case for switch statement for DEFC

Also fixes the title so everywhere it is `Disaster Emergency Fund (DEF) Code` rather than `Disaster and Emergency Fund Code (DEF)` and other inconsistent variations.

**JIRA Ticket:**
[DEV-5491](https://federal-spending-transparency.atlassian.net/browse/DEV-5491)
[DEV-5537](https://federal-spending-transparency.atlassian.net/browse/DEV-5537)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A`Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A`Verified mobile/tablet/desktop/monitor responsiveness
`N/A`Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A`All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A`[API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A`[Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A`Design review complete `if applicable`
`N/A`[API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
