### PR TITLE
Ftr/dev 5618/updating modal content

### DIFF
--- a/src/_scss/pages/modals/covid19/_covid19.scss
+++ b/src/_scss/pages/modals/covid19/_covid19.scss
@@ -12,11 +12,13 @@
                     font-size: rem(30);
                     line-height: rem(35);
                     padding: 0;
-                    padding-left: rem(17);
+                    padding-left: rem(30);
+                    @include align-items(flex-start);
+                    @include justify-content(flex-start);
                 }
             }
             .usa-dt-modal__close-button {
-                padding: rem(10);
+                // padding: rem(10);
                 @include align-self(flex-start);
                 svg {
                     width: rem(20);
@@ -27,16 +29,23 @@
         .usa-dt-modal__body {
             &.covid-modal-body {
                 padding-bottom: 0;
-                padding: rem(30) rem(45) rem(45) rem(45);
+                padding: rem(30) rem(30) rem(15) rem(30);
             }
             .covid-modal-h2 {
                 font-size: rem(19);
-                font-weight: 600;
+                font-weight: 400;
                 text-align: left;
                 line-height: rem(24);
             }
+
+            .covid-modal-bold {
+                font-weight: 600;
+            }
+
             .covid-modal-li {
                 text-align: left;
+                font-size: rem(19);
+                line-height: rem(24);
             }
             .usa-dt-modal__link {
                 @include display(flex);
@@ -46,7 +55,7 @@
                 }
                 &.covid-modal-button {
                     margin-top: rem(45);
-                    margin-bottom: rem(25);
+                    // margin-bottom: rem(25);
                     @include display(flex);
                     @include justify-content(center);
                 }
@@ -55,14 +64,15 @@
     }
 }
 
-@include media($medium-screen) {
-    .covid-modal {
+@include media($tablet-screen) {
+    .usa-dt-modal.covid-modal {
         width: rem(1056);
         .usa-dt-modal__header {
             &.covid-header {
                 h1 {
                     font-size: rem(34);
                     line-height: rem(42);
+                    padding-left: rem(80);
                 }
             }
         }

--- a/src/_scss/pages/modals/covid19/_covid19.scss
+++ b/src/_scss/pages/modals/covid19/_covid19.scss
@@ -4,15 +4,11 @@
         .usa-dt-modal__header {
             background: $color-disaster-covid-19;
             &.covid-header {
-                text-align: center;
                 color: $color-white;
                 @include display(flex);
-                @include justify-content(center);
-                @include align-items(center);
                 h1 {
                     margin-top: rem(17);
                     margin-bottom: rem(17);
-                    margin-right: auto;
                     font-size: rem(30);
                     line-height: rem(35);
                     padding: 0;
@@ -31,7 +27,7 @@
         .usa-dt-modal__body {
             &.covid-modal-body {
                 padding-bottom: 0;
-                padding: rem(10) rem(30) rem(10) rem(30);
+                padding: rem(30) rem(45) rem(45) rem(45);
             }
             .covid-modal-h2 {
                 font-size: rem(19);
@@ -62,17 +58,17 @@
 @include media($medium-screen) {
     .covid-modal {
         width: rem(1056);
-        .usa-dt-modal__header{
+        .usa-dt-modal__header {
             &.covid-header {
-                h1{
+                h1 {
                     font-size: rem(34);
                     line-height: rem(42);
                 }
             }
         }
-        .usa-dt-modal__body{
-            &.covid-modal-body{
-                padding: rem(30) rem(45) rem(45) rem(45);
+        .usa-dt-modal__body {
+            &.covid-modal-body {
+                padding: rem(10) rem(80) rem(10) rem(80);
             }
         }   
     }

--- a/src/_scss/pages/modals/covid19/_covid19.scss
+++ b/src/_scss/pages/modals/covid19/_covid19.scss
@@ -18,7 +18,6 @@
                 }
             }
             .usa-dt-modal__close-button {
-                // padding: rem(10);
                 @include align-self(flex-start);
                 svg {
                     width: rem(20);
@@ -55,7 +54,6 @@
                 }
                 &.covid-modal-button {
                     margin-top: rem(45);
-                    // margin-bottom: rem(25);
                     @include display(flex);
                     @include justify-content(center);
                 }

--- a/src/_scss/pages/modals/covid19/_covid19.scss
+++ b/src/_scss/pages/modals/covid19/_covid19.scss
@@ -66,7 +66,7 @@
 
 @include media($tablet-screen) {
     .usa-dt-modal.covid-modal {
-        width: rem(1056);
+        width: rem(768);
         .usa-dt-modal__header {
             &.covid-header {
                 h1 {
@@ -81,5 +81,11 @@
                 padding: rem(10) rem(80) rem(10) rem(80);
             }
         }   
+    }
+}
+
+@include media($large-screen) {
+    .usa-dt-modal.covid-modal {
+        width: rem(1056);
     }
 }

--- a/src/js/containers/covid19/CovidModalContainer.jsx
+++ b/src/js/containers/covid19/CovidModalContainer.jsx
@@ -74,7 +74,7 @@ const CovidModalContainer = ({
                             </li>
                         </ul>
                     </div>
-                    <h2 className="covid-modal-h2 covid-modal-bold">Try out our new <a onClick={handleGoToAdvancedSearch} href="#/search">Advanced Search Filter</a> for COVID-19:</h2>
+                    <h2 className="covid-modal-h2 covid-modal-bold">Try out our new <a onClick={handleGoToAdvancedSearch} href="#/search">Advanced Search</a> Filter for COVID-19:</h2>
                     <div>
                         <ul>
                             <li className="covid-modal-li">

--- a/src/js/containers/covid19/CovidModalContainer.jsx
+++ b/src/js/containers/covid19/CovidModalContainer.jsx
@@ -42,7 +42,7 @@ const CovidModalContainer = ({
             escapeExits>
             <div className="usa-dt-modal covid-modal">
                 <div className="usa-dt-modal__header covid-header">
-                    <h1>New to USAspending: Official COVID-19 Response Data</h1>
+                    <h1>New to USAspending: Official COVID-19 Spending Data</h1>
                     <button
                         className="usa-dt-modal__close-button"
                         onClick={closeModal}
@@ -52,37 +52,45 @@ const CovidModalContainer = ({
                     </button>
                 </div>
                 <div className="usa-dt-modal__body covid-modal-body">
-                    <h2 className="covid-modal-h2">Official spending data from the federal government&apos;s response to COVID-19 is now available on USAspending, which includes:</h2>
+                    <h2 className="covid-modal-h2">Official spending data from the federal government&apos;s response to COVID-19 is now available to view and download on USAspending. The new data includes:</h2>
                     <div>
                         <ul>
                             <li className="covid-modal-li">
-                                Disaster Emergency Fund (DEF) Code tags that highlight funding from the CARES Act and supplemental legislation
+                                <strong>Disaster Emergency Fund Code (DEFC)</strong> tags that highlight funding from the CARES Act and other COVID-19 supplemental appropriations
                             </li>
                             <li className="covid-modal-li">
-                                Outlay data showing what agencies have spent, in addition to the existing obligation data about what agencies have promised to pay
+                                <strong>Outlay data</strong> for COVID-19 showing what agencies have paid out, in addition to the existing obligation data showing what agencies have promised to pay
                             </li>
                             <li className="covid-modal-li">
-                                Breakdown of spending data by federal agency, award recipient, and a variety of budget categories
+                                <strong>Breakdown of spending data</strong> by federal agency, award recipient, and a variety of budget categories
                             </li>
                         </ul>
                     </div>
-                    <h2 className="covid-modal-h2">Visit our new <a href="#/disaster/covid-19">profile page dedicated to the COVID-19 Response:</a></h2>
+                    <h2 className="covid-modal-h2">Visit our new <a href="#/disaster/covid-19">profile page dedicated to the COVID-19 Spending:</a></h2>
                     <div>
                         <ul>
                             <li className="covid-modal-li">
-                                Our newest profile page shows you official COVID-19 spending information as submitted by federal agencies. Learn more about who received funding, which agencies outlayed funds, and what those funds purchased.
+                                Our newest profile page shows you official COVID-19 spending information as submitted by federal agencies. Learn more about <strong>who received funding, which agencies outlayed funds,</strong> and <strong>which programs were funded.</strong> All COVID-19 spending data is <strong>available for download</strong> on the page with one click.
                             </li>
                         </ul>
                     </div>
-                    <h2 className="covid-modal-h2">Try out our new <a onClick={handleGoToAdvancedSearch} href="#/search">Advanced Search</a> Filter for COVID-19:</h2>
+                    <h2 className="covid-modal-h2">Try out our new <a onClick={handleGoToAdvancedSearch} href="#/search">Advanced Search Filter</a> for COVID-19:</h2>
                     <div>
                         <ul>
                             <li className="covid-modal-li">
-                                Use the new &apos;Disaster Emergency Fund (DEF) Code&apos; filter to display awards related to the COVID-19 Response. Additional columns in the search results table show COVID-19 Response DEF Codes, Obligations, and Outlays.
+                                Use the new <strong>Disaster Emergency Fund Code (DEFC)</strong> filter to show awards related to COVID-19 spending. The new filter works alongside our existing filters, so you can narrow your search to exactly what you want. Additional columns were also added to the search results table to show <strong>COVID-19 spending DEFCs, Obligations,</strong> and <strong>Outlays.</strong>
                             </li>
                         </ul>
                     </div>
-                    <h2 className="covid-modal-h2">Keep an eye out for the purple COVID-19 Response badge found throughout the site. These badges indicate that the page contains information about COVID-19 spending.</h2>
+                    <h2 className="covid-modal-h2">See which awards were funded through COVID-19 appropriations on our Award Summary pages:</h2>
+                    <div>
+                        <ul>
+                            <li className="covid-modal-li">
+                                <strong>Purple COVID-19 badges</strong> on our Award Summary pages make it easy to identify which awards have been funded through COVID-19 appropriations. You can hover over the badge to see relevant <strong>DEFCs</strong> associated with that award. The charts found on Award Summary pages now feature <strong>COVID-19 obligation and outlay amounts.</strong>
+                            </li>
+                        </ul>
+                    </div>
+                    <h2 className="covid-modal-h2">We will update the site with new COVID-19 spending data and release more related features in the coming months. Sign up to receive email updates about when these new features, and more, are added!</h2>
                     <div className="usa-dt-modal__link covid-modal-button">
                         <button onClick={closeModal}>Close</button>
                     </div>

--- a/src/js/containers/covid19/CovidModalContainer.jsx
+++ b/src/js/containers/covid19/CovidModalContainer.jsx
@@ -52,45 +52,45 @@ const CovidModalContainer = ({
                     </button>
                 </div>
                 <div className="usa-dt-modal__body covid-modal-body">
-                    <h2 className="covid-modal-h2">Official spending data from the federal government&apos;s response to COVID-19 is now available to view and download on USAspending. The new data includes:</h2>
+                    <h2 className="covid-modal-h2"><span className="covid-modal-bold">Official spending data from the federal government&apos;s response to COVID-19 is now available to view and download on USAspending. The new data includes:</span></h2>
                     <div>
                         <ul>
                             <li className="covid-modal-li">
-                                <strong>Disaster Emergency Fund Code (DEFC)</strong> tags that highlight funding from the CARES Act and other COVID-19 supplemental appropriations
+                                <span className="covid-modal-bold">Disaster Emergency Fund Code (DEFC)</span> tags that highlight funding from the CARES Act and other COVID-19 supplemental appropriations
                             </li>
                             <li className="covid-modal-li">
-                                <strong>Outlay data</strong> for COVID-19 showing what agencies have paid out, in addition to the existing obligation data showing what agencies have promised to pay
+                                <span className="covid-modal-bold">Outlay data</span> for COVID-19 showing what agencies have paid out, in addition to the existing obligation data showing what agencies have promised to pay
                             </li>
                             <li className="covid-modal-li">
-                                <strong>Breakdown of spending data</strong> by federal agency, award recipient, and a variety of budget categories
+                                <span className="covid-modal-bold">Breakdown of spending data</span> by federal agency, award recipient, and a variety of budget categories
                             </li>
                         </ul>
                     </div>
-                    <h2 className="covid-modal-h2">Visit our new <a href="#/disaster/covid-19">profile page dedicated to the COVID-19 Spending:</a></h2>
+                    <h2 className="covid-modal-h2 covid-modal-bold">Visit our new <a href="#/disaster/covid-19">profile page dedicated to the COVID-19 Spending:</a></h2>
                     <div>
                         <ul>
                             <li className="covid-modal-li">
-                                Our newest profile page shows you official COVID-19 spending information as submitted by federal agencies. Learn more about <strong>who received funding, which agencies outlayed funds,</strong> and <strong>which programs were funded.</strong> All COVID-19 spending data is <strong>available for download</strong> on the page with one click.
+                                Our newest profile page shows you official COVID-19 spending information as submitted by federal agencies. Learn more about <span className="covid-modal-bold">who received funding, which agencies outlayed funds,</span> and <span className="covid-modal-bold">which programs were funded.</span> All COVID-19 spending data is <span className="covid-modal-bold">available for download</span> on the page with one click.
                             </li>
                         </ul>
                     </div>
-                    <h2 className="covid-modal-h2">Try out our new <a onClick={handleGoToAdvancedSearch} href="#/search">Advanced Search Filter</a> for COVID-19:</h2>
+                    <h2 className="covid-modal-h2 covid-modal-bold">Try out our new <a onClick={handleGoToAdvancedSearch} href="#/search">Advanced Search Filter</a> for COVID-19:</h2>
                     <div>
                         <ul>
                             <li className="covid-modal-li">
-                                Use the new <strong>Disaster Emergency Fund Code (DEFC)</strong> filter to show awards related to COVID-19 spending. The new filter works alongside our existing filters, so you can narrow your search to exactly what you want. Additional columns were also added to the search results table to show <strong>COVID-19 spending DEFCs, Obligations,</strong> and <strong>Outlays.</strong>
+                                Use the new <span className="covid-modal-bold">Disaster Emergency Fund Code (DEFC)</span> filter to show awards related to COVID-19 spending. The new filter works alongside our existing filters, so you can narrow your search to exactly what you want. Additional columns were also added to the search results table to show <span className="covid-modal-bold">COVID-19 spending DEFCs, Obligations,</span> and <span className="covid-modal-bold">Outlays.</span>
                             </li>
                         </ul>
                     </div>
-                    <h2 className="covid-modal-h2">See which awards were funded through COVID-19 appropriations on our Award Summary pages:</h2>
+                    <h2 className="covid-modal-h2 covid-modal-bold">See which awards were funded through COVID-19 appropriations on our Award Summary pages:</h2>
                     <div>
                         <ul>
                             <li className="covid-modal-li">
-                                <strong>Purple COVID-19 badges</strong> on our Award Summary pages make it easy to identify which awards have been funded through COVID-19 appropriations. You can hover over the badge to see relevant <strong>DEFCs</strong> associated with that award. The charts found on Award Summary pages now feature <strong>COVID-19 obligation and outlay amounts.</strong>
+                                <span className="covid-modal-bold">Purple COVID-19 badges</span> on our Award Summary pages make it easy to identify which awards have been funded through COVID-19 appropriations. You can hover over the badge to see relevant <span className="covid-modal-bold">DEFCs</span> associated with that award. The charts found on Award Summary pages now feature <span className="covid-modal-bold">COVID-19 obligation and outlay amounts.</span>
                             </li>
                         </ul>
                     </div>
-                    <h2 className="covid-modal-h2">We will update the site with new COVID-19 spending data and release more related features in the coming months. Sign up to receive email updates about when these new features, and more, are added!</h2>
+                    <h2 className="covid-modal-h2"><span className="covid-modal-bold">We will update the site with new COVID-19 spending data and release more related features in the coming months. <a href="mailto:join-usaspending@lists.fiscal.treasury.gov?subject=Yes!%20I'd%20like%20to%20receive%20updates.">Sign up</a></span> to receive email updates about when these new features, and more, are added!</h2>
                     <div className="usa-dt-modal__link covid-modal-button">
                         <button onClick={closeModal}>Close</button>
                     </div>


### PR DESCRIPTION
**High level description:**

Updated COVID modal content to reflect recent content changes. Also updated modal styling.

**Technical details:**

Updated CovidModalContainer.jsx to reflect content changes. Added in "sign up" email functionality. Updated _covid19.scss to address modal margin spacing and left-aligned modal title.

**JIRA Ticket:**
[DEV-5618](https://federal-spending-transparency.atlassian.net/browse/DEV-5618)

**Mockup:**
https://bahdigital.invisionapp.com/share/JGIAEFTP6NX

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [`N/A`] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [`N/A`] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [`N/A`] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [`N/A`] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [`N/A`] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
