### PR TITLE
[DEV-5501] Prime Recipient Name links navigate the user to "Invalid Award ID" page

### DIFF
--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -100,7 +100,7 @@ export default class ResultsTable extends React.Component {
             // for Sub-Awards
             cellClass = ResultsTableLinkCell;
             props.id = this.props.results[rowIndex].prime_award_recipient_id;
-            props.column = 'award';
+            props.column = 'recipient';
         }
         else if (column.columnName === 'Awarding Agency' && this.props.results[rowIndex].awarding_agency_id) {
             cellClass = ResultsTableLinkCell;


### PR DESCRIPTION

**High level description:**

This PR fixes the bug where users are taken to the Invalid Award ID page instead of recipient profile page when clicking on the prime recipient name under subawards.

**Technical details:**
The props.column value was being set to 'award' which resulted in building invalid links. Changing this value to 'recipient' results in a correct link and the user is navigated to the recipient profile page.

**JIRA Ticket:**
[DEV-5501](https://federal-spending-transparency.atlassian.net/browse/DEV-5501)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [ ] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
