### PR TITLE
[DEV-5749] Only Show COVID Badge for Awards with non-zero COVID DEFC Spending

### DIFF
--- a/src/js/components/award/Award.jsx
+++ b/src/js/components/award/Award.jsx
@@ -116,7 +116,7 @@ export default class Award extends React.Component {
                 <IdvContent
                     awardId={awardId}
                     overview={overview}
-                    counts={this.props.award.counts}
+                    details={this.props.award.idvDetails}
                     jumpToSection={this.jumpToSection} />
             );
         }

--- a/src/js/components/award/idv/IdvContent.jsx
+++ b/src/js/components/award/idv/IdvContent.jsx
@@ -6,6 +6,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
+import { getAllNetPositiveIdvFileCDefCodes } from 'helpers/idvHelper';
 import ReferencedAwardsContainer from 'containers/award/idv/ReferencedAwardsContainer';
 import IdvActivityContainer from 'containers/award/idv/IdvActivityContainer';
 import { glossaryLinks } from 'dataMapping/search/awardType';
@@ -23,14 +24,14 @@ import AwardSection from '../shared/AwardSection';
 
 const propTypes = {
     awardId: PropTypes.string,
-    counts: AWARD_COUNTS_PROPS,
+    details: AWARD_COUNTS_PROPS,
     overview: AWARD_OVERVIEW_PROPS,
     jumpToSection: PropTypes.func
 };
 
 const IdvContent = ({
     awardId,
-    counts,
+    details,
     overview,
     jumpToSection
 }) => {
@@ -50,7 +51,7 @@ const IdvContent = ({
     return (
         <AwardPageWrapper
             awardType="idv"
-            defCodes={overview.defCodes}
+            defCodes={getAllNetPositiveIdvFileCDefCodes(overview, details)}
             title={overview.title}
             lastModifiedDateLong={overview.dates.lastModifiedDateLong}
             glossaryLink={glossaryLink}
@@ -63,7 +64,7 @@ const IdvContent = ({
                     recipient={overview.recipient} />
                 <AwardOverviewRightSection
                     jumpToSection={jumpToSection}
-                    counts={counts}
+                    counts={details}
                     overview={overview}
                     setRelatedAwardsTab={setRelatedAwardsTab} />
             </AwardSection>

--- a/src/js/components/award/shared/AwardPageWrapper.jsx
+++ b/src/js/components/award/shared/AwardPageWrapper.jsx
@@ -3,17 +3,14 @@ import { TooltipWrapper } from 'data-transparency-ui';
 import { Link } from 'react-router-dom';
 
 import { awardTypeCodes } from 'dataMapping/search/awardType';
-import { getCovidFromFileC } from 'helpers/covid19Helper';
 
-import GlobalConstants from 'GlobalConstants';
 import { Glossary } from '../../sharedComponents/icons/Icons';
 import { AWARD_PAGE_WRAPPER_PROPS } from '../../../propTypes/index';
 import AwardStatus from './AwardStatus';
 import { CovidFlagTooltip } from '../shared/InfoTooltipContent';
 
-const isCaresReleased = GlobalConstants.CARES_ACT_RELEASED;
-
 const AwardPageWrapper = ({
+    // defCodes from api are already filtered down to covid codes only.
     defCodes,
     awardType,
     title,
@@ -24,9 +21,6 @@ const AwardPageWrapper = ({
     children,
     dates
 }) => {
-    const covidDefC = isCaresReleased
-        ? getCovidFromFileC(defCodes)
-        : [];
     const glossaryTitleText = awardTypeCodes[overviewType] ?
         `View glossary definition of ${awardTypeCodes[overviewType]}` :
         'View glossary definition';
@@ -44,8 +38,8 @@ const AwardPageWrapper = ({
                         <h3>{idLabel}</h3>
                         <p>{identifier}</p>
                     </div>
-                    {covidDefC.length > 0 &&
-                        <TooltipWrapper className="award-summary__covid-19-flag" tooltipComponent={<CovidFlagTooltip codes={covidDefC} />}>
+                    {defCodes.length > 0 &&
+                        <TooltipWrapper className="award-summary__covid-19-flag" tooltipComponent={<CovidFlagTooltip codes={defCodes} />}>
                             <span className="covid-spending-flag">
                                 COVID-19 Spending
                             </span>

--- a/src/js/components/award/shared/overview/AwardOverviewRightSection.jsx
+++ b/src/js/components/award/shared/overview/AwardOverviewRightSection.jsx
@@ -14,7 +14,7 @@ const propTypes = {
     jumpToSubAwardHistoryTable: PropTypes.func,
     setRelatedAwardsTab: PropTypes.func,
     jumpToSection: PropTypes.func,
-    counts: PropTypes.object,
+    details: PropTypes.object,
     overview: PropTypes.object,
     updateCFDAOverviewLinkClicked: PropTypes.func
 };
@@ -23,7 +23,7 @@ const AwardOverviewRightSection = ({
     jumpToSubAwardHistoryTable,
     setRelatedAwardsTab,
     jumpToSection,
-    counts,
+    details,
     overview,
     updateCFDAOverviewLinkClicked
 }) => {
@@ -37,7 +37,7 @@ const AwardOverviewRightSection = ({
             jumpToSubAwardHistoryTable={jumpToSubAwardHistoryTable}
             setRelatedAwardsTab={setRelatedAwardsTab}
             jumpToSection={jumpToSection}
-            counts={counts}
+            details={details}
             overview={overview} />);
     const dates = overview.category === 'idv' ? overview.dates : overview.periodOfPerformance;
     return (

--- a/src/js/components/award/shared/overview/RelatedAwards.jsx
+++ b/src/js/components/award/shared/overview/RelatedAwards.jsx
@@ -21,7 +21,7 @@ const propTypes = {
     jumpToSection: PropTypes.func,
     setRelatedAwardsTab: PropTypes.func,
     jumpToSubAwardHistoryTable: PropTypes.func,
-    counts: PropTypes.object
+    details: PropTypes.object
 };
 
 export default class RelatedAwards extends React.Component {
@@ -54,38 +54,38 @@ export default class RelatedAwards extends React.Component {
     }
 
     referencedAwardCounts() {
-        const { counts, overview } = this.props;
-        if (!counts) return null;
+        const { details, overview } = this.props;
+        if (!details) return null;
         let childData = [];
         if (overview.category === 'idv') {
             childData = [
                 {
-                    count: formatNumber(counts.child_awards),
+                    count: formatNumber(details.child_awards),
                     name: 'Child Award',
                     funcName: 'jumpToReferencedAwardsTableChildAwardsTab',
                     glossary: 'contract',
-                    postText: counts.child_awards === 1 ? 'Order' : 'Orders'
+                    postText: details.child_awards === 1 ? 'Order' : 'Orders'
                 },
                 {
-                    count: formatNumber(counts.child_idvs),
+                    count: formatNumber(details.child_idvs),
                     name: 'Child IDV',
                     funcName: 'jumpToReferencedAwardsTableChildIDVsTab',
                     glossary: 'IDV',
-                    postText: counts.child_idvs === 1 ? 'Order' : 'Orders'
+                    postText: details.child_idvs === 1 ? 'Order' : 'Orders'
                 },
                 {
-                    count: formatNumber(counts.grandchild_awards),
+                    count: formatNumber(details.grandchild_awards),
                     name: 'Grandchild Award',
                     funcName: 'jumpToReferencedAwardsTableGrandchildAwardsTab',
                     glossary: 'award',
-                    postText: counts.grandchild_awards === 1 ? 'Order' : 'Orders'
+                    postText: details.grandchild_awards === 1 ? 'Order' : 'Orders'
                 }
             ];
         }
         else {
             childData = [
                 {
-                    count: formatNumber(counts.subawardCount),
+                    count: formatNumber(details.subawardCount),
                     name: 'Sub-Awards',
                     funcName: 'jumpToAwardHistoryTableSubAwardsTab',
                     glossary: 'contract',

--- a/src/js/containers/award/idv/IdvAwardAmountsSectionContainer.jsx
+++ b/src/js/containers/award/idv/IdvAwardAmountsSectionContainer.jsx
@@ -16,7 +16,7 @@ import AggregatedAwardAmounts from 'components/award/idv/amounts/AggregatedAward
 
 const propTypes = {
     award: PropTypes.object,
-    setCounts: PropTypes.func,
+    setIdvDetails: PropTypes.func,
     jumpToSection: PropTypes.func
 };
 
@@ -95,7 +95,9 @@ export class IdvAmountsContainer extends React.Component {
 
         // Store the counts in Redux for use in the referenced awards table
         // and related awards section
-        this.props.setCounts({
+        this.props.setIdvDetails({
+            // api currently returns only defc associated with covid19
+            child_file_c: IdvHelper.getChildAwardFileCDetails(data),
             child_awards: data.child_award_count,
             child_idvs: data.child_idv_count,
             grandchild_awards: data.grandchild_award_count,

--- a/src/js/helpers/covid19Helper.js
+++ b/src/js/helpers/covid19Helper.js
@@ -129,9 +129,6 @@ export const createJumpToSectionForSidebar = (prefix, domSections) => (
     offset = getVerticalOffset()
 ) => jumpToSection(section, offset, prefix, domSections);
 
-export const getCovidFromFileC = (codes) => codes
-    .filter((code) => defCodes.includes(code));
-
 export const latestSubmissionDateFormatted = (availablePeriods) => availablePeriods
     .filter((s) => !s.is_quarter)
     .map((s) => moment.utc(s.period_end_date))

--- a/src/js/helpers/idvHelper.js
+++ b/src/js/helpers/idvHelper.js
@@ -56,14 +56,12 @@ export const fetchIdvActivity = (data) => apiRequest({
 });
 
 export const getAllNetPositiveIdvFileCDefCodes = (parentIdv, childIdv) => {
-    if (parentIdv && childIdv) {
-        return parentIdv
-            .fileC.obligations
-            .concat(parentIdv.fileC.outlays)
-            .concat(childIdv.child_file_c)
+    if (childIdv) {
+        return childIdv
+            .child_file_c
             .filter(({ amount }) => amount !== 0)
             .map(({ code }) => code)
-            .reduce((arr, item) => ([...new Set(arr.concat([item]))]), []);
+            .reduce((arr, item) => ([...new Set(arr.concat([item]))]), [...parentIdv.defCodes]);
     }
     return [];
 };

--- a/src/js/helpers/idvHelper.js
+++ b/src/js/helpers/idvHelper.js
@@ -54,3 +54,23 @@ export const fetchIdvActivity = (data) => apiRequest({
     method: 'post',
     data
 });
+
+export const getAllNetPositiveIdvFileCDefCodes = (parentIdv, childIdv) => {
+    if (parentIdv && childIdv) {
+        return parentIdv
+            .fileC.obligations
+            .concat(parentIdv.fileC.outlays)
+            .concat(childIdv.child_file_c)
+            .filter(({ amount }) => amount !== 0)
+            .map(({ code }) => code)
+            .reduce((arr, item) => ([...new Set(arr.concat([item]))]), []);
+    }
+    return [];
+};
+
+export const getChildAwardFileCDetails = (data) => data
+    .child_account_obligations_by_defc
+    .concat(data.child_account_outlays_by_defc)
+    .concat(data.grandchild_account_obligations_by_defc)
+    .concat(data.grandchild_account_outlays_by_defc)
+    .reduce((arr, item) => ([...new Set(arr.concat(item))]), []);

--- a/src/js/models/v2/award/BaseContract.js
+++ b/src/js/models/v2/award/BaseContract.js
@@ -37,8 +37,7 @@ BaseContract.populate = function populate(data) {
         fileC: {
             obligations: data.account_obligations_by_defc,
             outlays: data.account_outlays_by_defc
-        },
-        defCodes: data.disaster_emergency_fund_codes
+        }
     };
     this.populateCore(coreData);
 

--- a/src/js/models/v2/award/BaseFinancialAssistance.js
+++ b/src/js/models/v2/award/BaseFinancialAssistance.js
@@ -44,8 +44,7 @@ BaseFinancialAssistance.populate = function populate(data) {
         fileC: {
             obligations: data.account_obligations_by_defc,
             outlays: data.account_outlays_by_defc
-        },
-        defCodes: data.disaster_emergency_fund_codes
+        }
     };
     this.populateCore(coreData);
     if (data.cfda_info && data.cfda_info.length) {

--- a/src/js/models/v2/award/BaseIdv.js
+++ b/src/js/models/v2/award/BaseIdv.js
@@ -35,8 +35,7 @@ BaseIdv.populate = function populate(data) {
         fileC: {
             obligations: data.account_obligations_by_defc,
             outlays: data.account_outlays_by_defc
-        },
-        defCodes: data.disaster_emergency_fund_codes
+        }
     };
 
     this.populateCore(coreData);

--- a/src/js/models/v2/award/CoreAward.js
+++ b/src/js/models/v2/award/CoreAward.js
@@ -27,7 +27,13 @@ const CoreAward = {
         this.naics = data.naics || {};
         this.psc = data.psc || {};
         this.fileC = data.fileC || { obligations: [], outlays: [] };
-        this.defCodes = data.defCodes;
+        this.defCodes = data.fileC
+            ? data.fileC
+                .obligations
+                .concat(data.fileC.outlays)
+                .filter(({ amount }) => amount !== 0)
+                .reduce((acc, { code }) => ([...new Set([...acc, code])]), [])
+            : [];
     },
     get subawardTotal() {
         if (this._subawardTotal >= MoneyFormatter.unitValues.MILLION) {

--- a/src/js/redux/actions/award/awardActions.js
+++ b/src/js/redux/actions/award/awardActions.js
@@ -7,9 +7,9 @@ export const setAward = (overview) => ({
     overview
 });
 
-export const setCounts = (counts) => ({
-    type: 'SET_COUNTS',
-    counts
+export const setIdvDetails = (details) => ({
+    type: 'SET_IDV_DETAILS',
+    details
 });
 
 export const setTotalTransactionObligatedAmount = (total) => ({

--- a/src/js/redux/reducers/award/awardReducer.js
+++ b/src/js/redux/reducers/award/awardReducer.js
@@ -7,7 +7,7 @@ export const initialState = {
     id: '',
     category: '',
     overview: null,
-    counts: null,
+    idvDetails: null,
     totalTransactionObligatedAmount: 0
 };
 
@@ -20,9 +20,9 @@ const awardReducer = (state = initialState, action) => {
                 overview: action.overview
             });
         }
-        case 'SET_COUNTS': {
+        case 'SET_IDV_DETAILS': {
             return Object.assign({}, state, {
-                counts: action.counts
+                idvDetails: action.details
             });
         }
         case 'SET_TOTAL_TRANSACTION_OBLIGATED_AMOUNT': {

--- a/tests/helpers/idvHelper-test.js
+++ b/tests/helpers/idvHelper-test.js
@@ -35,21 +35,13 @@ describe('idvHelper', () => {
     describe('getAllNetPositiveIdvFileCDefCodes', () => {
         it('only returns non-zero items & de-dupes items in array', () => {
             const parentIdv = {
-                fileC: {
-                    obligations: mockData
-                        .child_account_obligations_by_defc
-                        .concat([createMockArrayItem('N', 0)]),
-                    outlays: mockData
-                        .child_account_outlays_by_defc
-                        .concat([createMockArrayItem('N', 0)])
-                }
+                defCodes: ['O']
             };
             const childIdv = {
-                child_file_c: [createMockArrayItem('O', 0), createMockArrayItem('O', -1)]
+                child_file_c: [createMockArrayItem('O', 0), createMockArrayItem('P', 1), createMockArrayItem('N', 0)]
             };
             const result = getAllNetPositiveIdvFileCDefCodes(parentIdv, childIdv);
-            console.log('result', result);
-            expect(result).toEqual(['L', 'O']);
+            expect(result).toEqual(['O', 'P']);
         });
     });
 });

--- a/tests/helpers/idvHelper-test.js
+++ b/tests/helpers/idvHelper-test.js
@@ -1,0 +1,55 @@
+import {
+    getAllNetPositiveIdvFileCDefCodes,
+    getChildAwardFileCDetails
+} from 'helpers/idvHelper';
+
+const createMockArrayItem = (code, amount) => ({ code, amount });
+
+const mockData = {
+    child_account_obligations_by_defc: [
+        createMockArrayItem('L', 10)
+    ],
+    child_account_outlays_by_defc: [
+        createMockArrayItem('L', 1)
+    ],
+    grandchild_account_obligations_by_defc: [
+        createMockArrayItem('M', 10)
+    ],
+    grandchild_account_outlays_by_defc: [
+        createMockArrayItem('M', 1)
+    ]
+};
+
+describe('idvHelper', () => {
+    describe('getChildAwardFileCDetails', () => {
+        it('returns all child and grand child objects in a single array', () => {
+            const result = getChildAwardFileCDetails(mockData);
+            expect(result).toEqual([
+                createMockArrayItem('L', 10),
+                createMockArrayItem('L', 1),
+                createMockArrayItem('M', 10),
+                createMockArrayItem('M', 1)
+            ]);
+        });
+    });
+    describe('getAllNetPositiveIdvFileCDefCodes', () => {
+        it('only returns non-zero items & de-dupes items in array', () => {
+            const parentIdv = {
+                fileC: {
+                    obligations: mockData
+                        .child_account_obligations_by_defc
+                        .concat([createMockArrayItem('N', 0)]),
+                    outlays: mockData
+                        .child_account_outlays_by_defc
+                        .concat([createMockArrayItem('N', 0)])
+                }
+            };
+            const childIdv = {
+                child_file_c: [createMockArrayItem('O', 0), createMockArrayItem('O', -1)]
+            };
+            const result = getAllNetPositiveIdvFileCDefCodes(parentIdv, childIdv);
+            console.log('result', result);
+            expect(result).toEqual(['L', 'O']);
+        });
+    });
+});

--- a/tests/models/award/CoreAward-test.js
+++ b/tests/models/award/CoreAward-test.js
@@ -44,6 +44,21 @@ describe('Core Award Model', () => {
         withoutFileC.populateCore({ ...awardData, account_obligations_by_def_code: [], account_outlays_by_def_code: [] });
         expect(withoutFileC.fileC.obligations).toEqual([]);
     });
+    it('should populate DefCodes', () => {
+        const withFileC = Object.create(CoreAward);
+        withFileC.populateCore({
+            ...awardData,
+            fileC: {
+                ...fileCData,
+                outlays: fileCData.outlays.concat([{ code: 'N', amount: 0 }])
+            }
+        });
+        expect(withFileC.defCodes.includes('N')).toEqual(false);
+
+        const withoutFileC = Object.create(CoreAward);
+        withoutFileC.populateCore(awardData);
+        expect(withoutFileC.defCodes).toEqual([]);
+    });
     describe('Getter functions', () => {
         it('should format the subaward total', () => {
             expect(award.subawardTotal).toEqual('$12,005');

--- a/tests/redux/reducers/award/awardReducer-test.js
+++ b/tests/redux/reducers/award/awardReducer-test.js
@@ -36,15 +36,13 @@ describe('awardReducer', () => {
             const action = {
                 type: 'SET_IDV_DETAILS',
                 details: {
-                    idvs: 42,
-                    contracts: 55
+                    test: 42
                 }
             };
 
             state = awardReducer(state, action);
 
-            expect(state.details.idvs).toEqual(42);
-            expect(state.details.contracts).toEqual(55);
+            expect(state.idvDetails.test).toEqual(42);
         });
     });
     describe('SET_TOTAL_TRANSACTION_OBLIGATED_AMOUNT', () => {

--- a/tests/redux/reducers/award/awardReducer-test.js
+++ b/tests/redux/reducers/award/awardReducer-test.js
@@ -29,13 +29,13 @@ describe('awardReducer', () => {
             expect(state.category).toEqual('contract');
         });
     });
-    describe('SET_COUNTS', () => {
+    describe('SET_IDV_DETAILS', () => {
         it('should set the referenced award counts to the provided object', () => {
             let state = awardReducer(undefined, {});
 
             const action = {
-                type: 'SET_COUNTS',
-                counts: {
+                type: 'SET_IDV_DETAILS',
+                details: {
                     idvs: 42,
                     contracts: 55
                 }
@@ -43,8 +43,8 @@ describe('awardReducer', () => {
 
             state = awardReducer(state, action);
 
-            expect(state.counts.idvs).toEqual(42);
-            expect(state.counts.contracts).toEqual(55);
+            expect(state.details.idvs).toEqual(42);
+            expect(state.details.contracts).toEqual(55);
         });
     });
     describe('SET_TOTAL_TRANSACTION_OBLIGATED_AMOUNT', () => {


### PR DESCRIPTION
**High level description:**
Badge for award summary page is present on awards w/o any DEFC spending.

**Technical details:**
We're ignoring the `apiPayload.disaster_emergency_fund_codes` and look at the payload response that shows the amount. 

For IDVs, we take into consideration the IDV itself as well as child/grand child awards. What this means practically speaking is that we have to look at the response from two end points, rather than just one like we do for all other award types.

**JIRA Ticket:**
[DEV-5749](https://federal-spending-transparency.atlassian.net/browse/DEV-5749)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A`Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A`Verified mobile/tablet/desktop/monitor responsiveness
`N/A`Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A`All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A`[API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A`[Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A`Design review complete `if applicable`
`N/A`[API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
