### PR TITLE
[DEV-5310] Making the Covid columns display as currency in Advanced Search Results

### DIFF
--- a/src/js/dataMapping/search/awardTableColumnTypes.js
+++ b/src/js/dataMapping/search/awardTableColumnTypes.js
@@ -1,5 +1,10 @@
-/* eslint-disable quote-props */
+// TODO: [DEV-5665] TECH DEBT: Refactor Results Table to Utilize the Prototypical Inheritance Pattern with Models
+// Refactor this table to use the model pattern?
+// Doing the data parsing at the component level is nice but doesnt really allow for testing.
+// Unless we migrate to snapshot testing?
+
 // disable quote props because a lot of these keys actually do need quotes, so for consistency sake
+/* eslint-disable quote-props */
 // we'll do them all
 export const awardTableColumnTypes = {
     'Award ID': 'string',
@@ -8,6 +13,8 @@ export const awardTableColumnTypes = {
     'End Date': 'date',
     'Last Date to Order': 'date',
     'Award Amount': 'currency',
+    'COVID-19 Outlays': 'currency',
+    'COVID-19 Obligations': 'currency',
     'Funding Agency': 'string',
     'Funding Sub Agency': 'string',
     'Contract Award Type': 'string',


### PR DESCRIPTION
**High level description:**
Showing the parsed dollar amounts in the Advanced Search table rather than the floating integer.

![image](https://user-images.githubusercontent.com/12897813/87726264-af61ea00-c78c-11ea-8e03-16f3f04435f4.png)

**Technical details:**
Updated a data mapping file to flag the column as "currency".

I created [a ticket recommending we migrate this table to implement the model pattern](https://federal-spending-transparency.atlassian.net/browse/DEV-5665) as this data parsing is kind of hard to discover and not tested.

**JIRA Ticket:**
[DEV-5310](https://federal-spending-transparency.atlassian.net/browse/DEV-5310)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
