### PR TITLE
DEV-5830 final CARES Act phase 2 edits

### DIFF
--- a/src/js/components/covid19/recipient/map/MapWrapper.jsx
+++ b/src/js/components/covid19/recipient/map/MapWrapper.jsx
@@ -456,7 +456,7 @@ export default class MapWrapper extends React.Component {
                 {this.tooltip()}
                 {this.props.children}
                 <div>
-                    <p className="map-data-message"><span className="bold-map-data-message">NOTE:</span> Amounts reported for Utah contain data submitted by HHS. <a href="data/data-limitations.pdf" target="_blank" rel="noopener noreferrer">See more information about HHS&apos;s data submission.</a></p>
+                    <p className="map-data-message"><span className="bold-map-data-message">NOTE:</span> Amounts reported for Utah reflect an award by HHS from the Provider Relief Fund (PRF) to a single entity in Utah which will make payments to recipients across the country. <a href="data/data-limitations.pdf" target="_blank" rel="noopener noreferrer">See more information about HHS&apos;s data submission.</a></p>
                 </div>
             </div>
         );

--- a/src/js/components/sharedComponents/header/InfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/InfoBanner.jsx
@@ -32,9 +32,9 @@ export default class InfoBanner extends React.Component {
         const content = kGlobalConstants.CARES_ACT_RELEASED_2 ? (
         <>
             <div className="info-banner__alert-text">
-                <p className="info-banner__title-text">New to USAspending: Official COVID-19 Spending Data</p>
+                <p className="info-banner__title-text">New to USAspending: COVID-19 Spending Data</p>
                 <p>
-                    USAspending now has official spending data from federal agencies related to the Coronavirus Aid, Relief, and Economic Security (CARES) Act and other COVID-19 appropriations.
+                    USAspending now has spending data from federal agencies related to the Coronavirus Aid, Relief, and Economic Security (CARES) Act and other COVID-19 appropriations.
                     <button onClick={this.props.triggerModal}> Learn more</button> about the new data and features, or <a href="#/disaster/covid-19">visit the profile page</a> to explore and download the data today!
                 </p>
             </div>

--- a/src/js/containers/covid19/CovidModalContainer.jsx
+++ b/src/js/containers/covid19/CovidModalContainer.jsx
@@ -86,7 +86,7 @@ const CovidModalContainer = ({
                         <div>
                             <ul>
                                 <li className="covid-modal-li">
-                                    Our newest profile page shows you official COVID-19 spending information as submitted by federal agencies. Learn more about <span className="covid-modal-bold">who received funding, which agencies outlayed funds,</span> and <span className="covid-modal-bold">which programs were funded.</span> All COVID-19 spending data is <span className="covid-modal-bold">available for download</span> on the profile page with one click. Read about our datasets and calculations on the <a onClick={handleGoToDsm} href="#/disaster/covid-19/data-sources">Data Sources &amp; Methodology</a> page.
+                                    Our newest profile page shows you COVID-19 spending information as submitted by federal agencies. Learn more about <span className="covid-modal-bold">who received funding, which agencies outlayed funds,</span> and <span className="covid-modal-bold">which programs were funded.</span> All COVID-19 spending data is <span className="covid-modal-bold">available for download</span> on the profile page with one click. Read about our datasets and calculations on the <a onClick={handleGoToDsm} href="#/disaster/covid-19/data-sources">Data Sources &amp; Methodology</a> page.
                                 </li>
                             </ul>
                         </div>

--- a/src/js/containers/covid19/CovidModalContainer.jsx
+++ b/src/js/containers/covid19/CovidModalContainer.jsx
@@ -68,7 +68,7 @@ const CovidModalContainer = ({
                         </button>
                     </div>
                     <div className="usa-dt-modal__body covid-modal-body">
-                        <h2 className="covid-modal-h2"><span className="covid-modal-bold">Official spending data from the federal government&apos;s response to COVID-19 is now available to view and download on USAspending. The new data includes:</span></h2>
+                        <h2 className="covid-modal-h2"><span className="covid-modal-bold">Spending data from the federal government&apos;s response to COVID-19 is now available to view and download on USAspending. The new data includes:</span></h2>
                         <div>
                             <ul>
                                 <li className="covid-modal-li">

--- a/src/js/containers/covid19/CovidModalContainer.jsx
+++ b/src/js/containers/covid19/CovidModalContainer.jsx
@@ -52,13 +52,13 @@ const CovidModalContainer = ({
             <Modal
                 mounted={mounted}
                 onExit={hideModal}
-                titleText="New to USAspending: Official COVID-19 Response Data"
+                titleText="New to USAspending: COVID-19 Response Data"
                 dialogClass="usa-dt-modal"
                 verticallyCenter
                 escapeExits>
                 <div className="usa-dt-modal covid-modal">
                     <div className="usa-dt-modal__header covid-header">
-                        <h1>New to USAspending: Official COVID-19 Spending Data</h1>
+                        <h1>New to USAspending: COVID-19 Spending Data</h1>
                         <button
                             className="usa-dt-modal__close-button"
                             onClick={hideModal}

--- a/src/js/containers/covid19/homepage/CovidFeatureContainer.jsx
+++ b/src/js/containers/covid19/homepage/CovidFeatureContainer.jsx
@@ -61,7 +61,7 @@ const CovidFeatureContainer = ({
 
             <div className="official-spending-data__content-wrapper">
                 <div className="official-spending-data__text">
-                    <h2 className="homepage-feature-title">Official COVID-19 Spending Data</h2>
+                    <h2 className="homepage-feature-title">COVID-19 Spending Data</h2>
                     <div className="feature-covid-official-spending-data__image-wrapper">
                         <img
                             className="feature-covid-official-spending-data__image-mobile"

--- a/src/js/containers/covid19/homepage/CovidFeatureContainer.jsx
+++ b/src/js/containers/covid19/homepage/CovidFeatureContainer.jsx
@@ -70,7 +70,7 @@ const CovidFeatureContainer = ({
                             alt="Illustration of people interacting with data" />
                     </div>
                     <div className="homepage-feature-description">
-                        <p>Official spending data from the federal government’s response to COVID-19 is now available to view and download on USAspending. Additional data and features will be released in the coming months. <button className="homepage-feature-description__button" onClick={triggerModal}>Learn more</button>about the updates made across the site related to COVID-19 spending.</p>
+                        <p>Spending data from the federal government’s response to COVID-19 is now available to view and download on USAspending. Additional data and features will be released in the coming months. <button className="homepage-feature-description__button" onClick={triggerModal}>Learn more</button>about the updates made across the site related to COVID-19 spending.</p>
                         <p>The new data includes:</p>
                         <ul>
                             <li><strong className="homepage-feature-description_weight_bold">Disaster Emergency Fund Code (DEFC)</strong> tags that highlight funding from the CARES Act and other COVID-19 supplemental appropriations.</li>

--- a/src/js/containers/covid19/homepage/CovidFeatureContainer.jsx
+++ b/src/js/containers/covid19/homepage/CovidFeatureContainer.jsx
@@ -135,7 +135,7 @@ const CovidFeatureContainer = ({
                             alt="Screenshot of COVID-19 Spending profile page" />
                     </div>
                     <div className="homepage-feature-description adv-search-spending-profile__text">
-                        <p>Our newest profile page shows you official COVID-19 spending information as submitted by federal agencies. Learn more about <strong className="homepage-feature-description_weight_bold">who received funding, which agencies outlayed funds,</strong> and <strong className="homepage-feature-description_weight_bold">which programs were funded</strong>.</p>
+                        <p>Our newest profile page shows you COVID-19 spending information as submitted by federal agencies. Learn more about <strong className="homepage-feature-description_weight_bold">who received funding, which agencies outlayed funds,</strong> and <strong className="homepage-feature-description_weight_bold">which programs were funded</strong>.</p>
                         <p>All COVID-19 spending data is <strong className="homepage-feature-description_weight_bold">available for download</strong> on the profile page with one click. You can also read about our datasets and calculations on the <a href="#/disaster/covid-19/data-sources">Data Sources &amp; Methodology</a> page </p>
                     </div>
                     <div className="feature-covid__button-wrap">

--- a/src/js/containers/covid19/homepage/CovidHighlights.jsx
+++ b/src/js/containers/covid19/homepage/CovidHighlights.jsx
@@ -275,7 +275,7 @@ export class CovidHighlights extends React.Component {
                             </span>
                         </h1>
                         <p>
-                            USAspending is the official open data source of federal spending information – including spending in response to COVID-19. We track how federal money is spent in communities across America and beyond. Learn more about government spending through interactive tools that explore elements of the federal budget, such as federal loan, grant, and contract data.
+                            USAspending is the official open data source of federal spending information. We track how federal money is spent in communities across America and beyond. Learn more about government spending through interactive tools that explore elements of the federal budget, such as federal loan, grant, and contract data.
                         </p>
                     </div>
                     <div


### PR DESCRIPTION
**High level description:**

- Updates copy for the COVID-19 profile note below the recipient map
- Removes "Official" where it was preceding references to COVID-19 data in the banner, modal, and homepage

**JIRA Ticket:**
[DEV-5830](https://federal-spending-transparency.atlassian.net/browse/DEV-5830)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Demo to testing
- N/A (text changes only) Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- N/A (text changes only) Verified mobile/tablet/desktop/monitor responsiveness
- N/A (text changes only) Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Code review complete
