### PR TITLE
DEV-5628 & DEV-5645 summary insight labels & order

### DIFF
--- a/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
+++ b/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
@@ -150,7 +150,7 @@ const AwardSpendingAgency = () => {
                     <OverviewData
                         key={data.label}
                         {...data}
-                        subtitle={`for all ${activeTab.subtitle}`}
+                        subtitle={`for All ${activeTab.subtitle}`}
                         amount={amounts[data.type]} />
                 ))}
             </div>

--- a/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
+++ b/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
@@ -19,13 +19,13 @@ const overviewData = [
         label: 'Number of Agencies'
     },
     {
-        type: 'awardOutlays',
-        label: 'Award Outlays',
+        type: 'awardObligations',
+        label: 'Award Obligations',
         dollarAmount: true
     },
     {
-        type: 'awardObligations',
-        label: 'Award Obligations',
+        type: 'awardOutlays',
+        label: 'Award Outlays',
         dollarAmount: true
     },
     {

--- a/src/js/containers/covid19/SummaryInsightsContainer.jsx
+++ b/src/js/containers/covid19/SummaryInsightsContainer.jsx
@@ -59,13 +59,18 @@ const SummaryInsightsContainer = ({ activeTab, resultsCount, overviewData }) => 
         numberOfAwards
     };
 
+    let subtitle = `for All ${(awardTypeGroupLabels[activeTab] || 'Awards')}`;
+    if (activeTab === 'other') {
+        subtitle = 'for All Other Financial Assistance';
+    }
+
     return (
         <div className="overview-data-group">
             {overviewData.map((data) => (
                 <OverviewData
                     key={data.label}
                     {...data}
-                    subtitle={`for all ${(awardTypeGroupLabels[activeTab] || 'awards').toLowerCase()}`}
+                    subtitle={subtitle}
                     amount={amounts[data.type]} />
             ))}
         </div>

--- a/src/js/containers/covid19/recipient/SummaryInsightsContainer.jsx
+++ b/src/js/containers/covid19/recipient/SummaryInsightsContainer.jsx
@@ -79,13 +79,18 @@ const SummaryInsightsContainer = ({ activeFilter }) => {
         numberOfAwards
     };
 
+    let subtitle = `for All ${(awardTypeGroupLabels[activeFilter] || 'Awards')}`;
+    if (activeFilter === 'other') {
+        subtitle = 'for All Other Financial Assistance';
+    }
+
     return (
         <div className="overview-data-group">
             {overviewData.map((data) => (
                 <OverviewData
                     key={data.label}
                     {...data}
-                    subtitle={`for all ${(awardTypeGroupLabels[activeFilter] || 'awards').toLowerCase()}`}
+                    subtitle={subtitle}
                     amount={amounts[data.type]} />
             ))}
         </div>

--- a/src/js/dataMapping/covid19/covid19.js
+++ b/src/js/dataMapping/covid19/covid19.js
@@ -275,7 +275,7 @@ export const spendingTableSortFields = {
 export const financialAssistanceTabs = [
     {
         internal: 'all',
-        label: 'All Awards'
+        label: 'Awards'
     },
     {
         internal: 'grants',
@@ -298,7 +298,7 @@ export const financialAssistanceTabs = [
 export const awardTypeTabs = [
     {
         internal: 'all',
-        label: 'All Awards'
+        label: 'Awards'
     },
     {
         internal: 'grants',


### PR DESCRIPTION
**High level description:**
On the COVID-19 Profile page:
- Capitalizes summary insight subtitles (e.g. `for all grants` -> `for All Grants`)
- Changes subtitle `for all other` to `for All Other Financial Assistance`
- Fixes a bug where the all awards tab was displaying `all All Awards`
- Fixes the order of Obligations and Outlays in the Award Spending by Agency section

**JIRA Ticket:**
[DEV-5628](https://federal-spending-transparency.atlassian.net/browse/DEV-5628) & [DEV-5645](https://federal-spending-transparency.atlassian.net/browse/DEV-5645)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA tickets
- N/A (text changes only) Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- N/A (text changes only) Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Code review complete
