### PR TITLE
[DEV-5538] Award Amounts Viz -- Handling case where outlayed amount is zero & [DEV-5477] Small Tweaks to Award Summary

### DIFF
--- a/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
@@ -421,7 +421,7 @@ $new-potential: #AAC6E2;
             }
             .award-amounts-viz__desc.asst-nff-zero,
             .award-amounts-viz__desc.loan-file-c-outlay--zero,
-            .award-amounts-viz__desc.idv-file-c-outlay--z,
+            .award-amounts-viz__desc.idv-file-c-outlay--zero,
             .award-amounts-viz__desc.contract-file-c-outlay--zero,
             .award-amounts-viz__desc.asst-file-c-outlay--zero {
                 &.asst-nff-zero {

--- a/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
@@ -419,8 +419,21 @@ $new-potential: #AAC6E2;
                     }
                 }
             }
-            .award-amounts-viz__desc.asst-nff-zero {
-                border-left: rem(5) solid $grants-line-color;
+            .award-amounts-viz__desc.asst-nff-zero,
+            .award-amounts-viz__desc.loan-file-c-outlay--zero,
+            .award-amounts-viz__desc.idv-file-c-outlay--z,
+            .award-amounts-viz__desc.contract-file-c-outlay--zero,
+            .award-amounts-viz__desc.asst-file-c-outlay--zero {
+                &.asst-nff-zero {
+                    border-left: rem(5) solid $grants-line-color;
+                }
+                &.loan-file-c-outlay--zero,
+                &.asst-file-c-outlay--zero,
+                &.idv-file-c-outlay--zero,
+                &.contract-file-c-outlay--zero {
+                    margin-top: rem(20);
+                    border-left: rem(5) solid $file-c-outlay;
+                }
                 border-right: none;
                 margin-top: rem(10);
                 @include display(flex);

--- a/src/js/components/award/financialAssistance/RectanglePercentViz.jsx
+++ b/src/js/components/award/financialAssistance/RectanglePercentViz.jsx
@@ -296,6 +296,14 @@ const RectanglePercentViz = ({
                                         300
                                     );
                                 }
+                                // when outlays are zero.
+                                else if (child.text.toLowerCase().includes('covid')) {
+                                    showTooltip(
+                                        child.tooltipData,
+                                        `275px`,
+                                        245
+                                    );
+                                }
                                 else {
                                     showTooltip(
                                         child.tooltipData,

--- a/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
@@ -83,7 +83,7 @@ const buildNormalProps = (awardType, data, hasFileC) => {
                         children: [{
                             labelSortOrder: 0,
                             labelPosition: 'bottom',
-                            className: `${awardType}-file-c-outlay`,
+                            className: `${data._fileCOutlay > 0 ? `${awardType}-file-c-outlay` : `${awardType}-file-c-outlay--zero`}`,
                             tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'fileCOutlay', data),
                             denominatorValue: data._fileCObligated,
                             rawValue: data._fileCOutlay,
@@ -199,7 +199,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
                                 children: [{
                                     labelSortOrder: 0,
                                     labelPosition: 'bottom',
-                                    className: `${awardType}-file-c-outlay`,
+                                    className: `${data._fileCOutlay > 0 ? `${awardType}-file-c-outlay` : `${awardType}-file-c-outlay--zero`}`,
                                     tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'fileCOutlay', data),
                                     denominatorValue: data._fileCObligated,
                                     rawValue: data._fileCOutlay,
@@ -342,7 +342,7 @@ const buildExceedsPotentialProps = (awardType, data, hasFileC) => {
                                 children: [{
                                     labelSortOrder: 0,
                                     labelPosition: 'bottom',
-                                    className: `${awardType}-file-c-outlay`,
+                                    className: `${data._fileCOutlay > 0 ? `${awardType}-file-c-outlay` : `${awardType}-file-c-outlay--zero`}`,
                                     tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'fileCOutlay', data),
                                     denominatorValue: data._fileCObligated,
                                     rawValue: data._fileCOutlay,
@@ -455,7 +455,7 @@ const AwardAmountsChart = ({ awardType, awardOverview, spendingScenario }) => {
                         children: [{
                             labelSortOrder: 0,
                             labelPosition: 'bottom',
-                            className: `asst-file-c-outlay`,
+                            className: `${awardAmounts._fileCOutlay > 0 ? `asst-file-c-outlay` : `asst-file-c-outlay--zero`}`,
                             tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'fileCOutlay', awardAmounts),
                             denominatorValue: awardAmounts._fileCObligated,
                             rawValue: awardAmounts._fileCOutlay,
@@ -510,7 +510,7 @@ const AwardAmountsChart = ({ awardType, awardOverview, spendingScenario }) => {
                             color: '#B699C6',
                             tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory('loan', 'fileCObligated', awardAmounts),
                             children: [{
-                                className: `loan-file-c-outlay`,
+                                className: `${awardAmounts._fileCOutlay > 0 ? `loan-file-c-outlay` : `loan-file-c-outlay--zero`}`,
                                 labelPosition: 'bottom',
                                 labelSortOrder: 0,
                                 rawValue: awardAmounts._fileCOutlay,


### PR DESCRIPTION
**High level description:**

Handling styles for tooltip and label when the covid outlayed amount is zero: `ASST_NON_12FA00PY63083044_12D2`

**Technical details:**
- Adding class name to covid-outlay label when amount is zero. SS 👇 
![image](https://user-images.githubusercontent.com/12897813/86637654-ef161e00-bfa3-11ea-9fd3-6c293283918b.png)
- Reusing styles for used for when non federal funding amount is zero 👇 
![image](https://user-images.githubusercontent.com/12897813/86637619-e0c80200-bfa3-11ea-9252-f92549d17a5c.png)
- Special logic for positioning the tooltip correctly.

**JIRA Ticket:**
[DEV-5538](https://federal-spending-transparency.atlassian.net/browse/DEV-5538)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
