### PR TITLE
DEV-4732 custom award downloads funding and awarding agency

### DIFF
--- a/src/js/components/bulkDownload/awards/AwardDataContent.jsx
+++ b/src/js/components/bulkDownload/awards/AwardDataContent.jsx
@@ -135,6 +135,8 @@ export default class AwardDataContent extends React.Component {
                             bulkAwardTypeChange={this.props.bulkAwardTypeChange}
                             toggleAwardTypeChange={this.props.toggleAwardTypeChange} />
                         <AgencyFilter
+                            currentAgencyType={awards.agencyType}
+                            agencyTypes={awardDownloadOptions.agencyTypes}
                             agencies={this.props.agencies}
                             subAgencies={this.props.subAgencies}
                             currentAgencies={currentAgencies}
@@ -167,7 +169,9 @@ export default class AwardDataContent extends React.Component {
                         <UserSelections
                             awards={awards}
                             agencies={this.props.agencies}
-                            subAgencies={this.props.subAgencies} />
+                            subAgencies={this.props.subAgencies}
+                            updateFilter={this.props.updateFilter}
+                            currentAgencyType={awards.agencyType} />
                         <SubmitButton
                             filters={awards}
                             validForm={this.state.validForm}

--- a/src/js/components/bulkDownload/awards/UserSelections.jsx
+++ b/src/js/components/bulkDownload/awards/UserSelections.jsx
@@ -18,6 +18,7 @@ export default class UserSelections extends React.Component {
         super(props);
 
         this.generateAwardTypeString = this.generateAwardTypeString.bind(this);
+        this.generateAgencyTypeString = this.generateAgencyTypeString.bind(this);
         this.generateAgencyString = this.generateAgencyString.bind(this);
         this.generateSubAgencyString = this.generateSubAgencyString.bind(this);
         this.generateLocationString = this.generateLocationString.bind(this);
@@ -86,6 +87,16 @@ export default class UserSelections extends React.Component {
         }
         return (
             <div className="selection__content selection__content-required">required</div>
+        );
+    }
+
+    generateAgencyTypeString() {
+        const options = awardDownloadOptions.agencyTypes;
+        const selectedOption = options.find((option) =>
+            option.name === this.props.awards.agencyType
+        );
+        return (
+            <div className="selection__content">{selectedOption.label}</div>
         );
     }
 
@@ -182,6 +193,7 @@ export default class UserSelections extends React.Component {
                 <div className="download-user-selections__left-col">
                     <div className="selection">
                         <div className="selection__heading">Agency</div>
+                        {this.generateAgencyTypeString()}
                         {this.generateAgencyString()}
                     </div>
                     <div className="selection">

--- a/src/js/components/bulkDownload/awards/filters/AgencyFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/AgencyFilter.jsx
@@ -10,6 +10,8 @@ import * as Icons from 'components/sharedComponents/icons/Icons';
 
 const propTypes = {
     agencies: PropTypes.object,
+    agencyTypes: PropTypes.array,
+    currentAgencyType: PropTypes.string,
     subAgencies: PropTypes.array,
     setSubAgencyList: PropTypes.func,
     currentAgencies: PropTypes.object,
@@ -26,10 +28,16 @@ export default class AgencyFilter extends React.Component {
             showSubAgencyPicker: false
         };
 
+        this.onChange = this.onChange.bind(this);
         this.toggleAgencyPicker = this.toggleAgencyPicker.bind(this);
         this.toggleSubAgencyPicker = this.toggleSubAgencyPicker.bind(this);
         this.handleAgencySelect = this.handleAgencySelect.bind(this);
         this.handleSubAgencySelect = this.handleSubAgencySelect.bind(this);
+    }
+
+    onChange(e) {
+        const target = e.target;
+        this.props.updateFilter('agencyType', target.value);
     }
 
     toggleAgencyPicker(e) {
@@ -168,12 +176,27 @@ export default class AgencyFilter extends React.Component {
             subAgencyDisabledClass = 'disabled';
         }
 
+        const agencyTypes = this.props.agencyTypes.map((agencyType) => (
+            <div
+                className="radio"
+                key={agencyType.name}>
+                <input
+                    type="radio"
+                    value={agencyType.name}
+                    name="agencyType"
+                    checked={this.props.currentAgencyType === agencyType.name}
+                    onChange={this.onChange} />
+                <label className="radio-label" htmlFor="locationType">{agencyType.label}</label>
+            </div>
+        ));
+
         return (
             <div className="download-filter">
                 <h3 className="download-filter__title">
-                    {icon} Select an awarding <span className="download-filter__title_em">agency</span> and <span>sub-agency</span>.
+                    {icon} Select an awarding or funding <span className="download-filter__title_em">agency</span> and <span>sub-agency</span>.
                 </h3>
                 <div className="download-filter__content">
+                    {agencyTypes}
                     <div className="filter-picker">
                         <label className="select-label" htmlFor="agency-select">
                             Agency

--- a/src/js/components/bulkDownload/awards/filters/AgencyFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/AgencyFilter.jsx
@@ -279,6 +279,7 @@ export default class AgencyFilter extends React.Component {
                             </div>
                         </div>
                     </div>
+                    <p className="download-filter__content-note"><span className="download-filter__content-note_bold">Note:</span> Prior to FY19, Financial Assistance awards only sporadically include Funding Agency data. Financial Assistance awards include: grants, direct payments, loans, insurance, and other financial assistance.</p>
                 </div>
             </div>
         );

--- a/src/js/components/bulkDownload/awards/filters/AgencyFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/AgencyFilter.jsx
@@ -279,7 +279,7 @@ export default class AgencyFilter extends React.Component {
                             </div>
                         </div>
                     </div>
-                    <p className="download-filter__content-note"><span className="download-filter__content-note_bold">Note:</span> Prior to FY19, Financial Assistance awards only sporadically include Funding Agency data. Financial Assistance awards include: grants, direct payments, loans, insurance, and other financial assistance.</p>
+                    <p className="download-filter__content-note"><span className="download-filter__content-note_bold">Note:</span> Prior to FY19, Financial Assistance awards (grants, direct payments, loans, insurance, and other financial assistance) only sporadically include Funding Agency data.</p>
                 </div>
             </div>
         );

--- a/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
+++ b/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
@@ -102,7 +102,6 @@ export class BulkDownloadPageContainer extends React.Component {
             filters: {
                 prime_award_types: primeAwardTypes,
                 sub_award_types: subAwardTypes,
-                agency_type: formState.agencyType,
                 agency: formState.agency.id,
                 sub_agency: formState.subAgency.name,
                 date_type: formState.dateType,
@@ -130,7 +129,7 @@ export class BulkDownloadPageContainer extends React.Component {
 
         if (formState.agencyType) {
             delete params.filters.agency;
-            const agencyParams = { type: formState.agencyType, tier: "toptier", name: formState.agency.name };
+            const agencyParams = { type: formState.agencyType === 'awarding_agency' ? 'awarding' : 'funding', tier: "toptier", name: formState.agency.name };
             if (formState.subAgency.name) {
                 agencyParams.tier = 'subtier';
             }

--- a/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
+++ b/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
@@ -129,11 +129,12 @@ export class BulkDownloadPageContainer extends React.Component {
 
         if (formState.agencyType) {
             delete params.filters.agency;
-            const agencyParams = { type: formState.agencyType === 'awarding_agency' ? 'awarding' : 'funding', tier: "toptier", name: formState.agency.name };
-            if (formState.subAgency.name) {
-                agencyParams.tier = 'subtier';
+            const topTierAgencyParams = { type: formState.agencyType === 'awarding_agency' ? 'awarding' : 'funding', tier: "toptier", name: formState.agency.name };
+            params.filters.agencies = [topTierAgencyParams];
+            if (formState.subAgency.name && formState.subAgency.name !== 'Select a Sub-Agency') {
+                const subTierAgencyParams = { type: formState.agencyType === 'awarding_agency' ? 'awarding' : 'funding', tier: "subtier", name: formState.subAgency.name };
+                params.filters.agencies = [topTierAgencyParams, subTierAgencyParams];
             }
-            params.filters.agencies = [agencyParams];
         }
 
         this.requestDownload(params, 'awards');

--- a/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
+++ b/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
@@ -102,7 +102,6 @@ export class BulkDownloadPageContainer extends React.Component {
             filters: {
                 prime_award_types: primeAwardTypes,
                 sub_award_types: subAwardTypes,
-                agency: formState.agency.id,
                 sub_agency: formState.subAgency.name,
                 date_type: formState.dateType,
                 date_range: {
@@ -127,15 +126,13 @@ export class BulkDownloadPageContainer extends React.Component {
             }
         }
 
-        if (formState.agencyType) {
-            delete params.filters.agency;
-            const topTierAgencyParams = { type: formState.agencyType === 'awarding_agency' ? 'awarding' : 'funding', tier: "toptier", name: formState.agency.name };
-            params.filters.agencies = [topTierAgencyParams];
-            if (formState.subAgency.name && formState.subAgency.name !== 'Select a Sub-Agency') {
-                const subTierAgencyParams = { type: formState.agencyType === 'awarding_agency' ? 'awarding' : 'funding', tier: "subtier", name: formState.subAgency.name };
-                params.filters.agencies = [topTierAgencyParams, subTierAgencyParams];
-            }
+        const agencyParams = { type: formState.agencyType === 'awarding_agency' ? 'awarding' : 'funding', tier: "toptier", name: formState.agency.name };
+        if (formState.subAgency.name && formState.subAgency.name !== 'Select a Sub-Agency') {
+            agencyParams.name = formState.subAgency.name;
+            agencyParams.tier = 'subtier';
+            agencyParams.toptier_name = formState.agency.name;
         }
+        params.filters.agencies = [agencyParams];
 
         this.requestDownload(params, 'awards');
 

--- a/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
+++ b/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
@@ -102,6 +102,7 @@ export class BulkDownloadPageContainer extends React.Component {
             filters: {
                 prime_award_types: primeAwardTypes,
                 sub_award_types: subAwardTypes,
+                agency_type: formState.agencyType,
                 agency: formState.agency.id,
                 sub_agency: formState.subAgency.name,
                 date_type: formState.dateType,
@@ -125,6 +126,15 @@ export class BulkDownloadPageContainer extends React.Component {
             } else {
                 params.filters[locationType.apiName] = [locations];
             }
+        }
+
+        if (formState.agencyType) {
+            delete params.filters.agency;
+            const agencyParams = { type: formState.agencyType, tier: "toptier", name: formState.agency.name };
+            if (formState.subAgency.name) {
+                agencyParams.tier = 'subtier';
+            }
+            params.filters.agencies = [agencyParams];
         }
 
         this.requestDownload(params, 'awards');

--- a/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
+++ b/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
@@ -81,6 +81,20 @@ export const awardDownloadOptions = {
             description: 'When the details of a reported award action were last updated'
         }
     ],
+    agencyTypes: [
+        {
+            name: 'awarding_agency',
+            label: 'Awarding Agency',
+            apiName: 'awarding',
+            apiScopeName: 'awarding_agency_scope'
+        },
+        {
+            name: 'funding_agency',
+            label: 'Funding Agency',
+            apiName: 'funding',
+            apiScopeName: 'funding_agency_scope'
+        }
+    ],
     locationTypes: [
         {
             name: 'recipient_location',

--- a/src/js/redux/reducers/bulkDownload/bulkDownloadReducer.js
+++ b/src/js/redux/reducers/bulkDownload/bulkDownloadReducer.js
@@ -30,6 +30,7 @@ export const initialState = {
             id: '',
             name: 'Select an Agency'
         },
+        agencyType: 'awarding_agency',
         subAgency: {
             id: '',
             name: 'Select a Sub-Agency'

--- a/tests/containers/bulkDownload/BulkDownloadPageContainer-test.jsx
+++ b/tests/containers/bulkDownload/BulkDownloadPageContainer-test.jsx
@@ -40,7 +40,9 @@ describe('BulkDownloadPageContainer', () => {
                 filters: {
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
-                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'toptier' }, { name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier' }],
+                    agencies: [{
+                        name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier', toptier_name: 'Mock Agency'
+                    }],
                     recipient_locations: [
                         {
                             country: 'USA',
@@ -91,7 +93,9 @@ describe('BulkDownloadPageContainer', () => {
                 columns: [],
                 file_format: 'csv',
                 filters: {
-                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'toptier' }, { name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier' }],
+                    agencies: [{
+                        name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier', toptier_name: 'Mock Agency'
+                    }],
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
                     recipient_scope: 'foreign',
@@ -139,7 +143,9 @@ describe('BulkDownloadPageContainer', () => {
                 columns: [],
                 file_format: 'csv',
                 filters: {
-                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'toptier' }, { name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier' }],
+                    agencies: [{
+                        name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier', toptier_name: 'Mock Agency'
+                    }],
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
                     date_range: {
@@ -186,7 +192,9 @@ describe('BulkDownloadPageContainer', () => {
                 columns: [],
                 file_format: 'csv',
                 filters: {
-                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'toptier' }, { name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier' }],
+                    agencies: [{
+                        name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier', toptier_name: 'Mock Agency'
+                    }],
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
                     recipient_locations: [
@@ -229,7 +237,9 @@ describe('BulkDownloadPageContainer', () => {
                 columns: [],
                 file_format: 'csv',
                 filters: {
-                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'toptier' }, { name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier' }],
+                    agencies: [{
+                        name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier', toptier_name: 'Mock Agency'
+                    }],
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
                     place_of_performance_locations: [
@@ -283,7 +293,9 @@ describe('BulkDownloadPageContainer', () => {
                 columns: [],
                 file_format: 'csv',
                 filters: {
-                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'toptier' }, { name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier' }],
+                    agencies: [{
+                        name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier', toptier_name: 'Mock Agency'
+                    }],
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
                     place_of_performance_scope: 'foreign',

--- a/tests/containers/bulkDownload/BulkDownloadPageContainer-test.jsx
+++ b/tests/containers/bulkDownload/BulkDownloadPageContainer-test.jsx
@@ -40,7 +40,7 @@ describe('BulkDownloadPageContainer', () => {
                 filters: {
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
-                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'subtier' }],
+                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'toptier' }, { name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier' }],
                     recipient_locations: [
                         {
                             country: 'USA',
@@ -91,7 +91,7 @@ describe('BulkDownloadPageContainer', () => {
                 columns: [],
                 file_format: 'csv',
                 filters: {
-                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'subtier' }],
+                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'toptier' }, { name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier' }],
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
                     recipient_scope: 'foreign',
@@ -139,7 +139,7 @@ describe('BulkDownloadPageContainer', () => {
                 columns: [],
                 file_format: 'csv',
                 filters: {
-                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'subtier' }],
+                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'toptier' }, { name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier' }],
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
                     date_range: {
@@ -186,7 +186,7 @@ describe('BulkDownloadPageContainer', () => {
                 columns: [],
                 file_format: 'csv',
                 filters: {
-                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'subtier' }],
+                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'toptier' }, { name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier' }],
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
                     recipient_locations: [
@@ -229,7 +229,7 @@ describe('BulkDownloadPageContainer', () => {
                 columns: [],
                 file_format: 'csv',
                 filters: {
-                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'subtier' }],
+                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'toptier' }, { name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier' }],
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
                     place_of_performance_locations: [
@@ -283,7 +283,7 @@ describe('BulkDownloadPageContainer', () => {
                 columns: [],
                 file_format: 'csv',
                 filters: {
-                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'subtier' }],
+                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'toptier' }, { name: 'Mock Sub-Agency', type: 'funding', tier: 'subtier' }],
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
                     place_of_performance_scope: 'foreign',

--- a/tests/containers/bulkDownload/BulkDownloadPageContainer-test.jsx
+++ b/tests/containers/bulkDownload/BulkDownloadPageContainer-test.jsx
@@ -40,7 +40,7 @@ describe('BulkDownloadPageContainer', () => {
                 filters: {
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
-                    agency: '123',
+                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'subtier' }],
                     recipient_locations: [
                         {
                             country: 'USA',
@@ -91,7 +91,7 @@ describe('BulkDownloadPageContainer', () => {
                 columns: [],
                 file_format: 'csv',
                 filters: {
-                    agency: '123',
+                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'subtier' }],
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
                     recipient_scope: 'foreign',
@@ -139,7 +139,7 @@ describe('BulkDownloadPageContainer', () => {
                 columns: [],
                 file_format: 'csv',
                 filters: {
-                    agency: '123',
+                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'subtier' }],
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
                     date_range: {
@@ -186,7 +186,7 @@ describe('BulkDownloadPageContainer', () => {
                 columns: [],
                 file_format: 'csv',
                 filters: {
-                    agency: '123',
+                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'subtier' }],
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
                     recipient_locations: [
@@ -229,13 +229,13 @@ describe('BulkDownloadPageContainer', () => {
                 columns: [],
                 file_format: 'csv',
                 filters: {
-                    agency: '123',
+                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'subtier' }],
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
                     place_of_performance_locations: [
                         {
                             country: 'USA',
-                            state: 'HI',
+                            state: 'HI'
                         }
                     ],
                     date_range: {
@@ -283,7 +283,7 @@ describe('BulkDownloadPageContainer', () => {
                 columns: [],
                 file_format: 'csv',
                 filters: {
-                    agency: '123',
+                    agencies: [{ name: 'Mock Agency', type: 'funding', tier: 'subtier' }],
                     prime_award_types: ["02", "03", "04", "05", "07", "08"],
                     sub_award_types: ['procurement'],
                     place_of_performance_scope: 'foreign',

--- a/tests/containers/bulkDownload/mockData.js
+++ b/tests/containers/bulkDownload/mockData.js
@@ -104,6 +104,7 @@ export const mockProps = {
             subAgency: {
                 name: 'Mock Sub-Agency'
             },
+            agencyType: 'funding_agency',
             locationType: 'recipient_location',
             location: {
                 country: {
@@ -171,7 +172,7 @@ export const mockAwardDownloadResponse = {
     file_name: 'mock_file.zip',
     file_url: 'mockurl/mock_file.zip',
     status_url: 'download/status?file_name=mock_file.zip',
-    download_request: {download_details: 'for award'}
+    download_request: { download_details: 'for award' }
 };
 
 export const mockArchiveResponse = {


### PR DESCRIPTION
**High level description:**
Adds radio buttons for funding and awarding agency to custom awards download page.

**JIRA Ticket:**
[DEV-4732](https://federal-spending-transparency.atlassian.net/browse/DEV-4732)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [N/A] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [N/A] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [x] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [x] [API #2737](https://github.com/fedspendingtransparency/usaspending-api/pull/2737) merged concurrently `if applicable`
- [ ] Code review complete
