### PR TITLE
[DEV-5233] Changing Request Object shape for DEFC Spending By Award

### DIFF
--- a/src/js/models/search/SearchAwardsOperation.js
+++ b/src/js/models/search/SearchAwardsOperation.js
@@ -44,6 +44,7 @@ class SearchAwardsOperation {
         this.selectedCFDA = [];
         this.naicsCodes = checkboxTreeKeys;
         this.pscCheckbox = checkboxTreeKeys;
+        // the defCodes don't actually send the checkboxTrees object shape to the API. See comment below.
         this.defCodes = checkboxTreeKeys;
         this.pricingType = [];
         this.setAside = [];
@@ -340,11 +341,10 @@ class SearchAwardsOperation {
 
         // Add Def Codes
         if (this.defCodes.require.length > 0) {
-            filters[rootKeys.defCodes] = { require: this.defCodes.require };
-            // at the moment, this will never be added unless we introduce some hierarchy.
-            if (this.defCodes.exclude.length > 0) {
-                filters[rootKeys.defCodes].exclude = this.defCodes.exclude;
-            }
+            // right now, due to the shape of this data, we never send excluded to the api, so the
+            // api expects just an array of strings. Should that ever change and the DEFC data becomes more complex
+            // and the checkbox tree is more like the others, we can easily migrate to the more complex request object.
+            filters[rootKeys.defCodes] = this.defCodes.require;
         }
 
         return filters;

--- a/tests/models/search/SearchAwardsOperation-test.js
+++ b/tests/models/search/SearchAwardsOperation-test.js
@@ -37,6 +37,7 @@ describe('SearchAwardsOperation', () => {
             });
             const requestObject = model.toParams();
             expect(Object.keys(requestObject).includes('def_codes')).toEqual(true);
+            expect(Array.isArray(requestObject.def_codes)).toEqual(true);
             expect(Object.keys(requestObject)).toEqual(['time_period', 'def_codes']);
             expect(requestObject.def_codes.counts).toBeFalsy();
         });


### PR DESCRIPTION
**High level description:**
We were expecting the request object to have the same shape as the other checkbox trees. But since the data -- at the moment -- is non-hierachial it doesn't actually require anything more than an array of strings to indicate what's selected.

**Technical details:**
We're actually keeping the structure in redux as is, and only changing this to an array at the request layer. This is most expedient, but also in the future perhaps the defc data will grow more complex and we will find a use for this data structure.

Updates the test as well 
**JIRA Ticket:**
[DEV-5233](https://federal-spending-transparency.atlassian.net/browse/DEV-5233)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
