### PR TITLE
DEV-5750 update CFDA award amounts request

### DIFF
--- a/src/js/containers/covid19/SummaryInsightsContainer.jsx
+++ b/src/js/containers/covid19/SummaryInsightsContainer.jsx
@@ -57,8 +57,12 @@ const SummaryInsightsContainer = ({
         if (activeTab !== 'all') {
             params.filter.award_type_codes = awardTypeGroups[activeTab];
         }
+        const amountsParams = { ...params };
+        if (assistanceOnly && activeTab === 'all') {
+            amountsParams.filter.award_type = 'assistance';
+        }
         if (defCodes && defCodes.length > 0) {
-            awardAmountRequest.current = fetchAwardAmounts(params);
+            awardAmountRequest.current = fetchAwardAmounts(amountsParams);
             awardCountRequest.current = fetchAwardCount(params);
             awardAmountRequest.current.promise
                 .then((res) => {


### PR DESCRIPTION
**High level description:**

DEV-5628 changed the summary squares on the CFDA section to read "All Assistance Awards". This PR updates the `/disaster/award/amount/` request to utilize a new request parameter to limit the results to assistance awards.

**JIRA Ticket:**
[DEV-5750](https://federal-spending-transparency.atlassian.net/browse/DEV-5750)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- N/A (change to API request params only) Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- N/A (change to API request params only) Verified mobile/tablet/desktop/monitor responsiveness
- N/A (change to API request params only) Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] [API contract](https://github.com/fedspendingtransparency/usaspending-api/blob/dev/usaspending_api/api_contracts/contracts/v2/disaster/award/amount.md) updated

Reviewer(s):
- [x] [API #2657](https://github.com/fedspendingtransparency/usaspending-api/pull/2657) merged concurrently
- [x] Code review complete
