### PR TITLE
[DEV-5242] More Precise Lines for Award Amounts Viz

### DIFF
--- a/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
@@ -207,7 +207,7 @@ $proc-current-offset: rem(5);
                     font-size: $small-font-size;
                 }
 
-                // Offsets for descriptions
+                // Offsets for Bar Value Descriptions; for example $10,000
                 &.idv-obligated,
                 &.contract-obligated {
                     margin-left: $proc-obligated-offset;
@@ -221,6 +221,12 @@ $proc-current-offset: rem(5);
                 &.idv-file-c-obligated,
                 &.contract-file-c-obligated {
                     margin-left: $proc-filec-obligated-offset;
+                }
+                &.asst-obligation {
+                    margin-left: rem(6);
+                }
+                &.asst-file-c-obligated {
+                    margin-left: rem(10);
                 }
             }
             .award-amounts-viz__label {
@@ -292,6 +298,14 @@ $proc-current-offset: rem(5);
                     &.idv-file-c-obligated,
                     &.contract-file-c-obligated {
                         margin-left: $proc-filec-obligated-offset;
+                    }
+
+                    &.asst-obligation {
+                        margin-left: rem(6);
+                    }
+
+                    &.asst-file-c-obligated {
+                        margin-left: rem(10);
                     }
                 }
             }
@@ -383,6 +397,9 @@ $proc-current-offset: rem(5);
                     &.contract-file-c-outlay {
                         margin-left: $proc-filec-outlay-offset;
                     }
+                    &.asst-file-c-outlay {
+                        margin-left: rem(12);
+                    }
                 }
                 .award-amounts-viz__line {
                     margin: rem(20) 0 rem(5) rem(1);
@@ -468,6 +485,12 @@ $proc-current-offset: rem(5);
                     &.contract-file-c-outlay,
                     &.idv-file-c-outlay {
                         margin-left: $proc-filec-outlay-offset;
+                    }
+                    &.asst-file-c-outlay {
+                        margin-left: rem(12);
+                    }
+                    &.asst-non-federal-funding {
+                        margin-right: rem(6);
                     }
                 }
             }

--- a/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
@@ -228,6 +228,12 @@ $proc-current-offset: rem(5);
                 &.asst-file-c-obligated {
                     margin-left: rem(10);
                 }
+                &.loan-file-c-obligated {
+                    margin-left: rem(7);
+                }
+                &.loan-file-c-subsidy {
+                    margin-left: rem(3);
+                }
             }
             .award-amounts-viz__label {
                 .award-amounts-viz__line {
@@ -304,8 +310,16 @@ $proc-current-offset: rem(5);
                         margin-left: rem(6);
                     }
 
+                    &.loan-subsidy {
+                        margin-left: rem(3);
+                    }
+
                     &.asst-file-c-obligated {
                         margin-left: rem(10);
+                    }
+
+                    &.loan-file-c-obligated {
+                        margin-left: rem(7);
                     }
                 }
             }
@@ -400,6 +414,10 @@ $proc-current-offset: rem(5);
                     &.asst-file-c-outlay {
                         margin-left: rem(12);
                     }
+
+                    &.loan-file-c-outlay {
+                        margin-left: rem(9);
+                    }
                 }
                 .award-amounts-viz__line {
                     margin: rem(20) 0 rem(5) rem(1);
@@ -442,7 +460,8 @@ $proc-current-offset: rem(5);
                             border-left: 1px solid $colors-grants-nff; 
                         }
                     }
-                    &.asst-total-funding {
+                    &.asst-total-funding,
+                    &.loan-face-value {
                         border-bottom: rem(1) solid $color-gray-light;
                         &::after,
                         &::before {
@@ -491,6 +510,10 @@ $proc-current-offset: rem(5);
                     }
                     &.asst-non-federal-funding {
                         margin-right: rem(6);
+                    }
+
+                    &.loan-file-c-outlay {
+                        margin-left: rem(9);
                     }
                 }
             }

--- a/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
@@ -28,8 +28,8 @@ $proc-current-offset: rem(5);
         background-color: $color-white;
         margin: rem(16) 0 0 0;
         padding: rem(3);
-        &.idv-extreme-overspending-obligated,
-        &.contract-extreme-overspending-obligated {
+        &.contract-extreme-overspending-obligated,
+        &.idv-extreme-overspending-obligated {
             border: none;
         }
         &.idv-potential,
@@ -133,14 +133,14 @@ $proc-current-offset: rem(5);
                 margin-bottom: rem(5);
                 .idv-extreme-overspending-label,
                 .contract-extreme-overspending-label,
-                .idv-overspending-obligated,
-                .contract-overspending-obligated {
+                .idv-overspending,
+                .contract-overspending {
                     text-align: right;
                     @include justify-content(flex-end);
                     border-left: none;
                     padding-right: rem(5);
-                    &.contract-overspending-obligated::after,
-                    &.idv-overspending-obligated::after {
+                    &.contract-overspending::after,
+                    &.idv-overspending::after {
                         content: ' ';
                         width: rem(5);
                         height: rem(55);
@@ -212,6 +212,8 @@ $proc-current-offset: rem(5);
                 &.contract-obligated {
                     margin-left: $proc-obligated-offset;
                 }
+                &.idv-overspending-obligated,
+                &.contract-overspending-obligated,
                 &.idv-extreme-overspending-obligated,
                 &.contract-extreme-overspending-obligated {
                     margin-left: rem(10);
@@ -238,11 +240,11 @@ $proc-current-offset: rem(5);
                         left: -1px;
                     }
                     &.idv-obligated,
-                    &.idv-obligated,
-                    &.contract-obligated,
                     &.contract-obligated,
                     &.asst-obligated,
                     &.asst-obligated,
+                    &.idv-overspending-obligated,
+                    &.contract-overspending-obligated,
                     &.idv-extreme-overspending-obligated,
                     &.contract-extreme-overspending-obligated,
                     &.asst-obligation {
@@ -280,6 +282,8 @@ $proc-current-offset: rem(5);
                         margin-left: $proc-obligated-offset;
                     }
 
+                    &.idv-overspending-obligated,
+                    &.contract-overspending-obligated,
                     &.idv-extreme-overspending-obligated,
                     &.contract-extreme-overspending-obligated {
                         margin-left: rem(10);
@@ -435,6 +439,7 @@ $proc-current-offset: rem(5);
                     &.idv-extreme-overspending-current,
                     &.contract-extreme-overspending-current {
                         border-bottom: rem(1) solid $colors-current;
+                        margin-left: $proc-current-offset;
                         &::after,
                         &::before {
                             border-left: rem(1) solid $colors-current;
@@ -463,15 +468,6 @@ $proc-current-offset: rem(5);
                     &.contract-file-c-outlay,
                     &.idv-file-c-outlay {
                         margin-left: $proc-filec-outlay-offset;
-                    }
-
-                    &.contract-current,
-                    &.idv-current {
-                        margin-left: $proc-current-offset;
-                    }
-                    &.contract-extreme-overspending-current,
-                    &.idv-extreme-overspending-current {
-                        margin-left: $proc-current-offset;
                     }
                 }
             }

--- a/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
@@ -207,7 +207,7 @@ $proc-current-offset: rem(5);
                     font-size: $small-font-size;
                 }
 
-                // Offsets for Bar Value Descriptions; for example $10,000
+                // Offsets for Bar Value Descriptions/text; for example where the section says $10,000 <spending category>
                 &.idv-obligated,
                 &.contract-obligated {
                     margin-left: $proc-obligated-offset;

--- a/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
@@ -1,6 +1,13 @@
 $exceeds-current-color: #fdb81e;
 $exceeds-potential-color: #e31c3d;
 
+// Offsets per DEV-5242:
+// refer to datamapping object; divide relevant value by 2.
+// for proper margin-left value of text offset.
+$obligated-padding: 2px;
+$file-c-obligated-padding: 4px;
+$file-c-outlay-padding: 6px;
+
 %award-amounts-viz__line-indicator {
     content: "";
     position: absolute;

--- a/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
@@ -173,6 +173,10 @@ $proc-current-offset: rem(5);
 
                 &.idv-obligated,
                 &.contract-obligated,
+                &.idv-extreme-overspending-obligated,
+                &.contract-extreme-overspending-obligated,
+                &.idv-overspending-obligated,
+                &.contract-overspending-obligated,
                 &.asst-obligation {
                     border-left: rem(4) solid $colors-obligated;
                 }
@@ -207,6 +211,10 @@ $proc-current-offset: rem(5);
                 &.idv-obligated,
                 &.contract-obligated {
                     margin-left: $proc-obligated-offset;
+                }
+                &.idv-extreme-overspending-obligated,
+                &.contract-extreme-overspending-obligated {
+                    margin-left: rem(10);
                 }
                 &.idv-file-c-obligated,
                 &.contract-file-c-obligated {
@@ -270,6 +278,11 @@ $proc-current-offset: rem(5);
                     &.idv-obligated,
                     &.contract-obligated {
                         margin-left: $proc-obligated-offset;
+                    }
+
+                    &.idv-extreme-overspending-obligated,
+                    &.contract-extreme-overspending-obligated {
+                        margin-left: rem(10);
                     }
 
                     &.idv-file-c-obligated,
@@ -454,6 +467,10 @@ $proc-current-offset: rem(5);
 
                     &.contract-current,
                     &.idv-current {
+                        margin-left: $proc-current-offset;
+                    }
+                    &.contract-extreme-overspending-current,
+                    &.idv-extreme-overspending-current {
                         margin-left: $proc-current-offset;
                     }
                 }

--- a/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_charts.scss
@@ -4,9 +4,10 @@ $exceeds-potential-color: #e31c3d;
 // Offsets per DEV-5242:
 // refer to datamapping object; divide relevant value by 2.
 // for proper margin-left value of text offset.
-$obligated-padding: 2px;
-$file-c-obligated-padding: 4px;
-$file-c-outlay-padding: 6px;
+$proc-obligated-offset: rem(5);
+$proc-filec-obligated-offset: rem(7);
+$proc-filec-outlay-offset: rem(9);
+$proc-current-offset: rem(5);
 
 %award-amounts-viz__line-indicator {
     content: "";
@@ -31,7 +32,13 @@ $file-c-outlay-padding: 6px;
         &.contract-extreme-overspending-obligated {
             border: none;
         }
+        &.idv-potential,
+        &.contract-potential {
+            background-color: $colors-potential;
+            border: none;
+        }
         .award-amounts-viz__bar-wrapper {
+            min-width: rem(7);
             // denominators have a fixed height.
             &.contract-potential,
             &.idv-potential,
@@ -50,7 +57,6 @@ $file-c-outlay-padding: 6px;
             background-color: #ececec;
             @include display(flex);
             .nested-obligations {
-                padding: rem(2);
                 width: 100%;
                 @include display(flex);
             }
@@ -196,6 +202,16 @@ $file-c-outlay-padding: 6px;
                 br {
                     font-size: $small-font-size;
                 }
+
+                // Offsets for descriptions
+                &.idv-obligated,
+                &.contract-obligated {
+                    margin-left: $proc-obligated-offset;
+                }
+                &.idv-file-c-obligated,
+                &.contract-file-c-obligated {
+                    margin-left: $proc-filec-obligated-offset;
+                }
             }
             .award-amounts-viz__label {
                 .award-amounts-viz__line {
@@ -249,6 +265,16 @@ $file-c-outlay-padding: 6px;
                         &::after {
                             border-left: rem(1) solid $colors-loans-subsidy;
                         }
+                    }
+
+                    &.idv-obligated,
+                    &.contract-obligated {
+                        margin-left: $proc-obligated-offset;
+                    }
+
+                    &.idv-file-c-obligated,
+                    &.contract-file-c-obligated {
+                        margin-left: $proc-filec-obligated-offset;
                     }
                 }
             }
@@ -334,6 +360,12 @@ $file-c-outlay-padding: 6px;
                             background: $colors-loans-face-value;
                         }                        
                     }
+
+                    // Offsets for descriptions
+                    &.idv-file-c-outlay,
+                    &.contract-file-c-outlay {
+                        margin-left: $proc-filec-outlay-offset;
+                    }
                 }
                 .award-amounts-viz__line {
                     margin: rem(20) 0 rem(5) rem(1);
@@ -414,6 +446,15 @@ $file-c-outlay-padding: 6px;
                         &::after {
                             border-left: rem(1) solid $color-disaster-covid-19;
                         }
+                    }
+                    &.contract-file-c-outlay,
+                    &.idv-file-c-outlay {
+                        margin-left: $proc-filec-outlay-offset;
+                    }
+
+                    &.contract-current,
+                    &.idv-current {
+                        margin-left: $proc-current-offset;
                     }
                 }
             }

--- a/src/js/components/award/financialAssistance/RectanglePercentViz.jsx
+++ b/src/js/components/award/financialAssistance/RectanglePercentViz.jsx
@@ -143,6 +143,7 @@ const RectanglePercentViz = ({
         if (data.improper && data.children) return data.children.map((child) => renderBarVisualization(child));
         // we dont render a bar using the improper object, just the label.
         if (data.improper) return null;
+        if (data.rawValue <= 0) return null;
         const barProps = {
             spendingCategory: `${data.className}`,
             barWrapperStyles: {

--- a/src/js/components/award/financialAssistance/RectanglePercentViz.jsx
+++ b/src/js/components/award/financialAssistance/RectanglePercentViz.jsx
@@ -143,7 +143,7 @@ const RectanglePercentViz = ({
         if (data.improper && data.children) return data.children.map((child) => renderBarVisualization(child));
         // we dont render a bar using the improper object, just the label.
         if (data.improper) return null;
-        if (data.rawValue <= 0) return null;
+        if (data.rawValue <= 0 || data?.barWidthOverrides?.rawValue <= 0) return null;
         const barProps = {
             spendingCategory: `${data.className}`,
             barWrapperStyles: {

--- a/src/js/components/award/financialAssistance/RectanglePercentViz.jsx
+++ b/src/js/components/award/financialAssistance/RectanglePercentViz.jsx
@@ -227,11 +227,11 @@ const RectanglePercentViz = ({
                         {child.rawValue > 0 &&
                             <BarLabelAndLine
                                 spendingCategory={child.className}
-                                labelClassName={`award-amounts-viz__label`}
+                                labelClassName="award-amounts-viz__label"
                                 lineClassName={`award-amounts-viz__line ${position}`}
                                 lineStyles={{
                                     backgroundColor: child.color,
-                                    width: generatePercentage(child.rawValue / denominator.rawValue)
+                                    width: `calc(${generatePercentage(child.rawValue / denominator.rawValue)} - ${child.lineOffset}px)`
                                 }} />
                         }
                         {Object.keys(child).includes('children') && renderLinesAndLabelsForPosition(child.children, position)}
@@ -255,17 +255,21 @@ const RectanglePercentViz = ({
                     {!isBarAbsent &&
                         <BarLabelAndLine
                             spendingCategory={child.className}
-                            labelClassName={`award-amounts-viz__label`}
+                            labelClassName="award-amounts-viz__label"
                             lineClassName={`award-amounts-viz__line ${position}`}
                             lineStyles={{
                                 backgroundColor: child.color,
                                 width: child?.barWidthOverrides?.applyToLine
-                                    ? generatePercentage(child.barWidthOverrides.rawValue / child.barWidthOverrides.denominatorValue)
-                                    : generatePercentage(child.rawValue / denominator.rawValue)
+                                    ? `calc(${generatePercentage(child.barWidthOverrides.rawValue / child.barWidthOverrides.denominatorValue)} - ${child.lineOffset}px)`
+                                    : `calc(${generatePercentage(child.rawValue / denominator.rawValue)} - ${child.lineOffset}px)`
                             }}>
                             <BarValue
                                 spendingCategory={child.className}
-                                style={{ width: child.labelSortOrder === 0 ? '100%' : generatePercentage(child.rawValue / denominator.rawValue) }}
+                                style={{
+                                    width: child.labelSortOrder === 0
+                                        ? '100%'
+                                        : `calc(${generatePercentage(child.rawValue / denominator.rawValue)})`
+                                }}
                                 className={`award-amounts-viz__desc ${position}`}
                                 onLeave={closeTooltip}
                                 onEnter={(e) => {

--- a/src/js/components/award/financialAssistance/RectanglePercentViz.jsx
+++ b/src/js/components/award/financialAssistance/RectanglePercentViz.jsx
@@ -98,8 +98,6 @@ const RectanglePercentViz = ({
         flattenArray(numerator?.children).some((obj) => obj?.text?.toLowerCase()?.includes('covid'))
     );
 
-    const classNameForCovid = isCaresReleased ? ' covid' : '';
-
     const isNumerator2Defined = (numerator2 !== null && numerator2?.rawValue > 0);
 
     const verticalTooltipOffset = isCaresReleased
@@ -146,7 +144,7 @@ const RectanglePercentViz = ({
         // we dont render a bar using the improper object, just the label.
         if (data.improper) return null;
         const barProps = {
-            spendingCategory: `${data.className}${classNameForCovid}`,
+            spendingCategory: `${data.className}`,
             barWrapperStyles: {
                 padding: (data.isImproper || !isNested) ? '0' : nestedBarStyles.padding,
                 width: data.barWidthOverrides
@@ -187,12 +185,12 @@ const RectanglePercentViz = ({
         .map((child) => {
             if (position === 'top') {
                 return (
-                    <div className={`award-amounts-viz__desc-container ${position}${classNameForCovid}`}>
+                    <div className={`award-amounts-viz__desc-container ${position}`}>
                         {child?.improper &&
                             <div className="improper">
                                 <BarValue
                                     spendingCategory={child.className}
-                                    className={`award-amounts-viz__desc ${position}${classNameForCovid}`}
+                                    className={`award-amounts-viz__desc ${position}`}
                                     onLeave={closeTooltip}
                                     onEnter={() => showTooltip(
                                         child.tooltipData,
@@ -203,7 +201,7 @@ const RectanglePercentViz = ({
                                     title={child.text} />
                                 <BarValue
                                     spendingCategory={child.improper.className}
-                                    className={`award-amounts-viz__desc ${position}${classNameForCovid}`}
+                                    className={`award-amounts-viz__desc ${position}`}
                                     onLeave={closeTooltip}
                                     onEnter={() => showTooltip(
                                         child.improper.tooltipData,
@@ -217,7 +215,7 @@ const RectanglePercentViz = ({
                         {!child.improper &&
                             <BarValue
                                 spendingCategory={child.className}
-                                className={`award-amounts-viz__desc ${position}${classNameForCovid}`}
+                                className={`award-amounts-viz__desc ${position}`}
                                 onLeave={closeTooltip}
                                 onEnter={() => showTooltip(
                                     child.tooltipData,
@@ -229,8 +227,8 @@ const RectanglePercentViz = ({
                         {child.rawValue > 0 &&
                             <BarLabelAndLine
                                 spendingCategory={child.className}
-                                labelClassName={`award-amounts-viz__label${classNameForCovid}`}
-                                lineClassName={`award-amounts-viz__line ${position}${classNameForCovid}`}
+                                labelClassName={`award-amounts-viz__label`}
+                                lineClassName={`award-amounts-viz__line ${position}`}
                                 lineStyles={{
                                     backgroundColor: child.color,
                                     width: generatePercentage(child.rawValue / denominator.rawValue)
@@ -253,12 +251,12 @@ const RectanglePercentViz = ({
             );
 
             return (
-                <div className={`award-amounts-viz__desc-container ${position}${classNameForCovid}`}>
+                <div className={`award-amounts-viz__desc-container ${position}`}>
                     {!isBarAbsent &&
                         <BarLabelAndLine
                             spendingCategory={child.className}
-                            labelClassName={`award-amounts-viz__label${classNameForCovid}`}
-                            lineClassName={`award-amounts-viz__line ${position}${classNameForCovid}`}
+                            labelClassName={`award-amounts-viz__label`}
+                            lineClassName={`award-amounts-viz__line ${position}`}
                             lineStyles={{
                                 backgroundColor: child.color,
                                 width: child?.barWidthOverrides?.applyToLine
@@ -268,7 +266,7 @@ const RectanglePercentViz = ({
                             <BarValue
                                 spendingCategory={child.className}
                                 style={{ width: child.labelSortOrder === 0 ? '100%' : generatePercentage(child.rawValue / denominator.rawValue) }}
-                                className={`award-amounts-viz__desc ${position}${classNameForCovid}`}
+                                className={`award-amounts-viz__desc ${position}`}
                                 onLeave={closeTooltip}
                                 onEnter={(e) => {
                                     e.stopPropagation();
@@ -285,7 +283,7 @@ const RectanglePercentViz = ({
                     {isBarAbsent &&
                         <BarValue
                             spendingCategory={child.className}
-                            className={`award-amounts-viz__desc ${position}${classNameForCovid}`}
+                            className={`award-amounts-viz__desc ${position}`}
                             onLeave={closeTooltip}
                             onEnter={(e) => {
                                 e.stopPropagation();

--- a/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
@@ -127,6 +127,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
             text: awardType === 'idv'
                 ? "Combined Potential Award Amounts"
                 : "Potential Award Amount",
+            lineOffset: 0,
             tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'potential', data)
         },
         numerator: {
@@ -137,6 +138,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
             rawValue: data._baseExercisedOptions,
             denominatorValue: data._totalObligation,
             value: data.baseExercisedOptionsAbbreviated,
+            lineOffset: lineOffsetsBySpendingCategory.current,
             text: awardType === 'idv'
                 ? "Combined Current Award Amounts"
                 : "Current Award Amount",
@@ -144,10 +146,11 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
             children: [{
                 labelSortOrder: 0,
                 labelPosition: 'top',
-                className: `${awardType}-obligated`,
+                className: `${awardType}-overspending-obligated`,
                 rawValue: data._totalObligation,
                 denominatorValue: data._baseAndAllOptions,
                 value: data.totalObligationAbbreviated,
+                lineOffset: lineOffsetsBySpendingCategory.obligationProcurement,
                 text: awardType === 'idv'
                     ? "Combined Obligated Amounts"
                     : "Obligated Amount",
@@ -156,7 +159,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
                 improper: {
                     labelSortOrder: 1,
                     labelPosition: 'hide',
-                    className: `${awardType}-overspending-obligated`,
+                    className: `${awardType}-overspending`,
                     rawValue: data._totalObligation,
                     denominatorValue: data._baseAndAllOptions,
                     value: data.overspendingAbbreviated,

--- a/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
@@ -433,6 +433,7 @@ const AwardAmountsChart = ({
                     rawValue: awardAmounts._totalFunding,
                     value: awardAmounts.totalFundingAbbreviated,
                     color: `#FFF`,
+                    lineOffset: 0,
                     text: `Total Funding`,
                     tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'totalFunding', awardAmounts)
                 },
@@ -444,6 +445,7 @@ const AwardAmountsChart = ({
                     rawValue: awardAmounts._totalObligation,
                     denominatorValue: awardAmounts._totalFunding,
                     value: awardAmounts.totalObligationAbbreviated,
+                    lineOffset: lineOffsetsBySpendingCategory.obligationAsst,
                     text: 'Obligated Amount',
                     color: obligatedColor
                 },
@@ -454,6 +456,7 @@ const AwardAmountsChart = ({
                     // fudging this for to get the correct tooltip position.
                     rawValue: awardAmounts._nonFederalFunding + awardAmounts._totalObligation,
                     denominatorValue: awardAmounts._totalFunding,
+                    lineOffset: lineOffsetsBySpendingCategory.nonFederalFunding,
                     barWidthOverrides: {
                         applyToLine: true,
                         rawValue: awardAmounts._nonFederalFunding,
@@ -476,12 +479,14 @@ const AwardAmountsChart = ({
                         rawValue: awardAmounts._fileCObligated,
                         denominatorValue: awardAmounts._totalObligation,
                         value: awardAmounts.fileCObligatedAbbreviated,
+                        lineOffset: lineOffsetsBySpendingCategory.fileCAsstObligation,
                         text: 'COVID-19 Response Obligations Amount',
                         color: covidObligatedColor,
                         children: [{
                             labelSortOrder: 0,
                             labelPosition: 'bottom',
                             className: `${awardAmounts._fileCOutlay > 0 ? `asst-file-c-outlay` : `asst-file-c-outlay--zero`}`,
+                            lineOffset: lineOffsetsBySpendingCategory.fileCAsstOutlay,
                             tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'fileCOutlay', awardAmounts),
                             denominatorValue: awardAmounts._fileCObligated,
                             rawValue: awardAmounts._fileCOutlay,

--- a/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
@@ -9,7 +9,9 @@ import {
     potentialColor,
     nonFederalFundingColor,
     subsidyColor,
-    faceValueColor
+    faceValueColor,
+    // Offsets per DEV-5242:
+    barLabelAndLineOffsetsBySpendingCategory
 } from 'dataMapping/award/awardAmountsSection';
 import { covidColor, covidObligatedColor } from 'dataMapping/covid19/covid19';
 import RectanglePercentViz from 'components/award/financialAssistance/RectanglePercentViz';

--- a/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
@@ -252,6 +252,7 @@ const buildExceedsPotentialProps = (awardType, data, hasFileC) => {
                 : "Obligated Amount",
             color: `transparent`,
             tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'obligated', data),
+            lineOffset: lineOffsetsBySpendingCategory.obligationProcurement,
             improper: {
                 labelSortOrder: 1,
                 labelPosition: 'hide',
@@ -274,6 +275,7 @@ const buildExceedsPotentialProps = (awardType, data, hasFileC) => {
             rawValue: data._baseAndAllOptions,
             denominatorValue: data._totalObligation,
             value: data.baseExercisedOptionsAbbreviated,
+            lineOffset: 0,
             text: null,
             color: potentialColor,
             children: [
@@ -289,7 +291,8 @@ const buildExceedsPotentialProps = (awardType, data, hasFileC) => {
                     text: awardType === 'idv'
                         ? "Combined Current Award Amounts"
                         : "Current Award Amount",
-                    color: obligatedColor
+                    color: obligatedColor,
+                    lineOffset: lineOffsetsBySpendingCategory.current
                 },
                 {
                     className: `${awardType}-extreme-overspending-potential`,
@@ -300,6 +303,7 @@ const buildExceedsPotentialProps = (awardType, data, hasFileC) => {
                     denominatorValue: data._totalObligation,
                     value: data.baseAndAllOptionsAbbreviated,
                     color: obligatedColor,
+                    lineOffset: 0,
                     barWidthOverrides: {
                         rawValue: data._baseAndAllOptions - data._baseExercisedOptions,
                         denominatorValue: data._baseAndAllOptions

--- a/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
@@ -11,7 +11,7 @@ import {
     subsidyColor,
     faceValueColor,
     // Offsets per DEV-5242:
-    barLabelAndLineOffsetsBySpendingCategory
+    lineOffsetsBySpendingCategory
 } from 'dataMapping/award/awardAmountsSection';
 import { covidColor, covidObligatedColor } from 'dataMapping/covid19/covid19';
 import RectanglePercentViz from 'components/award/financialAssistance/RectanglePercentViz';
@@ -38,6 +38,7 @@ const buildNormalProps = (awardType, data, hasFileC) => {
             rawValue: data._baseAndAllOptions,
             value: data.baseAndAllOptionsAbbreviated,
             color: potentialColor,
+            lineOffset: lineOffsetsBySpendingCategory.potential,
             text: awardType === 'idv'
                 ? "Combined Potential Award Amounts"
                 : "Potential Award Amount",
@@ -51,6 +52,7 @@ const buildNormalProps = (awardType, data, hasFileC) => {
             rawValue: data._baseExercisedOptions,
             denominatorValue: data._baseAndAllOptions,
             value: data.baseExercisedOptionsAbbreviated,
+            lineOffset: lineOffsetsBySpendingCategory.current,
             text: awardType === 'idv'
                 ? "Combined Current Award Amounts"
                 : "Current Award Amount",
@@ -67,7 +69,8 @@ const buildNormalProps = (awardType, data, hasFileC) => {
                         ? "Combined Obligated Amounts"
                         : "Obligated Amount",
                     color: obligatedColor,
-                    tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'obligated', data)
+                    tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'obligated', data),
+                    lineOffset: lineOffsetsBySpendingCategory.obligationProcurement
                 }
             ]
         }
@@ -91,6 +94,7 @@ const buildNormalProps = (awardType, data, hasFileC) => {
                         value: data.fileCObligatedAbbreviated,
                         text: 'COVID-19 Response Obligations Amount',
                         color: covidObligatedColor,
+                        lineOffset: lineOffsetsBySpendingCategory.fileCProcurementObligated,
                         children: [{
                             labelSortOrder: 0,
                             labelPosition: 'bottom',
@@ -100,7 +104,8 @@ const buildNormalProps = (awardType, data, hasFileC) => {
                             rawValue: data._fileCOutlay,
                             value: data.fileCOutlayAbbreviated,
                             text: 'COVID-19 Response Outlay Amount',
-                            color: covidColor
+                            color: covidColor,
+                            lineOffset: lineOffsetsBySpendingCategory.fileCProcurementOutlay
                         }]
                     }
                 ]
@@ -374,7 +379,11 @@ const buildExceedsPotentialProps = (awardType, data, hasFileC) => {
     };
 };
 
-const AwardAmountsChart = ({ awardType, awardOverview, spendingScenario }) => {
+const AwardAmountsChart = ({
+    awardType,
+    awardOverview,
+    spendingScenario
+}) => {
     const renderChartBySpendingScenario = (
         scenario = spendingScenario,
         type = awardType,

--- a/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
@@ -510,6 +510,7 @@ const AwardAmountsChart = ({
                     className: `${awardType}-subsidy`,
                     rawValue: awardAmounts._subsidy,
                     value: awardAmounts.subsidyAbbreviated,
+                    lineOffset: lineOffsetsBySpendingCategory.subsidy,
                     text: 'Original Subsidy Cost',
                     tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory('loan', 'subsidy', awardAmounts),
                     color: subsidyColor
@@ -520,6 +521,7 @@ const AwardAmountsChart = ({
                     className: `${awardType}-face-value`,
                     rawValue: awardAmounts._faceValue,
                     value: awardAmounts.faceValueAbbreviated,
+                    lineOffset: lineOffsetsBySpendingCategory.faceValue,
                     color: faceValueColor,
                     text: 'Face Value of Direct Loan',
                     tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory('loan', 'faceValue', awardAmounts)
@@ -538,6 +540,7 @@ const AwardAmountsChart = ({
                             text: 'COVID-19 Response Obligations Amount',
                             className: `loan-file-c-obligated`,
                             denominatorValue: awardAmounts._subsidy,
+                            lineOffset: lineOffsetsBySpendingCategory.loanFileCObligated,
                             color: covidObligatedColor,
                             tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory('loan', 'fileCObligated', awardAmounts),
                             children: [{
@@ -547,6 +550,7 @@ const AwardAmountsChart = ({
                                 rawValue: awardAmounts._fileCOutlay,
                                 value: awardAmounts.fileCOutlayAbbreviated,
                                 denominatorValue: awardAmounts._fileCObligated,
+                                lineOffset: lineOffsetsBySpendingCategory.loanFileCOutlay,
                                 text: 'COVID-19 Response Outlay Amount',
                                 color: covidColor,
                                 tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory('loan', 'fileCOutlay', awardAmounts)

--- a/src/js/components/award/shared/awardAmountsSection/charts/SharedBarComponents.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/charts/SharedBarComponents.jsx
@@ -50,26 +50,23 @@ const Bar = ({
     onLeave,
     barWrapperStyles = {},
     barStyles
-}) => {
-    if (barWrapperStyles.width === "0.00%") return null;
-    return (
-        <div
-            role="button"
-            tabIndex="0"
-            style={barWrapperStyles}
-            className={`award-amounts-viz__bar-wrapper ${spendingCategory}`}
-            onBlur={onLeave}
-            onFocus={onEnter}
-            onKeyPress={onEnter}
-            onMouseEnter={onEnter}
-            onMouseLeave={onLeave}
-            onClick={onEnter}>
-            <div className={`${className} ${spendingCategory}`} style={barStyles}>
-                {children}
-            </div>
+}) => (
+    <div
+        role="button"
+        tabIndex="0"
+        style={barWrapperStyles}
+        className={`award-amounts-viz__bar-wrapper ${spendingCategory}`}
+        onBlur={onLeave}
+        onFocus={onEnter}
+        onKeyPress={onEnter}
+        onMouseEnter={onEnter}
+        onMouseLeave={onLeave}
+        onClick={onEnter}>
+        <div className={`${className} ${spendingCategory}`} style={barStyles}>
+            {children}
         </div>
-    );
-};
+    </div>
+);
 
 Bar.propTypes = {
     className: PropTypes.string,

--- a/src/js/components/award/shared/awardAmountsSection/charts/SharedBarComponents.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/charts/SharedBarComponents.jsx
@@ -37,7 +37,7 @@ const BarLabelAndLine = ({
     labelClassName = 'award-amounts-viz__label'
 }) => (
     <div className={`${labelClassName} ${spendingCategory}`} style={labelStyles}>
-        <div className={`${lineClassName} ${spendingCategory}`} style={lineStyles} />
+        <div className={`${lineClassName} ${spendingCategory}`} style={{ ...lineStyles, minWidth: '4px' }} />
         {children}
     </div>
 );
@@ -50,23 +50,26 @@ const Bar = ({
     onLeave,
     barWrapperStyles = {},
     barStyles
-}) => (
-    <div
-        role="button"
-        tabIndex="0"
-        style={barWrapperStyles}
-        className={`award-amounts-viz__bar-wrapper ${spendingCategory}`}
-        onBlur={onLeave}
-        onFocus={onEnter}
-        onKeyPress={onEnter}
-        onMouseEnter={onEnter}
-        onMouseLeave={onLeave}
-        onClick={onEnter}>
-        <div className={`${className} ${spendingCategory}`} style={barStyles}>
-            {children}
+}) => {
+    if (barWrapperStyles.width === "0.00%") return null;
+    return (
+        <div
+            role="button"
+            tabIndex="0"
+            style={barWrapperStyles}
+            className={`award-amounts-viz__bar-wrapper ${spendingCategory}`}
+            onBlur={onLeave}
+            onFocus={onEnter}
+            onKeyPress={onEnter}
+            onMouseEnter={onEnter}
+            onMouseLeave={onLeave}
+            onClick={onEnter}>
+            <div className={`${className} ${spendingCategory}`} style={barStyles}>
+                {children}
+            </div>
         </div>
-    </div>
-);
+    );
+};
 
 Bar.propTypes = {
     className: PropTypes.string,

--- a/src/js/dataMapping/award/awardAmountsSection.js
+++ b/src/js/dataMapping/award/awardAmountsSection.js
@@ -130,9 +130,11 @@ export const lineOffsetsBySpendingCategory = {
     totalFunding: defaultPadding,
     nonFederalFunding: defaultPadding,
     faceValue: defaultPadding,
+    current: defaultPadding,
+    potential: 0,
     // cannot understand why we have to divide this by two...!!!???
     fileCProcurementObligated: (defaultPadding + (additionalPadding * 2)) / 2,
     fileCProcurementOutlay: (defaultPadding + (additionalPadding * 3)) / 2,
-    current: defaultPadding,
-    potential: 0
+    fileCAsstObligation: defaultPadding + (additionalPadding * 1),
+    fileCAsstOutlay: defaultPadding + (additionalPadding * 2)
 };

--- a/src/js/dataMapping/award/awardAmountsSection.js
+++ b/src/js/dataMapping/award/awardAmountsSection.js
@@ -116,3 +116,22 @@ export const potentialColor = '#AAC6E2';
 export const subsidyColor = '#0B424D';
 export const faceValueColor = '#F3F3F3';
 export const nonFederalFundingColor = '#47AAA7';
+
+// Offsets per DEV-5242:
+// 5px horizontal padding (border + padding) on each side.
+const defaultPadding = 10;
+// 2px of padding on each side
+const additionalPadding = 4;
+// Default padding + (additionalPadding * levels nested)
+const barLabelAndLineOffsetsBySpendingCategory = {
+    obligationProcurment: defaultPadding + (additionalPadding * 2),
+    obligationAsst: defaultPadding,
+    subsidy: defaultPadding,
+    totalFunding: defaultPadding,
+    nonFederalFunding: defaultPadding,
+    faceValue: defaultPadding,
+    fileCProcurmentObligated: defaultPadding + (additionalPadding * 3),
+    fileCProcurmentOutlay: defaultPadding + (additionalPadding * 4),
+    current: defaultPadding + additionalPadding,
+    potential: defaultPadding
+};

--- a/src/js/dataMapping/award/awardAmountsSection.js
+++ b/src/js/dataMapping/award/awardAmountsSection.js
@@ -126,15 +126,18 @@ const additionalPadding = 4;
 export const lineOffsetsBySpendingCategory = {
     obligationProcurement: defaultPadding + (additionalPadding * 1),
     obligationAsst: defaultPadding,
-    subsidy: defaultPadding,
+    // mark up for loans is a bit different.
+    subsidy: 3,
     totalFunding: defaultPadding,
     nonFederalFunding: defaultPadding,
-    faceValue: defaultPadding,
+    faceValue: 0,
     current: defaultPadding,
     potential: 0,
     // cannot understand why we have to divide this by two...!!!???
     fileCProcurementObligated: (defaultPadding + (additionalPadding * 2)) / 2,
     fileCProcurementOutlay: (defaultPadding + (additionalPadding * 3)) / 2,
     fileCAsstObligation: defaultPadding + (additionalPadding * 1),
-    fileCAsstOutlay: defaultPadding + (additionalPadding * 2)
+    fileCAsstOutlay: defaultPadding + (additionalPadding * 2),
+    loanFileCObligated: 7,
+    loanFileCOutlay: 9
 };

--- a/src/js/dataMapping/award/awardAmountsSection.js
+++ b/src/js/dataMapping/award/awardAmountsSection.js
@@ -118,20 +118,21 @@ export const faceValueColor = '#F3F3F3';
 export const nonFederalFundingColor = '#47AAA7';
 
 // Offsets per DEV-5242:
-// 5px horizontal padding (border + padding) on each side.
-const defaultPadding = 10;
-// 2px of padding on each side
+// 3px padding between outermost bar and first nested bar
+const defaultPadding = 6;
+// 2px of padding for each additional nested bar
 const additionalPadding = 4;
-// Default padding + (additionalPadding * levels nested)
-const barLabelAndLineOffsetsBySpendingCategory = {
-    obligationProcurment: defaultPadding + (additionalPadding * 2),
+// offset = defaultPadding + (additionalPadding * levels nested relative to outermost bar)
+export const lineOffsetsBySpendingCategory = {
+    obligationProcurement: defaultPadding + (additionalPadding * 1),
     obligationAsst: defaultPadding,
     subsidy: defaultPadding,
     totalFunding: defaultPadding,
     nonFederalFunding: defaultPadding,
     faceValue: defaultPadding,
-    fileCProcurmentObligated: defaultPadding + (additionalPadding * 3),
-    fileCProcurmentOutlay: defaultPadding + (additionalPadding * 4),
-    current: defaultPadding + additionalPadding,
-    potential: defaultPadding
+    // cannot understand why we have to divide this by two...!!!???
+    fileCProcurementObligated: (defaultPadding + (additionalPadding * 2)) / 2,
+    fileCProcurementOutlay: (defaultPadding + (additionalPadding * 3)) / 2,
+    current: defaultPadding,
+    potential: 0
 };

--- a/src/js/helpers/apiRequest.js
+++ b/src/js/helpers/apiRequest.js
@@ -5,15 +5,15 @@
 
 import Axios, { CancelToken } from 'axios';
 
+import kGlobalConstants from 'GlobalConstants';
+
 const mockUrl = `http://localhost:5000/api/`;
 const localUrl = `http://localhost:8000/api/`;
 
 const getBaseUrl = (params) => {
     if (params.isMocked) return mockUrl;
     if (params.isLocal) return localUrl;
-    // return kGlobalConstants.API;
-    // DEV-5242: Can find good awards via advanced search.
-    return 'https://qat-api.usaspending.gov/api/';
+    return kGlobalConstants.API;
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/js/helpers/apiRequest.js
+++ b/src/js/helpers/apiRequest.js
@@ -4,7 +4,6 @@
  **/
 
 import Axios, { CancelToken } from 'axios';
-import kGlobalConstants from 'GlobalConstants';
 
 const mockUrl = `http://localhost:5000/api/`;
 const localUrl = `http://localhost:8000/api/`;
@@ -12,7 +11,9 @@ const localUrl = `http://localhost:8000/api/`;
 const getBaseUrl = (params) => {
     if (params.isMocked) return mockUrl;
     if (params.isLocal) return localUrl;
-    return kGlobalConstants.API;
+    // return kGlobalConstants.API;
+    // DEV-5242: Can find good awards via advanced search.
+    return 'https://qat-api.usaspending.gov/api/';
 };
 
 // eslint-disable-next-line import/prefer-default-export


### PR DESCRIPTION
**High level description:**
The award amounts viz works but the lines drawn to outline the bars in the description do not consider the padding or nested position of the bars.

**Technical details:**
For each award type and each spending category, I have a value for the approximate amount of padding. I apply that padding to the line via a margin and the width of the line.

I have an object that stores these values in a dataMapping file.

Admittedly, the exact padding does not always look right so I have done some hacking here to just make it look right.

Here's a contrast for comparison:

QAT:
![image](https://user-images.githubusercontent.com/12897813/87995380-5613f680-cabd-11ea-8503-72b86557f21e.png)
LOCAL:
![image](https://user-images.githubusercontent.com/12897813/87995516-b9058d80-cabd-11ea-920f-f2440fd6cd73.png)


**JIRA Ticket:**
[DEV-5242](https://federal-spending-transparency.atlassian.net/browse/DEV-5242)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
