### PR TITLE
DEV-5638 losing place

### DIFF
--- a/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
+++ b/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
@@ -3,7 +3,7 @@
  * Created by Lizzie Salita 6/22/20
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { financialAssistanceTabs } from 'dataMapping/covid19/covid19';
 import { awardTypeGroups } from 'dataMapping/search/awardType';
@@ -12,6 +12,7 @@ import MoreOptionsTabs from 'components/sharedComponents/moreOptionsTabs/MoreOpt
 import SummaryInsightsContainer from 'containers/covid19/SummaryInsightsContainer';
 import SpendingByCFDAContainer from 'containers/covid19/assistanceListing/SpendingByCFDAContainer';
 import DateNote from '../DateNote';
+import { scrollIntoView } from '../../../containers/covid19/helpers/scrollHelper';
 
 const overviewData = [
     {
@@ -37,6 +38,7 @@ const overviewData = [
 const SpendingByCFDA = () => {
     const [activeTab, setActiveTab] = useState(financialAssistanceTabs[0].internal);
     const { defCodes } = useSelector((state) => state.covid19);
+    const moreOptionsTabsRef = useRef(null);
 
     const [tabCounts, setTabCounts] = useState({
         all: null,
@@ -81,6 +83,10 @@ const SpendingByCFDA = () => {
         }
     }, [defCodes]);
 
+    const scrollIntoViewTable = (loading, error, errorOrLoadingRef, tableWrapperRef, margin, scrollOptions, startPage, endPage, currentPage) => {
+        scrollIntoView(loading, error, errorOrLoadingRef, tableWrapperRef, margin, scrollOptions, startPage, endPage, currentPage, moreOptionsTabsRef);
+    };
+
     return (
         <div className="body__content assistance-listing">
             <DateNote />
@@ -90,18 +96,21 @@ const SpendingByCFDA = () => {
             <p className="body__narrative-description">
                 The total federal spending for the COVID-19 Response can be divided into different budget categories, including the different agencies that spent funds, the Federal Spending bills and Federal Accounts that funded the Response, and the different types of items and services that were purchased.
             </p>
-            <MoreOptionsTabs
-                tabs={financialAssistanceTabs}
-                tabCounts={tabCounts}
-                pickerLabel="More Award Types"
-                changeActiveTab={changeActiveTab} />
+            <div ref={moreOptionsTabsRef}>
+                <MoreOptionsTabs
+                    tabs={financialAssistanceTabs}
+                    tabCounts={tabCounts}
+                    pickerLabel="More Award Types"
+                    changeActiveTab={changeActiveTab} />
+            </div>
             <SummaryInsightsContainer
                 // pass CFDA count to the summary section so we don't have to make the same API request again
                 resultsCount={tabCounts[activeTab]}
                 activeTab={activeTab}
                 overviewData={overviewData} />
             <SpendingByCFDAContainer
-                activeTab={activeTab} />
+                activeTab={activeTab}
+                scrollIntoView={scrollIntoViewTable} />
         </div>
     );
 };

--- a/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
+++ b/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
@@ -3,7 +3,7 @@
  * Created by James Lee 6/18/20
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { fetchAwardCount, fetchAwardAmounts, fetchAgencyCount } from 'helpers/disasterHelper';
 import DateNote from 'components/covid19/DateNote';
@@ -12,6 +12,7 @@ import { awardTypeGroups } from 'dataMapping/search/awardType';
 import AwardSpendingAgencyTableContainer from 'containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer';
 import MoreOptionsTabs from '../../sharedComponents/moreOptionsTabs/MoreOptionsTabs';
 import OverviewData from '../OverviewData';
+import { scrollIntoView } from '../../../containers/covid19/helpers/scrollHelper';
 
 const overviewData = [
     {
@@ -58,6 +59,7 @@ const AwardSpendingAgency = () => {
     });
 
     const { defCodes } = useSelector((state) => state.covid19);
+    const moreOptionsTabsRef = useRef(null);
 
     useEffect(() => {
         if (defCodes && defCodes.length > 0) {
@@ -137,6 +139,10 @@ const AwardSpendingAgency = () => {
         });
     };
 
+    const scrollIntoViewTable = (loading, error, errorOrLoadingRef, tableWrapperRef, margin, scrollOptions, startPage, endPage, currentPage) => {
+        scrollIntoView(loading, error, errorOrLoadingRef, tableWrapperRef, margin, scrollOptions, startPage, endPage, currentPage, moreOptionsTabsRef);
+    };
+
     return (
         <div className="body__content award-spending">
             <DateNote />
@@ -144,7 +150,9 @@ const AwardSpendingAgency = () => {
             <p className="body__narrative-description">
                 Federal agencies allocate award funds. Agencies receive funding from the Federal Government, which they award to recipients in order to respond to the COVID-19 pandemic.
             </p>
-            <MoreOptionsTabs tabs={awardTypeTabs} tabCounts={tabCounts} pickerLabel="More Award Types" changeActiveTab={changeActiveTab} />
+            <div ref={moreOptionsTabsRef}>
+                <MoreOptionsTabs tabs={awardTypeTabs} tabCounts={tabCounts} pickerLabel="More Award Types" changeActiveTab={changeActiveTab} />
+            </div>
             <div className="overview-data-group">
                 {overviewData.map((data) => (
                     <OverviewData
@@ -155,7 +163,7 @@ const AwardSpendingAgency = () => {
                 ))}
             </div>
             <div className="award-spending__content">
-                <AwardSpendingAgencyTableContainer type={activeTab.internal} subHeading="Sub-Agencies" />
+                <AwardSpendingAgencyTableContainer type={activeTab.internal} subHeading="Sub-Agencies" scrollIntoView={scrollIntoViewTable} />
             </div>
         </div>
     );

--- a/src/js/components/covid19/budgetCategories/BudgetCategories.jsx
+++ b/src/js/components/covid19/budgetCategories/BudgetCategories.jsx
@@ -3,13 +3,14 @@
  * Created by James Lee 6/5/20
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import BudgetCategoriesTableContainer from 'containers/covid19/budgetCategories/BudgetCategoriesTableContainer';
 import DateNote from 'components/covid19/DateNote';
 import { fetchDisasterSpendingCount } from 'helpers/disasterHelper';
 import MoreOptionsTabs from '../../sharedComponents/moreOptionsTabs/MoreOptionsTabs';
 import OverviewData from '../OverviewData';
+import { scrollIntoView } from '../../../containers/covid19/helpers/scrollHelper';
 
 
 const tabs = [
@@ -33,6 +34,7 @@ const tabs = [
 const BudgetCategories = () => {
     const [activeTab, setActiveTab] = useState(tabs[0].internal);
     const [count, setCount] = useState(null);
+    const moreOptionsTabsRef = useRef(null);
 
     const { defCodes, overview } = useSelector((state) => state.covid19);
     const overviewData = [
@@ -88,6 +90,10 @@ const BudgetCategories = () => {
         totalOutlays: overview._totalOutlays
     };
 
+    const scrollIntoViewTable = (loading, error, errorOrLoadingRef, tableWrapperRef, margin, scrollOptions, startPage, endPage, currentPage) => {
+        scrollIntoView(loading, error, errorOrLoadingRef, tableWrapperRef, margin, scrollOptions, startPage, endPage, currentPage, moreOptionsTabsRef);
+    };
+
     return (
         <div className="body__content budget-categories">
             <DateNote />
@@ -95,7 +101,9 @@ const BudgetCategories = () => {
             <p className="body__narrative-description">
                 The total federal spending for the COVID-19 Response can be divided into different budget categories, including the different agencies that spent funds, the Federal Spending bills and Federal Accounts that funded the Response, and the different types of items and services that were purchased.
             </p>
-            <MoreOptionsTabs tabs={tabs} changeActiveTab={changeActiveTab} hideCounts />
+            <div ref={moreOptionsTabsRef}>
+                <MoreOptionsTabs tabs={tabs} changeActiveTab={changeActiveTab} hideCounts />
+            </div>
             <div className="overview-data-group">
                 {overviewData.map((data) => (
                     <OverviewData
@@ -107,7 +115,8 @@ const BudgetCategories = () => {
             <div className="budget-categories__content">
                 <BudgetCategoriesTableContainer
                     type={activeTab}
-                    subHeading={tabs.filter((tab) => tab.internal === activeTab)[0].subHeading} />
+                    subHeading={tabs.filter((tab) => tab.internal === activeTab)[0].subHeading}
+                    scrollIntoView={scrollIntoViewTable} />
             </div>
         </div>
     );

--- a/src/js/components/covid19/recipient/SpendingByRecipient.jsx
+++ b/src/js/components/covid19/recipient/SpendingByRecipient.jsx
@@ -3,7 +3,7 @@
  * Created by Lizzie Salita 7/8/20
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { awardTypeTabs } from 'dataMapping/covid19/covid19';
 import { awardTypeGroups } from 'dataMapping/search/awardType';
@@ -11,6 +11,7 @@ import { fetchDisasterSpendingCount } from 'helpers/disasterHelper';
 import SummaryInsightsContainer from 'containers/covid19/SummaryInsightsContainer';
 import SpendingByRecipientContainer from 'containers/covid19/recipient/SpendingByRecipientContainer';
 import AwardFilterButtons from './AwardFilterButtons';
+import { scrollIntoView } from '../../../containers/covid19/helpers/scrollHelper';
 
 const overviewData = [
     {
@@ -36,6 +37,7 @@ const overviewData = [
 const SpendingByRecipient = () => {
     const [activeTab, setActiveTab] = useState(awardTypeTabs[0].internal);
     const defCodes = useSelector((state) => state.covid19.defCodes);
+    const awardFilterButtonsRef = useRef(null);
 
     const [tabCounts, setTabCounts] = useState({
         all: null,
@@ -82,19 +84,25 @@ const SpendingByRecipient = () => {
             });
     }, [defCodes]);
 
+    const scrollIntoViewTable = (loading, error, errorOrLoadingRef, tableWrapperRef, margin, scrollOptions, startPage, endPage, currentPage) => {
+        scrollIntoView(loading, error, errorOrLoadingRef, tableWrapperRef, margin, scrollOptions, startPage, endPage, currentPage, awardFilterButtonsRef);
+    };
+
     return (
         <div className="spending-by-recipient">
-            <AwardFilterButtons
-                filters={awardTypeTabs}
-                onClick={changeActiveTab}
-                activeFilter={activeTab}
-                tabCounts={tabCounts} />
+            <div ref={awardFilterButtonsRef}>
+                <AwardFilterButtons
+                    filters={awardTypeTabs}
+                    onClick={changeActiveTab}
+                    activeFilter={activeTab}
+                    tabCounts={tabCounts} />
+            </div>
             <SummaryInsightsContainer
                 // pass Recipient count to the summary section so we don't have to make the same API request again
                 resultsCount={tabCounts[activeTab]}
                 activeTab={activeTab}
                 overviewData={overviewData} />
-            <SpendingByRecipientContainer activeTab={activeTab} />
+            <SpendingByRecipientContainer activeTab={activeTab} scrollIntoView={scrollIntoViewTable} />
         </div>
     );
 };

--- a/src/js/containers/covid19/assistanceListing/SpendingByCFDAContainer.jsx
+++ b/src/js/containers/covid19/assistanceListing/SpendingByCFDAContainer.jsx
@@ -20,10 +20,12 @@ import { clearAllFilters } from 'redux/actions/search/searchFilterActions';
 import { resetAppliedFilters, applyStagedFilters } from 'redux/actions/search/appliedFilterActions';
 import Router from 'containers/router/Router';
 import { initialState as defaultAdvancedSearchFilters, CheckboxTreeSelections } from 'redux/reducers/search/searchFiltersReducer';
-import { scrollIntoView } from '../helpers/scrollHelper';
 
 
-const propTypes = { activeTab: PropTypes.string.isRequired };
+const propTypes = {
+    activeTab: PropTypes.string.isRequired,
+    scrollIntoView: PropTypes.func.isRequired
+};
 
 const columns = [
     {
@@ -109,7 +111,7 @@ const loanColumns = [
     }
 ];
 
-const SpendingByCFDAContainer = ({ activeTab }) => {
+const SpendingByCFDAContainer = ({ activeTab, scrollIntoView }) => {
     const [currentPage, changeCurrentPage] = useState(1);
     const [pageSize, changePageSize] = useState(10);
     const [totalItems, setTotalItems] = useState(0);
@@ -120,9 +122,8 @@ const SpendingByCFDAContainer = ({ activeTab }) => {
     const [order, setOrder] = useState('desc');
     const [request, setRequest] = useState(null);
     const tableWrapperRef = useRef(null);
-    const paginationRef = useRef(null);
     const errorOrLoadingWrapperRef = useRef(null);
-    const paginationErrorOrLoadingRef = useRef(null);
+
 
     const updateSort = (field, direction) => {
         setSort(field);
@@ -247,11 +248,13 @@ const SpendingByCFDAContainer = ({ activeTab }) => {
     }, [currentPage]);
 
     useEffect(() => {
-        scrollIntoView(loading, error, paginationErrorOrLoadingRef, paginationRef, errorOrLoadingWrapperRef, tableWrapperRef, 40);
+        const startPage = 1;
+        const endPage = Math.ceil(totalItems / pageSize);
+        scrollIntoView(loading, error, errorOrLoadingWrapperRef, tableWrapperRef, 100, true, startPage, endPage, currentPage);
     }, [loading, error]);
 
     useEffect(() => {
-        window.scrollTo(0, document.documentElement.scrollTop);
+        window.scrollTo(0, 0);
     }, [document]);
 
     let message = null;
@@ -279,16 +282,14 @@ const SpendingByCFDAContainer = ({ activeTab }) => {
                     transitionLeave>
                     {message}
                 </CSSTransitionGroup>
-                <div ref={paginationErrorOrLoadingRef}>
-                    <Pagination
-                        currentPage={currentPage}
-                        changePage={changeCurrentPage}
-                        changeLimit={changePageSize}
-                        limitSelector
-                        resultsText
-                        pageSize={pageSize}
-                        totalItems={totalItems} />
-                </div>
+                <Pagination
+                    currentPage={currentPage}
+                    changePage={changeCurrentPage}
+                    changeLimit={changePageSize}
+                    limitSelector
+                    resultsText
+                    pageSize={pageSize}
+                    totalItems={totalItems} />
             </div>
         );
     }
@@ -302,16 +303,14 @@ const SpendingByCFDAContainer = ({ activeTab }) => {
                     updateSort={updateSort}
                     currentSort={{ field: sort, direction: order }} />
             </div>
-            <div ref={paginationRef}>
-                <Pagination
-                    currentPage={currentPage}
-                    changePage={changeCurrentPage}
-                    changeLimit={changePageSize}
-                    limitSelector
-                    resultsText
-                    pageSize={pageSize}
-                    totalItems={totalItems} />
-            </div>
+            <Pagination
+                currentPage={currentPage}
+                changePage={changeCurrentPage}
+                changeLimit={changePageSize}
+                limitSelector
+                resultsText
+                pageSize={pageSize}
+                totalItems={totalItems} />
         </div>
     );
 };

--- a/src/js/containers/covid19/assistanceListing/SpendingByCFDAContainer.jsx
+++ b/src/js/containers/covid19/assistanceListing/SpendingByCFDAContainer.jsx
@@ -121,6 +121,7 @@ const SpendingByCFDAContainer = ({ activeTab, scrollIntoView }) => {
     const [sort, setSort] = useState('obligation');
     const [order, setOrder] = useState('desc');
     const [request, setRequest] = useState(null);
+    const tableRef = useRef(null);
     const tableWrapperRef = useRef(null);
     const errorOrLoadingWrapperRef = useRef(null);
 
@@ -259,14 +260,22 @@ const SpendingByCFDAContainer = ({ activeTab, scrollIntoView }) => {
 
     let message = null;
     if (loading) {
+        let tableHeight = null;
+        if (tableRef.current) {
+            tableHeight = tableRef.current.offsetHeight;
+        }
         message = (
-            <div className="results-table-message-container">
+            <div className="results-table-message-container" style={{ minHeight: tableHeight }}>
                 <ResultsTableLoadingMessage />
             </div>
         );
     } else if (error) {
+        let tableHeight = null;
+        if (tableRef.current) {
+            tableHeight = tableRef.current.offsetHeight;
+        }
         message = (
-            <div className="results-table-message-container">
+            <div className="results-table-message-container" style={{ minHeight: tableHeight }}>
                 <ResultsTableErrorMessage />
             </div>
         );
@@ -296,7 +305,7 @@ const SpendingByCFDAContainer = ({ activeTab, scrollIntoView }) => {
 
     return (
         <div ref={tableWrapperRef}>
-            <div className="table-wrapper">
+            <div ref={tableRef} className="table-wrapper" >
                 <Table
                     columns={activeTab === 'loans' ? loanColumns : columns}
                     rows={parseRows(results)}

--- a/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
+++ b/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
@@ -15,11 +15,11 @@ import { awardTypeGroups } from 'dataMapping/search/awardType';
 import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import { fetchAwardSpendingByAgency, fetchLoansByAgency } from 'helpers/disasterHelper';
 import CoreSpendingTableRow from 'models/v2/covid19/CoreSpendingTableRow';
-import { scrollIntoView } from '../helpers/scrollHelper';
 
 const propTypes = {
     type: PropTypes.string.isRequired,
-    subHeading: PropTypes.string
+    subHeading: PropTypes.string,
+    scrollIntoView: PropTypes.func.isRequired
 };
 
 const awardSpendingAgencyTableColumns = (type) => {
@@ -117,9 +117,7 @@ const AwardSpendingAgencyTableContainer = (props) => {
     const defCodes = useSelector((state) => state.covid19.defCodes);
     const [request, setRequest] = useState(null);
     const tableWrapperRef = useRef(null);
-    const paginationRef = useRef(null);
     const errorOrLoadingWrapperRef = useRef(null);
-    const paginationErrorOrLoadingRef = useRef(null);
 
     const parseAwardSpendingByAgency = (data) => {
         const parsedData = data.map((item) => {
@@ -280,11 +278,13 @@ const AwardSpendingAgencyTableContainer = (props) => {
     }, [currentPage]);
 
     useEffect(() => {
-        scrollIntoView(loading, error, paginationErrorOrLoadingRef, paginationRef, errorOrLoadingWrapperRef, tableWrapperRef, 40);
+        const startPage = 1;
+        const endPage = Math.ceil(totalItems / pageSize);
+        props.scrollIntoView(loading, error, errorOrLoadingWrapperRef, tableWrapperRef, 100, true, startPage, endPage, currentPage);
     }, [loading, error]);
 
     useEffect(() => {
-        window.scrollTo(0, document.documentElement.scrollTop);
+        window.scrollTo(0, 0);
     }, [document]);
 
     let message = null;
@@ -312,16 +312,14 @@ const AwardSpendingAgencyTableContainer = (props) => {
                     transitionLeave>
                     {message}
                 </CSSTransitionGroup>
-                <div ref={paginationErrorOrLoadingRef}>
-                    <Pagination
-                        currentPage={currentPage}
-                        changePage={changeCurrentPage}
-                        changeLimit={changePageSize}
-                        limitSelector
-                        resultsText
-                        pageSize={pageSize}
-                        totalItems={totalItems} />
-                </div>
+                <Pagination
+                    currentPage={currentPage}
+                    changePage={changeCurrentPage}
+                    changeLimit={changePageSize}
+                    limitSelector
+                    resultsText
+                    pageSize={pageSize}
+                    totalItems={totalItems} />
             </div>
         );
     }
@@ -335,16 +333,14 @@ const AwardSpendingAgencyTableContainer = (props) => {
                 currentSort={{ field: sort, direction: order }}
                 updateSort={updateSort}
                 divider={props.subHeading} />
-            <div ref={paginationRef}>
-                <Pagination
-                    currentPage={currentPage}
-                    changePage={changeCurrentPage}
-                    changeLimit={changePageSize}
-                    limitSelector
-                    resultsText
-                    pageSize={pageSize}
-                    totalItems={totalItems} />
-            </div>
+            <Pagination
+                currentPage={currentPage}
+                changePage={changeCurrentPage}
+                changeLimit={changePageSize}
+                limitSelector
+                resultsText
+                pageSize={pageSize}
+                totalItems={totalItems} />
         </div>
     );
 };

--- a/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
+++ b/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
@@ -116,6 +116,7 @@ const AwardSpendingAgencyTableContainer = (props) => {
     const [error, setError] = useState(false);
     const defCodes = useSelector((state) => state.covid19.defCodes);
     const [request, setRequest] = useState(null);
+    const tableRef = useRef(null);
     const tableWrapperRef = useRef(null);
     const errorOrLoadingWrapperRef = useRef(null);
 
@@ -289,19 +290,26 @@ const AwardSpendingAgencyTableContainer = (props) => {
 
     let message = null;
     if (loading) {
+        let tableHeight = null;
+        if (tableRef.current) {
+            tableHeight = tableRef.current.offsetHeight;
+        }
         message = (
-            <div className="results-table-message-container">
+            <div className="results-table-message-container" style={{ minHeight: tableHeight }}>
                 <ResultsTableLoadingMessage />
             </div>
         );
     } else if (error) {
+        let tableHeight = null;
+        if (tableRef.current) {
+            tableHeight = tableRef.current.offsetHeight;
+        }
         message = (
-            <div className="results-table-message-container">
+            <div className="results-table-message-container" style={{ minHeight: tableHeight }}>
                 <ResultsTableErrorMessage />
             </div>
         );
     }
-
     if (message) {
         return (
             <div ref={errorOrLoadingWrapperRef}>
@@ -326,13 +334,15 @@ const AwardSpendingAgencyTableContainer = (props) => {
 
     return (
         <div ref={tableWrapperRef} className="table-wrapper">
-            <Table
-                expandable
-                rows={results}
-                columns={awardSpendingAgencyTableColumns(props.type)}
-                currentSort={{ field: sort, direction: order }}
-                updateSort={updateSort}
-                divider={props.subHeading} />
+            <div ref={tableRef}>
+                <Table
+                    expandable
+                    rows={results}
+                    columns={awardSpendingAgencyTableColumns(props.type)}
+                    currentSort={{ field: sort, direction: order }}
+                    updateSort={updateSort}
+                    divider={props.subHeading} />
+            </div>
             <Pagination
                 currentPage={currentPage}
                 changePage={changeCurrentPage}

--- a/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
+++ b/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
@@ -138,11 +138,11 @@ const BudgetCategoriesTableContainer = (props) => {
     const [error, setError] = useState(false);
     const [spendingCategory, setSpendingCategory] = useState("total_spending");
     const [request, setRequest] = useState(null);
+    const tableRef = useRef(null);
     const tableWrapperRef = useRef(null);
     const errorOrLoadingWrapperRef = useRef(null);
 
     const defCodes = useSelector((state) => state.covid19.defCodes);
-
 
     const parseSpendingDataAndSetResults = (data) => {
         const parsedData = data.map((item) => {
@@ -343,10 +343,6 @@ const BudgetCategoriesTableContainer = (props) => {
         props.scrollIntoView(loading, error, errorOrLoadingWrapperRef, tableWrapperRef, 100, true, startPage, endPage, currentPage);
     }, [loading, error]);
 
-    useEffect(() => {
-        window.scrollTo(0, 0);
-    }, [document]);
-
     const renderColumns = () => {
         if (props.type && spendingCategory) {
             if (props.type !== 'object_class' && spendingCategory === 'total_spending') {
@@ -370,14 +366,22 @@ const BudgetCategoriesTableContainer = (props) => {
 
     let message = null;
     if (loading) {
+        let tableHeight = null;
+        if (tableRef.current) {
+            tableHeight = tableRef.current.offsetHeight;
+        }
         message = (
-            <div className="results-table-message-container">
+            <div className="results-table-message-container" style={{ minHeight: tableHeight }}>
                 <ResultsTableLoadingMessage />
             </div>
         );
     } else if (error) {
+        let tableHeight = null;
+        if (tableRef.current) {
+            tableHeight = tableRef.current.offsetHeight;
+        }
         message = (
-            <div className="results-table-message-container">
+            <div className="results-table-message-container" style={{ minHeight: tableHeight }}>
                 <ResultsTableErrorMessage />
             </div>
         );
@@ -427,9 +431,9 @@ const BudgetCategoriesTableContainer = (props) => {
     }
 
     return (
-        <div ref={tableWrapperRef}>
+        <div ref={tableWrapperRef} className={`budget-categories-table_${budgetCategoriesCssMappingTypes[props.type]} table-wrapper`}>
             {spendingViewPicker()}
-            <div className={`budget-categories-table_${budgetCategoriesCssMappingTypes[props.type]} table-wrapper`}>
+            <div ref={tableRef}>
                 <Table
                     expandable
                     rows={results}
@@ -440,7 +444,7 @@ const BudgetCategoriesTableContainer = (props) => {
             </div>
             <Pagination
                 currentPage={currentPage}
-                changePage={changeCurrentPage}
+                changePage={(e) => changeCurrentPage(e)}
                 changeLimit={changePageSize}
                 limitSelector
                 resultsText

--- a/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
+++ b/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
@@ -22,12 +22,12 @@ import ResultsTableLoadingMessage from 'components/search/table/ResultsTableLoad
 import ResultsTableErrorMessage from 'components/search/table/ResultsTableErrorMessage';
 import BaseBudgetCategoryRow from 'models/v2/covid19/BaseBudgetCategoryRow';
 import { BudgetCategoriesInfo } from '../../../components/award/shared/InfoTooltipContent';
-import { scrollIntoView } from '../helpers/scrollHelper';
 
 
 const propTypes = {
     type: PropTypes.string.isRequired,
-    subHeading: PropTypes.string
+    subHeading: PropTypes.string,
+    scrollIntoView: PropTypes.func.isRequired
 };
 
 
@@ -139,9 +139,7 @@ const BudgetCategoriesTableContainer = (props) => {
     const [spendingCategory, setSpendingCategory] = useState("total_spending");
     const [request, setRequest] = useState(null);
     const tableWrapperRef = useRef(null);
-    const paginationRef = useRef(null);
     const errorOrLoadingWrapperRef = useRef(null);
-    const paginationErrorOrLoadingRef = useRef(null);
 
     const defCodes = useSelector((state) => state.covid19.defCodes);
 
@@ -340,11 +338,13 @@ const BudgetCategoriesTableContainer = (props) => {
     }, [currentPage]);
 
     useEffect(() => {
-        scrollIntoView(loading, error, paginationErrorOrLoadingRef, paginationRef, errorOrLoadingWrapperRef, tableWrapperRef, 40);
+        const startPage = 1;
+        const endPage = Math.ceil(totalItems / pageSize);
+        props.scrollIntoView(loading, error, errorOrLoadingWrapperRef, tableWrapperRef, 100, true, startPage, endPage, currentPage);
     }, [loading, error]);
 
     useEffect(() => {
-        window.scrollTo(0, document.documentElement.scrollTop);
+        window.scrollTo(0, 0);
     }, [document]);
 
     const renderColumns = () => {
@@ -414,16 +414,14 @@ const BudgetCategoriesTableContainer = (props) => {
                     transitionLeave>
                     {message}
                 </CSSTransitionGroup>
-                <div ref={paginationErrorOrLoadingRef}>
-                    <Pagination
-                        currentPage={currentPage}
-                        changePage={changeCurrentPage}
-                        changeLimit={changePageSize}
-                        limitSelector
-                        resultsText
-                        pageSize={pageSize}
-                        totalItems={totalItems} />
-                </div>
+                <Pagination
+                    currentPage={currentPage}
+                    changePage={changeCurrentPage}
+                    changeLimit={changePageSize}
+                    limitSelector
+                    resultsText
+                    pageSize={pageSize}
+                    totalItems={totalItems} />
             </div>
         );
     }
@@ -440,16 +438,14 @@ const BudgetCategoriesTableContainer = (props) => {
                     updateSort={updateSort}
                     divider={props.subHeading} />
             </div>
-            <div ref={paginationRef}>
-                <Pagination
-                    currentPage={currentPage}
-                    changePage={changeCurrentPage}
-                    changeLimit={changePageSize}
-                    limitSelector
-                    resultsText
-                    pageSize={pageSize}
-                    totalItems={totalItems} />
-            </div>
+            <Pagination
+                currentPage={currentPage}
+                changePage={changeCurrentPage}
+                changeLimit={changePageSize}
+                limitSelector
+                resultsText
+                pageSize={pageSize}
+                totalItems={totalItems} />
         </div>
     );
 };

--- a/src/js/containers/covid19/helpers/scrollHelper.jsx
+++ b/src/js/containers/covid19/helpers/scrollHelper.jsx
@@ -1,0 +1,30 @@
+export const isElementVisible = (ref) => {
+    const rect = ref.current.getBoundingClientRect();
+    const verticallyVisible = (rect.top <= window.innerHeight) && ((rect.top + rect.height) >= 0);
+    const horizontallyVisible = (rect.left <= window.innerWidth) && ((rect.left + rect.width) >= 0);
+    return (verticallyVisible && horizontallyVisible);
+};
+
+
+// this function does not work in IE11
+export const scrollIntoView = (loading, error, targetRef, targetReadyRef, wrapperRef, wrapperReadyRef, margin) => {
+    const isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
+
+    if ((loading || error) && targetRef.current && wrapperRef.current && window.pageYOffset > 0 && !isIE11) {
+        if (isElementVisible(wrapperRef)) {
+            wrapperRef.current.scrollIntoView(false);
+
+            // add margin to current Y position so that the glossary icon doesn't overlap
+            const scrollToCurrentYPos = document.documentElement.scrollTop;
+            window.scrollTo(0, scrollToCurrentYPos + margin);
+        }
+    } else if ((!loading || !error) && targetReadyRef.current && wrapperReadyRef.current && window.pageYOffset > 0 && !isIE11) {
+        if (isElementVisible(wrapperReadyRef)) {
+            wrapperReadyRef.current.scrollIntoView(false);
+
+            // add margin to current Y position so that the glossary icon doesn't overlap
+            const scrollToCurrentYPos = document.documentElement.scrollTop;
+            window.scrollTo(0, scrollToCurrentYPos + margin);
+        }
+    }
+};

--- a/src/js/containers/covid19/helpers/scrollHelper.jsx
+++ b/src/js/containers/covid19/helpers/scrollHelper.jsx
@@ -7,24 +7,26 @@ export const isElementVisible = (ref) => {
 
 
 // this function does not work in IE11
-export const scrollIntoView = (loading, error, targetRef, targetReadyRef, wrapperRef, wrapperReadyRef, margin) => {
+export const scrollIntoView = (loading, error, wrapperRef, wrapperReadyRef, margin, scrollIntoViewOptions, startPage, endPage, currentPage, moreOptionsTabsRef) => {
     const isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
 
-    if ((loading || error) && targetRef.current && wrapperRef.current && window.pageYOffset > 0 && !isIE11) {
-        if (isElementVisible(wrapperRef)) {
-            wrapperRef.current.scrollIntoView(false);
+    if ((loading || error) && !isIE11 && wrapperRef.current && moreOptionsTabsRef.current && isElementVisible(wrapperRef) && window.pageYOffset > 0) {
+        moreOptionsTabsRef.current.scrollIntoView(scrollIntoViewOptions);
+        const scrollToCurrentYPos = document.documentElement.scrollTop;
+        window.scrollTo(0, scrollToCurrentYPos - margin);
+    } else if (wrapperRef.current && moreOptionsTabsRef.current && !isElementVisible(wrapperRef) && (startPage === currentPage || endPage === currentPage) && window.pageYOffset > 0) {
+        moreOptionsTabsRef.current.scrollIntoView(scrollIntoViewOptions);
+        const scrollToCurrentYPos = document.documentElement.scrollTop;
+        window.scrollTo(0, scrollToCurrentYPos - margin);
+    }
 
-            // add margin to current Y position so that the glossary icon doesn't overlap
-            const scrollToCurrentYPos = document.documentElement.scrollTop;
-            window.scrollTo(0, scrollToCurrentYPos + margin);
-        }
-    } else if ((!loading || !error) && targetReadyRef.current && wrapperReadyRef.current && window.pageYOffset > 0 && !isIE11) {
-        if (isElementVisible(wrapperReadyRef)) {
-            wrapperReadyRef.current.scrollIntoView(false);
-
-            // add margin to current Y position so that the glossary icon doesn't overlap
-            const scrollToCurrentYPos = document.documentElement.scrollTop;
-            window.scrollTo(0, scrollToCurrentYPos + margin);
-        }
+    if ((!loading || !error) && !isIE11 && wrapperReadyRef.current && moreOptionsTabsRef.current && isElementVisible(wrapperReadyRef) && window.pageYOffset > 0) {
+        moreOptionsTabsRef.current.scrollIntoView(scrollIntoViewOptions);
+        const scrollToCurrentYPos = document.documentElement.scrollTop;
+        window.scrollTo(0, scrollToCurrentYPos - margin);
+    } else if (wrapperReadyRef.current && moreOptionsTabsRef.current && !isElementVisible(wrapperReadyRef) && (startPage === currentPage || endPage === currentPage) && window.pageYOffset > 0) {
+        moreOptionsTabsRef.current.scrollIntoView(scrollIntoViewOptions);
+        const scrollToCurrentYPos = document.documentElement.scrollTop;
+        window.scrollTo(0, scrollToCurrentYPos - margin);
     }
 };

--- a/src/js/containers/covid19/recipient/SpendingByRecipientContainer.jsx
+++ b/src/js/containers/covid19/recipient/SpendingByRecipientContainer.jsx
@@ -15,10 +15,10 @@ import { spendingTableSortFields } from 'dataMapping/covid19/covid19';
 import { fetchDisasterSpending, fetchLoanSpending } from 'helpers/disasterHelper';
 import ResultsTableLoadingMessage from 'components/search/table/ResultsTableLoadingMessage';
 import ResultsTableErrorMessage from 'components/search/table/ResultsTableErrorMessage';
-import { scrollIntoView } from '../helpers/scrollHelper';
 
 const propTypes = {
-    activeTab: PropTypes.string.isRequired
+    activeTab: PropTypes.string.isRequired,
+    scrollIntoView: PropTypes.func.isRequired
 };
 
 const columns = [
@@ -155,7 +155,7 @@ export const parseRows = (rows, activeTab) => (
     })
 );
 
-const SpendingByRecipientContainer = ({ activeTab }) => {
+const SpendingByRecipientContainer = ({ activeTab, scrollIntoView }) => {
     const [currentPage, changeCurrentPage] = useState(1);
     const [pageSize, changePageSize] = useState(10);
     const [totalItems, setTotalItems] = useState(0);
@@ -166,9 +166,7 @@ const SpendingByRecipientContainer = ({ activeTab }) => {
     const [order, setOrder] = useState('desc');
     const [request, setRequest] = useState(null);
     const tableWrapperRef = useRef(null);
-    const paginationRef = useRef(null);
     const errorOrLoadingWrapperRef = useRef(null);
-    const paginationErrorOrLoadingRef = useRef(null);
 
     const updateSort = (field, direction) => {
         setSort(field);
@@ -229,7 +227,9 @@ const SpendingByRecipientContainer = ({ activeTab }) => {
     }, [currentPage]);
 
     useEffect(() => {
-        scrollIntoView(loading, error, paginationErrorOrLoadingRef, paginationRef, errorOrLoadingWrapperRef, tableWrapperRef, 40);
+        const startPage = 1;
+        const endPage = Math.ceil(totalItems / pageSize);
+        scrollIntoView(loading, error, errorOrLoadingWrapperRef, tableWrapperRef, 130, true, startPage, endPage, currentPage);
     }, [loading, error]);
 
     let message = null;
@@ -257,16 +257,14 @@ const SpendingByRecipientContainer = ({ activeTab }) => {
                     transitionLeave>
                     {message}
                 </CSSTransitionGroup>
-                <div ref={paginationErrorOrLoadingRef}>
-                    <Pagination
-                        currentPage={currentPage}
-                        changePage={changeCurrentPage}
-                        changeLimit={changePageSize}
-                        limitSelector
-                        resultsText
-                        pageSize={pageSize}
-                        totalItems={totalItems} />
-                </div>
+                <Pagination
+                    currentPage={currentPage}
+                    changePage={changeCurrentPage}
+                    changeLimit={changePageSize}
+                    limitSelector
+                    resultsText
+                    pageSize={pageSize}
+                    totalItems={totalItems} />
             </div>
         );
     }
@@ -278,16 +276,14 @@ const SpendingByRecipientContainer = ({ activeTab }) => {
                 rows={results}
                 updateSort={updateSort}
                 currentSort={{ field: sort, direction: order }} />
-            <div ref={paginationRef}>
-                <Pagination
-                    currentPage={currentPage}
-                    changePage={changeCurrentPage}
-                    changeLimit={changePageSize}
-                    limitSelector
-                    resultsText
-                    pageSize={pageSize}
-                    totalItems={totalItems} />
-            </div>
+            <Pagination
+                currentPage={currentPage}
+                changePage={changeCurrentPage}
+                changeLimit={changePageSize}
+                limitSelector
+                resultsText
+                pageSize={pageSize}
+                totalItems={totalItems} />
         </div>
 
     );

--- a/src/js/containers/covid19/recipient/SpendingByRecipientContainer.jsx
+++ b/src/js/containers/covid19/recipient/SpendingByRecipientContainer.jsx
@@ -165,6 +165,7 @@ const SpendingByRecipientContainer = ({ activeTab, scrollIntoView }) => {
     const [sort, setSort] = useState('obligation');
     const [order, setOrder] = useState('desc');
     const [request, setRequest] = useState(null);
+    const tableRef = useRef(null);
     const tableWrapperRef = useRef(null);
     const errorOrLoadingWrapperRef = useRef(null);
 
@@ -234,14 +235,22 @@ const SpendingByRecipientContainer = ({ activeTab, scrollIntoView }) => {
 
     let message = null;
     if (loading) {
+        let tableHeight = null;
+        if (tableRef.current) {
+            tableHeight = tableRef.current.offsetHeight;
+        }
         message = (
-            <div className="results-table-message-container">
+            <div className="results-table-message-container" style={{ minHeight: tableHeight }}>
                 <ResultsTableLoadingMessage />
             </div>
         );
     } else if (error) {
+        let tableHeight = null;
+        if (tableRef.current) {
+            tableHeight = tableRef.current.offsetHeight;
+        }
         message = (
-            <div className="results-table-message-container">
+            <div className="results-table-message-container" style={{ minHeight: tableHeight }}>
                 <ResultsTableErrorMessage />
             </div>
         );
@@ -271,11 +280,13 @@ const SpendingByRecipientContainer = ({ activeTab, scrollIntoView }) => {
 
     return (
         <div ref={tableWrapperRef}className="table-wrapper">
-            <Table
-                columns={activeTab === 'loans' ? loanColumns : columns}
-                rows={results}
-                updateSort={updateSort}
-                currentSort={{ field: sort, direction: order }} />
+            <div ref={tableRef}>
+                <Table
+                    columns={activeTab === 'loans' ? loanColumns : columns}
+                    rows={results}
+                    updateSort={updateSort}
+                    currentSort={{ field: sort, direction: order }} />
+            </div>
             <Pagination
                 currentPage={currentPage}
                 changePage={changeCurrentPage}


### PR DESCRIPTION
**High level description:**
Fixes bug when using pagination or changing page size and screen jumps to random location.
Adds logic for scrolling to the top of the table when pagination or page size is changed.
Adds styling to the loading container so it takes the height of the table instead of a fixed height.

**Technical details:**
Scrolling to top logic is in `scrollHelper.jsx` and it doesn't work in IE11 because `scrollIntoView` not full supported in IE11.

**JIRA Ticket:**
[DEV-5638](https://federal-spending-transparency.atlassian.net/browse/DEV-5638)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge **Solution does not work in IE11**
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [N/A] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [N/A] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
