### PR TITLE
[DEV-5535] Standardize COVID Colors and Award Amounts Colors

### DIFF
--- a/src/_scss/core/_variables.scss
+++ b/src/_scss/core/_variables.scss
@@ -97,6 +97,7 @@ $color-gray-border:          #D8D8D8;
 $color-placeholder:          #747474;
 
 $color-disaster-covid-19:    #6E338E;
+$color-covid-19-obligations: #B699C6;
 
 
 // Global Paadding and Margins

--- a/src/_scss/core/_variables.scss
+++ b/src/_scss/core/_variables.scss
@@ -99,6 +99,15 @@ $color-placeholder:          #747474;
 $color-disaster-covid-19:    #6E338E;
 $color-covid-19-obligations: #B699C6;
 
+$colors-grants-nff: #47AAA7;
+$colors-loans-subsidy: #F5A623;
+
+$colors-obligated: #0A2F5A;
+$colors-current: #558EC6;
+$colors-potential: #AAC6E2;
+
+$file-c-outlay: $color-disaster-covid-19;
+$file-c-obligation: $color-covid-19-obligations;
 
 // Global Paadding and Margins
 // (example usage {padding: ($global-pad * 4);} = 60px of padding.)

--- a/src/_scss/core/_variables.scss
+++ b/src/_scss/core/_variables.scss
@@ -107,9 +107,6 @@ $colors-obligated: #0A2F5A;
 $colors-current: #558EC6;
 $colors-potential: #AAC6E2;
 
-$file-c-outlay: $color-disaster-covid-19;
-$file-c-obligation: $color-covid-19-obligations;
-
 // Global Paadding and Margins
 // (example usage {padding: ($global-pad * 4);} = 60px of padding.)
 $global-pad-mrg: rem(15);

--- a/src/_scss/core/_variables.scss
+++ b/src/_scss/core/_variables.scss
@@ -100,7 +100,8 @@ $color-disaster-covid-19:    #6E338E;
 $color-covid-19-obligations: #B699C6;
 
 $colors-grants-nff: #47AAA7;
-$colors-loans-subsidy: #F5A623;
+$colors-loans-subsidy: #0B424D;
+$colors-loans-face-value: #F3F3F3;
 
 $colors-obligated: #0A2F5A;
 $colors-current: #558EC6;

--- a/src/_scss/pages/award/awardPage.scss
+++ b/src/_scss/pages/award/awardPage.scss
@@ -98,7 +98,7 @@
                   @include display(flex);
                   @include justify-content(center);
                   @include align-items(center);
-                  background: #6E338E;
+                  background: $color-disaster-covid-19;
                   color: $color-white;
                   font-size: rem(14);
                   font-weight: 600;

--- a/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
@@ -160,7 +160,7 @@ $exceeds-potential-color: #e31c3d;
 
                 &.idv-obligated,
                 &.contract-obligated,
-                &.asst-obligated {
+                &.asst-obligation {
                     border-left: rem(4) solid $colors-obligated;
                 }
 
@@ -213,7 +213,8 @@ $exceeds-potential-color: #e31c3d;
                     &.asst-obligated,
                     &.asst-obligated,
                     &.idv-extreme-overspending-obligated,
-                    &.contract-extreme-overspending-obligated {
+                    &.contract-extreme-overspending-obligated,
+                    &.asst-obligation {
                         border-bottom: rem(1) solid $colors-obligated;
                         &::before,
                         &::after {
@@ -314,12 +315,17 @@ $exceeds-potential-color: #e31c3d;
                             }
                         }
                     }
-                    &.loan-face-value::after,
-                    &.asst-total-funding::after {
-                        content: ' ';
-                        height: rem(45);
-                        border: rem(1) solid $color-gray;
-                        width: rem(5);
+                    &.loan-face-value,
+                    &.asst-total-funding {
+                        &::after {
+                            content: ' ';
+                            height: rem(45);
+                            width: rem(5);
+                            border: rem(1) solid $color-gray-light;
+                        }
+                        &.loan-face-value::after {
+                            background: $colors-loans-face-value;
+                        }                        
                     }
                 }
                 .award-amounts-viz__line {
@@ -361,6 +367,13 @@ $exceeds-potential-color: #e31c3d;
                             top: -9px;
                             right: -1px;
                             border-left: 1px solid $colors-grants-nff; 
+                        }
+                    }
+                    &.asst-total-funding {
+                        border-bottom: rem(1) solid $color-gray-light;
+                        &::after,
+                        &::before {
+                            border-left: 1px solid $color-gray-light; 
                         }
                     }
                     &.idv-current,

--- a/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
@@ -59,30 +59,22 @@ $file-c-obligation: $color-covid-19-obligations;
                 border-top: .4rem solid $potential;
                 border-bottom: .4rem solid $potential;
                 background: repeating-linear-gradient(45deg,$obligated, $obligated .8rem,#fdb81e 0,#fdb81e 1rem);
-                &.covid {
-                    border-top: .4rem solid $potential;
-                    border-bottom: .4rem solid $potential;
-                }
             }
             .award-amounts-viz__bar-wrapper {
                 &.idv-extreme-overspending-potential-wrapper,
                 &.contract-extreme-overspending-potential-wrapper {
-                    border: 0.2rem solid #5b616b;
+                    border: 0.2rem solid $potential;
                     background-color: #fff;
                     .award-amounts-viz__bar .nested-obligations .award-amounts-viz__bar,
                     .award-amounts-viz__bar .nested-obligations .award-amounts-viz__bar {
                         &.contract-extreme-overspending-current,
                         &.idv-extreme-overspending-current {
-                            border: solid 0.4rem $color-gray-lighter;
-                        }
-                        &.covid.contract-extreme-overspending-current,
-                        &.covid.idv-extreme-overspending-current {
                             border: solid 0.4rem $current;
                         }
                         &.contract-extreme-overspending-potential,
                         &.idv-extreme-overspending-potential {
-                            border-top: 4px solid white;
-                            border-bottom: 4px solid white;
+                            border-top: 4px solid $potential;
+                            border-bottom: 4px solid $potential;
                         }
                     }
                 }
@@ -226,7 +218,9 @@ $file-c-obligation: $color-covid-19-obligations;
                     &.contract-obligated,
                     &.contract-obligated,
                     &.asst-obligated,
-                    &.asst-obligated {
+                    &.asst-obligated,
+                    &.idv-extreme-overspending-obligated,
+                    &.contract-extreme-overspending-obligated {
                         border-bottom: rem(1) solid $obligated;
                         &::before,
                         &::after {
@@ -379,7 +373,9 @@ $file-c-obligation: $color-covid-19-obligations;
                     &.idv-current,
                     &.contract-current,
                     &.idv-overspending-current,
-                    &.contract-overspending-current {
+                    &.contract-overspending-current,
+                    &.idv-extreme-overspending-current,
+                    &.contract-extreme-overspending-current {
                         border-bottom: rem(1) solid $current;
                         &::after,
                         &::before {

--- a/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
@@ -5,8 +5,8 @@ $obligated: #0A2F5A;
 $current: #558EC6;
 $potential: #AAC6E2;
 
-$file-c-outlay: #6E338E;
-$file-c-obligation: #B699C6;
+$file-c-outlay: $color-disaster-covid-19;
+$file-c-obligation: $color-covid-19-obligations;
 
 %award-amounts-viz__line-indicator {
     content: "";

--- a/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
@@ -56,9 +56,9 @@ $file-c-obligation: $color-covid-19-obligations;
             }
             &.idv-overspending,
             &.contract-overspending {
-                border-top: .4rem solid $color-gray-lightest;
-                border-bottom: .4rem solid $color-gray-lightest;
-                background: repeating-linear-gradient(45deg,#4773aa,#4773aa .8rem,#fdb81e 0,#fdb81e 1rem);
+                border-top: .4rem solid $potential;
+                border-bottom: .4rem solid $potential;
+                background: repeating-linear-gradient(45deg,$obligated, $obligated .8rem,#fdb81e 0,#fdb81e 1rem);
                 &.covid {
                     border-top: .4rem solid $potential;
                     border-bottom: .4rem solid $potential;
@@ -95,13 +95,13 @@ $file-c-obligation: $color-covid-19-obligations;
 
             &.idv-overspending-current,
             &.contract-overspending-current {
-                border: rem(4) solid $color-gray-lighter;
+                border: rem(4) solid $current;
             }
 
             &.idv-extreme-overspending,
             &.contract-extreme-overspending {
                 height: rem(40);
-                background: repeating-linear-gradient(45deg, #4773aa, #4773aa 0.8rem, #e31c3d 0.2rem, #e31c3d 1rem);
+                background: repeating-linear-gradient(45deg, $obligated, $obligated 0.8rem, #e31c3d 0.2rem, #e31c3d 1rem);
                 border-top: solid 0.4rem #fff;
                 border-bottom: solid 0.4rem #fff;
             }
@@ -168,16 +168,22 @@ $file-c-obligation: $color-covid-19-obligations;
                 @include align-items(flex-end);
                 font-size: $base-font-size;
                 color: $color-gray;
-                border-left: solid rem(4) $color-cool-blue-light;
                 width: auto;
                 text-align: left;
                 @include flex(1 1 auto);
                 margin-bottom: 0;
+
+                &.idv-obligated,
+                &.contract-obligated,
+                &.asst-obligated {
+                    border-left: rem(4) solid $obligated;
+                }
+
                 &.idv-file-c-obligated,
                 &.contract-file-c-obligated,
                 &.loan-file-c-obligated,
                 &.asst-file-c-obligated {
-                    border-left: solid rem(4) $file-c-obligation;
+                    border-left: rem(4) solid $file-c-obligation;
                     margin-top: rem(17);
                     strong {
                         font-size: $h6-font-size;
@@ -205,25 +211,27 @@ $file-c-obligation: $color-covid-19-obligations;
                     position: relative;
                     width: 99.5%;
                     height: rem(1);
-                    border-bottom: rem(1) solid $color-cool-blue-light;
                     &::after {
                         @extend %award-amounts-viz__line-indicator;
-                        border-left: rem(1) solid $color-cool-blue-light;
                         top: 0px;
                         right: -1px;
                     }
                     &::before {
                         @extend %award-amounts-viz__line-indicator;
-                        border-left: rem(1) solid $color-cool-blue-light;
                         top: 0px;
                         left: -1px;
                     }
-                    &.covid::before,
-                    &.covid::after {
-                        border-left: rem(1) solid $obligated;
-                    }
-                    &.covid {
+                    &.idv-obligated,
+                    &.idv-obligated,
+                    &.contract-obligated,
+                    &.contract-obligated,
+                    &.asst-obligated,
+                    &.asst-obligated {
                         border-bottom: rem(1) solid $obligated;
+                        &::before,
+                        &::after {
+                            border-left: rem(1) solid $obligated;
+                        }
                     }
                     &.idv-file-c-obligated,
                     &.contract-file-c-obligated,
@@ -268,44 +276,25 @@ $file-c-obligation: $color-covid-19-obligations;
                 }
                 .award-amounts-viz__desc {
                     @include display(flex);
-                    &:not(.covid) {
-                        &.contract-current,
-                        &.idv-current {
-                            border-right: rem(5) solid $color-gray-lighter;
-                        }
-                        &.idv-potential::after,
-                        &.contract-potential::after,
-                        &.idv-overspending-potential::after,
-                        &.contract-overspending-potential::after,
-                        &.idv-extreme-overspending-potential::after,
-                        &.contract-extreme-overspending-potential::after {
-                            content: ' ';
-                            height: rem(45);
-                            border: rem(1) solid $color-gray;
-                            background-color: #ECECDC;
-                            width: rem(5);
-                        }
-                        &.non-federal-funding {
-                            border-right: rem(5) solid $grants-line-color;
-                        }
+                    &.contract-current,
+                    &.idv-current,
+                    &.idv-overspending-current,
+                    &.contract-overspending-current,
+                    &.contract-extreme-overspending-current,
+                    &.idv-extreme-overspending-current {
+                        border-right: rem(5) solid $current;
                     }
-                    &.covid {
-                        &.contract-current,
-                        &.idv-current,
-                        &.contract-overspending-current,
-                        &.idv-overspending-current,
-                        &.contract-extreme-overspending-current,
-                        &.idv-extreme-overspending-current {
-                            border-right: 5px solid $current;
-                        }
-                        &.idv-potential,
-                        &.contract-potential,
-                        &.idv-overspending-potential,
-                        &.contract-overspending-potential,
-                        &.idv-extreme-overspending-potential,
-                        &.contract-extreme-overspending-potential {
-                            border-right: 5px solid $potential;
-                        }
+                    &.non-federal-funding {
+                        border-right: rem(5) solid $grants-line-color;
+                    }
+
+                    &.idv-potential,
+                    &.contract-potential,
+                    &.idv-overspending-potential,
+                    &.contract-overspending-potential,
+                    &.idv-extreme-overspending-potential,
+                    &.contract-extreme-overspending-potential {
+                        border-right: 5px solid $potential;
                     }
                     .award-amounts-viz__desc-text {
                         @include flex(1 1 auto);
@@ -348,14 +337,12 @@ $file-c-obligation: $color-covid-19-obligations;
                 }
                 .award-amounts-viz__line {
                     margin: rem(20) 0 rem(5) rem(1);
-                    border-bottom: rem(1) solid $color-gray-lighter;
                     position: relative;
                     width: 99.5%;
                     height: rem(1);
                     &::after,
                     &::before {
                         @extend %award-amounts-viz__line-indicator;
-                        border-left: rem(1) solid $color-gray-lighter;
                         top: -9px;
                         right: -1px;
                     }
@@ -389,15 +376,20 @@ $file-c-obligation: $color-covid-19-obligations;
                             border-left: 1px solid $grants-line-color; 
                         }
                     }
-                    &.covid.contract-current {
+                    &.idv-current,
+                    &.contract-current,
+                    &.idv-overspending-current,
+                    &.contract-overspending-current {
                         border-bottom: rem(1) solid $current;
                         &::after,
                         &::before {
                             border-left: rem(1) solid $current;
                         }
                     }
-                    &.covid.idv-potential,
-                    &.covid.contract-potential {
+                    &.idv-potential,
+                    &.contract-potential,
+                    &.idv-extreme-overspending-potential,
+                    &.contract-extreme-overspending-potential {
                         border-bottom: rem(1) solid $potential;
                         &::before,
                         &::after {

--- a/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
@@ -1,12 +1,5 @@
-$grants-line-color: #47AAA7;
-$loans-line-color: #F5A623;
-
-$obligated: #0A2F5A;
-$current: #558EC6;
-$potential: #AAC6E2;
-
-$file-c-outlay: $color-disaster-covid-19;
-$file-c-obligation: $color-covid-19-obligations;
+$exceeds-current-color: #fdb81e;
+$exceeds-potential-color: #e31c3d;
 
 %award-amounts-viz__line-indicator {
     content: "";
@@ -56,25 +49,25 @@ $file-c-obligation: $color-covid-19-obligations;
             }
             &.idv-overspending,
             &.contract-overspending {
-                border-top: .4rem solid $potential;
-                border-bottom: .4rem solid $potential;
-                background: repeating-linear-gradient(45deg,$obligated, $obligated .8rem,#fdb81e 0,#fdb81e 1rem);
+                border-top: .4rem solid $colors-potential;
+                border-bottom: .4rem solid $colors-potential;
+                background: repeating-linear-gradient(45deg, $colors-obligated, $colors-obligated .8rem,$exceeds-current-color 0,$exceeds-current-color 1rem);
             }
             .award-amounts-viz__bar-wrapper {
                 &.idv-extreme-overspending-potential-wrapper,
                 &.contract-extreme-overspending-potential-wrapper {
-                    border: 0.2rem solid $potential;
+                    border: 0.2rem solid $colors-potential;
                     background-color: #fff;
                     .award-amounts-viz__bar .nested-obligations .award-amounts-viz__bar,
                     .award-amounts-viz__bar .nested-obligations .award-amounts-viz__bar {
                         &.contract-extreme-overspending-current,
                         &.idv-extreme-overspending-current {
-                            border: solid 0.4rem $current;
+                            border: solid 0.4rem $colors-current;
                         }
                         &.contract-extreme-overspending-potential,
                         &.idv-extreme-overspending-potential {
-                            border-top: 4px solid $potential;
-                            border-bottom: 4px solid $potential;
+                            border-top: 4px solid $colors-potential;
+                            border-bottom: 4px solid $colors-potential;
                         }
                     }
                 }
@@ -87,13 +80,13 @@ $file-c-obligation: $color-covid-19-obligations;
 
             &.idv-overspending-current,
             &.contract-overspending-current {
-                border: rem(4) solid $current;
+                border: rem(4) solid $colors-current;
             }
 
             &.idv-extreme-overspending,
             &.contract-extreme-overspending {
                 height: rem(40);
-                background: repeating-linear-gradient(45deg, $obligated, $obligated 0.8rem, #e31c3d 0.2rem, #e31c3d 1rem);
+                background: repeating-linear-gradient(45deg, $colors-obligated, $colors-obligated 0.8rem, #e31c3d 0.2rem, #e31c3d 1rem);
                 border-top: solid 0.4rem #fff;
                 border-bottom: solid 0.4rem #fff;
             }
@@ -138,8 +131,8 @@ $file-c-obligation: $color-covid-19-obligations;
                         content: ' ';
                         width: rem(5);
                         height: rem(55);
-                        border: solid rem(1) #fdb81e;
-                        background: repeating-linear-gradient(45deg, #fff, #fff 0.5rem, #fdb81e 0.2rem, #fdb81e 0.7rem);
+                        border: solid rem(1) $exceeds-current-color;
+                        background: repeating-linear-gradient(45deg, #fff, #fff 0.5rem, $exceeds-current-color 0.2rem, $exceeds-current-color 0.7rem);
                         margin-left: rem(5);                        
                     }
                     &.contract-extreme-overspending-label::after,
@@ -168,21 +161,21 @@ $file-c-obligation: $color-covid-19-obligations;
                 &.idv-obligated,
                 &.contract-obligated,
                 &.asst-obligated {
-                    border-left: rem(4) solid $obligated;
+                    border-left: rem(4) solid $colors-obligated;
                 }
 
                 &.idv-file-c-obligated,
                 &.contract-file-c-obligated,
                 &.loan-file-c-obligated,
                 &.asst-file-c-obligated {
-                    border-left: rem(4) solid $file-c-obligation;
+                    border-left: rem(4) solid $color-covid-19-obligations;
                     margin-top: rem(17);
                     strong {
                         font-size: $h6-font-size;
                     }
                 }
                 &.loan-subsidy {
-                    border-left: solid rem(4) $loans-line-color;
+                    border-left: solid rem(4) $colors-loans-subsidy;
                     flex-wrap: wrap;
                     span {
                         // this span is only present when the loans subsidy amount is zero
@@ -221,32 +214,32 @@ $file-c-obligation: $color-covid-19-obligations;
                     &.asst-obligated,
                     &.idv-extreme-overspending-obligated,
                     &.contract-extreme-overspending-obligated {
-                        border-bottom: rem(1) solid $obligated;
+                        border-bottom: rem(1) solid $colors-obligated;
                         &::before,
                         &::after {
-                            border-left: rem(1) solid $obligated;
+                            border-left: rem(1) solid $colors-obligated;
                         }
                     }
                     &.idv-file-c-obligated,
                     &.contract-file-c-obligated,
                     &.asst-file-c-obligated,
                     &.loan-file-c-obligated {
-                        border-bottom: rem(1) solid $file-c-obligation;
+                        border-bottom: rem(1) solid $color-covid-19-obligations;
                         &::before,
                         &::after {
-                            border-left: rem(1) solid $file-c-obligation;
+                            border-left: rem(1) solid $color-covid-19-obligations;
                         }
                     }
                     &.loan-subsidy {
-                        border-bottom: rem(1) solid $loans-line-color;
+                        border-bottom: rem(1) solid $colors-loans-subsidy;
                         &::before {
                             @extend %award-amounts-viz__line-indicator;
                             top: 0px;
                             left: -1px;
-                            border-left: rem(1) solid $loans-line-color;
+                            border-left: rem(1) solid $colors-loans-subsidy;
                         }
                         &::after {
-                            border-left: rem(1) solid $loans-line-color;
+                            border-left: rem(1) solid $colors-loans-subsidy;
                         }
                     }
                 }
@@ -276,10 +269,10 @@ $file-c-obligation: $color-covid-19-obligations;
                     &.contract-overspending-current,
                     &.contract-extreme-overspending-current,
                     &.idv-extreme-overspending-current {
-                        border-right: rem(5) solid $current;
+                        border-right: rem(5) solid $colors-current;
                     }
                     &.non-federal-funding {
-                        border-right: rem(5) solid $grants-line-color;
+                        border-right: rem(5) solid $colors-grants-nff;
                     }
 
                     &.idv-potential,
@@ -288,7 +281,7 @@ $file-c-obligation: $color-covid-19-obligations;
                     &.contract-overspending-potential,
                     &.idv-extreme-overspending-potential,
                     &.contract-extreme-overspending-potential {
-                        border-right: 5px solid $potential;
+                        border-right: 5px solid $colors-potential;
                     }
                     .award-amounts-viz__desc-text {
                         @include flex(1 1 auto);
@@ -312,7 +305,7 @@ $file-c-obligation: $color-covid-19-obligations;
                     &.loan-file-c-outlay,
                     &.idv-file-c-outlay,
                     &.asst-file-c-outlay {
-                        border-left: rem(4) solid $file-c-outlay;
+                        border-left: rem(4) solid $color-disaster-covid-19;
                         .award-amounts-viz__desc-text {
                             text-align: left;
                             padding-left: rem(5);
@@ -351,23 +344,23 @@ $file-c-obligation: $color-covid-19-obligations;
                     &.asst-file-c-outlay::before,
                     &.loan-file-c-outlay::after,
                     &.loan-file-c-outlay::before  {
-                        border-left: rem(1) solid $file-c-outlay;
+                        border-left: rem(1) solid $color-disaster-covid-19;
                     }
         
                     &.asst-non-federal-funding {
-                        border-bottom: 1px solid $grants-line-color;
+                        border-bottom: 1px solid $colors-grants-nff;
                         &::before {
                             @extend %award-amounts-viz__line-indicator;
                             top: -9px;
                             right: -1px;
                             left: -1px;
-                            border-left: 1px solid $grants-line-color;
+                            border-left: 1px solid $colors-grants-nff;
                         }
                         &::after {
                             @extend %award-amounts-viz__line-indicator;
                             top: -9px;
                             right: -1px;
-                            border-left: 1px solid $grants-line-color; 
+                            border-left: 1px solid $colors-grants-nff; 
                         }
                     }
                     &.idv-current,
@@ -376,30 +369,30 @@ $file-c-obligation: $color-covid-19-obligations;
                     &.contract-overspending-current,
                     &.idv-extreme-overspending-current,
                     &.contract-extreme-overspending-current {
-                        border-bottom: rem(1) solid $current;
+                        border-bottom: rem(1) solid $colors-current;
                         &::after,
                         &::before {
-                            border-left: rem(1) solid $current;
+                            border-left: rem(1) solid $colors-current;
                         }
                     }
                     &.idv-potential,
                     &.contract-potential,
                     &.idv-extreme-overspending-potential,
                     &.contract-extreme-overspending-potential {
-                        border-bottom: rem(1) solid $potential;
+                        border-bottom: rem(1) solid $colors-potential;
                         &::before,
                         &::after {
-                            border-left: rem(1) solid $potential;
+                            border-left: rem(1) solid $colors-potential;
                         }
                     }
                     &.contract-file-c-outlay,
                     &.idv-file-c-outlay,
                     &.asst-file-c-outlay,
                     &.loan-file-c-outlay {
-                        border-bottom: rem(1) solid $file-c-outlay;
+                        border-bottom: rem(1) solid $color-disaster-covid-19;
                         &::before,
                         &::after {
-                            border-left: rem(1) solid $file-c-outlay;
+                            border-left: rem(1) solid $color-disaster-covid-19;
                         }
                     }
                 }
@@ -410,14 +403,14 @@ $file-c-obligation: $color-covid-19-obligations;
             .award-amounts-viz__desc.contract-file-c-outlay--zero,
             .award-amounts-viz__desc.asst-file-c-outlay--zero {
                 &.asst-nff-zero {
-                    border-left: rem(5) solid $grants-line-color;
+                    border-left: rem(5) solid $colors-grants-nff;
                 }
                 &.loan-file-c-outlay--zero,
                 &.asst-file-c-outlay--zero,
                 &.idv-file-c-outlay--zero,
                 &.contract-file-c-outlay--zero {
                     margin-top: rem(20);
-                    border-left: rem(5) solid $file-c-outlay;
+                    border-left: rem(5) solid $color-disaster-covid-19;
                 }
                 border-right: none;
                 margin-top: rem(10);

--- a/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
@@ -43,8 +43,8 @@
     }
 
     .award-amounts__file-c-outlays {
-        background-color: #6E338E;
-        border: rem(2) solid #6E338E;
+        background-color: $color-disaster-covid-19;
+        border: rem(2) solid $color-disaster-covid-19;
     }
 
     .award-amounts__potential {
@@ -67,8 +67,8 @@
     }
 
     .award-amounts__file-c-obligations {
-        background-color: #B699C6;
-        border: rem(2) solid #B699C6;
+        background-color: $color-covid-19-obligations;
+        border: rem(2) solid $color-covid-19-obligations;
     }
     
     .award-amounts__data-icon_overspending {

--- a/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
@@ -26,7 +26,7 @@
     }
 
     .award-amounts__data-icon_green {
-        background-color: #47AAA7;
+        background-color: $colors-grants-nff;
     }
     
     .award-amounts__data-icon_gray {
@@ -34,7 +34,7 @@
     }
     
     .award-amounts__data-icon_yellow {
-        background-color: #F5A623;
+        background-color: $colors-loans-subsidy;
     }
     
     .award-amounts__data-icon_transparent {
@@ -48,22 +48,15 @@
     }
 
     .award-amounts__potential {
-        background-color:#AAC6E2;
+        background-color: $colors-potential;
     }
 
     .award-amounts__current {
-        background-color: #558EC6;
+        background-color: $colors-current;
     }
 
     .award-amounts__obligated {
-        background-color: #4773aa;
-    }
-
-    &.contract,
-    &.idv {
-        .award-amounts__obligated {
-            background-color: #0A2F5A;
-        }
+        background-color: $colors-obligated;
     }
 
     .award-amounts__file-c-obligations {

--- a/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
@@ -33,8 +33,13 @@
         background-color: #BBBBBB;
     }
     
-    .award-amounts__data-icon_yellow {
+    .award-amounts__data-icon_subsidy {
         background-color: $colors-loans-subsidy;
+    }
+
+    .award-amounts__data-icon_face-value {
+        background-color: $colors-loans-face-value;
+        border: rem(2) solid #BBBBBB;
     }
     
     .award-amounts__data-icon_transparent {

--- a/src/_scss/pages/covid19/index.scss
+++ b/src/_scss/pages/covid19/index.scss
@@ -167,7 +167,7 @@
                     background-color: #763E94;
                 }
                 .color-purple {
-                    color: #6E338E;
+                    color: $color-disaster-covid-19;
                 }
                 .heading__container {
                     border-radius: 0.5rem 0.5rem 0 0;

--- a/src/_scss/pages/search/filters/otherFilters/_defCheckbox.scss
+++ b/src/_scss/pages/search/filters/otherFilters/_defCheckbox.scss
@@ -22,7 +22,7 @@
                         display: none;
                       }
                       .checkbox-tree-label__label {
-                        background: #6E338E;
+                        background: $color-disaster-covid-19;
                         color: white;
                         display: flex;
                         align-items: center;

--- a/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
@@ -7,7 +7,9 @@ import {
     obligatedColor,
     currentColor,
     potentialColor,
-    nonFederalFundingColor
+    nonFederalFundingColor,
+    subsidyColor,
+    faceValueColor
 } from 'dataMapping/award/awardAmountsSection';
 import { covidColor, covidObligatedColor } from 'dataMapping/covid19/covid19';
 import RectanglePercentViz from 'components/award/financialAssistance/RectanglePercentViz';
@@ -107,7 +109,6 @@ const buildNormalProps = (awardType, data, hasFileC) => {
 
 // Only for Contract and IDV Awards
 const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
-    const showCares = (isCaresActReleased && hasFileC);
     const chartProps = {
         denominator: {
             labelPosition: 'bottom',
@@ -115,7 +116,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
             className: `${awardType}-potential`,
             rawValue: data._baseAndAllOptions,
             value: data.baseAndAllOptionsAbbreviated,
-            color: (showCares) ? potentialColor : `#ececec`,
+            color: potentialColor,
             text: awardType === 'idv'
                 ? "Combined Potential Award Amounts"
                 : "Potential Award Amount",
@@ -132,7 +133,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
             text: awardType === 'idv'
                 ? "Combined Current Award Amounts"
                 : "Current Award Amount",
-            color: (showCares) ? obligatedColor : `#4773aa`,
+            color: obligatedColor,
             children: [{
                 labelSortOrder: 0,
                 labelPosition: 'top',
@@ -143,7 +144,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
                 text: awardType === 'idv'
                     ? "Combined Obligated Amounts"
                     : "Obligated Amount",
-                color: (showCares) ? obligatedColor : `#4773aa`,
+                color: obligatedColor,
                 tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'obligated', data),
                 improper: {
                     labelSortOrder: 1,
@@ -155,7 +156,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
                     text: awardType === 'idv'
                         ? "Exceeds Combined Current Award Amounts"
                         : "Exceeds Current Award Amount",
-                    color: (showCares) ? obligatedColor : `#4773aa`,
+                    color: obligatedColor,
                     tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'exceedsCurrent', data)
                 }
             }]
@@ -267,7 +268,7 @@ const buildExceedsPotentialProps = (awardType, data, hasFileC) => {
             denominatorValue: data._totalObligation,
             value: data.baseExercisedOptionsAbbreviated,
             text: null,
-            color: `transparent`,
+            color: potentialColor,
             children: [
                 {
                     labelSortOrder: 1,
@@ -281,7 +282,7 @@ const buildExceedsPotentialProps = (awardType, data, hasFileC) => {
                     text: awardType === 'idv'
                         ? "Combined Current Award Amounts"
                         : "Current Award Amount",
-                    color: obligatedColo`
+                    color: obligatedColor
                 },
                 {
                     className: `${awardType}-extreme-overspending-potential`,
@@ -426,7 +427,7 @@ const AwardAmountsChart = ({ awardType, awardOverview, spendingScenario }) => {
                     denominatorValue: awardAmounts._totalFunding,
                     value: awardAmounts.totalObligationAbbreviated,
                     text: 'Obligated Amount',
-                    color: `#4773aa`
+                    color: obligatedColor
                 },
                 numerator2: {
                     className: awardAmounts._nonFederalFunding > 0 ? `asst-non-federal-funding` : `asst-nff-zero`,
@@ -488,7 +489,7 @@ const AwardAmountsChart = ({ awardType, awardOverview, spendingScenario }) => {
                     value: awardAmounts.subsidyAbbreviated,
                     text: 'Original Subsidy Cost',
                     tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory('loan', 'subsidy', awardAmounts),
-                    color: '#F5A623'
+                    color: subsidyColor
                 },
                 denominator: {
                     labelPosition: 'bottom',
@@ -498,7 +499,7 @@ const AwardAmountsChart = ({ awardType, awardOverview, spendingScenario }) => {
                     value: awardAmounts.faceValueAbbreviated,
                     text: 'Face Value of Direct Loan',
                     tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory('loan', 'faceValue', awardAmounts),
-                    color: '#fff'
+                    color: faceValueColor
                 }
             };
             const props = showFileC
@@ -524,7 +525,7 @@ const AwardAmountsChart = ({ awardType, awardOverview, spendingScenario }) => {
                                 value: awardAmounts.fileCOutlayAbbreviated,
                                 denominatorValue: awardAmounts._fileCObligated,
                                 text: 'COVID-19 Response Outlay Amount',
-                                color: '#6E338E',
+                                color: covidColor,
                                 tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory('loan', 'fileCOutlay', awardAmounts)
                             }]
                         }]

--- a/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
@@ -497,9 +497,9 @@ const AwardAmountsChart = ({ awardType, awardOverview, spendingScenario }) => {
                     className: `${awardType}-face-value`,
                     rawValue: awardAmounts._faceValue,
                     value: awardAmounts.faceValueAbbreviated,
+                    color: faceValueColor,
                     text: 'Face Value of Direct Loan',
-                    tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory('loan', 'faceValue', awardAmounts),
-                    color: faceValueColor
+                    tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory('loan', 'faceValue', awardAmounts)
                 }
             };
             const props = showFileC

--- a/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
@@ -2,7 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import GlobalConstants from "GlobalConstants";
-import { asstAwardTypesWithSimilarAwardAmountData } from 'dataMapping/award/awardAmountsSection';
+import {
+    asstAwardTypesWithSimilarAwardAmountData,
+    obligatedColor,
+    currentColor,
+    potentialColor,
+    nonFederalFundingColor
+} from 'dataMapping/award/awardAmountsSection';
+import { covidColor, covidObligatedColor } from 'dataMapping/covid19/covid19';
 import RectanglePercentViz from 'components/award/financialAssistance/RectanglePercentViz';
 
 import { getTooltipPropsByAwardTypeAndSpendingCategory } from '../Tooltips';
@@ -26,7 +33,7 @@ const buildNormalProps = (awardType, data, hasFileC) => {
             className: `${awardType}-potential`,
             rawValue: data._baseAndAllOptions,
             value: data.baseAndAllOptionsAbbreviated,
-            color: (isCaresActReleased && hasFileC) ? '#AAC6E2' : `#ececec`,
+            color: potentialColor,
             text: awardType === 'idv'
                 ? "Combined Potential Award Amounts"
                 : "Potential Award Amount",
@@ -43,7 +50,7 @@ const buildNormalProps = (awardType, data, hasFileC) => {
             text: awardType === 'idv'
                 ? "Combined Current Award Amounts"
                 : "Current Award Amount",
-            color: (isCaresActReleased && hasFileC) ? '#558EC6' : `#d8d8d8`,
+            color: currentColor,
             children: [
                 {
                     labelSortOrder: 0,
@@ -55,7 +62,7 @@ const buildNormalProps = (awardType, data, hasFileC) => {
                     text: awardType === 'idv'
                         ? "Combined Obligated Amounts"
                         : "Obligated Amount",
-                    color: (isCaresActReleased && hasFileC) ? '#0A2F5A' : `#4773aa`,
+                    color: obligatedColor,
                     tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'obligated', data)
                 }
             ]
@@ -79,7 +86,7 @@ const buildNormalProps = (awardType, data, hasFileC) => {
                         denominatorValue: data._totalObligation,
                         value: data.fileCObligatedAbbreviated,
                         text: 'COVID-19 Response Obligations Amount',
-                        color: `#B699C6`,
+                        color: covidObligatedColor,
                         children: [{
                             labelSortOrder: 0,
                             labelPosition: 'bottom',
@@ -89,7 +96,7 @@ const buildNormalProps = (awardType, data, hasFileC) => {
                             rawValue: data._fileCOutlay,
                             value: data.fileCOutlayAbbreviated,
                             text: 'COVID-19 Response Outlay Amount',
-                            color: `#6E338E`
+                            color: covidColor
                         }]
                     }
                 ]
@@ -108,7 +115,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
             className: `${awardType}-potential`,
             rawValue: data._baseAndAllOptions,
             value: data.baseAndAllOptionsAbbreviated,
-            color: (showCares) ? '#AAC6E2' : `#ececec`,
+            color: (showCares) ? potentialColor : `#ececec`,
             text: awardType === 'idv'
                 ? "Combined Potential Award Amounts"
                 : "Potential Award Amount",
@@ -125,7 +132,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
             text: awardType === 'idv'
                 ? "Combined Current Award Amounts"
                 : "Current Award Amount",
-            color: (showCares) ? '#0A2F5A' : `#4773aa`,
+            color: (showCares) ? obligatedColor : `#4773aa`,
             children: [{
                 labelSortOrder: 0,
                 labelPosition: 'top',
@@ -136,7 +143,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
                 text: awardType === 'idv'
                     ? "Combined Obligated Amounts"
                     : "Obligated Amount",
-                color: (showCares) ? '#0A2F5A' : `#4773aa`,
+                color: (showCares) ? obligatedColor : `#4773aa`,
                 tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'obligated', data),
                 improper: {
                     labelSortOrder: 1,
@@ -148,7 +155,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
                     text: awardType === 'idv'
                         ? "Exceeds Combined Current Award Amounts"
                         : "Exceeds Current Award Amount",
-                    color: (showCares) ? '#0A2F5A' : `#4773aa`,
+                    color: (showCares) ? obligatedColor : `#4773aa`,
                     tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'exceedsCurrent', data)
                 }
             }]
@@ -167,7 +174,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
             text: awardType === 'idv'
                 ? "Exceeds Combined Current Award Amounts"
                 : "Exceeds Current Award Amount",
-            color: (isCaresActReleased && hasFileC) ? '#0A2F5A' : `#4773aa`,
+            color: obligatedColor,
             tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'exceedsCurrent', data)
         }
     };
@@ -195,7 +202,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
                                     rawValue: data._fileCObligated,
                                     denominatorValue: data._baseExercisedOptions
                                 },
-                                color: `#B699C6`,
+                                color: covidObligatedColor,
                                 children: [{
                                     labelSortOrder: 0,
                                     labelPosition: 'bottom',
@@ -209,7 +216,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
                                         denominatorValue: data._fileCObligated
                                     },
                                     text: 'COVID-19 Response Outlay Amount',
-                                    color: `#6E338E`
+                                    color: covidColor
                                 }]
                             }
                         ]
@@ -247,7 +254,7 @@ const buildExceedsPotentialProps = (awardType, data, hasFileC) => {
                 text: awardType === 'idv'
                     ? "Exceeds Combined Potential Award Amounts"
                     : "Exceeds Potential Award Amount",
-                color: (isCaresActReleased && hasFileC) ? '#0A2F5A' : `#4773aa`,
+                color: obligatedColor,
                 tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'exceedsCurrent', data)
             }
         },
@@ -274,7 +281,7 @@ const buildExceedsPotentialProps = (awardType, data, hasFileC) => {
                     text: awardType === 'idv'
                         ? "Combined Current Award Amounts"
                         : "Current Award Amount",
-                    color: (isCaresActReleased && hasFileC) ? '#0A2F5A' : `#4773aa`
+                    color: obligatedColo`
                 },
                 {
                     className: `${awardType}-extreme-overspending-potential`,
@@ -284,7 +291,7 @@ const buildExceedsPotentialProps = (awardType, data, hasFileC) => {
                     rawValue: data._baseAndAllOptions,
                     denominatorValue: data._totalObligation,
                     value: data.baseAndAllOptionsAbbreviated,
-                    color: (isCaresActReleased && hasFileC) ? '#0A2F5A' : `#4773aa`,
+                    color: obligatedColor,
                     barWidthOverrides: {
                         rawValue: data._baseAndAllOptions - data._baseExercisedOptions,
                         denominatorValue: data._baseAndAllOptions
@@ -310,7 +317,7 @@ const buildExceedsPotentialProps = (awardType, data, hasFileC) => {
             text: awardType === 'idv'
                 ? "Exceeds Combined Potential Award Amounts"
                 : "Exceeds Potential Award Amount",
-            color: (isCaresActReleased && hasFileC) ? '#AAC6E2' : `#ececec`,
+            color: potentialColor,
             tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'exceedsPotential', data)
         }
     };
@@ -338,7 +345,7 @@ const buildExceedsPotentialProps = (awardType, data, hasFileC) => {
                                     rawValue: data._fileCObligated,
                                     denominatorValue: data._baseExercisedOptions
                                 },
-                                color: `#B699C6`,
+                                color: covidObligatedColor,
                                 children: [{
                                     labelSortOrder: 0,
                                     labelPosition: 'bottom',
@@ -352,7 +359,7 @@ const buildExceedsPotentialProps = (awardType, data, hasFileC) => {
                                         denominatorValue: data._fileCObligated
                                     },
                                     text: 'COVID-19 Response Outlay Amount',
-                                    color: `#6E338E`
+                                    color: covidColor
                                 }]
                             }
                         ]
@@ -434,7 +441,7 @@ const AwardAmountsChart = ({ awardType, awardOverview, spendingScenario }) => {
                         denominatorValue: awardAmounts._totalFunding
                     },
                     value: awardAmounts.nonFederalFundingAbbreviated,
-                    color: `#47AAA7`,
+                    color: nonFederalFundingColor,
                     text: "Non Federal Funding",
                     tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'nonFederalFunding', awardAmounts)
                 }
@@ -451,7 +458,7 @@ const AwardAmountsChart = ({ awardType, awardOverview, spendingScenario }) => {
                         denominatorValue: awardAmounts._totalObligation,
                         value: awardAmounts.fileCObligatedAbbreviated,
                         text: 'COVID-19 Response Obligations Amount',
-                        color: `#B699C6`,
+                        color: covidObligatedColor,
                         children: [{
                             labelSortOrder: 0,
                             labelPosition: 'bottom',
@@ -461,7 +468,7 @@ const AwardAmountsChart = ({ awardType, awardOverview, spendingScenario }) => {
                             rawValue: awardAmounts._fileCOutlay,
                             value: awardAmounts.fileCOutlayAbbreviated,
                             text: 'COVID-19 Response Outlay Amount',
-                            color: `#6E338E`
+                            color: covidColor
                         }]
                     }
                 ];
@@ -507,7 +514,7 @@ const AwardAmountsChart = ({ awardType, awardOverview, spendingScenario }) => {
                             text: 'COVID-19 Response Obligations Amount',
                             className: `loan-file-c-obligated`,
                             denominatorValue: awardAmounts._subsidy,
-                            color: '#B699C6',
+                            color: covidObligatedColor,
                             tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory('loan', 'fileCObligated', awardAmounts),
                             children: [{
                                 className: `${awardAmounts._fileCOutlay > 0 ? `loan-file-c-outlay` : `loan-file-c-outlay--zero`}`,

--- a/src/js/dataMapping/award/awardAmountsSection.js
+++ b/src/js/dataMapping/award/awardAmountsSection.js
@@ -64,8 +64,8 @@ export const awardTableClassMap = {
     "Potential Amount": "award-amounts__potential",
     "Non-Federal Funding": "award-amounts__data-icon_green",
     "Total Funding": "award-amounts__data-icon_transparent",
-    "Face Value of Direct Loan": "award-amounts__data-icon_transparent",
-    "Original Subsidy Cost": "award-amounts__data-icon_yellow",
+    "Face Value of Direct Loan": "award-amounts__data-icon_face-value",
+    "Original Subsidy Cost": "award-amounts__data-icon_subsidy",
     "COVID-19 Response Obligated Amount": "award-amounts__file-c-obligations",
     "COVID-19 Response Outlayed Amount": "award-amounts__file-c-outlays"
 };

--- a/src/js/dataMapping/award/awardAmountsSection.js
+++ b/src/js/dataMapping/award/awardAmountsSection.js
@@ -109,3 +109,10 @@ export const tableTitlesBySpendingCategoryAndAwardType = {
 
 // similar relationship between spending categories
 export const asstAwardTypesWithSimilarAwardAmountData = ['grant', 'other', 'insurance', 'direct payment'];
+
+export const obligatedColor = '#0A2F5A';
+export const currentColor = '#558EC6';
+export const potentialColor = '#AAC6E2';
+export const subsidyColor = '#0B424D';
+export const faceValueColor = '#F3F3F3';
+export const nonFederalFundingColor = '#47AAA7';

--- a/src/js/dataMapping/covid19/covid19.js
+++ b/src/js/dataMapping/covid19/covid19.js
@@ -80,3 +80,6 @@ export const awardTypeTabs = [
         label: 'Contract IDVs'
     }
 ];
+
+export const covidColor = '#6E338E';
+export const covidObligatedColor = '#B699C6';


### PR DESCRIPTION
**High level description:**
Wherever we're using COVID colors, we're referring now to a variable that contains the correct hex value.

Also, we had to update the colors for the award amounts viz for proper contrast with the new File C spending categories.

**Technical details:**
- Creates variables
- Uses variables
- Updates colors passed to Non-Normative Contracts and IDVs so that they look nice. 
![image](https://user-images.githubusercontent.com/12897813/87479531-a7257580-c5f9-11ea-9f4c-41728cd2cc0b.png)
![image](https://user-images.githubusercontent.com/12897813/87479541-ae4c8380-c5f9-11ea-930e-0e7f9b75d72b.png)

**JIRA Ticket:**
[DEV-5535](https://federal-spending-transparency.atlassian.net/browse/DEV-5535)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
