### PR TITLE
QAT Bug/dev 5777/award summary tooltips

### DIFF
--- a/src/js/components/award/shared/awardAmountsSection/Tooltips.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/Tooltips.jsx
@@ -16,7 +16,7 @@ const fileCProps = {
     title: PropTypes.string
 };
 
-export const FileCOutlayTooltip = ({ total, awardType, title = "COVID-19 Response Outlay Amount" }) => (
+export const FileCOutlayTooltip = ({ total, awardType, title = "COVID-19 Outlayed Amount" }) => (
     <div className="award-amounts-tt">
         <h4 className="tooltip__title">{title}</h4>
         <h5 className="tooltip__amount--loans">{total}</h5>
@@ -57,7 +57,7 @@ export const FileCOutlayTooltip = ({ total, awardType, title = "COVID-19 Respons
 
 FileCOutlayTooltip.propTypes = totalPropTypes;
 
-export const FileCObligatedTooltip = ({ total, awardType, title = "COVID-19 Response Obligated Amount" }) => (
+export const FileCObligatedTooltip = ({ total, awardType, title = "COVID-19 Obligated Amount" }) => (
     <div className="award-amounts-tt">
         <h4 className="tooltip__title">{title}</h4>
         <h5 className="tooltip__amount--loans">{total}</h5>


### PR DESCRIPTION
**High level description:**

Progress bar tooltips still had the word "Response" in their headings. In this PR I corrected those headings so that they match the label of the progress bar and legend.

**Technical details:**

Edited `FileCOutlayTooltip` and `FileCObligatedTooltip` components so that their heading matches the chart and legend labels.

**JIRA Ticket:**
[DEV-5777](https://federal-spending-transparency.atlassian.net/browse/DEV-5777)

**Mockup:**
N/A - applicable screenshots linked in ticket above

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [`N/A`] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [`N/A`] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [`N/A`] Verified mobile/tablet/desktop/monitor responsiveness
- [`N/A`] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [`N/A`] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [`N/A`] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [`N/A`] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [`N/A`] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [`N/A`] Design review complete `if applicable`
- [`N/A`] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
