### PR TITLE
DEV-5639 fix sorting by first column

### DIFF
--- a/src/js/containers/covid19/assistanceListing/SpendingByCFDAContainer.jsx
+++ b/src/js/containers/covid19/assistanceListing/SpendingByCFDAContainer.jsx
@@ -26,7 +26,7 @@ const propTypes = { activeTab: PropTypes.string.isRequired };
 
 const columns = [
     {
-        title: 'assistanceListing',
+        title: 'name',
         displayName: (
             <>
                 <div>CFDA Program</div>

--- a/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
+++ b/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
@@ -5,7 +5,6 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import { snakeCase } from 'lodash';
 import { isCancel } from 'axios';
 import ResultsTableLoadingMessage from 'components/search/table/ResultsTableLoadingMessage';
 import ResultsTableErrorMessage from 'components/search/table/ResultsTableErrorMessage';
@@ -211,7 +210,7 @@ const AwardSpendingAgencyTableContainer = (props) => {
                     pagination: {
                         limit: pageSize,
                         page: currentPage,
-                        sort: snakeCase(sort),
+                        sort: spendingTableSortFields[sort],
                         order
                     },
                     spending_type: 'award'

--- a/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
+++ b/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
@@ -11,6 +11,7 @@ import ResultsTableLoadingMessage from 'components/search/table/ResultsTableLoad
 import ResultsTableErrorMessage from 'components/search/table/ResultsTableErrorMessage';
 import PropTypes from 'prop-types';
 import { Table, Pagination } from 'data-transparency-ui';
+import { spendingTableSortFields } from 'dataMapping/covid19/covid19';
 import { awardTypeGroups } from 'dataMapping/search/awardType';
 import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import { fetchAwardSpendingByAgency, fetchLoansByAgency } from 'helpers/disasterHelper';
@@ -179,7 +180,7 @@ const AwardSpendingAgencyTableContainer = (props) => {
                     pagination: {
                         limit: pageSize,
                         page: currentPage,
-                        sort: snakeCase(sort),
+                        sort: spendingTableSortFields[sort],
                         order
                     },
                     spending_type: 'award'
@@ -193,7 +194,7 @@ const AwardSpendingAgencyTableContainer = (props) => {
                     pagination: {
                         limit: pageSize,
                         page: currentPage,
-                        sort: snakeCase(sort),
+                        sort: spendingTableSortFields[sort],
                         order
                     },
                     spending_type: 'award'

--- a/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
+++ b/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
@@ -14,14 +14,15 @@ import {
     budgetColumns,
     budgetDropdownFieldValues,
     budgetCategoriesCssMappingTypes,
-    budgetCategoriesSort,
+    defaultSort,
+    budgetCategoriesNameSort,
     apiSpendingTypes
 } from 'dataMapping/covid19/budgetCategories/BudgetCategoriesTableColumns';
 import { fetchDisasterSpending, fetchLoanSpending } from 'helpers/disasterHelper';
 import ResultsTableLoadingMessage from 'components/search/table/ResultsTableLoadingMessage';
 import ResultsTableErrorMessage from 'components/search/table/ResultsTableErrorMessage';
 import BaseBudgetCategoryRow from 'models/v2/covid19/BaseBudgetCategoryRow';
-import { BudgetCategoriesInfo } from '../../../components/award/shared/InfoTooltipContent';
+import { BudgetCategoriesInfo } from 'components/award/shared/InfoTooltipContent';
 
 
 const propTypes = {
@@ -124,7 +125,6 @@ const BudgetCategoriesTableContainer = (props) => {
     const [currentPage, changeCurrentPage] = useState(1);
     const [pageSize, changePageSize] = useState(10);
     const [totalItems, setTotalItems] = useState(0);
-    const [sortAndOrder, setSortAndOrder] = useState(budgetCategoriesSort);
     const [sort, setSort] = useState('totalBudgetaryResources');
     const [order, setOrder] = useState('desc');
     const updateSort = (field, direction) => {
@@ -137,7 +137,6 @@ const BudgetCategoriesTableContainer = (props) => {
     const [spendingCategory, setSpendingCategory] = useState("total_spending");
     const [request, setRequest] = useState(null);
     const defCodes = useSelector((state) => state.covid19.defCodes);
-
 
     const parseSpendingDataAndSetResults = (data) => {
         const parsedData = data.map((item) => {
@@ -213,10 +212,8 @@ const BudgetCategoriesTableContainer = (props) => {
         }
 
         setLoading(true);
-        if (defCodes && defCodes.length > 0 && spendingCategory && sortAndOrder) {
-            // if type is agency then sort name column by description
-            const sortMap = props.type === 'agency' && sortAndOrder[props.type][spendingCategory].sort === 'name' ? 'description' : snakeCase([sortAndOrder[props.type][spendingCategory].sort]);
-
+        if (defCodes && defCodes.length > 0 && spendingCategory) {
+            const apiSortField = sort === 'name' ? budgetCategoriesNameSort[props.type] : snakeCase(sort);
             if (spendingCategory === 'loan_spending') {
                 const params = {
                     filter: {
@@ -225,8 +222,8 @@ const BudgetCategoriesTableContainer = (props) => {
                     pagination: {
                         limit: pageSize,
                         page: currentPage,
-                        sort: sortMap,
-                        order: sortAndOrder[props.type][spendingCategory].order
+                        sort: apiSortField,
+                        order
                     }
                 };
                 const requestLoanSpending = fetchLoanSpending(props.type, params);
@@ -254,8 +251,8 @@ const BudgetCategoriesTableContainer = (props) => {
                     pagination: {
                         limit: pageSize,
                         page: currentPage,
-                        sort: sortMap,
-                        order: sortAndOrder[props.type][spendingCategory].order
+                        sort: apiSortField,
+                        order
                     }
                 };
                 const disasterSpendingRequest = fetchDisasterSpending(props.type, params);
@@ -278,55 +275,17 @@ const BudgetCategoriesTableContainer = (props) => {
         }
     });
 
-    const setSortAndOrderCallback = useCallback(() => {
-        const tabCategory = Object.keys(sortAndOrder).filter((key) => key === props.type)[0];
-        const dropdownCategory = Object.keys(sortAndOrder[tabCategory]).filter((val) => val === spendingCategory)[0];
-        if (tabCategory && dropdownCategory) {
-            const categoryName = tabCategory;
-            const dropdownCategoryName = dropdownCategory;
-            const slice = sortAndOrder[categoryName][dropdownCategoryName];
-            setSort(slice.sort);
-            setOrder(slice.order);
-        }
-    });
-
-    const storeSortAndOrderObjectCallback = useCallback(() => {
-        const tabCategory = Object.keys(sortAndOrder).filter((key) => key === props.type);
-        const dropdownCategory = Object.keys(sortAndOrder[tabCategory]).filter((val) => val === spendingCategory);
-
-        if (tabCategory && dropdownCategory) {
-            const categoryName = tabCategory[0];
-            const dropdownCategoryName = dropdownCategory[0];
-
-            const modifiedSortObj = {
-                ...sortAndOrder,
-                [categoryName]: {
-                    ...sortAndOrder[categoryName],
-                    [dropdownCategoryName]: {
-                        sort,
-                        order
-                    }
-                }
-
-            };
-            setSortAndOrder(modifiedSortObj);
-        }
-    });
-
-
     useEffect(() => {
-        setSortAndOrderCallback();
+        // Reset to default sort when the active tab or spending category changes
+        setSort(defaultSort[props.type][spendingCategory].sort);
+        setOrder(defaultSort[props.type][spendingCategory].order);
     }, [props.type, spendingCategory]);
-
-    useEffect(() => {
-        storeSortAndOrderObjectCallback();
-    }, [sort, order]);
 
     useEffect(() => {
         // Reset to the first page
         changeCurrentPage(1);
         fetchBudgetSpendingCallback();
-    }, [props.type, pageSize, sortAndOrder, defCodes]);
+    }, [props.type, pageSize, defCodes, sort, order]);
 
     useEffect(() => {
         fetchBudgetSpendingCallback();

--- a/src/js/containers/covid19/recipient/SpendingByRecipientContainer.jsx
+++ b/src/js/containers/covid19/recipient/SpendingByRecipientContainer.jsx
@@ -25,7 +25,7 @@ const propTypes = {
 
 const columns = [
     {
-        title: 'recipient',
+        title: 'name',
         displayName: 'Recipient'
     },
     {

--- a/src/js/dataMapping/covid19/budgetCategories/BudgetCategoriesTableColumns.js
+++ b/src/js/dataMapping/covid19/budgetCategories/BudgetCategoriesTableColumns.js
@@ -61,7 +61,7 @@ export const budgetCategoriesCssMappingTypes = {
     object_class: 'object-class'
 };
 
-export const budgetCategoriesSort = {
+export const defaultSort = {
     federal_account: {
         total_spending: {
             sort: 'totalBudgetaryResources',
@@ -104,4 +104,10 @@ export const budgetCategoriesSort = {
             order: 'desc'
         }
     }
+};
+
+export const budgetCategoriesNameSort = {
+    agency: 'description',
+    federal_account: 'code',
+    object_class: 'code'
 };


### PR DESCRIPTION
**High level description:**

Fixes the sort field parameter for the first column in COVID-19 Profile Federal Accounts, Recipients, Agency, and CFDA tables.

**Technical details:**
- Previously, the `pagination.sort` param was being incorrectly passed as `name` or left out because it was `undefined`. The first column generally should correlate to sorting by the API field `description`, except for Budget Categories section -> Federal Accounts and Object Classes tabs, which should sort by `code`. 
- Simplifies `BudgetCategoriesTableContainer` by removing `sortAndOrder` from state, since `sort` and `order` are already stored independently
-  Consistent use of `spendingTableSortFields` data mapping and `name` as the `title` of the first column

**JIRA Ticket:**
[DEV-5639](https://federal-spending-transparency.atlassian.net/browse/DEV-5639)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- N/A Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- N/A Verified mobile/tablet/desktop/monitor responsiveness
- N/A Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Code review complete
