### PR TITLE
[DEV-5751] Mapping to correct property of response object for IDV Aggregate award amounts

### DIFF
--- a/src/js/models/v2/award/BaseAwardAmounts.js
+++ b/src/js/models/v2/award/BaseAwardAmounts.js
@@ -33,7 +33,7 @@ const BaseAwardAmounts = {
         this._baseExercisedOptions = parseFloat(
             data.child_award_base_exercised_options_val + data.grandchild_award_base_exercised_options_val
         ) || 0;
-        this._fileCOutlay = getCovid19Totals(data.child_account_obligations_by_defc);
+        this._fileCOutlay = getCovid19Totals(data.child_account_outlays_by_defc);
         this._fileCObligated = getCovid19Totals(data.child_account_obligations_by_defc);
     },
     populateIdv(data) {

--- a/tests/models/award/BaseAwardAmounts-test.js
+++ b/tests/models/award/BaseAwardAmounts-test.js
@@ -229,16 +229,27 @@ describe('BaseAwardAmounts', () => {
         });
     });
     describe('fileC getters', () => {
-        const addCovidSpending = (obj, obligated, outlayed) => ({
-            ...obj,
-            fileC: {
-                obligations: [{ amount: 1, code: 'not-covid' }, { amount: obligated, code: 'M' }],
-                outlays: [{ amount: 1, code: 'not-covid' }, { amount: outlayed, code: 'M' }]
+        const addCovidSpending = (obj, obligated, outlayed, isAgg = false) => {
+            if (isAgg) {
+                return {
+                    ...obj,
+                    child_account_outlays_by_defc: [{ amount: 1, code: 'not-covid' }, { amount: outlayed, code: 'M' }],
+                    child_account_obligations_by_defc: [{ amount: 1, code: 'not-covid' }, { amount: obligated, code: 'M' }]
+                };
             }
-        });
+            return {
+                ...obj,
+                fileC: {
+                    obligations: [{ amount: 1, code: 'not-covid' }, { amount: obligated, code: 'M' }],
+                    outlays: [{ amount: 1, code: 'not-covid' }, { amount: outlayed, code: 'M' }]
+                }
+            };
+        };
+
         it.each([
             ['contract', 'CONT_AWD_N0001917C0001_9700_-NONE-_-NONE-', addCovidSpending(mockContract, 5000000, 2500000)],
             ['idv', 'CONT_IDV_EDFSA09D0012_9100', addCovidSpending(mockIdv, 5000000, 2500000)],
+            ['idv_aggregated', 'CONT_IDV_EDFSA09D0012_9100', addCovidSpending(mockIdv, 5000000, 2500000, true)],
             ['grant', 'ASST_NON_1905CA5MAP_7530', addCovidSpending(mockGrant, 5000000, 2500000)],
             ['loan', 'ASST_NON_13789835_12D2', addCovidSpending(mockLoan, 5000000, 2500000)]
         ])('For %s awards, get formatted and get abbreviated file c data returns as expected', (


### PR DESCRIPTION
**High level description:**
In the models, we were looking at the wrong property on the response object.

**Technical details:**
Map to correct object property and add test.

**JIRA Ticket:**
[DEV-5751](https://federal-spending-transparency.atlassian.net/browse/DEV-5751)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
