### PR TITLE
DEV-5414 update COVID profile url

### DIFF
--- a/src/js/components/sharedComponents/header/DropdownItem.jsx
+++ b/src/js/components/sharedComponents/header/DropdownItem.jsx
@@ -13,7 +13,7 @@ import DropdownComingSoon from './DropdownComingSoon';
 
 const propTypes = {
     url: PropTypes.string,
-    label: PropTypes.string,
+    label: PropTypes.node,
     enabled: PropTypes.bool,
     newTab: PropTypes.bool,
     isFirst: PropTypes.bool,

--- a/src/js/containers/router/RouterRoutes.js
+++ b/src/js/containers/router/RouterRoutes.js
@@ -304,8 +304,8 @@ if (kGlobalConstants.DEV) {
 if (kGlobalConstants.CARES_ACT_RELEASED) {
     routes.routes.push(
         {
-            path: '/covid-19',
-            parent: '/covid-19',
+            path: '/disaster/covid-19',
+            parent: '/disaster',
             addToSitemap: false,
             component: (cb) => {
                 require.ensure([], (require) => {


### PR DESCRIPTION
**High level description:**

The navigation link to the COVID profile page was added referencing the url `/disaster/covid-19`, but the page still lived at `/covid-19`

**Technical details:**

- Also fixes a prop types console error in the `DropdownItem` component

**JIRA Ticket:**
[DEV-5414](https://federal-spending-transparency.atlassian.net/browse/DEV-5414)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
- [x] Code review complete
