### PR TITLE
[DEV-5757] Adv Search label corrections

### DIFF
--- a/src/js/containers/search/filters/def/DEFCheckboxTree.jsx
+++ b/src/js/containers/search/filters/def/DEFCheckboxTree.jsx
@@ -125,7 +125,7 @@ export class DEFCheckboxTree extends React.Component {
                         className="selected-filters"
                         role="status">
                         {this.props.counts.map((node) => {
-                            const label = `${node.value} - ${node.label} (${node.count})`;
+                            const label = `${node.label} (${node.count})`;
                             return (
                                 <button
                                     key={uniqueId()}

--- a/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
+++ b/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
@@ -195,7 +195,7 @@ export class TopFilterBarContainer extends React.Component {
         }
         if (selected) {
             filter.code = 'defCodes';
-            filter.name = 'Disaster Emergency Fund Codes (DEFC)';
+            filter.name = 'Disaster Emergency Fund Code (DEFC)';
             return filter;
         }
         return null;


### PR DESCRIPTION
**High level description:**

**Top of Adv Search page**
DEFC label now uses "Code" singular

**Bottom of COVID-19 Spending selected checkbox**
Selected chip now says "COVID-19 Spending (<count>)"

**Technical details:**

Edited labels in `DEFCheckboxTree.jsx` (bottom of checkbox filters) and `TopFilterBarContainer.jsx` (top of page)

Technical details for the knowledge of other developers.

**JIRA Ticket:**
[DEV-5757](https://federal-spending-transparency.atlassian.net/browse/DEV-5757)

**Mockup:**
N/A - related screenshots are linked in the ticket above

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [`N/A`] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [`N/A`] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [`N/A`] Verified mobile/tablet/desktop/monitor responsiveness
- [`N/A`] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [`N/A`] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [`N/A`] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [`N/A`] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [`N/A`] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [`N/A`] Design review complete `if applicable`
- [`N/A`] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
