### PR TITLE
DEV-5299 fix CFDA code format

### DIFF
--- a/src/js/models/v2/covid19/BaseSpendingByCfdaRow.js
+++ b/src/js/models/v2/covid19/BaseSpendingByCfdaRow.js
@@ -12,12 +12,11 @@ BaseSpendingByCfdaRow.populate = function populate(data) {
     this.populateCore(data);
     // Add properties specific to CFDA
     this._link = data.resource_link || '';
-    this._number = (this._id && this._code) ? `${this._id}.${this._code}` : '';
-    if (this._number && this.description) {
-        this.name = `${this._number}: ${this.description}`;
+    if (this._code && this.description) {
+        this.name = `${this._code}: ${this.description}`;
     }
     else {
-        this.name = `${this._number}${this.description}` || '--';
+        this.name = `${this._code}${this.description}` || '--';
     }
 };
 

--- a/tests/containers/covid19/SpendingByCFDAContainer-test.jsx
+++ b/tests/containers/covid19/SpendingByCFDAContainer-test.jsx
@@ -12,8 +12,7 @@ describe('SpendingByCFDAContainer', () => {
         it('should parse returned CFDA data', () => {
             const mockResults = [
                 {
-                    id: '43',
-                    code: '090',
+                    code: '43.090',
                     description: 'Description text',
                     children: [],
                     count: 5400,
@@ -22,8 +21,7 @@ describe('SpendingByCFDAContainer', () => {
                     resource_link: 'https://beta.sam.gov/fal/25b529f3b5f94b6c939bc0ae8424ae6c/view'
                 },
                 {
-                    id: '44',
-                    code: '091',
+                    code: '44.091',
                     description: 'Description text 2',
                     children: [],
                     count: 5401,
@@ -63,8 +61,7 @@ describe('SpendingByCFDAContainer', () => {
         it('should parse returned CFDA loans data', () => {
             const mockResults = [
                 {
-                    id: '43',
-                    code: '090',
+                    code: '43.090',
                     description: 'Description text',
                     children: [],
                     count: 5400,
@@ -74,8 +71,7 @@ describe('SpendingByCFDAContainer', () => {
                     face_value_of_loan: 56000001.02
                 },
                 {
-                    id: '44',
-                    code: '091',
+                    code: '44.091',
                     description: 'Description text 2',
                     children: [],
                     count: 5401,

--- a/tests/models/covid19/BaseSpendingByCfdaRow-test.js
+++ b/tests/models/covid19/BaseSpendingByCfdaRow-test.js
@@ -12,11 +12,8 @@ row.populate(mockCfdaData);
 describe('COVID-19 spending by CFDA row', () => {
     describe('CoreSpendingTableRow properties', () => {
         describe('name column properties', () => {
-            it('should store the id', () => {
-                expect(row._id).toEqual('43');
-            });
-            it('should store the code', () => {
-                expect(row._code).toEqual('090');
+            it('should store the code (CFDA number)', () => {
+                expect(row._code).toEqual('43.090');
             });
             it('should store the description', () => {
                 expect(row.description).toEqual('Description text');
@@ -56,10 +53,7 @@ describe('COVID-19 spending by CFDA row', () => {
         });
     });
     describe('CFDA-specific properties', () => {
-        it('should format the number using the id and code', () => {
-            expect(row._number).toEqual('43.090');
-        });
-        it('should format the name using the number and description', () => {
+        it('should format the name using the code and description', () => {
             expect(row.name).toEqual('43.090: Description text');
         });
         it('should store the resource link value', () => {

--- a/tests/models/covid19/mockData.js
+++ b/tests/models/covid19/mockData.js
@@ -24,8 +24,7 @@ export const mockOverviewData = {
 };
 
 export const mockCfdaData = {
-    id: '43',
-    code: '090',
+    code: '43.090',
     description: 'Description text',
     children: [],
     count: 5400,


### PR DESCRIPTION
**High level description:**

Display just the `code` property from the API response, instead of a combination of `code` and `id`.

**Technical details:**

- Updates the data model and unit tests

**JIRA Ticket:**
[DEV-5469](https://federal-spending-transparency.atlassian.net/browse/DEV-5469), subtask of [DEV-5299](https://federal-spending-transparency.atlassian.net/browse/DEV-5299)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models

Reviewer(s):
- [x] Code review complete
