### PR TITLE
DEV-5031 fix case where unchecking one checkbox would show message

### DIFF
--- a/src/js/containers/search/filters/TimePeriodContainer.jsx
+++ b/src/js/containers/search/filters/TimePeriodContainer.jsx
@@ -121,10 +121,16 @@ export class TimePeriodContainer extends React.Component {
             const appliedValue = this.props.appliedFilters[appliedField];
             const activeValue = this.props[activeField];
 
+            // do not set time filter to dirty when 1 checkbox is unchecked
+            if ((activeValue && activeValue.size === 0) && (appliedValue && appliedValue.size >= 1)) {
+                return true;
+            }
+
             if (!is(appliedValue, activeValue)) {
                 // field has changed
                 return false;
             }
+
 
             return true;
         });

--- a/tests/containers/search/filters/TimePeriodContainer-test.jsx
+++ b/tests/containers/search/filters/TimePeriodContainer-test.jsx
@@ -123,8 +123,7 @@ describe('TimePeriodContainer', () => {
             });
 
             const changed = container.instance().dirtyFilters();
-            expect(changed).toBeTruthy();
-            expect(typeof changed).toEqual('symbol');
+            expect(changed).toBeFalsy();
         });
         it('should return null when the staged filters match with the applied filters', () => {
             const container = shallow(<TimePeriodContainer


### PR DESCRIPTION
**High level description:**
Fixes case in advanced search Time period filter.
When we only have one checkbox and it is unchecked, we don't want it to show the "Filter Selected" hint message.

**Technical details:**
Added extra logic to dirtyFilters function for Time Period filter.

**JIRA Ticket:**
[DEV-5031](https://federal-spending-transparency.atlassian.net/browse/DEV-5031)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [N/A] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [N/A] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [N/A] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
