### PR TITLE
[DEV-5796] Remove whitespace from search bar input

### DIFF
--- a/src/js/components/covid19/SearchBar.jsx
+++ b/src/js/components/covid19/SearchBar.jsx
@@ -34,7 +34,9 @@ const SearchBar = ({ setQuery, currentSearchTerm }) => {
     };
 
     const onSubmit = () => {
-        setQuery(searchString);
+        const trimmedSearchString = searchString.trim();
+        setQuery(trimmedSearchString);
+        setSearchString(trimmedSearchString);
     };
 
     const handleClick = (e) => {


### PR DESCRIPTION
**High level description:**

Currently the search bar is allowing someone to search with whitespace surrounding their search. This causes an issue since for backend the search is trimmed of whitespace. The fix will trim off the whitespace before a user submits the search. If the original search is `TEST` and it is updated to be `TEST      ` then once the user clicks to search the whitespace at the end will be removed from the search reflecting this change in the search bar when they click back in.

**Technical details:**

Trim whitespace from searched strings after a user is done entering their search term.

**JIRA Ticket:**
[DEV-5796](https://federal-spending-transparency.atlassian.net/browse/DEV-5796)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)

Reviewer(s):
- [x] Code review complete
