### PR TITLE
DEV-5776 catch WebGL error when not supported

### DIFF
--- a/src/_scss/pages/covid19/recipient/recipientContainer.scss
+++ b/src/_scss/pages/covid19/recipient/recipientContainer.scss
@@ -1,5 +1,6 @@
 .recipient__container {
   width: 100%;
+  @import "../search/results/table/tableMessages";
   .count-tabs {
     &.recipient__tabs-container {
       width: 100%;

--- a/src/js/components/search/table/ResultsTableErrorMessage.jsx
+++ b/src/js/components/search/table/ResultsTableErrorMessage.jsx
@@ -4,21 +4,34 @@
   **/
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { ExclamationTriangle } from 'components/sharedComponents/icons/Icons';
 
-const ResultsTableErrorMessage = () => (
+const defaultProps = {
+    title: 'An error occurred.',
+    description: 'Something went wrong while gathering your data.'
+};
+
+const propTypes = {
+    title: PropTypes.string,
+    description: PropTypes.string
+};
+const ResultsTableErrorMessage = ({ title, description }) => (
     <div className="results-table-error">
         <div className="icon">
             <ExclamationTriangle alt="An error occurred" />
         </div>
         <div className="title">
-            An error occurred.
+            {title}
         </div>
         <div className="description">
-            Something went wrong while gathering your data.
+            {description}
         </div>
     </div>
 );
 
+
+ResultsTableErrorMessage.propTypes = propTypes;
+ResultsTableErrorMessage.defaultProps = defaultProps;
 export default ResultsTableErrorMessage;

--- a/src/js/containers/covid19/recipient/map/MapContainer.jsx
+++ b/src/js/containers/covid19/recipient/map/MapContainer.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { isCancel } from 'axios';
 import { uniqueId, keyBy, isEqual } from 'lodash';
+import MapboxGL from 'mapbox-gl/dist/mapbox-gl';
 import MapWrapper from 'components/covid19/recipient/map/MapWrapper';
 import AwardFilterButtons from 'components/covid19/recipient/AwardFilterButtons';
 import MapBroadcaster from 'helpers/mapBroadcaster';
@@ -15,6 +16,7 @@ import LoadingSpinner from 'components/sharedComponents/LoadingSpinner';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import MapMessage from 'components/search/visualizations/geo/MapMessage';
 import RecipientMapTooltip from 'components/covid19/recipient/map/RecipientMapTooltip';
+import ResultsTableErrorMessage from 'components/search/table/ResultsTableErrorMessage';
 import {
     centerOfMap,
     filters,
@@ -337,7 +339,14 @@ export class MapContainer extends React.Component {
 
     render() {
         let message = null;
-        if (this.state.loading) {
+
+        if (!MapboxGL.supported()) {
+            return (
+                <div className="results-table-message-container">
+                    <ResultsTableErrorMessage title="Webgl Required." description="Please enable webgl in your browser settings to view this visualization." />
+                </div>
+            );
+        } else if (this.state.loading) {
             message = (
                 <MapMessage>
                     <div className="map-loading">

--- a/src/js/containers/covid19/recipient/map/MapContainer.jsx
+++ b/src/js/containers/covid19/recipient/map/MapContainer.jsx
@@ -343,7 +343,7 @@ export class MapContainer extends React.Component {
         if (!MapboxGL.supported()) {
             return (
                 <div className="results-table-message-container">
-                    <ResultsTableErrorMessage title="Webgl Required." description="Please enable webgl in your browser settings to view this visualization." />
+                    <ResultsTableErrorMessage title="WebGL Required." description="Please enable WebGL in your browser settings to view this visualization." />
                 </div>
             );
         } else if (this.state.loading) {


### PR DESCRIPTION
**High level description:**
Adds a fix to mapbox which catches the WebGL error when it isn't supported. The user will see an error only for the mapbox map which instructs to user to enable WebGL if they want to see the visualization.

**Technical details:**
To test WebGL being disabled, open firefox and go type `about:config` for the url. Then, type `webgl.disabled` in the search bar. Set it to enabled or true.

**JIRA Ticket:**
[DEV-5776](https://federal-spending-transparency.atlassian.net/browse/DEV-5776)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [N/A] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [N/A] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [N/A] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
