### PR TITLE
[router-upgrade-warmfix] Clear table when filters are manually deselected

### DIFF
--- a/src/js/containers/search/SearchSidebarSubmitContainer.jsx
+++ b/src/js/containers/search/SearchSidebarSubmitContainer.jsx
@@ -89,7 +89,12 @@ export class SearchSidebarSubmitContainer extends React.Component {
 
     applyStagedFilters() {
         this.props.setAppliedFilterCompletion(false);
-        this.props.applyStagedFilters(this.props.stagedFilters);
+        if (areFiltersEqual(this.props.stagedFilters)) {
+            this.resetFilters();
+        }
+        else {
+            this.props.applyStagedFilters(this.props.stagedFilters);
+        }
         this.setState({
             filtersChanged: false
         });

--- a/tests/containers/search/SearchSidebarSubmitContainer-test.jsx
+++ b/tests/containers/search/SearchSidebarSubmitContainer-test.jsx
@@ -106,9 +106,9 @@ describe('SearchSidebarSubmitContainer', () => {
         });
     });
     describe('applyStagedFilters', () => {
-        it('should tell Redux to copy the staged filter set to the applied filter set', () => {
+        it('should call reset filters when staged filters are empty', () => {
             const actions = Object.assign({}, mockActions, {
-                applyStagedFilters: jest.fn()
+                clearStagedFilters: jest.fn()
             });
 
             const container = shallow(
@@ -116,6 +116,29 @@ describe('SearchSidebarSubmitContainer', () => {
                     {...mockRedux}
                     {...actions} />
             );
+
+            container.instance().applyStagedFilters();
+
+            expect(actions.clearStagedFilters).toHaveBeenCalledTimes(1);
+        });
+        it('should call applied filters when staged filters are non-empty', () => {
+            const actions = Object.assign({}, mockActions, {
+                applyStagedFilters: jest.fn()
+            });
+
+            const container = shallow(
+                <SearchSidebarSubmitContainer
+                    {...mockRedux}
+                    {...actions}
+                    stagedFilters={{
+                        ...mockRedux.stagedFilters,
+                        filters: {
+                            ...mockRedux.stagedFilters,
+                            timePeriodFY: mockRedux.stagedFilters.timePeriodFY.add('2020')
+                        }
+                    }} />
+            );
+
             container.instance().applyStagedFilters();
 
             expect(actions.applyStagedFilters).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Yet another bug was found on the search page with the new router. This time, we're making sure that when the user unselects all filters and hits submit, we clear the table. 

- [x] Code review complete
