### PR TITLE
DEV-5628 capitalization of 'all' in COVID summary insights

### DIFF
--- a/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
+++ b/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
@@ -150,7 +150,7 @@ const AwardSpendingAgency = () => {
                     <OverviewData
                         key={data.label}
                         {...data}
-                        subtitle={`for All ${activeTab.subtitle}`}
+                        subtitle={`for ${activeTab.internal === 'all' ? 'All' : 'all'} ${activeTab.subtitle}`}
                         amount={amounts[data.type]} />
                 ))}
             </div>

--- a/src/js/containers/covid19/SummaryInsightsContainer.jsx
+++ b/src/js/containers/covid19/SummaryInsightsContainer.jsx
@@ -59,9 +59,9 @@ const SummaryInsightsContainer = ({ activeTab, resultsCount, overviewData }) => 
         numberOfAwards
     };
 
-    let subtitle = `for All ${(awardTypeGroupLabels[activeTab] || 'Awards')}`;
+    let subtitle = `for ${activeTab === 'all' ? 'All' : 'all'} ${(awardTypeGroupLabels[activeTab] || 'Awards')}`;
     if (activeTab === 'other') {
-        subtitle = 'for All Other Financial Assistance';
+        subtitle = 'for all Other Financial Assistance';
     }
 
     return (

--- a/src/js/containers/covid19/recipient/SummaryInsightsContainer.jsx
+++ b/src/js/containers/covid19/recipient/SummaryInsightsContainer.jsx
@@ -79,9 +79,9 @@ const SummaryInsightsContainer = ({ activeFilter }) => {
         numberOfAwards
     };
 
-    let subtitle = `for All ${(awardTypeGroupLabels[activeFilter] || 'Awards')}`;
+    let subtitle = `for ${activeFilter === 'all' ? 'All' : 'all'} ${(awardTypeGroupLabels[activeFilter] || 'Awards')}`;
     if (activeFilter === 'other') {
-        subtitle = 'for All Other Financial Assistance';
+        subtitle = 'for all Other Financial Assistance';
     }
 
     return (


### PR DESCRIPTION
**High level description:**

Per Ross's feedback from demos, lowercase `all` (e.g. `all Grants` etc.) except in the `All Awards` tab.

**JIRA Ticket:**
[DEV-5628](https://federal-spending-transparency.atlassian.net/browse/DEV-5628)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- N/A (text change only) Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- N/A (text change only) Verified mobile/tablet/desktop/monitor responsiveness
- N/A (text change only) Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Code review complete
