### PR TITLE
Add CARES Act phase 2 global constant

### DIFF
--- a/src/js/GlobalConstants.js
+++ b/src/js/GlobalConstants.js
@@ -15,11 +15,12 @@ const globalConstants = {
     FISCAL_YEAR: 2017,
     MAPBOX_TOKEN: process.env.MAPBOX_TOKEN,
     QAT: (process.env.ENV === 'qat'),
-    CARES_ACT_RELEASED: (
+    // Phase 1 release
+    CARES_ACT_RELEASED: true,
+    // Phase 2 release
+    CARES_ACT_RELEASED_2: (
         process.env.ENV === 'dev' ||
-        process.env.ENV === 'sandbox' ||
-        process.env.ENV === 'qat' ||
-        process.env.ENV === 'staging'
+        process.env.ENV === 'sandbox'
     )
 };
 

--- a/src/js/components/homepage/features/Features.jsx
+++ b/src/js/components/homepage/features/Features.jsx
@@ -18,7 +18,7 @@ const Features = () => (
         className="homepage-features"
         aria-label="Web site features">
         <div className="homepage-features__content">
-            {kGlobalConstants.CARES_ACT_RELEASED && <CovidFeatureContainer />}
+            {kGlobalConstants.CARES_ACT_RELEASED_2 && <CovidFeatureContainer />}
             <PaneFeature />
             <SpendingExplorerFeature />
             <SearchFeature />

--- a/src/js/components/homepage/features/PaneFeature.jsx
+++ b/src/js/components/homepage/features/PaneFeature.jsx
@@ -26,7 +26,7 @@ const PaneFeature = () => {
     return (
         <div className="feature-pane">
             <div className="feature-pane__wrapper">
-                <h2 className="feature-pane__title">{GlobalConstants.CARES_ACT_RELEASED ? 'OTHER DATA ACT CONTENT' : 'FEATURED CONTENT'}</h2>
+                <h2 className="feature-pane__title">{GlobalConstants.CARES_ACT_RELEASED_2 ? 'OTHER DATA ACT CONTENT' : 'FEATURED CONTENT'}</h2>
                 <div className="feature-pane__content-wrapper">
                     <div className="feature-pane__content feature-pane__content-fiscal-data">
                         <div>


### PR DESCRIPTION
**High level description:**

- Adds a new Global Constant which will allow us to hide certain CARES Act features for phase 1 of launch
- Hides some COVID content on the Homepage for phase 1

**Technical details:**

- `CARES_ACT_RELEASED: true` +  `CARES_ACT_RELEASED_2: false` = phase 1
- Open to discussion about which environments should have phase 2 "turned on" in the meantime

**JIRA Ticket:**
[DEV-5807](https://federal-spending-transparency.atlassian.net/browse/DEV-5807)

- [x] Code review complete
