### PR TITLE
DEV-5840 Fix data as of notes

### DIFF
--- a/src/js/components/covid19/DateNote.jsx
+++ b/src/js/components/covid19/DateNote.jsx
@@ -14,7 +14,7 @@ const DateNote = ({ styles }) => {
     if (!date) return null;
     return (
         <div style={{ ...styles }} className="covid__date-note">
-            Data as of {date}
+            Data through {date}
         </div>
     );
 };

--- a/src/js/helpers/covid19Helper.js
+++ b/src/js/helpers/covid19Helper.js
@@ -134,7 +134,7 @@ export const getCovidFromFileC = (codes) => codes
 
 export const latestSubmissionDateFormatted = (availablePeriods) => availablePeriods
     .filter((s) => !s.is_quarter)
-    .map((s) => moment.utc(s.submission_reveal_date))
+    .map((s) => moment.utc(s.period_end_date))
     .sort((a, b) => b.valueOf() - a.valueOf())
     .find((s) => Date.now() >= s.valueOf())
     .format('MMMM DD[,] YYYY');

--- a/tests/helpers/covid19Helper-test.js
+++ b/tests/helpers/covid19Helper-test.js
@@ -12,7 +12,7 @@ import mockSubmissions from '../testResources/covid19MockData';
 describe('Covid 19 Helper', () => {
     describe('latestSubmissionDateFormatted', () => {
         it('should find the latest submission date and format it', () => {
-            expect(latestSubmissionDateFormatted(mockSubmissions)).toEqual('June 30, 2020');
+            expect(latestSubmissionDateFormatted(mockSubmissions)).toEqual('May 31, 2020');
         });
     });
     describe('areCountsDefined', () => {


### PR DESCRIPTION
**High level description:**

- Fixes the "Data as of" dates on COVID visualizations
- Changes language from "Data as of" to "Data through"

**JIRA Ticket**
[DEV-5840](https://federal-spending-transparency.atlassian.net/browse/DEV-5840)

The following are ALL required for the PR to be merged:

Reviewer(s):

- [ ] Code review complete
