### PR TITLE
change scale to exponential for covid19 map

### DIFF
--- a/src/js/components/covid19/recipient/map/MapWrapper.jsx
+++ b/src/js/components/covid19/recipient/map/MapWrapper.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { uniq, cloneDeep } from 'lodash';
 
-import * as MapHelper from 'helpers/mapHelper';
+import * as Covid19Helper from 'helpers/covid19Helper';
 import MapBroadcaster from 'helpers/mapBroadcaster';
 import { mapboxSources, visualizationColors } from 'dataMapping/covid19/recipient/map/map';
 import MapBox from 'components/search/visualizations/geo/map/MapBox';
@@ -362,7 +362,7 @@ export default class MapWrapper extends React.Component {
 
         const source = mapboxSources[this.props.activeFilters.territory];
         // calculate the range of data
-        const scale = MapHelper.calculateRange(this.props.data.values);
+        const scale = Covid19Helper.calculateCovidMapRange(this.props.data.values);
         // prepare a set of blank (false) filters
         const filterValues = visualizationColors.map(() => (
             []

--- a/src/js/components/covid19/recipient/map/MapWrapper.jsx
+++ b/src/js/components/covid19/recipient/map/MapWrapper.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { uniq, cloneDeep } from 'lodash';
 
-import * as Covid19Helper from 'helpers/covid19Helper';
+import { calculateCovidMapRange } from 'helpers/covid19Helper';
 import MapBroadcaster from 'helpers/mapBroadcaster';
 import { mapboxSources, visualizationColors } from 'dataMapping/covid19/recipient/map/map';
 import MapBox from 'components/search/visualizations/geo/map/MapBox';
@@ -362,7 +362,7 @@ export default class MapWrapper extends React.Component {
 
         const source = mapboxSources[this.props.activeFilters.territory];
         // calculate the range of data
-        const scale = Covid19Helper.calculateCovidMapRange(this.props.data.values);
+        const scale = calculateCovidMapRange(this.props.data.values);
         // prepare a set of blank (false) filters
         const filterValues = visualizationColors.map(() => (
             []

--- a/src/js/dataMapping/covid19/recipient/map/map.js
+++ b/src/js/dataMapping/covid19/recipient/map/map.js
@@ -162,12 +162,12 @@ export const logMapScopeEvent = (scope) => {
 };
 
 export const visualizationColors = [
-    '#dfe5ea',
-    '#dfe5ea',
-    '#c9d2d7',
-    '#6c8a8e',
-    '#3e5c6a',
-    '#083546'
+    'rgba(1, 43, 58, 0.12)',
+    'rgba(1, 43, 58, 0.30)',
+    'rgba(1, 43, 58, 0.48)',
+    'rgba(1, 43, 58, 0.65)',
+    'rgba(1, 43, 58, 0.85)',
+    'rgba(1, 43, 58, 1)'
 ];
 
 export const tooltipLabels = {

--- a/src/js/helpers/covid19Helper.js
+++ b/src/js/helpers/covid19Helper.js
@@ -4,9 +4,8 @@
  */
 
 import { useState } from 'react';
-import { snakeCase } from 'lodash';
+import { snakeCase, min, max } from 'lodash';
 import moment from 'moment';
-import { min, max } from 'lodash';
 import { scalePow } from 'd3-scale';
 
 import { defCodes } from 'dataMapping/covid19/covid19';


### PR DESCRIPTION
**High level description:**

make colors on Covid19 map more distinct to get a better visual representation of the data 

**Technical details:**

change scale for Covid19 map to better fit data. changed colors for 6 buckets in covid19 map

**JIRA Ticket:**
[DEV-5819)](https://federal-spending-transparency.atlassian.net/browse/DEV-5819)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] Code review complete
