### PR TITLE
DEV-5592 covid19 download tooltip

### DIFF
--- a/src/_scss/pages/covid19/_stickyHeader.scss
+++ b/src/_scss/pages/covid19/_stickyHeader.scss
@@ -1,4 +1,5 @@
 .sticky-header .sticky-header__container .sticky-header__header {
+    @import "layouts/search/header/_downloadButton";
     @include display(flex);
     @include justify-content(flex-start);
     @include align-items(center);

--- a/src/js/components/covid19/DownloadHover.jsx
+++ b/src/js/components/covid19/DownloadHover.jsx
@@ -1,0 +1,32 @@
+/**
+ * DownloadHover.jsx
+ * Created by James Lee 7/16/2020
+ */
+
+import React from 'react';
+import { ExclamationTriangle } from 'components/sharedComponents/icons/Icons';
+
+const DownloadHover = () => (
+    <div className="download-hover-spacer">
+        <div
+            className="download-hover"
+            id="no-download-hover"
+            role="tooltip">
+            <div className="download-hover-interior">
+                <div className="hover-content">
+                    <div className="icon">
+                        <ExclamationTriangle alt="Download is not available" />
+                    </div>
+                    <div className="message">
+                        <div>This download does not include Account Breakdowns by Award data (File C).</div>
+                        <br />
+                        <div>To download this data, please visit <br />the <a href="#/download_center/custom_account_data">Custom Account Data</a> page.</div>
+                    </div>
+                </div>
+                <div className="tooltip-pointer right" />
+            </div>
+        </div>
+    </div>
+);
+
+export default DownloadHover;

--- a/src/js/components/covid19/DownloadHover.jsx
+++ b/src/js/components/covid19/DownloadHover.jsx
@@ -18,15 +18,16 @@ const DownloadHover = () => (
                         <ExclamationTriangle alt="Download is not available" />
                     </div>
                     <div className="message">
-                        <div>This download does not include Account Breakdowns by Award data (File C).</div>
+                        <div>This download includes all data displayed on this page (as well as many additional data elements), with the exception of a few aspects one would need the more granular Account Breakdown by Award data (File C) to reproduce. If you wish to download this more granular data, visit the{' '}
+                            <a href="/#/download_center/custom_account_data">Custom Account Data</a> download page.
+                        </div>
                         <br />
-                        <div>To download this data, please visit <br />the <a href="#/download_center/custom_account_data">Custom Account Data</a> page.</div>
+                        <div>See the Data Sources section for more information on how downloadable data maps to this page.</div>
                     </div>
                 </div>
                 <div className="tooltip-pointer right" />
             </div>
         </div>
-    </div>
-);
+    </div>);
 
 export default DownloadHover;

--- a/src/js/components/sharedComponents/stickyHeader/DownloadIconButton.jsx
+++ b/src/js/components/sharedComponents/stickyHeader/DownloadIconButton.jsx
@@ -3,9 +3,10 @@
  * Created by Lizzie Salita 7/9/20
  **/
 
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import DownloadHover from 'components/covid19/DownloadHover';
 
 const propTypes = {
     onClick: PropTypes.func,
@@ -13,6 +14,7 @@ const propTypes = {
 };
 
 const DownloadIconButton = ({ onClick, downloadInFlight }) => {
+    const [showHover, setShowHover] = useState(false);
     const startDownload = (e) => {
         e.preventDefault();
         if (!downloadInFlight) {
@@ -20,12 +22,26 @@ const DownloadIconButton = ({ onClick, downloadInFlight }) => {
         }
     };
 
+    const onMouseEnter = () => setShowHover(true);
+    const onMouseLeave = () => setShowHover(false);
+
+    let hover = null;
+    if (showHover && !downloadInFlight) {
+        hover = (<DownloadHover />);
+    }
+
     const disabledClass = downloadInFlight ? ' sticky-header__button_disabled' : '';
     const buttonText = downloadInFlight ? 'Preparing Download...' : 'Download';
     const icon = downloadInFlight ? 'spinner' : 'download';
 
     return (
-        <>
+        <div
+            className="download-wrap"
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+            onFocus={onMouseEnter}
+            onBlur={onMouseLeave}>
+            {hover}
             <button
                 className={`sticky-header__button${disabledClass}`}
                 title={buttonText}
@@ -35,7 +51,7 @@ const DownloadIconButton = ({ onClick, downloadInFlight }) => {
                 <FontAwesomeIcon icon={icon} spin={!!downloadInFlight} />
             </button>
             <span>Download</span>
-        </>
+        </div>
     );
 };
 


### PR DESCRIPTION
**High level description:**
Adds download tooltip on hover for top download button.

**JIRA Ticket:**
[DEV-5592](https://federal-spending-transparency.atlassian.net/browse/DEV-5592)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension) **Ability to tab to link in hover tooltip will possibly be post-mvp**
- [N/A] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [N/A] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
