### PR TITLE
DEV-5807 hide part of Budget Category description

### DIFF
--- a/src/js/components/covid19/budgetCategories/BudgetCategories.jsx
+++ b/src/js/components/covid19/budgetCategories/BudgetCategories.jsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
+import kGlobalConstants from 'GlobalConstants';
 import BudgetCategoriesTableContainer from 'containers/covid19/budgetCategories/BudgetCategoriesTableContainer';
 import DateNote from 'components/covid19/DateNote';
 import { fetchDisasterSpendingCount } from 'helpers/disasterHelper';
@@ -114,9 +115,11 @@ const BudgetCategories = () => {
                     In this section, we present the total amount of COVID-19 funding divided into three high-level budget categories: the <span className="glossary-term">Agencies</span> <GlossaryLink currentUrl="disaster/covid-19" term="agency" /> who are authorizing the funds to be spent; the <span className="glossary-term">Federal Accounts</span> <GlossaryLink currentUrl="disaster/covid-19" term="federal-account" /> from which agencies authorize spending; and the <span className="glossary-term">Object Classes</span> <GlossaryLink currentUrl="disaster/covid-19" term="object-class" /> of the goods and services purchased with this funding.
                 </p>
                 <ReadMore>
-                    <p>
-                        This section includes both award spending (detailed in the sections below) and non-award spending, such as internal federal agency expenses.
-                    </p>
+                    {kGlobalConstants.CARES_ACT_RELEASED_2 && (
+                        <p>
+                            This section includes both award spending (detailed in the sections below) and non-award spending, such as internal federal agency expenses.
+                        </p>
+                    )}
                     <p>
                         In the chart below, see how much is available to be spent (Total Budgetary Resources), how much has been promised to be spent (Total Obligations), and how much has actually been paid out (Total Outlays).
                     </p>


### PR DESCRIPTION
**High level description:**

For phase 1, hides the paragraph of the Budget Category section description that references award spending.

**JIRA Ticket:**
[DEV-5813](https://federal-spending-transparency.atlassian.net/browse/DEV-5813), subtask of [DEV-5807](https://federal-spending-transparency.atlassian.net/browse/DEV-5807)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- N/A Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- N/A Verified mobile/tablet/desktop/monitor responsiveness
- N/A Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Code review complete
