### PR TITLE
[DEV-5197] Preventing onSubmit triggered by onClick of disabled Quarter

### DIFF
--- a/src/js/components/bulkDownload/accounts/AccountDataContent.jsx
+++ b/src/js/components/bulkDownload/accounts/AccountDataContent.jsx
@@ -55,9 +55,7 @@ export default class AccountDataContent extends React.Component {
         this.props.clearAccountFilters();
     }
 
-    handleSubmit(e) {
-        e.preventDefault();
-
+    handleSubmit() {
         this.props.clickedDownload();
     }
 
@@ -86,9 +84,7 @@ export default class AccountDataContent extends React.Component {
                 <div className="download-center__filters">
                     <h2 className="download-center__title">Custom Account Data</h2>
                     <FilterSelection valid={accounts.budgetFunction.code !== '' || accounts.agency.id !== ''} />
-                    <form
-                        className="download-center-form"
-                        onSubmit={this.handleSubmit}>
+                    <form className="download-center-form">
                         <BudgetFunctionFilter
                             budgetFunctions={this.props.budgetFunctions}
                             budgetSubfunctions={this.props.budgetSubfunctions}
@@ -125,6 +121,7 @@ export default class AccountDataContent extends React.Component {
                         <UserSelections
                             accounts={accounts} />
                         <SubmitButton
+                            handleSubmit={this.handleSubmit}
                             validForm={this.state.validForm}
                             filters={accounts}
                             validDates

--- a/src/js/components/bulkDownload/accounts/AccountDataContent.jsx
+++ b/src/js/components/bulkDownload/accounts/AccountDataContent.jsx
@@ -84,7 +84,7 @@ export default class AccountDataContent extends React.Component {
                 <div className="download-center__filters">
                     <h2 className="download-center__title">Custom Account Data</h2>
                     <FilterSelection valid={accounts.budgetFunction.code !== '' || accounts.agency.id !== ''} />
-                    <form className="download-center-form">
+                    <div className="download-center-form">
                         <BudgetFunctionFilter
                             budgetFunctions={this.props.budgetFunctions}
                             budgetSubfunctions={this.props.budgetSubfunctions}
@@ -126,7 +126,7 @@ export default class AccountDataContent extends React.Component {
                             filters={accounts}
                             validDates
                             dataType="accounts" />
-                    </form>
+                    </div>
                     <button className="download-center__reset" onClick={this.resetForm}>
                         Reset form and start over
                     </button>

--- a/src/js/components/bulkDownload/awards/SubmitButton.jsx
+++ b/src/js/components/bulkDownload/awards/SubmitButton.jsx
@@ -14,7 +14,8 @@ const propTypes = {
     validForm: PropTypes.bool,
     filters: PropTypes.object,
     validDates: PropTypes.bool,
-    dataType: PropTypes.string
+    dataType: PropTypes.string,
+    handleSubmit: PropTypes.func
 };
 
 export default class SubmitButton extends React.Component {
@@ -29,6 +30,7 @@ export default class SubmitButton extends React.Component {
 
         this.onMouseEnter = this.onMouseEnter.bind(this);
         this.onMouseLeave = this.onMouseLeave.bind(this);
+        this.onClick = this.onClick.bind(this);
         this.measureOffset = throttle(this.measureOffset.bind(this), 16);
     }
 
@@ -53,6 +55,11 @@ export default class SubmitButton extends React.Component {
         this.setState({
             showHover: false
         });
+    }
+
+    onClick(e) {
+        e.preventDefault();
+        this.props.handleSubmit();
     }
 
     measureOffset() {
@@ -100,7 +107,7 @@ export default class SubmitButton extends React.Component {
         if (this.props.validForm && this.props.validDates) {
             submitButton = (
                 <div className="submit-button">
-                    <input type="submit" value="Download" />
+                    <input type="submit" value="Download" onClick={this.props.handleSubmit} />
                 </div>
             );
         }


### PR DESCRIPTION
**High level description:**
There is a bug where clicking a disabled quarter on the account download page triggers the download.

**Technical details:**
This was happening because in the component from the library, we are not preventing an onClick event on the Quarter Picker from bubbling up to the form and creating false positive for the onSubmit event.

Rather than fix the component library now, I've changed our implementation such that we aren't looking for an onSubmit event on the form generally, but rather we're attaching an onClick event to the submit button itself. This avoids the problem. [I created a ticket for the component library so we can fix the root cause later](https://federal-spending-transparency.atlassian.net/browse/DEV-DEV-5687).

**JIRA Ticket:**
[DEV-5197](https://federal-spending-transparency.atlassian.net/browse/DEV-5197)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
