### PR TITLE
Dev-5718 Recipient Map Min Zoom Territory Filters 2

### DIFF
--- a/src/js/dataMapping/covid19/recipient/map/map.js
+++ b/src/js/dataMapping/covid19/recipient/map/map.js
@@ -127,16 +127,14 @@ export const mapboxSources = {
     },
     county: {
         label: 'county',
-        minZoom: 5,
-        url: 'mapbox://usaspending.83g94wbo',
-        layer: 'tl_2017_us_county-7dgoe0',
+        url: 'mapbox://usaspending.29sdfmwu',
+        layer: 'tl_2019_us_county',
         filterKey: 'GEOID' // the county GEOID is state FIPS + county FIPS
     },
     district: {
         label: 'congressional district',
-        minZoom: 4,
-        url: 'mapbox://usaspending.a4bkzui0',
-        layer: 'tl_2018_us_cd116-34qpds',
+        url: 'mapbox://usaspending.3kh310z9',
+        layer: 'tl_2018_us_cd116',
         filterKey: 'GEOID' // the GEOID is state FIPS + district
     },
     zip: {


### PR DESCRIPTION
**High level description:**

Recipient map territory filters all have a min zoom of 2.

**Technical details:**

> • create new tileset in mapbox for congressional districts

> • create new tileset in mapbox for counties

> • apply the above tilesets in for respective filters

**JIRA Ticket:**
[DEV-5718](https://federal-spending-transparency.atlassian.net/browse/DEV-5718)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [N/A] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [N/A] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [N/A] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
