### PR TITLE
[DEV-5041 spending explorer periods

### DIFF
--- a/src/_scss/pages/explorer/detail/sidebar/sidebar.scss
+++ b/src/_scss/pages/explorer/detail/sidebar/sidebar.scss
@@ -10,6 +10,39 @@
 
     background-color: $color-gray-dark;
     color: $color-white;
+    .usa-dt-quarter-picker__list {
+        @include flex-wrap(wrap);
+        @media(min-width: $tablet-screen) {
+            @include flex-wrap(nowrap);
+        }
+    }
+    .usa-dt-quarter-picker__period-list-container {
+        p {
+            font-weight: 600;
+        }
+        .usa-dt-quarter-picker__period-list .usa-dt-quarter-picker__list-item {
+            // the generic period styles
+            margin: rem(0) rem(1);
+            .usa-dt-quarter-picker__quarter {
+                width: rem(24);
+                font-weight: $font-bold;
+                padding-right: 0;
+                padding-left: 0;
+            }
+            // period representing two periods (1-2)
+            &.double-period .usa-dt-quarter-picker__quarter {
+                width: rem(48);
+            }
+            // period representing three periods (1-3)
+            &.triple-period .usa-dt-quarter-picker__quarter {
+                width: rem(72);
+            }
+            // period representing three periods w/ two-digit integers (10-12)
+            &.triple-period--extra-wide .usa-dt-quarter-picker__quarter {
+                width: rem(72);
+            }
+        }
+    }
     @import "./_home";
     @import "./_quarter";
     @import "./_fyPicker";

--- a/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
+++ b/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import Analytics from 'helpers/analytics/Analytics';
 
 import { Home } from 'components/sharedComponents/icons/Icons';
-import { lastCompletedQuarterInFY } from 'containers/explorer/detail/helpers/explorerQuarters';
+import { lastCompletedQuarterInFY, lastPeriodByQuarter } from 'containers/explorer/detail/helpers/explorerQuarters';
 import QuarterPickerWithFY from 'components/sharedComponents/QuarterPickerWithFY';
 import VerticalTrail from './VerticalTrail';
 
@@ -66,11 +66,20 @@ export default class ExplorerSidebar extends React.Component {
         // Log analytic event
         this.logTimePeriodEvent(lastQuarter.quarter, lastQuarter.year);
 
-        this.props.setExplorerPeriod({
-            fy: `${lastQuarter.year}`,
-            quarter: `${lastQuarter.quarter}`,
-            period: null
-        });
+        if (year >= 2020) {
+            this.props.setExplorerPeriod({
+                fy: `${lastQuarter.year}`,
+                period: `${lastPeriodByQuarter(lastQuarter.quarter)}`,
+                quarter: null
+            });
+        }
+        else {
+            this.props.setExplorerPeriod({
+                fy: `${lastQuarter.year}`,
+                quarter: `${lastQuarter.quarter}`,
+                period: null
+            });
+        }
         this.setState({
             showFYMenu: false
         });
@@ -120,10 +129,9 @@ export default class ExplorerSidebar extends React.Component {
 
                 <QuarterPickerWithFY
                     selectedFy={this.props.fy}
-                    quarter={this.props.quarter}
                     handleQuarterPickerSelection={this.pickedQuarter}
-                    handlePickedYear={this.pickedYear} />
-
+                    handlePickedYear={this.pickedYear}
+                    latestSelectedTimeInterval={this.props.period == null ? this.props.quarter : this.props.period} />
                 <VerticalTrail
                     trail={this.props.trail.toArray()}
                     rewindToFilter={this.props.rewindToFilter} />

--- a/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
+++ b/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import Analytics from 'helpers/analytics/Analytics';
 
 import { Home } from 'components/sharedComponents/icons/Icons';
-import { lastCompletedQuarterInFY, lastPeriodByQuarter } from 'containers/explorer/detail/helpers/explorerQuarters';
+import { lastCompletedQuarterInFY } from 'containers/explorer/detail/helpers/explorerQuarters';
 import QuarterPickerWithFY from 'components/sharedComponents/QuarterPickerWithFY';
 import VerticalTrail from './VerticalTrail';
 

--- a/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
+++ b/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
@@ -9,10 +9,10 @@ import PropTypes from 'prop-types';
 import Analytics from 'helpers/analytics/Analytics';
 
 import { Home } from 'components/sharedComponents/icons/Icons';
-import { lastCompletedQuarterInFY } from 'containers/explorer/detail/helpers/explorerQuarters';
-
+import { lastCompletedQuarterInFY, lastPeriodByQuarter } from 'containers/explorer/detail/helpers/explorerQuarters';
+import QuarterPickerWithFY from 'components/sharedComponents/QuarterPickerWithFY';
 import VerticalTrail from './VerticalTrail';
-import QuarterPicker from './QuarterPicker';
+
 
 const propTypes = {
     fy: PropTypes.string,
@@ -65,10 +65,18 @@ export default class ExplorerSidebar extends React.Component {
         // Log analytic event
         this.logTimePeriodEvent(lastQuarter.quarter, lastQuarter.year);
 
-        this.props.setExplorerPeriod({
-            fy: `${lastQuarter.year}`,
-            quarter: `${lastQuarter.quarter}`
-        });
+        if (year >= 2020) {
+            this.props.setExplorerPeriod({
+                fy: `${lastQuarter.year}`,
+                period: `${lastPeriodByQuarter(lastQuarter.quarter)}`
+            });
+        }
+        else {
+            this.props.setExplorerPeriod({
+                fy: `${lastQuarter.year}`,
+                quarter: `${lastQuarter.quarter}`
+            });
+        }
         this.setState({
             showFYMenu: false
         });
@@ -82,11 +90,18 @@ export default class ExplorerSidebar extends React.Component {
 
         // Log analytic event
         this.logTimePeriodEvent(quarter, this.props.fy);
-
-        this.props.setExplorerPeriod({
-            quarter,
-            fy: this.props.fy
-        });
+        if (this.props.fy >= 2020) {
+            this.props.setExplorerPeriod({
+                period: quarter,
+                fy: this.props.fy
+            });
+        }
+        else {
+            this.props.setExplorerPeriod({
+                quarter,
+                fy: this.props.fy
+            });
+        }
     }
 
     render() {
@@ -107,11 +122,11 @@ export default class ExplorerSidebar extends React.Component {
                     </a>
                 </div>
 
-                <QuarterPicker
-                    fy={this.props.fy}
+                <QuarterPickerWithFY
+                    selectedFy={this.props.fy}
                     quarter={this.props.quarter}
-                    pickedQuarter={this.pickedQuarter}
-                    pickedYear={this.pickedYear} />
+                    handleQuarterPickerSelection={this.pickedQuarter}
+                    handlePickedYear={this.pickedYear} />
 
                 <VerticalTrail
                     trail={this.props.trail.toArray()}

--- a/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
+++ b/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
@@ -69,7 +69,7 @@ export default class ExplorerSidebar extends React.Component {
         if (year >= 2020) {
             this.props.setExplorerPeriod({
                 fy: `${lastQuarter.year}`,
-                period: `${lastPeriodByQuarter(lastQuarter.quarter)}`,
+                period: `${lastPeriodByQuarter[lastQuarter.quarter]}`,
                 quarter: null
             });
         }

--- a/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
+++ b/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
@@ -17,6 +17,7 @@ import VerticalTrail from './VerticalTrail';
 const propTypes = {
     fy: PropTypes.string,
     quarter: PropTypes.string,
+    period: PropTypes.string,
     trail: PropTypes.object,
     setExplorerPeriod: PropTypes.func,
     rewindToFilter: PropTypes.func

--- a/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
+++ b/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
@@ -66,18 +66,11 @@ export default class ExplorerSidebar extends React.Component {
         // Log analytic event
         this.logTimePeriodEvent(lastQuarter.quarter, lastQuarter.year);
 
-        if (year >= 2020) {
-            this.props.setExplorerPeriod({
-                fy: `${lastQuarter.year}`,
-                period: `${lastPeriodByQuarter(lastQuarter.quarter)}`
-            });
-        }
-        else {
-            this.props.setExplorerPeriod({
-                fy: `${lastQuarter.year}`,
-                quarter: `${lastQuarter.quarter}`
-            });
-        }
+        this.props.setExplorerPeriod({
+            fy: `${lastQuarter.year}`,
+            quarter: `${lastQuarter.quarter}`,
+            period: null
+        });
         this.setState({
             showFYMenu: false
         });
@@ -94,13 +87,15 @@ export default class ExplorerSidebar extends React.Component {
         if (this.props.fy >= 2020) {
             this.props.setExplorerPeriod({
                 period: quarter,
-                fy: this.props.fy
+                fy: this.props.fy,
+                quarter: null
             });
         }
         else {
             this.props.setExplorerPeriod({
                 quarter,
-                fy: this.props.fy
+                fy: this.props.fy,
+                period: null
             });
         }
     }

--- a/src/js/containers/explorer/detail/DetailContentContainer.jsx
+++ b/src/js/containers/explorer/detail/DetailContentContainer.jsx
@@ -118,9 +118,16 @@ export class DetailContentContainer extends React.Component {
         }
 
         // perform the API request
+        const requestFilters = Object.assign({}, this.state.filters);
+        if (requestFilters.quarter == null) {
+            delete requestFilters.quarter;
+        }
+        if (requestFilters.period == null) {
+            delete requestFilters.period;
+        }
         this.request = ExplorerHelper.fetchBreakdown({
             type: request.subdivision,
-            filters: this.state.filters
+            filters: requestFilters
         });
 
         this.request.promise

--- a/src/js/containers/explorer/detail/DetailContentContainer.jsx
+++ b/src/js/containers/explorer/detail/DetailContentContainer.jsx
@@ -59,30 +59,34 @@ export class DetailContentContainer extends React.Component {
         this.prepareRootRequest(
             this.props.explorer.root,
             this.props.explorer.fy,
-            this.props.explorer.quarter
+            this.props.explorer.quarter,
+            this.props.explorer.period
         );
     }
 
     componentDidUpdate(prevProps) {
         if (prevProps.explorer.root !== this.props.explorer.root ||
             prevProps.explorer.fy !== this.props.explorer.fy ||
-            prevProps.explorer.quarter !== this.props.explorer.quarter) {
+            prevProps.explorer.quarter !== this.props.explorer.quarter ||
+            prevProps.explorer.period !== this.props.explorer.period) {
             // root changed, reload everything
             this.prepareRootRequest(
                 this.props.explorer.root,
                 this.props.explorer.fy,
-                this.props.explorer.quarter
+                this.props.explorer.quarter,
+                this.props.explorer.period
             );
         }
     }
 
-    prepareRootRequest(rootType, fy, quarter) {
+    prepareRootRequest(rootType, fy, quarter, period) {
         // we need to make a root request
         // at the root level, ignore all filters except for the root
         // in fact, just to be safe, let's overwrite the filter props
         const resetFilters = {
             fy,
-            quarter
+            quarter,
+            period
         };
 
         // make the request
@@ -411,7 +415,7 @@ export class DetailContentContainer extends React.Component {
             this.setState({
                 transitionSteps: steps
             }, () => {
-                this.prepareRootRequest(this.props.explorer.root, this.props.explorer.fy, this.props.explorer.quarter);
+                this.prepareRootRequest(this.props.explorer.root, this.props.explorer.fy, this.props.explorer.quarter, this.props.explorer.period);
             });
             return;
         }
@@ -419,7 +423,8 @@ export class DetailContentContainer extends React.Component {
         // iterate through the trail to rebuild the filter set
         const newFilters = {
             fy: this.props.explorer.fy,
-            quarter: this.props.explorer.quarter
+            quarter: this.props.explorer.quarter,
+            period: this.props.explorer.period
         };
         const newTrail = [];
         // iterate through the trail and include only those filters up to the point we are rewinding
@@ -524,6 +529,7 @@ export class DetailContentContainer extends React.Component {
                 <ExplorerSidebar
                     fy={this.props.explorer.fy}
                     quarter={this.props.explorer.quarter}
+                    period={this.props.explorer.period}
                     trail={this.props.explorer.trail}
                     setExplorerPeriod={this.props.setExplorerPeriod}
                     rewindToFilter={this.rewindToFilter} />

--- a/src/js/redux/actions/explorer/explorerActions.js
+++ b/src/js/redux/actions/explorer/explorerActions.js
@@ -11,7 +11,8 @@ export const setExplorerRoot = (state) => ({
 export const setExplorerPeriod = (state) => ({
     type: 'SET_EXPLORER_PERIOD',
     fy: state.fy,
-    quarter: state.quarter
+    quarter: state.quarter,
+    period: state.period
 });
 
 export const setExplorerActive = (state) => ({

--- a/src/js/redux/actions/explorer/explorerActions.js
+++ b/src/js/redux/actions/explorer/explorerActions.js
@@ -9,7 +9,7 @@ export const setExplorerRoot = (state) => ({
 });
 
 export const setExplorerPeriod = (state) => ({
-    type: 'SET_EXPLORER_PERIOD',
+    type: 'SET_EXPLORER_TIME_PERIOD',
     fy: state.fy,
     quarter: state.quarter,
     period: state.period

--- a/src/js/redux/reducers/explorer/explorerReducer.js
+++ b/src/js/redux/reducers/explorer/explorerReducer.js
@@ -35,7 +35,8 @@ const explorerReducer = (state = initialState, action) => {
         case 'SET_EXPLORER_PERIOD': {
             return Object.assign({}, state, {
                 fy: action.fy,
-                quarter: action.quarter
+                quarter: action.quarter,
+                period: action.period
             });
         }
         case 'SET_EXPLORER_ROOT': {

--- a/src/js/redux/reducers/explorer/explorerReducer.js
+++ b/src/js/redux/reducers/explorer/explorerReducer.js
@@ -4,7 +4,7 @@
  **/
 
 import { List, Record } from 'immutable';
-import { defaultQuarters } from 'containers/explorer/detail/helpers/explorerQuarters';
+import { defaultQuarters, lastPeriodByQuarter } from 'containers/explorer/detail/helpers/explorerQuarters';
 
 export const ActiveScreen = new Record({
     within: '', // within is the data type that the total is a slice WITHIN
@@ -18,7 +18,8 @@ const initialQuarters = defaultQuarters();
 export const initialState = {
     root: 'object_class',
     fy: `${initialQuarters.year}`,
-    quarter: `${Math.max(...initialQuarters.quarters)}`,
+    quarter: initialQuarters.year >= 2020 ? null : `${Math.max(...initialQuarters.quarters)}`,
+    period: initialQuarters.year >= 2020 ? `${lastPeriodByQuarter[Math.max(...initialQuarters.quarters)]}` : null,
     active: new ActiveScreen(),
     trail: new List([]),
     table: {

--- a/src/js/redux/reducers/explorer/explorerReducer.js
+++ b/src/js/redux/reducers/explorer/explorerReducer.js
@@ -32,11 +32,11 @@ export const initialState = {
 
 const explorerReducer = (state = initialState, action) => {
     switch (action.type) {
-        case 'SET_EXPLORER_PERIOD': {
+        case 'SET_EXPLORER_TIME_PERIOD': {
             return Object.assign({}, state, {
                 fy: action.fy,
-                quarter: action.quarter,
-                period: action.period
+                period: action.period,
+                quarter: action.quarter
             });
         }
         case 'SET_EXPLORER_ROOT': {

--- a/tests/containers/explorer/detail/DetailContentContainer-test.jsx
+++ b/tests/containers/explorer/detail/DetailContentContainer-test.jsx
@@ -47,7 +47,7 @@ describe('DetailContentContainer', () => {
             });
 
             expect(mockPrepareRoot).toHaveBeenCalledTimes(1);
-            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '4');
+            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '4', undefined);
         });
         it('should reload from root when the fy prop changes', () => {
             const mockPrepareRoot = jest.fn();
@@ -64,7 +64,7 @@ describe('DetailContentContainer', () => {
             });
 
             expect(mockPrepareRoot).toHaveBeenCalledTimes(1);
-            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '4');
+            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '4', undefined);
         });
         it('should reload from root when the quarter prop changes', () => {
             const mockPrepareRoot = jest.fn();
@@ -81,7 +81,24 @@ describe('DetailContentContainer', () => {
             });
 
             expect(mockPrepareRoot).toHaveBeenCalledTimes(1);
-            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '4');
+            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '4', undefined);
+        });
+        it('should reload from root when the period prop changes', () => {
+            const mockPrepareRoot = jest.fn();
+
+            const container = shallow(<DetailContentContainer
+                {...mockActions}
+                explorer={mockReducerRoot} />);
+            container.instance().prepareRootRequest = mockPrepareRoot;
+
+            container.instance().componentDidUpdate({
+                explorer: Object.assign({}, mockReducerRoot, {
+                    period: '5'
+                })
+            });
+
+            expect(mockPrepareRoot).toHaveBeenCalledTimes(1);
+            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '4', undefined);
         });
     });
     it('should make an API call on mount', async () => {
@@ -105,7 +122,7 @@ describe('DetailContentContainer', () => {
 
             container.instance().loadData = jest.fn();
 
-            container.instance().prepareRootRequest('agency', '1984', '4');
+            container.instance().prepareRootRequest('agency', '1984', '4', undefined);
             expect(container.state().filters.fy).toEqual('1984');
             expect(container.state().filters.quarter).toEqual('4');
         });
@@ -118,7 +135,7 @@ describe('DetailContentContainer', () => {
 
             container.instance().loadData = jest.fn();
 
-            container.instance().prepareRootRequest('agency', '1984', '4');
+            container.instance().prepareRootRequest('agency', '1984', '4', undefined);
             expect(container.instance().loadData).toHaveBeenCalledTimes(1);
             expect(container.instance().loadData).toHaveBeenCalledWith({
                 within: 'root',
@@ -369,7 +386,7 @@ describe('DetailContentContainer', () => {
             container.instance().rewindToFilter(0);
 
             expect(mockPrepareRoot).toHaveBeenCalledTimes(1);
-            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '2');
+            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '2', undefined);
         });
         it ('should overwrite the explorer trail and update the transition steps', () => {
             const container = mount(<DetailContentContainer

--- a/tests/containers/explorer/detail/DetailContentContainer-test.jsx
+++ b/tests/containers/explorer/detail/DetailContentContainer-test.jsx
@@ -47,7 +47,7 @@ describe('DetailContentContainer', () => {
             });
 
             expect(mockPrepareRoot).toHaveBeenCalledTimes(1);
-            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '4', undefined);
+            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '4', null);
         });
         it('should reload from root when the fy prop changes', () => {
             const mockPrepareRoot = jest.fn();
@@ -64,7 +64,7 @@ describe('DetailContentContainer', () => {
             });
 
             expect(mockPrepareRoot).toHaveBeenCalledTimes(1);
-            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '4', undefined);
+            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '4', null);
         });
         it('should reload from root when the quarter prop changes', () => {
             const mockPrepareRoot = jest.fn();
@@ -81,7 +81,7 @@ describe('DetailContentContainer', () => {
             });
 
             expect(mockPrepareRoot).toHaveBeenCalledTimes(1);
-            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '4', undefined);
+            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '4', null);
         });
         it('should reload from root when the period prop changes', () => {
             const mockPrepareRoot = jest.fn();
@@ -98,7 +98,7 @@ describe('DetailContentContainer', () => {
             });
 
             expect(mockPrepareRoot).toHaveBeenCalledTimes(1);
-            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '4', undefined);
+            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '4', null);
         });
     });
     it('should make an API call on mount', async () => {
@@ -122,7 +122,7 @@ describe('DetailContentContainer', () => {
 
             container.instance().loadData = jest.fn();
 
-            container.instance().prepareRootRequest('agency', '1984', '4', undefined);
+            container.instance().prepareRootRequest('agency', '1984', '4', null);
             expect(container.state().filters.fy).toEqual('1984');
             expect(container.state().filters.quarter).toEqual('4');
         });
@@ -141,7 +141,7 @@ describe('DetailContentContainer', () => {
                 })
             });
 
-            container.instance().prepareRootRequest('agency', '1984', undefined, '5');
+            container.instance().prepareRootRequest('agency', '1984', null, '5');
             expect(container.state().filters.fy).toEqual('1984');
             expect(container.state().filters.period).toEqual('5');
         });
@@ -154,7 +154,7 @@ describe('DetailContentContainer', () => {
 
             container.instance().loadData = jest.fn();
 
-            container.instance().prepareRootRequest('agency', '1984', '4', undefined);
+            container.instance().prepareRootRequest('agency', '1984', '4', null);
             expect(container.instance().loadData).toHaveBeenCalledTimes(1);
             expect(container.instance().loadData).toHaveBeenCalledWith({
                 within: 'root',
@@ -405,7 +405,7 @@ describe('DetailContentContainer', () => {
             container.instance().rewindToFilter(0);
 
             expect(mockPrepareRoot).toHaveBeenCalledTimes(1);
-            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '2', undefined);
+            expect(mockPrepareRoot).toHaveBeenCalledWith('agency', '1984', '2', null);
         });
         it ('should overwrite the explorer trail and update the transition steps', () => {
             const container = mount(<DetailContentContainer

--- a/tests/containers/explorer/detail/DetailContentContainer-test.jsx
+++ b/tests/containers/explorer/detail/DetailContentContainer-test.jsx
@@ -126,6 +126,25 @@ describe('DetailContentContainer', () => {
             expect(container.state().filters.fy).toEqual('1984');
             expect(container.state().filters.quarter).toEqual('4');
         });
+        it('should create a filterset that consists of the provided fiscal year and period', () => {
+            const container = shallow(
+                <DetailContentContainer
+                    {...mockActions}
+                    explorer={mockReducerRoot} />
+            );
+
+            container.instance().loadData = jest.fn();
+            
+            container.instance().componentDidUpdate({
+                explorer: Object.assign({}, mockReducerRoot, {
+                    period: '5'
+                })
+            });
+
+            container.instance().prepareRootRequest('agency', '1984', undefined, '5');
+            expect(container.state().filters.fy).toEqual('1984');
+            expect(container.state().filters.period).toEqual('5');
+        });
         it('should make a root-level API call with the provided subdivision type', () => {
             const container = shallow(
                 <DetailContentContainer

--- a/tests/containers/explorer/detail/mockData.js
+++ b/tests/containers/explorer/detail/mockData.js
@@ -53,6 +53,7 @@ export const mockReducerRoot = {
     root: 'agency',
     fy: '1984',
     quarter: '4',
+    period: null,
     active: new ActiveScreen({
         within: 'root',
         subdivision: 'agency',
@@ -107,6 +108,7 @@ export const mockDeeperRoot = {
     root: 'agency',
     fy: '1984',
     quarter: '2',
+    period: null,
     active: new ActiveScreen({
         within: 'federal_account',
         subdivision: 'award',

--- a/tests/redux/reducers/explorer/explorerReducer-test.js
+++ b/tests/redux/reducers/explorer/explorerReducer-test.js
@@ -5,31 +5,33 @@ jest.mock('helpers/fiscalYearHelper', () => require('./mockCurrentFiscalYear'));
 jest.mock('containers/explorer/detail/helpers/explorerQuarters', () => require('./mockQuarterHelper'));
 
 describe('explorerReducer', () => {
-    describe('SET_EXPLORER_PERIOD', () => {
+    describe('SET_EXPLORER_TIME_PERIOD', () => {
         it('should update the FY and quarter to the given value', () => {
             const action = {
-                type: 'SET_EXPLORER_PERIOD',
+                type: 'SET_EXPLORER_TIME_PERIOD',
                 fy: '1984',
-                quarter: '3'
+                quarter: '3',
+                period: null
             };
             const state = explorerReducer(undefined, action);
             expect(state.fy).toEqual('1984');
             expect(state.quarter).toEqual('3');
-            expect(state.period).toEqual(undefined);
+            expect(state.period).toEqual(null);
         });
     });
 
     describe('SET_EXPLORER_PERIOD', () => {
         it('should update the FY and period to the given value', () => {
             const action = {
-                type: 'SET_EXPLORER_PERIOD',
+                type: 'SET_EXPLORER_TIME_PERIOD',
                 fy: '1984',
-                period: '3'
+                period: '3',
+                quarter: null
             };
             const state = explorerReducer(undefined, action);
             expect(state.fy).toEqual('1984');
             expect(state.period).toEqual('3');
-            expect(state.quarter).toEqual(undefined);
+            expect(state.quarter).toEqual(null);
         });
     });
 

--- a/tests/redux/reducers/explorer/explorerReducer-test.js
+++ b/tests/redux/reducers/explorer/explorerReducer-test.js
@@ -15,6 +15,21 @@ describe('explorerReducer', () => {
             const state = explorerReducer(undefined, action);
             expect(state.fy).toEqual('1984');
             expect(state.quarter).toEqual('3');
+            expect(state.period).toEqual(undefined);
+        });
+    });
+
+    describe('SET_EXPLORER_PERIOD', () => {
+        it('should update the FY and period to the given value', () => {
+            const action = {
+                type: 'SET_EXPLORER_PERIOD',
+                fy: '1984',
+                period: '3'
+            };
+            const state = explorerReducer(undefined, action);
+            expect(state.fy).toEqual('1984');
+            expect(state.period).toEqual('3');
+            expect(state.quarter).toEqual(undefined);
         });
     });
 


### PR DESCRIPTION
**High level description:**

Adds the option to choose periods instead of quarters (when applicable) to the Spending Explorer.

**Technical details:**

Technical details for the knowledge of other developers.

**JIRA Ticket:**
[DEV-5401](https://federal-spending-transparency.atlassian.net/browse/DEV-5401)

**Mockup:**
https://bahdigital.invisionapp.com/share/C8IADXT2BD4#/screens

The following are ALL required for the PR to be merged:

Author:
- [X] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [X] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [X] Verified mobile/tablet/desktop/monitor responsiveness
- [X] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [X] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [X] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [x] [API #2736](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently 
- [ ] Code review complete
