### PR TITLE
DEV-5813 remove budget categories dropdown

### DIFF
--- a/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
+++ b/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
@@ -10,6 +10,7 @@ import { isCancel } from 'axios';
 import PropTypes from 'prop-types';
 import { Table, Pagination, Picker } from 'data-transparency-ui';
 import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
+import kGlobalConstants from 'GlobalConstants';
 
 import {
     budgetColumns,
@@ -327,7 +328,7 @@ const BudgetCategoriesTableContainer = (props) => {
     if (message) {
         return (
             <div ref={errorOrLoadingWrapperRef}>
-                {spendingViewPicker()}
+                {kGlobalConstants.CARES_ACT_RELEASED_2 && spendingViewPicker()}
                 <Pagination
                     currentPage={currentPage}
                     changePage={changeCurrentPage}
@@ -357,7 +358,7 @@ const BudgetCategoriesTableContainer = (props) => {
 
     return (
         <div ref={tableWrapperRef} className="table-wrapper">
-            {spendingViewPicker()}
+            {kGlobalConstants.CARES_ACT_RELEASED_2 && spendingViewPicker()}
             <Pagination
                 currentPage={currentPage}
                 changePage={changeCurrentPage}


### PR DESCRIPTION
**High level description:**

Hides the Budget Category section spending view dropdown for phase 1.

**JIRA Ticket:**
[DEV-5813](https://federal-spending-transparency.atlassian.net/browse/DEV-5813), subtask of [DEV-5807](https://federal-spending-transparency.atlassian.net/browse/DEV-5807)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- N/A Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Code review complete
