### PR TITLE
QAT DEV-5774 assistance award count

### DIFF
--- a/src/js/containers/covid19/SummaryInsightsContainer.jsx
+++ b/src/js/containers/covid19/SummaryInsightsContainer.jsx
@@ -7,7 +7,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { awardTypeGroups, awardTypeGroupLabels } from 'dataMapping/search/awardType';
-import { fetchAwardAmounts, fetchAwardCount } from 'helpers/disasterHelper';
+import { fetchAwardAmounts } from 'helpers/disasterHelper';
 import OverviewData from 'components/covid19/OverviewData';
 import { useInFlightList } from 'helpers/covid19Helper';
 import { isEqual } from 'lodash';
@@ -30,7 +30,6 @@ const SummaryInsightsContainer = ({
     areCountsLoading,
     assistanceOnly
 }) => {
-    const awardCountRequest = useRef();
     const awardAmountRequest = useRef();
     const [awardOutlays, setAwardOutlays] = useState(null);
     const [awardObligations, setAwardObligations] = useState(null);
@@ -43,9 +42,6 @@ const SummaryInsightsContainer = ({
         setAwardOutlays(null);
         setAwardObligations(null);
         setNumberOfAwards(null);
-        if (awardCountRequest.current) {
-            awardCountRequest.current.cancel();
-        }
         if (awardAmountRequest.current) {
             awardAmountRequest.current.cancel();
         }
@@ -57,21 +53,16 @@ const SummaryInsightsContainer = ({
         if (activeTab !== 'all') {
             params.filter.award_type_codes = awardTypeGroups[activeTab];
         }
-        const amountsParams = { ...params };
         if (assistanceOnly && activeTab === 'all') {
-            amountsParams.filter.award_type = 'assistance';
+            params.filter.award_type = 'assistance';
         }
         if (defCodes && defCodes.length > 0) {
-            awardAmountRequest.current = fetchAwardAmounts(amountsParams);
-            awardCountRequest.current = fetchAwardCount(params);
+            awardAmountRequest.current = fetchAwardAmounts(params);
             awardAmountRequest.current.promise
                 .then((res) => {
                     setAwardObligations(res.data.obligation);
                     setAwardOutlays(res.data.outlay);
-                });
-            awardCountRequest.current.promise
-                .then((res) => {
-                    setNumberOfAwards(res.data.count);
+                    setNumberOfAwards(res.data.award_count);
                 });
         }
     }, [defCodes, activeTab]);

--- a/src/js/containers/covid19/recipient/SummaryInsightsContainer.jsx
+++ b/src/js/containers/covid19/recipient/SummaryInsightsContainer.jsx
@@ -9,7 +9,7 @@ import { useSelector } from 'react-redux';
 import { isEqual } from 'lodash';
 
 import { awardTypeGroups, awardTypeGroupLabels } from 'dataMapping/search/awardType';
-import { fetchAwardAmounts, fetchAwardCount, fetchDisasterSpendingCount } from 'helpers/disasterHelper';
+import { fetchAwardAmounts, fetchDisasterSpendingCount } from 'helpers/disasterHelper';
 import { useInFlightList } from 'helpers/covid19Helper';
 import OverviewData from 'components/covid19/OverviewData';
 
@@ -42,7 +42,6 @@ const initialInFlightState = overviewData.map((d) => d.type);
 
 const SummaryInsightsContainer = ({ activeFilter }) => {
     const awardAmountRequest = useRef();
-    const awardCountRequest = useRef();
     const recipientCountRequest = useRef();
     const [awardOutlays, setAwardOutlays] = useState(null);
     const [awardObligations, setAwardObligations] = useState(null);
@@ -59,9 +58,6 @@ const SummaryInsightsContainer = ({ activeFilter }) => {
         if (awardAmountRequest.current) {
             awardAmountRequest.current.cancel();
         }
-        if (awardCountRequest.current) {
-            awardCountRequest.current.cancel();
-        }
         // Reset any existing counts
         setAwardOutlays(null);
         setAwardObligations(null);
@@ -77,17 +73,13 @@ const SummaryInsightsContainer = ({ activeFilter }) => {
             params.filter.award_type_codes = awardTypeGroups[activeFilter];
         }
         awardAmountRequest.current = fetchAwardAmounts(params);
-        awardCountRequest.current = fetchAwardCount(params);
         recipientCountRequest.current = fetchDisasterSpendingCount('recipient', params);
 
         awardAmountRequest.current.promise
             .then((res) => {
                 setAwardObligations(res.data.obligation);
                 setAwardOutlays(res.data.outlay);
-            });
-        awardCountRequest.current.promise
-            .then((res) => {
-                setNumberOfAwards(res.data.count);
+                setNumberOfAwards(res.data.award_count);
             });
         recipientCountRequest.current.promise
             .then((res) => {

--- a/src/js/helpers/disasterHelper.js
+++ b/src/js/helpers/disasterHelper.js
@@ -71,12 +71,6 @@ export const fetchNewAwardsOverTime = (params) => apiRequest({
     data: params
 });
 
-export const fetchAwardCount = (params) => apiRequest({
-    url: 'v2/disaster/award/count/',
-    method: 'post',
-    data: params
-});
-
 export const fetchCfdaCount = (params) => apiRequest({
     url: 'v2/disaster/cfda/count/',
     method: 'post',


### PR DESCRIPTION
**High level description:**

Fixes the "Number of Awards for All Assistance Awards" in the CFDA section.  

**Technical details:**

Gets the `award_count` from `disaster/award/amounts` endpoint instead of `disaster/award/count`, since the former accepts the `"award_type": "assistance"` param. Phases out use of `disaster/award/count` throughout the page.

**JIRA Ticket:**
[DEV-5774](https://federal-spending-transparency.atlassian.net/browse/DEV-5774)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- N/A (API request change only) Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- N/A (API request change only)  Verified mobile/tablet/desktop/monitor responsiveness
- N/A (API request change only) Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Code review complete
