### PR TITLE
DEV-5633 fix COVID share button links

### DIFF
--- a/src/js/components/sharedComponents/stickyHeader/ShareIcon.jsx
+++ b/src/js/components/sharedComponents/stickyHeader/ShareIcon.jsx
@@ -3,20 +3,26 @@ import PropTypes from "prop-types";
 import { Picker } from "data-transparency-ui";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { debounce } from "lodash";
-
-import { socialShareOptions, getSocialShareFn, getBaseUrl } from 'helpers/socialShare';
+import {
+    socialShareOptions,
+    getSocialShareFn,
+    getBaseUrl,
+    getBaseUrlNoHash
+} from 'helpers/socialShare';
 
 const propTypes = {
     slug: PropTypes.string,
     email: PropTypes.shape({
         subject: PropTypes.string,
         body: PropTypes.string
-    })
+    }),
+    noHash: PropTypes.bool
 };
 
 const ShareIcon = ({
     slug,
-    email: { subject, body }
+    email: { subject, body },
+    noHash
 }) => {
     const [showConfirmationText, setConfirmationText] = useState(false);
     const hideConfirmationText = debounce(() => setConfirmationText(false), 1750);
@@ -42,7 +48,7 @@ const ShareIcon = ({
             };
         }
         if (option.name === 'email') {
-            const onClick = getSocialShareFn(option.name).bind(null, {
+            const onClick = getSocialShareFn(option.name, noHash).bind(null, {
                 subject,
                 body
             });
@@ -53,13 +59,19 @@ const ShareIcon = ({
         }
         return {
             ...option,
-            onClick: getSocialShareFn(option.name).bind(null, slug)
+            onClick: getSocialShareFn(option.name, noHash).bind(null, slug)
         };
     });
 
     return (
         <div className="sticky-header__toolbar-item">
-            <input id="slug" type="text" className="text" style={{ position: 'absolute', right: '9999px', opacity: 0 }} value={getBaseUrl(slug)} readOnly />
+            <input
+                id="slug"
+                type="text"
+                className="text"
+                style={{ position: 'absolute', right: '9999px', opacity: 0 }}
+                value={noHash ? getBaseUrlNoHash(slug) : getBaseUrl(slug)}
+                readOnly />
             <Picker
                 dropdownDirection="left"
                 options={socialSharePickerOptions}

--- a/src/js/containers/covid19/Covid19Container.jsx
+++ b/src/js/containers/covid19/Covid19Container.jsx
@@ -165,7 +165,8 @@ const Covid19Container = () => {
                         {/* <hr /> */}
                         <ShareIcon
                             slug={slug}
-                            email={getEmailSocialShareData} />
+                            email={getEmailSocialShareData}
+                            noHash />
                         <div className="sticky-header__toolbar-item">
                             <DownloadButtonContainer />
                         </div>

--- a/src/js/dataMapping/covid19/covid19.js
+++ b/src/js/dataMapping/covid19/covid19.js
@@ -3,13 +3,13 @@
  * Created by Jonathan Hill 06/02/20
  */
 
-import { getBaseUrl } from 'helpers/socialShare';
+import { getBaseUrlNoHash } from 'helpers/socialShare';
 
 export const slug = 'covid-19';
 
 export const getEmailSocialShareData = {
-    subject: 'USAspending.gov COVID-19 Response: ',
-    body: `View the COVID-19 Response on USAspending.gov: ${getBaseUrl(slug)}`
+    subject: 'USAspending.gov COVID-19 Response',
+    body: `View the COVID-19 Response on USAspending.gov: ${getBaseUrlNoHash(slug)}`
 };
 
 export const scrollPositionOfSiteHeader = (cookie) => (cookie ? 96 : 187);

--- a/src/js/helpers/socialShare.jsx
+++ b/src/js/helpers/socialShare.jsx
@@ -55,10 +55,17 @@ const handlersBySocialMedium = {
 
 export const getBaseUrl = (slug) => `https://www.usaspending.gov/#/${slug}`;
 
-export const getSocialShareFn = (socialMedium) => {
+// Currently only used on the COVID profile, since we have a special redirect set
+// up for usaspending.gov/covid-19 --> usaspending.gov/#/disaster/covid-19
+export const getBaseUrlNoHash = (slug) => `https://www.usaspending.gov/${slug}`;
+
+export const getSocialShareFn = (socialMedium, noHash = false) => {
     const fn = handlersBySocialMedium[socialMedium];
     if (socialMedium === 'email') {
         return (args) => fn(args);
+    }
+    if (noHash) {
+        return (slg) => fn(getBaseUrlNoHash(slg));
     }
     return (slg) => fn(getBaseUrl(slg));
 };

--- a/tests/helpers/socialShare-test.js
+++ b/tests/helpers/socialShare-test.js
@@ -6,7 +6,8 @@
 import {
     getSocialShareFn,
     getBaseUrl,
-    socialUrls
+    socialUrls,
+    getBaseUrlNoHash
 } from 'helpers/socialShare';
 
 import "../testResources/mockGlobalConstants";
@@ -18,6 +19,12 @@ describe('socialShare helper', () => {
             expect(result).toEqual(`https://www.usaspending.gov/#/agency/123`);
         });
     });
+    describe('getBaseUrlNoHash', () => {
+        it('generates the right url with no hash', () => {
+            const result = getBaseUrlNoHash('agency/123');
+            expect(result).toEqual(`https://www.usaspending.gov/agency/123`);
+        });
+    });
     describe('getSocialShareFn', () => {
         const testUrl = encodeURIComponent(getBaseUrl('spending_exploder'));
         it.each([
@@ -27,6 +34,23 @@ describe('socialShare helper', () => {
             ['linkedin', `${socialUrls.linkedin}${testUrl}`]
         ])('generates the right url for %s', (medium, expectedUrl) => {
             const fn = getSocialShareFn(medium);
+            fn('spending_exploder');
+            expect(window.open).toHaveBeenCalledWith(
+                expectedUrl,
+                "_blank",
+                "left=20,top=20,width=500,height=500,toolbar=1,resizable=0"
+            );
+        });
+    });
+    describe('getSocialShareFn - no hash', () => {
+        const testUrl = encodeURIComponent(getBaseUrlNoHash('spending_exploder'));
+        it.each([
+            ['facebook', `${socialUrls.facebook}${testUrl}`],
+            ['twitter', `${socialUrls.twitter}${testUrl}`],
+            ['reddit', `${socialUrls.reddit}${testUrl}`],
+            ['linkedin', `${socialUrls.linkedin}${testUrl}`]
+        ])('generates the right url for %s', (medium, expectedUrl) => {
+            const fn = getSocialShareFn(medium, true);
             fn('spending_exploder');
             expect(window.open).toHaveBeenCalledWith(
                 expectedUrl,


### PR DESCRIPTION
**High level description:**

Changes the url of links generated by our social share button from `/#/covid-19` to `/covid-19` (without the hash), which has a redirect in place to go to `/#/disaster/covid-19`. 

**Technical details:**

- This is for marketing reasons (usaspending.gov/covid-19 is easier to remember & looks cleaner than usaspending.gov/#/disaster/covid-19)
- Redirect is already in place: [https://www.usaspending.gov/covid-19](https://www.usaspending.gov/covid-19) (but will 404 in prod before launch)

**JIRA Ticket:**
[DEV-5633](https://federal-spending-transparency.atlassian.net/browse/DEV-5633)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- N/A (no UI changes) Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- N/A (no UI changes) Verified mobile/tablet/desktop/monitor responsiveness
- N/A (no UI changes) Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models

Reviewer(s):
- [x] Code review complete
