### PR TITLE
Fix CARES Act homepage dark release

### DIFF
--- a/src/js/components/homepage/features/Features.jsx
+++ b/src/js/components/homepage/features/Features.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 
 import CovidFeatureContainer from 'containers/covid19/homepage/CovidFeatureContainer';
+import kGlobalConstants from 'GlobalConstants';
 import SpendingExplorerFeature from './SpendingExplorerFeature';
 import SearchFeature from './SearchFeature';
 import PaneFeature from './PaneFeature';
@@ -17,7 +18,7 @@ const Features = () => (
         className="homepage-features"
         aria-label="Web site features">
         <div className="homepage-features__content">
-            <CovidFeatureContainer />
+            {kGlobalConstants.CARES_ACT_RELEASED && <CovidFeatureContainer />}
             <PaneFeature />
             <SpendingExplorerFeature />
             <SearchFeature />

--- a/src/js/components/homepage/features/PaneFeature.jsx
+++ b/src/js/components/homepage/features/PaneFeature.jsx
@@ -26,7 +26,7 @@ const PaneFeature = () => {
     return (
         <div className="feature-pane">
             <div className="feature-pane__wrapper">
-                <h2 className="feature-pane__title">OTHER DATA ACT CONTENT</h2>
+                <h2 className="feature-pane__title">{GlobalConstants.CARES_ACT_RELEASED ? 'OTHER DATA ACT CONTENT' : 'FEATURED CONTENT'}</h2>
                 <div className="feature-pane__content-wrapper">
                     <div className="feature-pane__content feature-pane__content-fiscal-data">
                         <div>

--- a/src/js/components/sharedComponents/header/Dropdown.jsx
+++ b/src/js/components/sharedComponents/header/Dropdown.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import kGlobalConstants from 'GlobalConstants';
 import { AngleDown } from 'components/sharedComponents/icons/Icons';
 
 import DropdownItem from './DropdownItem';
@@ -76,6 +77,7 @@ export default class Dropdown extends React.Component {
                     <div className="nav-dropdown__parent-label">
                         {
                             this.props.label === "Profiles" &&
+                            kGlobalConstants.CARES_ACT_RELEASED &&
                             <div className="new-badge-outer">
                                 <div className="new-badge-middle">
                                     <div className="new-badge-inner" />

--- a/src/js/components/sharedComponents/header/InfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/InfoBanner.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Analytics from 'helpers/analytics/Analytics';
+import kGlobalConstants from 'GlobalConstants';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { CovidHomepageCookie } from './Header';
@@ -28,26 +29,62 @@ export default class InfoBanner extends React.Component {
     }
 
     render() {
+        const content = kGlobalConstants.CARES_ACT_RELEASED ? (
+        <>
+            <div className="info-banner__alert-text">
+                <p className="info-banner__title-text">New to USAspending: Official COVID-19 Spending Data</p>
+                <p>
+                    USAspending now has official spending data from federal agencies related to the Coronavirus Aid, Relief, and Economic Security (CARES) Act and other COVID-19 appropriations.
+                    <button onClick={this.props.triggerModal}> Learn more</button> about the new data and features, or <a href="#/disaster/covid-19">visit the profile page</a> to explore and download the data today!
+                </p>
+            </div>
+            <button
+                className="info-banner__close-button"
+                title="Dismiss message"
+                aria-label="Dismiss message"
+                onClick={this.bannerClosed}>
+                <FontAwesomeIcon size="lg" alt="Dismiss message" icon="times" />
+            </button>
+        </>
+        ) :
+            (
+            <>
+                <div className="info-banner__alert-text">
+                    <div className="info-banner__title-text">
+                        Coming soon to USAspending -- New Tools to Search and Display COVID-19 Spending Data:
+                    </div>
+                    Based on&nbsp;
+                    <a
+                        href="https://www.whitehouse.gov/wp-content/uploads/2020/04/Implementation-Guidance-for-Supplemental-Funding-Provided-in-Response.pdf"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={this.clickedBannerLink}>
+                        OMB Memo M-20-21
+                    </a>
+                    <span className="info-banner__description-external-link">
+                        <FontAwesomeIcon icon="external-link-alt" />
+                    </span>
+                    , Federal agencies will begin supplementing existing reporting of
+                    spending related to the Coronavirus Aid, Relief, and Economic Security (CARES) Act, as
+                    well as other COVID-19 appropriations in July 2020.
+                </div>
+                <button
+                    className="info-banner__close-button"
+                    title="Dismiss message"
+                    aria-label="Dismiss message"
+                    onClick={this.bannerClosed}>
+                    <FontAwesomeIcon size="lg" alt="Dismiss message" icon="times" />
+                </button>
+            </>
+            );
+
         return (
             <div className="info-banner">
                 <div className="info-banner__content">
                     <span className="info-banner__info-circle">
                         <FontAwesomeIcon size="lg" icon="info-circle" />
                     </span>
-                    <div className="info-banner__alert-text">
-                        <p className="info-banner__title-text">New to USAspending: Official COVID-19 Spending Data</p>
-                        <p>
-                            USAspending now has official spending data from federal agencies related to the Coronavirus Aid, Relief, and Economic Security (CARES) Act and other COVID-19 appropriations.
-                            <button onClick={this.props.triggerModal}> Learn more</button> about the new data and features, or <a href="#/disaster/covid-19">visit the profile page</a> to explore and download the data today!
-                        </p>
-                    </div>
-                    <button
-                        className="info-banner__close-button"
-                        title="Dismiss message"
-                        aria-label="Dismiss message"
-                        onClick={this.bannerClosed}>
-                        <FontAwesomeIcon size="lg" alt="Dismiss message" icon="times" />
-                    </button>
+                    {content}
                 </div>
             </div>
         );

--- a/src/js/components/sharedComponents/header/mobile/MobileDropdown.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileDropdown.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import kGlobalConstants from 'GlobalConstants';
 import { AngleUp, AngleDown } from 'components/sharedComponents/icons/Icons';
 
 
@@ -75,6 +76,7 @@ export default class MobileDropdown extends React.Component {
                     <span className="mobile-dropdown__parent-label">
                         {
                             this.props.label === "Profiles" &&
+                            kGlobalConstants.CARES_ACT_RELEASED &&
                             <div className="new-badge-outer">
                                 <div className="new-badge-middle">
                                     <div className="new-badge-inner" />


### PR DESCRIPTION
Hides the following features until the CARES Act launch constant is set to `true`:

- Homepage content
- Updated info banner
- New indicator in Profiles site navigation

- [x] Code review complete