### PR TITLE
QAT DEV-5602 clear search min chars

### DIFF
--- a/src/js/components/covid19/SearchBar.jsx
+++ b/src/js/components/covid19/SearchBar.jsx
@@ -12,6 +12,9 @@ const propTypes = {
     currentSearchTerm: PropTypes.string
 };
 
+// the minimum number of characters a user is required to enter before they can perform a search
+const minChars = 2;
+
 const SearchBar = ({ setQuery, currentSearchTerm }) => {
     const [searchString, setSearchString] = useState(currentSearchTerm);
 
@@ -33,10 +36,21 @@ const SearchBar = ({ setQuery, currentSearchTerm }) => {
         if (searchString && currentSearchTerm === searchString) {
             resetSearch();
         }
+        if (currentSearchTerm && searchString.length < minChars) {
+            resetSearch();
+        }
         else {
             onSubmit();
         }
     };
+
+    let icon = 'search';
+    if (searchString && currentSearchTerm === searchString) {
+        icon = 'times';
+    }
+    else if (currentSearchTerm && searchString.length < minChars) {
+        icon = 'times';
+    }
 
     return (
         <form className="search-bar">
@@ -46,11 +60,11 @@ const SearchBar = ({ setQuery, currentSearchTerm }) => {
                 type="text"
                 onChange={onChange} />
             <button
-                disabled={searchString.length < 2}
+                disabled={searchString.length < minChars && !currentSearchTerm}
                 aria-label="Search"
                 onClick={handleClick}
                 className="search-bar__button">
-                <FontAwesomeIcon icon={(searchString && currentSearchTerm === searchString) ? 'times' : 'search'} />
+                <FontAwesomeIcon icon={icon} />
             </button>
         </form>
     );

--- a/src/js/components/covid19/SearchBar.jsx
+++ b/src/js/components/covid19/SearchBar.jsx
@@ -42,7 +42,7 @@ const SearchBar = ({ setQuery, currentSearchTerm }) => {
         if (searchString && currentSearchTerm === searchString) {
             resetSearch();
         }
-        if (currentSearchTerm && searchString.length < minChars) {
+        else if (currentSearchTerm && searchString.length < minChars) {
             resetSearch();
         }
         else {

--- a/src/js/components/covid19/SearchBar.jsx
+++ b/src/js/components/covid19/SearchBar.jsx
@@ -18,17 +18,23 @@ const minChars = 2;
 const SearchBar = ({ setQuery, currentSearchTerm }) => {
     const [searchString, setSearchString] = useState(currentSearchTerm);
 
+    const resetSearch = () => {
+        setSearchString('');
+        setQuery('');
+    };
+
     const onChange = (e) => {
-        setSearchString(e.target.value);
+        if (currentSearchTerm && !e.target.value) {
+            // auto-reset the search when all input is deleted
+            resetSearch();
+        }
+        else {
+            setSearchString(e.target.value);
+        }
     };
 
     const onSubmit = () => {
         setQuery(searchString);
-    };
-
-    const resetSearch = () => {
-        setSearchString('');
-        setQuery('');
     };
 
     const handleClick = (e) => {


### PR DESCRIPTION
**High level description:**

Resolves an edge case that came up during demos: currently, if you enter a search term and then delete your input, there is no way to reset the search unless you re-type the same search term. These changes auto-reset the search when all input is deleted, and allow users to clear their search with only 1 character of input.

**JIRA Ticket:**
[DEV-5602](https://federal-spending-transparency.atlassian.net/browse/DEV-5602)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- N/A Verified mobile/tablet/desktop/monitor responsiveness
- N/A Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Code review complete
