### PR TITLE
Ftr/dev 5616/non covid page updates

### DIFF
--- a/src/js/components/award/shared/AwardPageWrapper.jsx
+++ b/src/js/components/award/shared/AwardPageWrapper.jsx
@@ -46,7 +46,7 @@ const AwardPageWrapper = ({
                     {covidDefC.length > 0 &&
                         <TooltipWrapper className="award-summary__covid-19-flag" tooltipComponent={<CovidFlagTooltip codes={covidDefC} />}>
                             <span className="covid-spending-flag">
-                                COVID-19 Response
+                                COVID-19 Spending
                             </span>
                         </TooltipWrapper>
                     }

--- a/src/js/components/award/shared/InfoTooltipContent.jsx
+++ b/src/js/components/award/shared/InfoTooltipContent.jsx
@@ -1280,10 +1280,10 @@ export const CFDASectionInfo = (
 export const CovidFlagTooltip = ({ codes }) => (
     <div className="award-summary-tooltip covid-19">
         <div className="tooltip__title">
-            COVID-19 Response
+            COVID-19 Spending
         </div>
         <div className="tooltip__text">
-            <p>This award is part of the COVID-19 Response because part of its spending was derived from funds associated with the following <strong>Disaster and Emergency Fund Codes</strong> (DEFC): </p>
+            <p>This award is part of the COVID-19 Spending because part of its spending was derived from funds associated with the following <strong>Disaster Emergency Fund Codes</strong> (DEFC): </p>
             <p style={{ textAlign: 'center' }}>
                 {codes.map((code, i, arr) => {
                     if (i === arr.length - 1) {

--- a/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
@@ -92,7 +92,7 @@ const buildNormalProps = (awardType, data, hasFileC) => {
                         rawValue: data._fileCObligated,
                         denominatorValue: data._totalObligation,
                         value: data.fileCObligatedAbbreviated,
-                        text: 'COVID-19 Response Obligations Amount',
+                        text: 'COVID-19 Obligated Amount',
                         color: covidObligatedColor,
                         lineOffset: lineOffsetsBySpendingCategory.fileCProcurementObligated,
                         children: [{
@@ -103,7 +103,7 @@ const buildNormalProps = (awardType, data, hasFileC) => {
                             denominatorValue: data._fileCObligated,
                             rawValue: data._fileCOutlay,
                             value: data.fileCOutlayAbbreviated,
-                            text: 'COVID-19 Response Outlay Amount',
+                            text: 'COVID-19 Outlayed Amount',
                             color: covidColor,
                             lineOffset: lineOffsetsBySpendingCategory.fileCProcurementOutlay
                         }]
@@ -208,7 +208,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
                                 rawValue: data._fileCObligated,
                                 denominatorValue: data._totalObligation,
                                 value: data.fileCObligatedAbbreviated,
-                                text: 'COVID-19 Response Obligations Amount',
+                                text: 'COVID-19 Obligated Amount',
                                 barWidthOverrides: {
                                     rawValue: data._fileCObligated,
                                     denominatorValue: data._baseExercisedOptions
@@ -226,7 +226,7 @@ const buildExceedsCurrentProps = (awardType, data, hasFileC) => {
                                         rawValue: data._fileCOutlay,
                                         denominatorValue: data._fileCObligated
                                     },
-                                    text: 'COVID-19 Response Outlay Amount',
+                                    text: 'COVID-19 Outlayed Amount',
                                     color: covidColor
                                 }]
                             }
@@ -355,7 +355,7 @@ const buildExceedsPotentialProps = (awardType, data, hasFileC) => {
                                 rawValue: data._fileCObligated,
                                 denominatorValue: data._totalObligation,
                                 value: data.fileCObligatedAbbreviated,
-                                text: 'COVID-19 Response Obligations Amount',
+                                text: 'COVID-19 Obligated Amount',
                                 barWidthOverrides: {
                                     rawValue: data._fileCObligated,
                                     denominatorValue: data._baseExercisedOptions
@@ -373,7 +373,7 @@ const buildExceedsPotentialProps = (awardType, data, hasFileC) => {
                                         rawValue: data._fileCOutlay,
                                         denominatorValue: data._fileCObligated
                                     },
-                                    text: 'COVID-19 Response Outlay Amount',
+                                    text: 'COVID-19 Outlayed Amount',
                                     color: covidColor
                                 }]
                             }
@@ -480,7 +480,7 @@ const AwardAmountsChart = ({
                         denominatorValue: awardAmounts._totalObligation,
                         value: awardAmounts.fileCObligatedAbbreviated,
                         lineOffset: lineOffsetsBySpendingCategory.fileCAsstObligation,
-                        text: 'COVID-19 Response Obligations Amount',
+                        text: 'COVID-19 Obligated Amount',
                         color: covidObligatedColor,
                         children: [{
                             labelSortOrder: 0,
@@ -491,7 +491,7 @@ const AwardAmountsChart = ({
                             denominatorValue: awardAmounts._fileCObligated,
                             rawValue: awardAmounts._fileCOutlay,
                             value: awardAmounts.fileCOutlayAbbreviated,
-                            text: 'COVID-19 Response Outlay Amount',
+                            text: 'COVID-19 Outlayed Amount',
                             color: covidColor
                         }]
                     }
@@ -537,7 +537,7 @@ const AwardAmountsChart = ({
                             labelSortOrder: 1,
                             rawValue: awardAmounts._fileCObligated,
                             value: awardAmounts.fileCObligatedAbbreviated,
-                            text: 'COVID-19 Response Obligations Amount',
+                            text: 'COVID-19 Obligated Amount',
                             className: `loan-file-c-obligated`,
                             denominatorValue: awardAmounts._subsidy,
                             lineOffset: lineOffsetsBySpendingCategory.loanFileCObligated,
@@ -551,7 +551,7 @@ const AwardAmountsChart = ({
                                 value: awardAmounts.fileCOutlayAbbreviated,
                                 denominatorValue: awardAmounts._fileCObligated,
                                 lineOffset: lineOffsetsBySpendingCategory.loanFileCOutlay,
-                                text: 'COVID-19 Response Outlay Amount',
+                                text: 'COVID-19 Outlayed Amount',
                                 color: covidColor,
                                 tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory('loan', 'fileCOutlay', awardAmounts)
                             }]

--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -123,7 +123,7 @@ export default class ResultsTable extends React.Component {
             }
         }
         else if (
-            (column.columnName === 'COVID-19 Response Obligations' || column.columnName === 'COVID-19 Response Outlays')
+            (column.columnName === 'COVID-19 Obligations' || column.columnName === 'COVID-19 Outlays')
             && !this.props.results[rowIndex][column.columnName]) {
             props.value = '--';
         }

--- a/src/js/containers/search/filters/def/DEFCheckboxTree.jsx
+++ b/src/js/containers/search/filters/def/DEFCheckboxTree.jsx
@@ -15,7 +15,7 @@ export const NewBadge = () => (
 );
 
 const covidParentNode = {
-    label: "COVID-19 Response",
+    label: "COVID-19 Spending",
     value: "COVID",
     className: "def-checkbox-label--covid",
     expandDisabled: true,
@@ -34,7 +34,7 @@ const parseCovidCodes = (codes) => codes.filter((code) => code.disaster === 'cov
     }), covidParentNode);
 
 const defaultExpanded = ['COVID'];
-const countLabel = { value: 'COVID-19', count: 0, label: 'COVID-19 Response' };
+const countLabel = { value: 'COVID-19', count: 0, label: 'COVID-19 Spending' };
 
 export class DEFCheckboxTree extends React.Component {
     constructor(props) {

--- a/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
+++ b/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
@@ -195,7 +195,7 @@ export class TopFilterBarContainer extends React.Component {
         }
         if (selected) {
             filter.code = 'defCodes';
-            filter.name = 'Disaster Emergency Fund (DEF) Codes';
+            filter.name = 'Disaster Emergency Fund Codes (DEFC)';
             return filter;
         }
         return null;

--- a/src/js/dataMapping/award/awardAmountsSection.js
+++ b/src/js/dataMapping/award/awardAmountsSection.js
@@ -66,8 +66,8 @@ export const awardTableClassMap = {
     "Total Funding": "award-amounts__data-icon_transparent",
     "Face Value of Direct Loan": "award-amounts__data-icon_face-value",
     "Original Subsidy Cost": "award-amounts__data-icon_subsidy",
-    "COVID-19 Response Obligated Amount": "award-amounts__file-c-obligations",
-    "COVID-19 Response Outlayed Amount": "award-amounts__file-c-outlays"
+    "COVID-19 Obligated Amount": "award-amounts__file-c-obligations",
+    "COVID-19 Outlayed Amount": "award-amounts__file-c-outlays"
 };
 
 export const tableTitlesBySpendingCategoryAndAwardType = {
@@ -75,35 +75,35 @@ export const tableTitlesBySpendingCategoryAndAwardType = {
         totalFundingFormatted: 'Total Funding',
         nonFederalFundingFormatted: 'Non-Federal Funding',
         totalObligationFormatted: 'Obligated Amount',
-        fileCOutlayFormatted: 'COVID-19 Response Outlayed Amount',
-        fileCObligatedFormatted: 'COVID-19 Response Obligated Amount'
+        fileCOutlayFormatted: 'COVID-19 Outlayed Amount',
+        fileCObligatedFormatted: 'COVID-19 Obligated Amount'
     },
     idv_aggregated: {
         baseExercisedOptionsFormatted: 'Combined Current Amounts',
         baseAndAllOptionsFormatted: 'Combined Potential Amounts',
         totalObligationFormatted: 'Combined Obligated Amounts',
-        fileCOutlayFormatted: 'COVID-19 Response Outlayed Amount',
-        fileCObligatedFormatted: 'COVID-19 Response Obligated Amount'
+        fileCOutlayFormatted: 'COVID-19 Outlayed Amount',
+        fileCObligatedFormatted: 'COVID-19 Obligated Amount'
     },
     contract: {
         baseExercisedOptionsFormatted: 'Current Amount',
         baseAndAllOptionsFormatted: 'Potential Amount',
         totalObligationFormatted: 'Obligated Amount',
-        fileCOutlayFormatted: 'COVID-19 Response Outlayed Amount',
-        fileCObligatedFormatted: 'COVID-19 Response Obligated Amount'
+        fileCOutlayFormatted: 'COVID-19 Outlayed Amount',
+        fileCObligatedFormatted: 'COVID-19 Obligated Amount'
     },
     idv: {
         baseExercisedOptionsFormatted: 'Current Amount',
         baseAndAllOptionsFormatted: 'Potential Amount',
         totalObligationFormatted: 'Obligated Amount',
-        fileCOutlayFormatted: 'COVID-19 Response Outlayed Amount',
-        fileCObligatedFormatted: 'COVID-19 Response Obligated Amount'
+        fileCOutlayFormatted: 'COVID-19 Outlayed Amount',
+        fileCObligatedFormatted: 'COVID-19 Obligated Amount'
     },
     loan: {
         subsidyFormatted: 'Original Subsidy Cost',
         faceValueFormatted: 'Face Value of Direct Loan',
-        fileCOutlayFormatted: 'COVID-19 Response Outlayed Amount',
-        fileCObligatedFormatted: 'COVID-19 Response Obligated Amount'
+        fileCOutlayFormatted: 'COVID-19 Outlayed Amount',
+        fileCObligatedFormatted: 'COVID-19 Obligated Amount'
     }
 };
 

--- a/src/js/dataMapping/navigation/menuOptions.jsx
+++ b/src/js/dataMapping/navigation/menuOptions.jsx
@@ -8,7 +8,7 @@ import kGlobalConstants from 'GlobalConstants';
 
 const New = () => (
     <span>
-        COVID-19 Response
+        COVID-19 Spending
         <span className="covid-newbadge"> NEW</span>
     </span>);
 

--- a/src/js/dataMapping/search/awardTableColumns.jsx
+++ b/src/js/dataMapping/search/awardTableColumns.jsx
@@ -235,7 +235,7 @@ const subawardColumns = [
 ];
 
 const awardColWidth = 280;
-const covidColWidth = 182;
+const covidColWidth = 190;
 const covidColor = '#6E338E';
 
 const defaultContract = [

--- a/src/js/dataMapping/search/awardTableColumns.jsx
+++ b/src/js/dataMapping/search/awardTableColumns.jsx
@@ -311,17 +311,13 @@ const defaultIdvColumns = [
 
 const covidObligationsCol = {
     title: 'COVID-19 Obligations',
-    subtitle: 'Obligations',
     background: covidColor,
-    displayName: 'COVID-19 Response',
     customWidth: covidColWidth
 };
 
 const covidOutlaysCol = {
     title: 'COVID-19 Outlays',
-    subtitle: 'Outlays',
     background: covidColor,
-    displayName: 'COVID-19 Response',
     customWidth: covidColWidth
 };
 


### PR DESCRIPTION
**High level description:**

Non-COVID profile page edits for language change from "Response" to "Spending"

**Technical details:**

Edited labels for Global Nav, Advanced Seach, COVID badge + tooltip, and Award Summary pages
(homepage edits in separate PR for DEV-5113, modal edits in separate PR for DEV-5618)

**JIRA Ticket:**
DEV-5616 is a sub-task of DEV-5594
[DEV-5594](https://federal-spending-transparency.atlassian.net/browse/DEV-5594)

**Mockup:**
Various mockups for each screen are linked in the ticket A/C above

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [`N/A`] Verified mobile/tablet/desktop/monitor responsiveness
- [`N/A`] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [`N/A`] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [`N/A`] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [`N/A`] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [`N/A`] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [`N/A`] Design review complete `if applicable`
- [`N/A`] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [`N/A`] Code review complete
