### PR TITLE
[hotfix/tas-component-filter] The Treasury Component Filter is Broken, Providing Tests & a fix

### DIFF
--- a/src/js/models/search/SearchAwardsOperation.js
+++ b/src/js/models/search/SearchAwardsOperation.js
@@ -218,7 +218,7 @@ class SearchAwardsOperation {
                     exclude: this.tasCheckbox.exclude
                 };
             }
-            else {
+            else if (this.tasCheckbox.require.length > 0) {
                 filters[rootKeys.tasCheckbox] = { require: trimCheckedToCommonAncestors(this.tasCheckbox.require) };
             }
         }

--- a/tests/models/search/SearchAwardsOperation-test.js
+++ b/tests/models/search/SearchAwardsOperation-test.js
@@ -2,6 +2,9 @@
  * SearchAwardOperation-test.js
  * Created by Max Kendall on 06/08/2020.
  */
+
+import { OrderedMap } from 'immutable';
+
 import { CheckboxTreeSelections } from "redux/reducers/search/searchFiltersReducer";
 import SearchAwardsOperation from "models/search/SearchAwardsOperation";
 import { initialState } from "redux/reducers/search/searchFiltersReducer";
@@ -25,7 +28,18 @@ describe('SearchAwardsOperation', () => {
             expect(Object.keys(requestObject)).toEqual(['time_period', 'tas_codes']);
             expect(requestObject.tas_codes.counts).toBeFalsy();
         });
-        it('does not put an empty exclude or count array for def_codes property when defcode-checkbox tree items are selected', () => {
+        it('does not put an empty require, count, or exclude array for tas_codes property when treasury_account_components are selected', () => {
+            const model = new SearchAwardsOperation();
+            model.fromState({
+                ...initialState,
+                treasuryAccounts: new OrderedMap({ 'test': { test: '123' } })
+            });
+            const requestObject = model.toParams();
+            expect(Object.keys(requestObject).includes('treasury_account_components')).toEqual(true);
+            expect(Object.keys(requestObject)).toEqual(['time_period', 'treasury_account_components']);
+            expect(requestObject.tas_codes).toBeFalsy();
+        });
+        it('does not put an empty exclude or count array for def_codes property when def code-checkbox tree items are selected', () => {
             const model = new SearchAwardsOperation();
             model.fromState({
                 ...initialState,


### PR DESCRIPTION
**High level description:**
A congressional staffer is trying to use the `treasury account components` filter and the request object it's building is not working.

**Technical details:**
The request object has a `tas_codes : { require: [] }` property/value when selecting a treasury account component (not the tas checkbox tree). This breaks the request object. Not good!!

Adds a test to ensure this doesnt happen.

The following are ALL required for the PR to be merged:

Author:
`N/A` Linked to this PR in JIRA ticket
`N/A`Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A`Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A`Verified mobile/tablet/desktop/monitor responsiveness
`N/A`Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A`All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A`[API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A`[Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A`Design review complete `if applicable`
`N/A`[API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
