### PR TITLE
STAGING -- [DEV-5773] Home Page Style Polish, including Updates to Modal

### DIFF
--- a/src/_scss/pages/homepage/features/_covidFeature.scss
+++ b/src/_scss/pages/homepage/features/_covidFeature.scss
@@ -48,7 +48,6 @@
     
                 @include media ($medium-screen) {
                     display: block;
-                    margin: auto 0;
                     width: 35vw;
                     height: 25vw;
                     max-width: none;

--- a/src/_scss/pages/homepage/features/_covidFeature.scss
+++ b/src/_scss/pages/homepage/features/_covidFeature.scss
@@ -47,6 +47,7 @@
     
                 @include media ($medium-screen) {
                     display: block;
+                    margin: auto 0;
                     width: 35vw;
                     height: 25vw;
                     max-width: none;

--- a/src/_scss/pages/homepage/features/_covidFeature.scss
+++ b/src/_scss/pages/homepage/features/_covidFeature.scss
@@ -25,6 +25,7 @@
                 font-size: rem(18);
                 padding-right: rem(5);
                 color: $color-primary;
+                font-weight: $font-semibold;
             }
         }
 

--- a/src/_scss/pages/homepage/hero/_covid-hero.scss
+++ b/src/_scss/pages/homepage/hero/_covid-hero.scss
@@ -145,14 +145,14 @@
                     li.covid-highlights__highlight {
                         list-style-type: none;
                         @include display(flex);
+                        @include flex-direction(column);
                         @include flex-wrap(wrap);
-                        @include flex-wrap(column);
                         @include align-items(flex-end);
                         @include justify-content(flex-end);
                         opacity: 0.5;
                         margin: 0;
                         padding: rem(15) 0;
-                        width: 100%;
+                        width: 75%;
                         transition: opacity .5s ease-in;
                         &:hover {
                           opacity: 1;

--- a/src/_scss/pages/homepage/hero/_covid-hero.scss
+++ b/src/_scss/pages/homepage/hero/_covid-hero.scss
@@ -134,7 +134,7 @@
                 }
                 ul.covid-highlights {
                     @include display(flex);
-                    @include flex-direction(column);
+                    @include flex-wrap(wrap);
                     @include align-items(flex-end);
                     transform: rotateX(30deg) rotateY(-30deg) rotateZ(0deg) perspective(0);
                     padding: 0;
@@ -146,17 +146,17 @@
                         list-style-type: none;
                         @include display(flex);
                         @include flex-wrap(wrap);
-                        @include flex-direction(column);
+                        @include flex-wrap(column);
                         @include align-items(flex-end);
                         @include justify-content(flex-end);
-                        opacity: 0.75;
+                        opacity: 0.5;
                         margin: 0;
                         padding: rem(15) 0;
                         width: 100%;
                         transition: opacity .5s ease-in;
                         &:hover {
-                            opacity: 1;
-                        }
+                          opacity: 1;
+                       }
                         &.loading {
                           @include align-items(flex-start);
                           @include justify-content(flex-start);

--- a/src/_scss/pages/modals/covid19/_covid19.scss
+++ b/src/_scss/pages/modals/covid19/_covid19.scss
@@ -43,8 +43,8 @@
 
             .covid-modal-li {
                 text-align: left;
-                font-size: rem(19);
-                line-height: rem(24);
+                font-size: rem(14);
+                line-height: rem(18);
             }
             .usa-dt-modal__link {
                 @include display(flex);

--- a/src/js/components/covid19/DataSourcesAndMethodologiesPage.jsx
+++ b/src/js/components/covid19/DataSourcesAndMethodologiesPage.jsx
@@ -11,8 +11,8 @@ import { scrollToY } from 'helpers/scrollToHelper';
 import { scrollPositionOfSiteHeader } from 'dataMapping/covid19/covid19';
 
 import Footer from 'containers/Footer';
+import Header from 'containers/shared/HeaderContainer';
 import MetaTags from 'components/sharedComponents/metaTags/MetaTags';
-import Header from 'components/sharedComponents/header/Header';
 import StickyHeader from 'components/sharedComponents/stickyHeader/StickyHeader';
 import Sidebar from 'components/sharedComponents/sidebar/Sidebar';
 import ExternalLink from 'components/sharedComponents/ExternalLink';


### PR DESCRIPTION
**High level description:**
The home page is unacceptable in safari:
![image](https://user-images.githubusercontent.com/12897813/88979092-f1138a00-d28e-11ea-908e-9f82fa6a2249.png)

Per Marco's request, bolding the font for the `Learn More` link on the home page
![image](https://user-images.githubusercontent.com/12897813/88979128-02f52d00-d28f-11ea-8d90-959b6a07636d.png)

Updating the font size in the modal as well.

**Technical details:**
SCSS updates

**JIRA Ticket:**
[DEV-5773](https://federal-spending-transparency.atlassian.net/browse/DEV-5773)
The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
