### PR TITLE
QAT -- [DEV-5536] Closing Modal on Link Click

### DIFF
--- a/src/js/containers/covid19/CovidModalContainer.jsx
+++ b/src/js/containers/covid19/CovidModalContainer.jsx
@@ -20,6 +20,7 @@ const CovidModalContainer = ({
 }) => {
     const handleGoToAdvancedSearch = (e) => {
         e.preventDefault();
+        hideModal();
         clearFilters();
         resetFilters();
         stageDefCodesForAdvancedSearch({
@@ -32,6 +33,13 @@ const CovidModalContainer = ({
         });
         Router.history.push('/search');
     };
+
+    const handleGoToCovidProfile = (e) => {
+        e.preventDefault();
+        hideModal();
+        Router.history.push('/disaster/covid-19');
+    };
+
     return (
         <Modal
             mounted={mounted}
@@ -66,7 +74,7 @@ const CovidModalContainer = ({
                             </li>
                         </ul>
                     </div>
-                    <h2 className="covid-modal-h2 covid-modal-bold">Visit our new <a href="#/disaster/covid-19">profile page dedicated to the COVID-19 Spending:</a></h2>
+                    <h2 className="covid-modal-h2 covid-modal-bold">Visit our new <a onClick={handleGoToCovidProfile} href="#/disaster/covid-19">profile page dedicated to the COVID-19 Spending:</a></h2>
                     <div>
                         <ul>
                             <li className="covid-modal-li">

--- a/src/js/containers/covid19/homepage/CovidHighlights.jsx
+++ b/src/js/containers/covid19/homepage/CovidHighlights.jsx
@@ -18,7 +18,7 @@ import TotalAmount from 'components/homepage/hero/TotalAmount';
 const defaultParams = {
     pagination: {
         page: 1,
-        limit: 10,
+        limit: 100,
         order: "desc",
         sort: "outlay"
     },


### PR DESCRIPTION
**High level description:**
When you click a link on the modal, the modal doesn't close.

**Technical details:**
Add invocation of `hideModal` on click

**JIRA Ticket:**
[DEV-5536](https://federal-spending-transparency.atlassian.net/browse/DEV-5536)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
