### PR TITLE
DEV-5630 fix "Data as of" dates

### DIFF
--- a/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
+++ b/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
@@ -39,7 +39,7 @@ const SpendingByCFDA = () => {
     const [isRedirectModalMounted, setIsRedirectModalMounted] = useState(false);
     const [redirectModalURL, setRedirectModalURL] = useState('');
     const [activeTab, setActiveTab] = useState(financialAssistanceTabs[0].internal);
-    const { defCodes, latestSubmissionDate } = useSelector((state) => state.covid19);
+    const { defCodes } = useSelector((state) => state.covid19);
 
     const [tabCounts, setTabCounts] = useState({
         all: null,
@@ -96,7 +96,7 @@ const SpendingByCFDA = () => {
 
     return (
         <div className="body__content assistance-listing">
-            <DateNote dateString={latestSubmissionDate} />
+            <DateNote />
             <h3 className="body__narrative">
                 These are the assistance listings that supported the COVID-19 Response with <strong>awards</strong>.
             </h3>

--- a/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
+++ b/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
@@ -12,6 +12,7 @@ import RedirectModal from 'components/sharedComponents/RedirectModal';
 import MoreOptionsTabs from 'components/sharedComponents/moreOptionsTabs/MoreOptionsTabs';
 import SummaryInsightsContainer from 'containers/covid19/SummaryInsightsContainer';
 import SpendingByCFDAContainer from 'containers/covid19/assistanceListing/SpendingByCFDAContainer';
+import DateNote from '../DateNote';
 
 const overviewData = [
     {
@@ -38,7 +39,7 @@ const SpendingByCFDA = () => {
     const [isRedirectModalMounted, setIsRedirectModalMounted] = useState(false);
     const [redirectModalURL, setRedirectModalURL] = useState('');
     const [activeTab, setActiveTab] = useState(financialAssistanceTabs[0].internal);
-    const defCodes = useSelector((state) => state.covid19.defCodes);
+    const { defCodes, latestSubmissionDate } = useSelector((state) => state.covid19);
 
     const [tabCounts, setTabCounts] = useState({
         all: null,
@@ -95,6 +96,7 @@ const SpendingByCFDA = () => {
 
     return (
         <div className="body__content assistance-listing">
+            <DateNote dateString={latestSubmissionDate} />
             <h3 className="body__narrative">
                 These are the assistance listings that supported the COVID-19 Response with <strong>awards</strong>.
             </h3>

--- a/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
+++ b/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
@@ -57,8 +57,7 @@ const AwardSpendingAgency = () => {
         other: null
     });
 
-    const defCodes = useSelector((state) => state.covid19.defCodes);
-    const dateString = "June 30, 2020";
+    const { defCodes, latestSubmissionDate } = useSelector((state) => state.covid19);
 
     useEffect(() => {
         if (defCodes && defCodes.length > 0) {
@@ -140,7 +139,7 @@ const AwardSpendingAgency = () => {
 
     return (
         <div className="body__content award-spending">
-            <DateNote dateString={dateString} />
+            <DateNote dateString={latestSubmissionDate} />
             <h3 className="body__narrative">These are the federal agencies who spent COVID-19 Response funding on <strong>awards.</strong></h3>
             <p className="body__narrative-description">
                 Federal agencies allocate award funds. Agencies receive funding from the Federal Government, which they award to recipients in order to respond to the COVID-19 pandemic.

--- a/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
+++ b/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
@@ -57,7 +57,7 @@ const AwardSpendingAgency = () => {
         other: null
     });
 
-    const { defCodes, latestSubmissionDate } = useSelector((state) => state.covid19);
+    const { defCodes } = useSelector((state) => state.covid19);
 
     useEffect(() => {
         if (defCodes && defCodes.length > 0) {
@@ -139,7 +139,7 @@ const AwardSpendingAgency = () => {
 
     return (
         <div className="body__content award-spending">
-            <DateNote dateString={latestSubmissionDate} />
+            <DateNote />
             <h3 className="body__narrative">These are the federal agencies who spent COVID-19 Response funding on <strong>awards.</strong></h3>
             <p className="body__narrative-description">
                 Federal agencies allocate award funds. Agencies receive funding from the Federal Government, which they award to recipients in order to respond to the COVID-19 pandemic.

--- a/src/js/components/covid19/budgetCategories/BudgetCategories.jsx
+++ b/src/js/components/covid19/budgetCategories/BudgetCategories.jsx
@@ -38,7 +38,7 @@ const BudgetCategories = () => {
     const [totalObligations, setTotalObligations] = useState(null);
     const [totalOutlays, setTotalOutlays] = useState(null);
 
-    const defCodes = useSelector((state) => state.covid19.defCodes);
+    const { defCodes, latestSubmissionDate } = useSelector((state) => state.covid19);
     const overviewData = [
         {
             type: 'count',
@@ -60,9 +60,6 @@ const BudgetCategories = () => {
             dollarAmount: true
         }
     ];
-
-    // TODO - Remove hard coded values
-    const dateString = "June 30, 2020";
 
     const changeActiveTab = (tab) => {
         const tabInternal = tabs.filter((item) => item.internal === tab)[0].internal;
@@ -106,7 +103,7 @@ const BudgetCategories = () => {
 
     return (
         <div className="body__content budget-categories">
-            <DateNote dateString={dateString} />
+            <DateNote dateString={latestSubmissionDate} />
             <h3 className="body__narrative">This is how the <strong>total spending</strong> of the COVID-19 Response was categorized.</h3>
             <p className="body__narrative-description">
                 The total federal spending for the COVID-19 Response can be divided into different budget categories, including the different agencies that spent funds, the Federal Spending bills and Federal Accounts that funded the Response, and the different types of items and services that were purchased.

--- a/src/js/components/covid19/budgetCategories/BudgetCategories.jsx
+++ b/src/js/components/covid19/budgetCategories/BudgetCategories.jsx
@@ -38,7 +38,7 @@ const BudgetCategories = () => {
     const [totalObligations, setTotalObligations] = useState(null);
     const [totalOutlays, setTotalOutlays] = useState(null);
 
-    const { defCodes, latestSubmissionDate } = useSelector((state) => state.covid19);
+    const { defCodes } = useSelector((state) => state.covid19);
     const overviewData = [
         {
             type: 'count',
@@ -103,7 +103,7 @@ const BudgetCategories = () => {
 
     return (
         <div className="body__content budget-categories">
-            <DateNote dateString={latestSubmissionDate} />
+            <DateNote />
             <h3 className="body__narrative">This is how the <strong>total spending</strong> of the COVID-19 Response was categorized.</h3>
             <p className="body__narrative-description">
                 The total federal spending for the COVID-19 Response can be divided into different budget categories, including the different agencies that spent funds, the Federal Spending bills and Federal Accounts that funded the Response, and the different types of items and services that were purchased.

--- a/src/js/helpers/covid19Helper.js
+++ b/src/js/helpers/covid19Helper.js
@@ -50,7 +50,7 @@ export const getCovidFromFileC = (codes) => codes
 
 export const latestSubmissionDateFormatted = (availablePeriods) => availablePeriods
     .filter((s) => !s.is_quarter)
-    .map((s) => moment.utc(s.submission_due_date))
+    .map((s) => moment.utc(s.submission_reveal_date))
     .sort((a, b) => b.valueOf() - a.valueOf())
     .find((s) => Date.now() >= s.valueOf())
     .format('MMM DD[,] YYYY');

--- a/tests/helpers/covid19Helper-test.js
+++ b/tests/helpers/covid19Helper-test.js
@@ -8,6 +8,6 @@ import mockSubmissions from '../testResources/covid19MockData';
 
 describe('Covid 19 Helper', () => {
     it('should find the latest submission date and format it', () => {
-        expect(latestSubmissionDateFormatted(mockSubmissions)).toEqual('Jun 29, 2020');
+        expect(latestSubmissionDateFormatted(mockSubmissions)).toEqual('Jun 30, 2020');
     });
 });


### PR DESCRIPTION
**High level description:**

Corrects the "Data as of" date displayed above visualizations on the COVID profile page.

**Technical details:**

- Reference the API field `submission_reveal_date` instead of `submission_due_date`
- Replaces a few places we were still hard-coding the date
- Adds the Date component to the Award Spending by CFDA Section

**JIRA Ticket:**
[DEV-5630](https://federal-spending-transparency.atlassian.net/browse/DEV-5630)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- N/A (no UI changes) Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- N/A (no UI changes)  Verified mobile/tablet/desktop/monitor responsiveness
- N/A (no UI changes)  Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`

Reviewer(s):
- [x] Code review complete
