### PR TITLE
DEV-5636 & DEV-5690 Object Class display

### DIFF
--- a/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
+++ b/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
@@ -142,26 +142,13 @@ const BudgetCategoriesTableContainer = (props) => {
     const parseSpendingDataAndSetResults = (data) => {
         const parsedData = data.map((item) => {
             const budgetCategoryRow = Object.create(BaseBudgetCategoryRow);
-            budgetCategoryRow.populate(item);
-
-            // show only description for agency
-            if (props.type === 'agency') {
-                budgetCategoryRow.name = budgetCategoryRow.description;
-            }
+            budgetCategoryRow.populate(item, props.type);
 
             let rowChildren = [];
             if (item.children && item.children.length > 0) {
                 rowChildren = item.children.map((childItem) => {
                     const budgetCategoryChildRow = Object.create(BaseBudgetCategoryRow);
-                    budgetCategoryChildRow.populate(childItem);
-                    // update name of children to not include description, just make the name the code for only federal account
-                    if (props.type === 'federal_account') {
-                        budgetCategoryChildRow.name = budgetCategoryChildRow._code;
-                    } else if (props.type === 'object_class') {
-                        budgetCategoryChildRow.name = `${budgetCategoryChildRow._code} — ${budgetCategoryChildRow.description}`;
-                    } else if (props.type === 'agency') {
-                        budgetCategoryChildRow.name = budgetCategoryChildRow.description;
-                    }
+                    budgetCategoryChildRow.populate(childItem, props.type, true);
                     return budgetCategoryChildRow;
                 });
             }

--- a/src/js/models/v2/covid19/BaseBudgetCategoryRow.js
+++ b/src/js/models/v2/covid19/BaseBudgetCategoryRow.js
@@ -8,18 +8,36 @@ import CoreSpendingTableRow from './CoreSpendingTableRow';
 
 const BaseBudgetCategoryRow = Object.create(CoreSpendingTableRow);
 
-BaseBudgetCategoryRow.populate = function populate(data) {
+BaseBudgetCategoryRow.populate = function populate(data, rowType, isChild = false) {
     // Generate generic object properties using the core model
     this.populateCore(data);
     // Add properties specific to Budget Categories
     this._totalBudgetaryResources = data.total_budgetary_resources || 0;
     this.totalBudgetaryResources = formatMoney(this._totalBudgetaryResources);
-    if (this._code && this.description) {
-        this.name = `${this._code} - ${this.description}`;
+
+    let code = this._code;
+    if (this._code && rowType === 'object_class' && isChild) {
+        // Add a period before the last digit of Object Class codes
+        code = `${code.slice(0, -1)}.${code.slice(-1)}`;
     }
-    else {
-        this.name = `${this._code}${this.description}` || '--';
+    this.code = code;
+
+    let name = this.description;
+
+    if (rowType === 'object_class' || rowType === 'federal_account') {
+        if (isChild && rowType === 'federal_account') {
+            // just display the code for Treasury Accounts
+            name = this.code || '--';
+        }
+        else if (this.code && this.description) {
+            name = `${this.code}: ${this.description}`;
+        }
+        else {
+            name = `${this.code}${this.description}` || '--';
+        }
     }
+
+    this.name = name;
 };
 
 export default BaseBudgetCategoryRow;


### PR DESCRIPTION
**High level description:**

Updates to COVID-19 Profile Budget Category row formatting:

- Add a period to Object Class codes (e.g. `41.0` instead of `410`)
- Separate code and description with a colon instead of a hyphen for Federal Accounts and Object Classes (e.g. `41.0: Grants, subsidies, and contributions` instead of `41.0 - Grants, subsidies, and contributions`)

**Technical details:**

- Moves some of the formatting logic from the container to the model by passing the active tab and boolean indicating a child row to the `populate` method

**JIRA Ticket:**
[DEV-5636](https://federal-spending-transparency.atlassian.net/browse/DEV-5636), [DEV-5690](https://federal-spending-transparency.atlassian.net/browse/DEV-5690)

**Mockup:**
https://bahdigital.invisionapp.com/share/ERIAEJU8Y52

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA tickets
- N/A (text changes only) Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- N/A (text changes only) Verified mobile/tablet/desktop/monitor responsiveness
- N/A (text changes only) Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`

Reviewer(s):
- [ ] Code review complete
