### PR TITLE
DEV-5031 [FIX] added clear hint logic to hide hint in certain cases in advanced search time period filter

### DIFF
--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -45,7 +45,8 @@ export default class TimePeriod extends React.Component {
             description: '',
             isActive: false,
             selectedFY: new Set(),
-            allFY: false
+            allFY: false,
+            clearHint: false
         };
 
         // bind functions
@@ -56,6 +57,7 @@ export default class TimePeriod extends React.Component {
         this.toggleFilters = this.toggleFilters.bind(this);
         this.validateDates = this.validateDates.bind(this);
         this.removeDateRange = this.removeDateRange.bind(this);
+        this.clearHint = this.clearHint.bind(this);
     }
 
     componentDidMount() {
@@ -67,11 +69,20 @@ export default class TimePeriod extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
+        if (this.state.clearHint) {
+            this.clearHint(false);
+        }
         if (this.props.dirtyFilters && prevProps.dirtyFilters !== this.props.dirtyFilters) {
             if (this.hint) {
                 this.hint.showHint();
             }
         }
+    }
+
+    clearHint(val) {
+        this.setState({
+            clearHint: val
+        });
     }
 
     prepopulateDatePickers() {
@@ -134,7 +145,9 @@ export default class TimePeriod extends React.Component {
         }
     }
 
+
     toggleFilters(e) {
+        this.clearHint(true);
         this.props.changeTab(e.target.value);
     }
 
@@ -206,6 +219,7 @@ export default class TimePeriod extends React.Component {
     }
 
     removeDateRange() {
+        this.clearHint(true);
         this.props.updateFilter({
             dateType: 'dr',
             startDate: null,
@@ -316,10 +330,12 @@ export default class TimePeriod extends React.Component {
                     </ul>
                     { showFilter }
                     { errorDetails }
-                    <SubmitHint
-                        ref={(component) => {
-                            this.hint = component;
-                        }} />
+                    {!this.state.clearHint &&
+                        <SubmitHint
+                            ref={(component) => {
+                                this.hint = component;
+                            }} />
+                    }
                 </div>
             </div>
         );


### PR DESCRIPTION
**High level description:**
Fixes issue with hint message appearing when it should not in time period advanced search filter.

**Technical details:**
Added `clearHint` logic in `TimePeriod` to hide the hint message in certain cases cases:
1) When removing a filter at any time, we don't want to show the message
(i.e. removing a date range filter after submitting)
2) When switching active tabs, we don't want to show the message.

**JIRA Ticket:**
[DEV-5031](https://federal-spending-transparency.atlassian.net/browse/DEV-5031)

**Mockup:**
See Melissa's clip in jira ticket above and slack message below:
https://data-transparency-bfs.slack.com/archives/C0149JM6A82/p1598552529007800

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [N/A] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [N/A] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [N/A] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
