### PR TITLE
[DEV-5136] Showing FileC Data in Award Amounts Table when Outlays or Obligated is non-zero

### DIFF
--- a/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
@@ -56,7 +56,14 @@
     }
 
     .award-amounts__obligated {
-        background-color: #0A2F5A;
+        background-color: #4773aa;
+    }
+
+    &.contract,
+    &.idv {
+        .award-amounts__obligated {
+            background-color: #0A2F5A;
+        }
     }
 
     .award-amounts__file-c-obligations {

--- a/src/js/components/award/idv/amounts/AggregatedAwardAmounts.jsx
+++ b/src/js/components/award/idv/amounts/AggregatedAwardAmounts.jsx
@@ -88,7 +88,10 @@ export default class AggregatedAwardAmounts extends React.Component {
                     awardAmountType="idv_aggregated"
                     showFileC={(
                         showCaresActViz &&
-                        awardAmounts._fileCObligated !== 0
+                        (
+                            awardAmounts._fileCObligated !== 0 ||
+                            awardAmounts._fileCOutlay !== 0
+                        )
                     )}
                     awardData={awardAmounts}
                     spendingScenario={spendingScenario} />

--- a/src/js/components/award/idv/amounts/AggregatedAwardAmounts.jsx
+++ b/src/js/components/award/idv/amounts/AggregatedAwardAmounts.jsx
@@ -88,7 +88,7 @@ export default class AggregatedAwardAmounts extends React.Component {
                     awardAmountType="idv_aggregated"
                     showFileC={(
                         showCaresActViz &&
-                        awardAmounts._fileCObligated > 0
+                        awardAmounts._fileCObligated !== 0
                     )}
                     awardData={awardAmounts}
                     spendingScenario={spendingScenario} />

--- a/src/js/components/award/idv/amounts/AwardAmounts.jsx
+++ b/src/js/components/award/idv/amounts/AwardAmounts.jsx
@@ -59,7 +59,10 @@ export default class AwardAmounts extends React.Component {
             <AwardAmountsTable
                 showFileC={(
                     GlobalConstants.CARES_ACT_RELEASED &&
-                    awards._fileCObligated !== 0
+                    (
+                        awards._fileCObligated !== 0 ||
+                        awards._fileCOutlay !== 0
+                    )
                 )}
                 awardData={awards}
                 awardAmountType="idv"

--- a/src/js/components/award/idv/amounts/AwardAmounts.jsx
+++ b/src/js/components/award/idv/amounts/AwardAmounts.jsx
@@ -59,7 +59,7 @@ export default class AwardAmounts extends React.Component {
             <AwardAmountsTable
                 showFileC={(
                     GlobalConstants.CARES_ACT_RELEASED &&
-                    awards._fileCObligated > 0
+                    awards._fileCObligated !== 0
                 )}
                 awardData={awards}
                 awardAmountType="idv"

--- a/src/js/components/award/shared/awardAmountsSection/AwardAmountsSection.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/AwardAmountsSection.jsx
@@ -40,7 +40,7 @@ const AwardAmountsSection = ({
                     <AwardAmountsTable
                         showFileC={(
                             showCaresActViz &&
-                            awardOverview._fileCObligated > 0
+                            awardOverview._fileCObligated !== 0
                         )}
                         awardData={awardOverview}
                         awardAmountType={awardType}

--- a/src/js/components/award/shared/awardAmountsSection/AwardAmountsSection.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/AwardAmountsSection.jsx
@@ -40,7 +40,10 @@ const AwardAmountsSection = ({
                     <AwardAmountsTable
                         showFileC={(
                             showCaresActViz &&
-                            awardOverview._fileCObligated !== 0
+                            (
+                                awardOverview._fileCObligated !== 0 ||
+                                awardOverview._fileCOutlay !== 0
+                            )
                         )}
                         awardData={awardOverview}
                         awardAmountType={awardType}

--- a/src/js/components/award/shared/awardAmountsSection/AwardAmountsTable.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/AwardAmountsTable.jsx
@@ -88,7 +88,7 @@ const AwardAmountsTable = ({
     const overspendingRow = getOverSpendingRow(awardData, spendingScenario);
 
     return (
-        <div className="award-amounts__data-wrapper">
+        <div className={`award-amounts__data-wrapper ${awardAmountType}`}>
             {Object.keys(amountMapByCategoryTitle)
                 .map((title) => (
                     <div key={uniqueId(title)} className="award-amounts__data-content">

--- a/src/js/dataMapping/award/awardAmountsSection.js
+++ b/src/js/dataMapping/award/awardAmountsSection.js
@@ -63,7 +63,7 @@ export const awardTableClassMap = {
     "Current Amount": "award-amounts__current",
     "Potential Amount": "award-amounts__potential",
     "Non-Federal Funding": "award-amounts__data-icon_green",
-    "Total Funding": "award-amounts__data-icon_gray",
+    "Total Funding": "award-amounts__data-icon_transparent",
     "Face Value of Direct Loan": "award-amounts__data-icon_transparent",
     "Original Subsidy Cost": "award-amounts__data-icon_yellow",
     "COVID-19 Response Obligated Amount": "award-amounts__file-c-obligations",


### PR DESCRIPTION
**High level description:**
We weren't showing fileC data in the award amounts viz table if they were less than zero.

**Technical details:**
- Change conditional to show file c data if it is non zero
- Updated class names so legend colors are correct based on award type

**JIRA Ticket:**
[DEV-1234](https://federal-spending-transparency.atlassian.net/browse/DEV-1234)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
