### PR TITLE
DEV-5602 & DEV-5629 COVID recipient search bar and links update

### DIFF
--- a/src/_scss/pages/covid19/_searchBar.scss
+++ b/src/_scss/pages/covid19/_searchBar.scss
@@ -1,0 +1,24 @@
+.search-bar {
+    border: 1px solid $color-gray-lighter;
+    @include display(flex);
+    @include align-items(center);
+    max-width: 40rem;
+    margin: 2rem 0;
+    .search-bar__input {
+        @include flex(1 1 auto);
+        line-height: rem(28);
+        padding: rem(5) rem(10);
+        border: 0;
+    }
+    .search-bar__button {
+        @include flex(0 0 auto);
+        @include button-unstyled;
+        padding: 0 rem(15);
+        color: $color-gray-light;
+        font-size: rem(26);
+        &:disabled {
+            color: $color-gray-lighter;
+            cursor: not-allowed;
+        }
+    }
+}

--- a/src/_scss/pages/covid19/index.scss
+++ b/src/_scss/pages/covid19/index.scss
@@ -100,6 +100,7 @@
             .body__section {
                 @import "../agency/v2/tabs";
                 @import "./dataSourcesAndMethodology";
+                @import './searchBar';
 
                 @include display(flex);
                 @include flex-wrap(wrap);

--- a/src/_scss/pages/covid19/index.scss
+++ b/src/_scss/pages/covid19/index.scss
@@ -92,7 +92,8 @@
                         }
                     }
                     .query-matched {
-                        background-color: $color-gold;
+                        font-weight: $font-semibold;
+                        text-decoration: underline;
                     }
                 }
             }

--- a/src/_scss/pages/covid19/index.scss
+++ b/src/_scss/pages/covid19/index.scss
@@ -92,8 +92,7 @@
                         }
                     }
                     .query-matched {
-                        text-decoration: underline;
-                        font-weight: $font-semibold;
+                        background-color: $color-gold;
                     }
                 }
             }

--- a/src/_scss/pages/covid19/index.scss
+++ b/src/_scss/pages/covid19/index.scss
@@ -91,6 +91,10 @@
                             white-space: nowrap;
                         }
                     }
+                    .query-matched {
+                        text-decoration: underline;
+                        font-weight: $font-semibold;
+                    }
                 }
             }
 

--- a/src/_scss/pages/covid19/recipient/_spendingByRecipient.scss
+++ b/src/_scss/pages/covid19/recipient/_spendingByRecipient.scss
@@ -2,4 +2,8 @@
     .overview-data-group {
         border-top: solid rem(1) $color-gray-lighter;
     }
+    .usda-table {
+        // because the search bar sits above the table in this section
+        margin-top: 0;
+    }
 }

--- a/src/js/components/covid19/SearchBar.jsx
+++ b/src/js/components/covid19/SearchBar.jsx
@@ -8,12 +8,12 @@ import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 const propTypes = {
-    setQuery: PropTypes.func.isRequired,
-    query: PropTypes.string
+    setQuery: PropTypes.func.isRequired
 };
 
-const SearchBar = ({ setQuery, query }) => {
-    const [searchString, setSearchString] = useState(query);
+const SearchBar = ({ setQuery }) => {
+    const [currentSearchTerm, setCurrentSearchTerm] = useState('');
+    const [searchString, setSearchString] = useState('');
 
     const onChange = (e) => {
         setSearchString(e.target.value);
@@ -21,6 +21,7 @@ const SearchBar = ({ setQuery, query }) => {
 
     const onSubmit = () => {
         setQuery(searchString);
+        setCurrentSearchTerm(searchString);
     };
 
     const resetSearch = () => {
@@ -29,7 +30,7 @@ const SearchBar = ({ setQuery, query }) => {
     };
 
     const handleClick = () => {
-        if (searchString && query === searchString) {
+        if (searchString && currentSearchTerm === searchString) {
             resetSearch();
         }
         else {
@@ -49,7 +50,7 @@ const SearchBar = ({ setQuery, query }) => {
                 aria-label="Search"
                 onClick={handleClick}
                 className="search-bar__button">
-                <FontAwesomeIcon icon={(searchString && query === searchString) ? 'times' : 'search'} />
+                <FontAwesomeIcon icon={(searchString && currentSearchTerm === searchString) ? 'times' : 'search'} />
             </button>
         </form>
     );

--- a/src/js/components/covid19/SearchBar.jsx
+++ b/src/js/components/covid19/SearchBar.jsx
@@ -1,0 +1,63 @@
+/**
+ * SearchBar.jsx
+ * Created by Lizzie Salita 7/16/20
+ */
+
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+const propTypes = {
+    setQuery: PropTypes.func.isRequired,
+    query: PropTypes.string
+};
+
+const SearchBar = ({ setQuery, query }) => {
+    const [searchString, setSearchString] = useState(query);
+
+    const onChange = (e) => {
+        setSearchString(e.target.value);
+    };
+
+    const onSubmit = (e) => {
+        e.preventDefault();
+        setQuery(searchString);
+    };
+
+    const resetSearch = (e) => {
+        e.preventDefault();
+        setSearchString('');
+        setQuery('');
+    };
+
+    const handleClick = (e) => {
+        if (searchString && query === searchString) {
+            resetSearch(e);
+        }
+        else {
+            onSubmit(e);
+        }
+    };
+
+    return (
+        <div className="search-bar">
+            <form className="search-bar__form">
+                <input
+                    className="search-bar__input"
+                    value={searchString}
+                    type="text"
+                    onChange={onChange} />
+                <button
+                    disabled={searchString.length < 3}
+                    aria-label="Search"
+                    onClick={handleClick}
+                    className="search-bar__button">
+                    <FontAwesomeIcon icon={(searchString && query === searchString) ? 'times' : 'search'} />
+                </button>
+            </form>
+        </div>
+    );
+};
+
+SearchBar.propTypes = propTypes;
+export default SearchBar;

--- a/src/js/components/covid19/SearchBar.jsx
+++ b/src/js/components/covid19/SearchBar.jsx
@@ -40,22 +40,20 @@ const SearchBar = ({ setQuery, query }) => {
     };
 
     return (
-        <div className="search-bar">
-            <form className="search-bar__form">
-                <input
-                    className="search-bar__input"
-                    value={searchString}
-                    type="text"
-                    onChange={onChange} />
-                <button
-                    disabled={searchString.length < 3}
-                    aria-label="Search"
-                    onClick={handleClick}
-                    className="search-bar__button">
-                    <FontAwesomeIcon icon={(searchString && query === searchString) ? 'times' : 'search'} />
-                </button>
-            </form>
-        </div>
+        <form className="search-bar">
+            <input
+                className="search-bar__input"
+                value={searchString}
+                type="text"
+                onChange={onChange} />
+            <button
+                disabled={searchString.length < 3}
+                aria-label="Search"
+                onClick={handleClick}
+                className="search-bar__button">
+                <FontAwesomeIcon icon={(searchString && query === searchString) ? 'times' : 'search'} />
+            </button>
+        </form>
     );
 };
 

--- a/src/js/components/covid19/SearchBar.jsx
+++ b/src/js/components/covid19/SearchBar.jsx
@@ -19,23 +19,21 @@ const SearchBar = ({ setQuery, query }) => {
         setSearchString(e.target.value);
     };
 
-    const onSubmit = (e) => {
-        e.preventDefault();
+    const onSubmit = () => {
         setQuery(searchString);
     };
 
-    const resetSearch = (e) => {
-        e.preventDefault();
+    const resetSearch = () => {
         setSearchString('');
         setQuery('');
     };
 
-    const handleClick = (e) => {
+    const handleClick = () => {
         if (searchString && query === searchString) {
-            resetSearch(e);
+            resetSearch();
         }
         else {
-            onSubmit(e);
+            onSubmit();
         }
     };
 

--- a/src/js/components/covid19/SearchBar.jsx
+++ b/src/js/components/covid19/SearchBar.jsx
@@ -47,7 +47,7 @@ const SearchBar = ({ setQuery, query }) => {
                 type="text"
                 onChange={onChange} />
             <button
-                disabled={searchString.length < 3}
+                disabled={searchString.length < 2}
                 aria-label="Search"
                 onClick={handleClick}
                 className="search-bar__button">

--- a/src/js/components/covid19/recipient/SpendingByRecipient.jsx
+++ b/src/js/components/covid19/recipient/SpendingByRecipient.jsx
@@ -69,7 +69,7 @@ const SpendingByRecipient = () => {
         });
         // Wait for all the requests to complete and then store the results in state
         Promise.all(promises)
-            .then(([allRes, grantsRes, directPaymentsRes, loansRes, otherRes, contractRes, idvRes]) => {
+            .then(([allRes, grantsRes, loansRes, directPaymentsRes, otherRes, contractRes, idvRes]) => {
                 setTabCounts({
                     all: allRes.data.count,
                     grants: grantsRes.data.count,

--- a/src/js/containers/covid19/recipient/SpendingByRecipientContainer.jsx
+++ b/src/js/containers/covid19/recipient/SpendingByRecipientContainer.jsx
@@ -15,6 +15,7 @@ import { spendingTableSortFields } from 'dataMapping/covid19/covid19';
 import { fetchDisasterSpending, fetchLoanSpending } from 'helpers/disasterHelper';
 import ResultsTableLoadingMessage from 'components/search/table/ResultsTableLoadingMessage';
 import ResultsTableErrorMessage from 'components/search/table/ResultsTableErrorMessage';
+import ResultsTableNoResults from 'components/search/table/ResultsTableNoResults';
 import SearchBar from 'components/covid19/SearchBar';
 
 const propTypes = {
@@ -241,40 +242,44 @@ const SpendingByRecipientContainer = ({ activeTab }) => {
                 <ResultsTableErrorMessage />
             </div>
         );
-    }
-
-    if (message) {
-        return (
-            <>
-                <CSSTransitionGroup
-                    transitionName="table-message-fade"
-                    transitionLeaveTimeout={225}
-                    transitionEnterTimeout={195}
-                    transitionLeave>
-                    {message}
-                </CSSTransitionGroup>
-            </>
+    } else if (results.length === 0) {
+        message = (
+            <div className="results-table-message-container">
+                <ResultsTableNoResults />
+            </div>
         );
     }
+
+    const content = message ? (
+        <CSSTransitionGroup
+            transitionName="table-message-fade"
+            transitionLeaveTimeout={225}
+            transitionEnterTimeout={195}
+            transitionLeave>
+            {message}
+        </CSSTransitionGroup>
+    ) : (
+        <div className="table-wrapper">
+            <Table
+                columns={activeTab === 'loans' ? loanColumns : columns}
+                rows={results}
+                updateSort={updateSort}
+                currentSort={{ field: sort, direction: order }} />
+        </div>
+    );
 
     return (
         <>
             <SearchBar setQuery={setQuery} query={query} />
-            <div className="table-wrapper">
-                <Table
-                    columns={activeTab === 'loans' ? loanColumns : columns}
-                    rows={results}
-                    updateSort={updateSort}
-                    currentSort={{ field: sort, direction: order }} />
-            </div>
-            <Pagination
+            {content}
+            {(results.length > 0 || error) && <Pagination
                 currentPage={currentPage}
                 changePage={changeCurrentPage}
                 changeLimit={changePageSize}
                 limitSelector
                 resultsText
                 pageSize={pageSize}
-                totalItems={totalItems} />
+                totalItems={totalItems} />}
         </>
     );
 };

--- a/src/js/containers/covid19/recipient/SpendingByRecipientContainer.jsx
+++ b/src/js/containers/covid19/recipient/SpendingByRecipientContainer.jsx
@@ -269,7 +269,7 @@ const SpendingByRecipientContainer = ({ activeTab }) => {
 
     return (
         <>
-            <SearchBar setQuery={setQuery} query={query} />
+            <SearchBar setQuery={setQuery} />
             {content}
             {(results.length > 0 || error) && <Pagination
                 currentPage={currentPage}

--- a/src/js/containers/covid19/recipient/SpendingByRecipientContainer.jsx
+++ b/src/js/containers/covid19/recipient/SpendingByRecipientContainer.jsx
@@ -102,6 +102,7 @@ export const parseRows = (rows, activeTab, query) => (
         const rowData = Object.create(BaseSpendingByRecipientRow);
         rowData.populate(row);
         let description = rowData.description;
+        let link = description;
         if (query) {
             // wrap the part of the recipient name matching the search string
             // with a span for styling
@@ -113,12 +114,11 @@ export const parseRows = (rows, activeTab, query) => (
                 </span>
             ));
         }
-        let link = description;
         if (rowData._childId && rowData._recipientId) {
             // there are two profile pages for this recipient
             link = (
                 <>
-                    {description} (
+                    {description}&nbsp;(
                     <a href={`#/recipient/${rowData._childId}`}>
                         as Child
                     </a>,&nbsp;
@@ -140,9 +140,9 @@ export const parseRows = (rows, activeTab, query) => (
         if (activeTab === 'loans') {
             return [
                 link,
-                rowData.faceValueOfLoan,
                 rowData.obligation,
                 rowData.outlay,
+                rowData.faceValueOfLoan,
                 rowData.count
             ];
         }

--- a/src/js/containers/covid19/recipient/SpendingByRecipientContainer.jsx
+++ b/src/js/containers/covid19/recipient/SpendingByRecipientContainer.jsx
@@ -15,6 +15,7 @@ import { spendingTableSortFields } from 'dataMapping/covid19/covid19';
 import { fetchDisasterSpending, fetchLoanSpending } from 'helpers/disasterHelper';
 import ResultsTableLoadingMessage from 'components/search/table/ResultsTableLoadingMessage';
 import ResultsTableErrorMessage from 'components/search/table/ResultsTableErrorMessage';
+import SearchBar from 'components/covid19/SearchBar';
 
 const propTypes = {
     activeTab: PropTypes.string.isRequired
@@ -163,6 +164,7 @@ const SpendingByRecipientContainer = ({ activeTab }) => {
     const [error, setError] = useState(false);
     const [sort, setSort] = useState('obligation');
     const [order, setOrder] = useState('desc');
+    const [query, setQuery] = useState('');
     const [request, setRequest] = useState(null);
 
     const updateSort = (field, direction) => {
@@ -191,6 +193,9 @@ const SpendingByRecipientContainer = ({ activeTab }) => {
             if (activeTab !== 'all') {
                 params.filter.award_type_codes = awardTypeGroups[activeTab];
             }
+            if (query) {
+                params.filter.query = query;
+            }
             let recipientRequest = fetchDisasterSpending('recipient', params);
             if (activeTab === 'loans') {
                 recipientRequest = fetchLoanSpending('recipient', params);
@@ -217,7 +222,7 @@ const SpendingByRecipientContainer = ({ activeTab }) => {
         // Reset to the first page
         changeCurrentPage(1);
         fetchSpendingByRecipientCallback();
-    }, [pageSize, defCodes, sort, order, activeTab]);
+    }, [pageSize, defCodes, sort, order, activeTab, query]);
 
     useEffect(() => {
         fetchSpendingByRecipientCallback();
@@ -248,13 +253,13 @@ const SpendingByRecipientContainer = ({ activeTab }) => {
                     transitionLeave>
                     {message}
                 </CSSTransitionGroup>
-
             </>
         );
     }
 
     return (
         <>
+            <SearchBar setQuery={setQuery} query={query} />
             <div className="table-wrapper">
                 <Table
                     columns={activeTab === 'loans' ? loanColumns : columns}

--- a/tests/containers/covid19/SpendingByRecipientContainer-test.jsx
+++ b/tests/containers/covid19/SpendingByRecipientContainer-test.jsx
@@ -1,0 +1,121 @@
+/**
+ * SpendingByRecipientContainer-test.js
+ * Created by Lizzie Salita 7/17/20
+ * */
+
+import { parseRows, generateDescription } from 'containers/covid19/recipient/SpendingByRecipientContainer';
+import React from 'react';
+
+describe('SpendingByRecipientContainer', () => {
+    const mockResults = [
+        {
+            code: "987654321",
+            count: 2,
+            description: "RECIPIENT 3",
+            id: ["d2894d22-67fc-f9cb-4005-33fa6a29ef86-C", "d2894d22-67fc-f9cb-4005-33fa6a29ef86-R"],
+            obligation: 2200.0,
+            outlay: 1100.0
+        },
+        {
+            code: "456789123",
+            count: 1,
+            description: "RECIPIENT 2",
+            id: ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
+            obligation: 20.0,
+            outlay: 0.0
+        }
+    ];
+    describe('parseRows', () => {
+        it('should parse returned recipient data', () => {
+            const expected = [
+                [
+                    (
+                        <>
+                            {mockResults[0].description}&nbsp;(
+                            <a href="#/recipient/d2894d22-67fc-f9cb-4005-33fa6a29ef86-C">
+                                as Child
+                            </a>,&nbsp;
+                            <a href="#/recipient/d2894d22-67fc-f9cb-4005-33fa6a29ef86-R">
+                                as Recipient
+                            </a>
+                            )
+                        </>
+                    ),
+                    '$2,200',
+                    '$1,100',
+                    '2'
+                ],
+                [
+                    (
+                        <a href="#/recipient/3c92491a-f2cd-ec7d-294b-7daf91511866-R">
+                            RECIPIENT 2
+                        </a>
+                    ),
+                    '$20',
+                    '$0',
+                    '1'
+                ]
+            ];
+
+            const parsed = parseRows(mockResults, 'all', '');
+            expect(parsed).toEqual(expected);
+        });
+        it('should parse returned recipient loans data', () => {
+            const mockLoanResults = [
+                {
+                    code: "987654321",
+                    count: 2,
+                    description: "RECIPIENT 3",
+                    face_value_of_loan: 100.0,
+                    id: ["d2894d22-67fc-f9cb-4005-33fa6a29ef86-C", "d2894d22-67fc-f9cb-4005-33fa6a29ef86-R"],
+                    obligation: 2200.0,
+                    outlay: 1100.0
+                },
+                {
+                    code: "456789123",
+                    count: 1,
+                    description: "RECIPIENT 2",
+                    face_value_of_loan: 200.0,
+                    id: ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
+                    obligation: 20.0,
+                    outlay: 0.0
+                }
+            ];
+
+            const expected = [
+                [
+                    (
+                        <>
+                            {mockLoanResults[0].description}&nbsp;(
+                            <a href="#/recipient/d2894d22-67fc-f9cb-4005-33fa6a29ef86-C">
+                                as Child
+                            </a>,&nbsp;
+                            <a href="#/recipient/d2894d22-67fc-f9cb-4005-33fa6a29ef86-R">
+                                as Recipient
+                            </a>
+                            )
+                        </>
+                    ),
+                    '$2,200',
+                    '$1,100',
+                    '$100',
+                    '2'
+                ],
+                [
+                    (
+                        <a href="#/recipient/3c92491a-f2cd-ec7d-294b-7daf91511866-R">
+                            RECIPIENT 2
+                        </a>
+                    ),
+                    '$20',
+                    '$0',
+                    '$200',
+                    '1'
+                ]
+            ];
+
+            const parsed = parseRows(mockLoanResults, 'loans', '');
+            expect(parsed).toEqual(expected);
+        });
+    });
+});


### PR DESCRIPTION
**High level description:**
Adds a search bar to the COVID Profile **Spending by Recipient** section > **Recipients** tab table

**Technical details:**

- Adds `query` param to API request when the search string is more than 3 characters
- Creates a `SearchBar` component that could be reused in other sections of the page
- Styles substring of the recipient name that matches the search input
- When only one recipient profile page is available, link the recipient name instead of using `as Child`/ `as Recipient`
- Fixes a bug causing the Loans and Direct Payment tab counts to be swapped

**JIRA Ticket:**
[DEV-5602](https://federal-spending-transparency.atlassian.net/browse/DEV-5602) (search bar), [DEV-5629](https://federal-spending-transparency.atlassian.net/browse/DEV-5629) (recipient links)

**Mockup:**
https://bahdigital.invisionapp.com/share/TPIAEAE7HVG#/296042274_COVID-_Recipients_-_Recipient_Location_-_Recipient

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA tickets
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`

Reviewer(s):
- [x] Design review complete @AGuyNamedMarco & @marcyheld 
- [ ] Code review complete
