### PR TITLE
DEV-5347 warmfix tab counts

### DIFF
--- a/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
+++ b/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
@@ -81,7 +81,7 @@ const AwardSpendingAgency = () => {
             });
             // Wait for all the requests to complete and then store the results in state
             Promise.all(promises)
-                .then(([allRes, contractsRes, idvsRes, grantsRes, directPaymentsRes, loansRes, otherRes]) => {
+                .then(([allRes, grantsRes, loansRes, directPaymentsRes, otherRes, contractsRes, idvsRes]) => {
                     setTabCounts({
                         all: allRes.data.count,
                         contracts: contractsRes.data.count,


### PR DESCRIPTION
**High level description:**

Fixes a bug causing the Award Spending by Agency tab counts not to match the number of results in the corresponding table.

**Technical details:**

Updated the expected order of API responses to match the order of the tabs. 

**JIRA Ticket:**
[DEV-5347](https://federal-spending-transparency.atlassian.net/browse/DEV-5347)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
- [x] Code review complete
