### PR TITLE
DEV-5630 spell out month in "data as of" notes

### DIFF
--- a/src/js/helpers/covid19Helper.js
+++ b/src/js/helpers/covid19Helper.js
@@ -54,4 +54,4 @@ export const latestSubmissionDateFormatted = (availablePeriods) => availablePeri
     .map((s) => moment.utc(s.submission_reveal_date))
     .sort((a, b) => b.valueOf() - a.valueOf())
     .find((s) => Date.now() >= s.valueOf())
-    .format('MMM DD[,] YYYY');
+    .format('MMMM DD[,] YYYY');

--- a/tests/helpers/covid19Helper-test.js
+++ b/tests/helpers/covid19Helper-test.js
@@ -8,6 +8,6 @@ import mockSubmissions from '../testResources/covid19MockData';
 
 describe('Covid 19 Helper', () => {
     it('should find the latest submission date and format it', () => {
-        expect(latestSubmissionDateFormatted(mockSubmissions)).toEqual('Jun 30, 2020');
+        expect(latestSubmissionDateFormatted(mockSubmissions)).toEqual('June 30, 2020');
     });
 });


### PR DESCRIPTION
**High level description:**

Spells out the full month (e.g. `June 30, 2020` instead of `Jun 30, 2020`) in "Data as of" notes on the COVID-19 profile page.

**JIRA Ticket:**
Follow-up fix for [DEV-5630](https://federal-spending-transparency.atlassian.net/browse/DEV-5630)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- N/A Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- N/A Verified mobile/tablet/desktop/monitor responsiveness
- N/A Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models


Reviewer(s):
- [x] Code review complete
