### PR TITLE
DEV-5655 fixes analytics firing for DEFC filters

### DIFF
--- a/src/js/containers/search/filters/def/DEFCheckboxTree.jsx
+++ b/src/js/containers/search/filters/def/DEFCheckboxTree.jsx
@@ -10,7 +10,6 @@ import CheckboxTree from 'components/sharedComponents/CheckboxTree';
 import { updateDefCodes } from 'redux/actions/search/searchFilterActions';
 import SubmitHint from 'components/sharedComponents/filterSidebar/SubmitHint';
 import DEFCheckboxTreeLabel from 'components/search/filters/defc/DEFCheckboxTreeLabel';
-import Analytics from 'helpers/analytics/Analytics';
 
 export const NewBadge = () => (
     <div className="new-badge">NEW</div>
@@ -76,10 +75,6 @@ export class DEFCheckboxTree extends React.Component {
                 []
             );
         }
-        Analytics.event({
-            category: 'covid-19 - advanced search',
-            action: `DEFC filter - ${this.props.checked}`
-        });
     };
 
     fetchCodes = async () => {

--- a/src/js/containers/search/helpers/searchAnalytics.js
+++ b/src/js/containers/search/helpers/searchAnalytics.js
@@ -16,11 +16,19 @@ import {
     setAsideDefinitions,
     extentCompetedDefinitions
 } from 'dataMapping/search/contractFields';
-import { defCodeQueryString } from "helpers/disasterHelper";
 
 import Analytics from 'helpers/analytics/Analytics';
 
 const eventCategory = 'Advanced Search - Search Filter';
+
+const getStringFromArray = (arrOfStr) => arrOfStr
+    .sort()
+    .reduce((acc, code, i, array) => {
+        if (array.length - 1 === i) {
+            return `${acc}${code}`;
+        }
+        return `${acc}${code}, `;
+    }, '');
 
 export const convertDateRange = (range) => {
     if (range.length !== 2) {
@@ -126,6 +134,12 @@ export const combineAwardTypeGroups = (filters) => {
     return fullTypes.concat(remainingFilters);
 };
 
+export const handleCheckboxTreeSelection = (value, label) => {
+    const selectedValues = value.get('require');
+    if (selectedValues.length) return convertReducibleValue([selectedValues], label, getStringFromArray);
+    return null;
+};
+
 export const convertFilter = (type, value) => {
     switch (type) {
         case 'keyword':
@@ -168,23 +182,26 @@ export const convertFilter = (type, value) => {
                 'CFDA Program',
                 (cfda) => `${cfda.program_number} - ${cfda.program_title}`
             );
-        case 'defCodes':
-            return convertReducibleValue(
+        case 'defCodes': {
+            return handleCheckboxTreeSelection(
                 value,
-                'DEFC Filter',
-                defCodeQueryString
+                'DEFC Filter'
             );
-        case 'selectedNAICS':
-            return convertReducibleValue(
+        }
+        case 'naicsCodes':
+            return handleCheckboxTreeSelection(
                 value,
-                'NAICS Code',
-                (naics) => `${naics.naics} - ${naics.naics_description}`
+                'NAICS Codes'
             );
-        case 'selectedPSC':
-            return convertReducibleValue(
+        case 'pscCodes':
+            return handleCheckboxTreeSelection(
                 value,
-                'Product or Service Code (PSC)',
-                (psc) => `${psc.product_or_service_code} - ${psc.psc_description}`
+                'Product or Service Code (PSC)'
+            );
+        case 'tasCodes':
+            return handleCheckboxTreeSelection(
+                value,
+                'Treasury Account Symbol (TAS)'
             );
         case 'pricingType':
             return convertReducibleValue(

--- a/src/js/containers/search/helpers/searchAnalytics.js
+++ b/src/js/containers/search/helpers/searchAnalytics.js
@@ -16,6 +16,7 @@ import {
     setAsideDefinitions,
     extentCompetedDefinitions
 } from 'dataMapping/search/contractFields';
+import { defCodeQueryString } from "helpers/disasterHelper";
 
 import Analytics from 'helpers/analytics/Analytics';
 
@@ -166,6 +167,12 @@ export const convertFilter = (type, value) => {
                 value,
                 'CFDA Program',
                 (cfda) => `${cfda.program_number} - ${cfda.program_title}`
+            );
+        case 'defCodes':
+            return convertReducibleValue(
+                value,
+                'DEFC Filter',
+                defCodeQueryString
             );
         case 'selectedNAICS':
             return convertReducibleValue(


### PR DESCRIPTION
**High level description:**

Fixes issue with analytics event firing when users click on DEFC filters without submitting search. We want to see the analytics events with the selected filters only on submission.

**Technical details:**

Added case for DEFC codes in searchAnalytics.js to get the selected filters on submit

**JIRA Ticket:**
[DEV-5655](https://federal-spending-transparency.atlassian.net/browse/DEV-5655)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [`N/A`] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [`N/A`] Verified mobile/tablet/desktop/monitor responsiveness
- [`N/A`] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [`N/A`] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [`N/A`] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [`N/A`] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [`N/A`] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [`N/A`] Design review complete `if applicable`
- [`N/A`] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
