### PR TITLE
[DEV-5939] removes broken links for agencies in spending explorer

### DIFF
--- a/src/js/components/explorer/detail/DetailContent.jsx
+++ b/src/js/components/explorer/detail/DetailContent.jsx
@@ -192,6 +192,7 @@ export default class DetailContent extends React.Component {
                 isLoading={this.props.isLoading}
                 within={lastFilter.within}
                 title={lastFilter.title}
+                link={lastFilter.link}
                 id={id}
                 fy={this.props.fy}
                 lastUpdate={this.props.lastUpdate}

--- a/src/js/components/explorer/detail/header/DetailHeader.jsx
+++ b/src/js/components/explorer/detail/header/DetailHeader.jsx
@@ -23,6 +23,7 @@ const propTypes = {
     total: PropTypes.number,
     title: PropTypes.string,
     id: PropTypes.string,
+    link: PropTypes.bool,
     parent: PropTypes.string,
     isTruncated: PropTypes.bool,
     isLoading: PropTypes.bool
@@ -63,7 +64,7 @@ const dataType = (type, parent) => {
     );
 };
 
-const heading = (type, title, id) => {
+const heading = (type, title, id, link) => {
     if (type === 'Federal Account') {
         return (
             <h2 className="detail-header__title">
@@ -84,7 +85,7 @@ const heading = (type, title, id) => {
                 onClick={exitExplorer.bind(null, `/agency/${id}`)}>
                 {title}
             </Link>);
-        if (title === "Unreported Data") {
+        if (title === "Unreported Data" || link === false) {
             header = (
                 <span className="detail-header__title">
                     {title}
@@ -120,7 +121,7 @@ const DetailHeader = (props) => {
                     <div className="detail-header__subtitle">
                         You&apos;ve chosen
                     </div>
-                    {heading(type, props.title, props.id)}
+                    {heading(type, props.title, props.id, props.link)}
                     {dataType(type, props.parent)}
                 </div>
                 <div className="right-side">

--- a/src/js/containers/explorer/detail/DetailContentContainer.jsx
+++ b/src/js/containers/explorer/detail/DetailContentContainer.jsx
@@ -366,7 +366,8 @@ export class DetailContentContainer extends React.Component {
             subdivision: nextSubdivision,
             title: data.name,
             id: data.id,
-            accountNumber: data.account_number || ''
+            accountNumber: data.account_number || '',
+            link: data.link
         };
 
         this.props.resetExplorerTable();

--- a/src/js/containers/explorer/detail/table/ExplorerTableContainer.jsx
+++ b/src/js/containers/explorer/detail/table/ExplorerTableContainer.jsx
@@ -110,7 +110,8 @@ export class ExplorerTableContainer extends React.Component {
                     name: item.name,
                     obligated_amount: formattedCurrency,
                     percent_of_total: percent
-                }
+                },
+                link: item.link
             };
             results.push(result);
         });


### PR DESCRIPTION
**High level description:**

Prevents adding a hyperlink to agency pages in the spending exploreer if there is no agency profile page for that agency.

**JIRA Ticket:**
[DEV-5939](https://federal-spending-transparency.atlassian.net/browse/DEV-5939)

The following are ALL required for the PR to be merged:

Author:
- [X] Linked to this PR in JIRA ticket
- [N/A] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [X] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [N/A] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [x] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [x] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated 

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [ ] [API #2755](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
