### PR TITLE
Ftr/dev 5830/add disclaimer line about utah to map

### DIFF
--- a/src/_scss/pages/covid19/recipient/recipientContainer.scss
+++ b/src/_scss/pages/covid19/recipient/recipientContainer.scss
@@ -40,13 +40,16 @@
             @include h3;
             margin: 0;
         }
-        
+
         .map-container {
             height: rem(475);
             width: 100%;
         }
         .map-data-message {
           font-size: rem(14);
+        }
+        .bold-map-data-message {
+          font-weight: 600;
         }
         @import "pages/search/results/visualizations/geo/map/map";
         .map-container {

--- a/src/_scss/pages/covid19/recipient/recipientContainer.scss
+++ b/src/_scss/pages/covid19/recipient/recipientContainer.scss
@@ -40,10 +40,13 @@
             @include h3;
             margin: 0;
         }
-
+        
         .map-container {
             height: rem(475);
             width: 100%;
+        }
+        .map-data-message {
+          font-size: rem(14);
         }
         @import "pages/search/results/visualizations/geo/map/map";
         .map-container {

--- a/src/js/components/covid19/recipient/map/MapWrapper.jsx
+++ b/src/js/components/covid19/recipient/map/MapWrapper.jsx
@@ -451,7 +451,7 @@ export default class MapWrapper extends React.Component {
                 {this.tooltip()}
                 {this.props.children}
                 <div>
-                    <p className="map-data-message">Amounts reported for Utah contain data submitted by HHS. <a href="https://www.usaspending.gov/data/covid_19_data_limitations.pdf">See more information about HHS&apos;s data submission.</a></p>
+                    <p className="map-data-message"><span className="bold-map-data-message">NOTE:</span> Amounts reported for Utah contain data submitted by HHS. <a href="data/data-limitations.pdf" target="_blank" rel="noopener noreferrer">See more information about HHS&apos;s data submission.</a></p>
                 </div>
             </div>
         );

--- a/src/js/components/covid19/recipient/map/MapWrapper.jsx
+++ b/src/js/components/covid19/recipient/map/MapWrapper.jsx
@@ -450,6 +450,9 @@ export default class MapWrapper extends React.Component {
                 {this.legend()}
                 {this.tooltip()}
                 {this.props.children}
+                <div>
+                    <p className="map-data-message">Amounts reported for Utah contain data submitted by HHS. <a href="https://www.usaspending.gov/data/covid_19_data_limitations.pdf">See more information about HHS&apos;s data submission.</a></p>
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
**High level description:**

Added HHS Utah disclaimer underneath Recipients section map.

**Technical details:**

Edited `MapWrapper.jsx` (added in disclaimer text) and `recipientContainer.scss` (added styling for disclaimer text)

**JIRA Ticket:**
[DEV-5830](https://federal-spending-transparency.atlassian.net/browse/DEV-5830)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [`N/A`] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [`N/A`] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [`N/A`] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [`N/A`] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [`N/A`] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [`N/A`] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [`N/A`] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [`N/A`] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
