### PR TITLE
QAT DEV-5788 remove placeholder tooltips

### DIFF
--- a/src/js/components/award/shared/InfoTooltipContent.jsx
+++ b/src/js/components/award/shared/InfoTooltipContent.jsx
@@ -1297,17 +1297,6 @@ export const CovidFlagTooltip = ({ codes }) => (
     </div>
 );
 
-export const BudgetCategoriesInfo = (
-    <div className="budget-categories-tooltip">
-        <div className="tooltip__title">
-            Coming Soon
-        </div>
-        <div className="tooltip__text">
-            <p>The tooltip content for this section is currently under review.</p>
-        </div>
-    </div>
-);
-
 export const recipientOverviewLoanInfo = (
     <div className="recipient-overview-tooltip">
         <div className="tooltip__title">

--- a/src/js/components/covid19/Covid19Section.jsx
+++ b/src/js/components/covid19/Covid19Section.jsx
@@ -7,8 +7,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { snakeCase } from 'lodash';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { TooltipWrapper } from 'data-transparency-ui';
-import { TooltipComponent } from 'containers/covid19/helpers/covid19';
 
 const propTypes = {
     section: PropTypes.string,
@@ -33,18 +31,9 @@ const Covid19Section = ({
                     <FontAwesomeIcon size="lg" icon={icon} />
                 </div>
                 <h2>{title}</h2>
-                <TooltipWrapper
-                    className="covid19-tt"
-                    icon="info"
-                    tooltipComponent={<TooltipComponent />} />
             </div>
             <div className="body__header-right">
                 {headerText}
-                <TooltipWrapper
-                    className="covid19-tt"
-                    tooltipPosition="left"
-                    icon="info"
-                    tooltipComponent={<TooltipComponent />} />
             </div>
         </div>
         {children}

--- a/src/js/components/covid19/recipient/map/MapFiltersHeader.jsx
+++ b/src/js/components/covid19/recipient/map/MapFiltersHeader.jsx
@@ -1,16 +1,10 @@
 import React from 'react';
-import { TooltipWrapper } from 'data-transparency-ui';
-import { TooltipComponent } from 'containers/covid19/helpers/covid19';
 
 const MapLegendHeader = () => (
     <div className="map__filters-header__title">
         <div className="map-filters-header__title-text">
             Show on Map
         </div>
-        <TooltipWrapper
-            className="tooltip-wrapper award-section-tt"
-            icon="info"
-            tooltipComponent={<TooltipComponent />} />
     </div>
 );
 

--- a/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
+++ b/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
@@ -8,7 +8,7 @@ import { snakeCase } from 'lodash';
 import { useSelector } from 'react-redux';
 import { isCancel } from 'axios';
 import PropTypes from 'prop-types';
-import { Table, Pagination, TooltipWrapper, Picker } from 'data-transparency-ui';
+import { Table, Pagination, Picker } from 'data-transparency-ui';
 import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import {
     budgetColumns,
@@ -21,8 +21,6 @@ import { fetchDisasterSpending, fetchLoanSpending } from 'helpers/disasterHelper
 import ResultsTableLoadingMessage from 'components/search/table/ResultsTableLoadingMessage';
 import ResultsTableErrorMessage from 'components/search/table/ResultsTableErrorMessage';
 import BaseBudgetCategoryRow from 'models/v2/covid19/BaseBudgetCategoryRow';
-import { BudgetCategoriesInfo } from 'components/award/shared/InfoTooltipContent';
-
 
 const propTypes = {
     type: PropTypes.string.isRequired,
@@ -318,12 +316,6 @@ const BudgetCategoriesTableContainer = (props) => {
                     value: key,
                     onClick: spendingCategoryOnChange
                 }))} />
-            <TooltipWrapper
-                className="budget-categories-section-tt"
-                icon="info"
-                tooltipPosition="right"
-                tabIndex={0}
-                tooltipComponent={BudgetCategoriesInfo} />
         </div>
     );
 

--- a/src/js/containers/covid19/helpers/covid19.jsx
+++ b/src/js/containers/covid19/helpers/covid19.jsx
@@ -12,13 +12,6 @@ import BudgetCategories from 'components/covid19/budgetCategories/BudgetCategori
 import AwardQuestion from 'components/covid19/AwardQuestions';
 import SpendingByCFDA from 'components/covid19/assistanceListing/SpendingByCFDA';
 
-export const TooltipComponent = () => (
-    <div className="covid19-tt">
-        <h4 className="tooltip__title">Coming Soon</h4>
-        <p className="tooltip__text">The tooltip content for this section is currently under review.</p>
-    </div>
-);
-
 const totalSpendingText = (
     <div className="body__header-text">
       This section covers <strong>Total Spending</strong>
@@ -31,20 +24,11 @@ const awardSpendingText = (
     </div>
 );
 
-const totalSpendingTooltip = (
-    <div>Content is Coming soon</div>
-);
-
-const awardSpedingTooltip = (
-    <div>Content is Coming soon</div>
-);
-
 export const componentByCovid19Section = () => ({
     overview: {
         icon: 'hand-holding-medical',
         component: <OverviewContainer />,
         headerText: totalSpendingText,
-        headerTextTooltip: totalSpendingTooltip,
         showInMenu: true,
         showInMainSection: true,
         title: 'Overview'
@@ -53,7 +37,6 @@ export const componentByCovid19Section = () => ({
         icon: 'cubes',
         component: <BudgetCategories />,
         headerText: totalSpendingText,
-        headerTextTooltipooltip: totalSpendingTooltip,
         showInMenu: true,
         showInMainSection: true,
         title: 'Total Spending by Budget Category'
@@ -67,7 +50,6 @@ export const componentByCovid19Section = () => ({
         icon: 'building',
         component: <RecipientContainer />,
         headerText: awardSpendingText,
-        headerTextTooltip: awardSpedingTooltip,
         showInMenu: true,
         showInMainSection: true,
         title: 'Award Spending by Recipient'
@@ -76,7 +58,6 @@ export const componentByCovid19Section = () => ({
         icon: 'sitemap',
         component: <AwardSpendingAgency />,
         headerText: awardSpendingText,
-        headerTextTooltip: awardSpedingTooltip,
         showInMenu: true,
         showInMainSection: true,
         title: 'Award Spending by Agency'
@@ -85,7 +66,6 @@ export const componentByCovid19Section = () => ({
         icon: 'plus-circle',
         component: <SpendingByCFDA />,
         headerText: awardSpendingText,
-        headerTextTooltip: awardSpedingTooltip,
         showInMenu: true,
         showInMainSection: true,
         title: 'Award Spending by CFDA Program (Assistance Listing)'


### PR DESCRIPTION
**High level description:**

Removes "Coming Soon" tooltips from the COVID profile page for launch.

**JIRA Ticket**
[DEV-5788](https://federal-spending-transparency.atlassian.net/browse/DEV-5788)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in the JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Code review complete
