### PR TITLE
[DEV-5401] fix css/ period selection

### DIFF
--- a/src/_scss/pages/explorer/detail/sidebar/sidebar.scss
+++ b/src/_scss/pages/explorer/detail/sidebar/sidebar.scss
@@ -16,12 +16,6 @@
             @include flex-wrap(nowrap);
         }
     }
-    .usa-dt-quarter-picker__list li:first-child ul li:first-child {
-        border-radius: rem(30) 0 0 rem(30);
-    }
-    .usa-dt-quarter-picker__list li:last-child ul li:last-child {
-        border-radius: 0 rem(30) rem(30) 0;
-    }
     .usa-dt-quarter-picker__period-list-container {
         p {
             font-weight: 600;
@@ -29,7 +23,6 @@
         .usa-dt-quarter-picker__period-list .usa-dt-quarter-picker__list-item {
             // the generic period styles
             margin: rem(0) rem(1);
-            background-color: $color-white;
             .usa-dt-quarter-picker__quarter {
                 width: rem(24);
                 font-weight: $font-bold;
@@ -47,18 +40,6 @@
             // period representing three periods w/ two-digit integers (10-12)
             &.triple-period--extra-wide .usa-dt-quarter-picker__quarter {
                 width: rem(72);
-            }
-        }
-    }
-    .quarter-picker {
-        ul.quarter-picker__list {
-            button.quarter-picker__quarter {
-                &[disabled] {
-                    background-color: $color-gray;
-                    cursor: not-allowed;
-                    color: $color-gray-dark;
-                    opacity: 0.90;
-                }
             }
         }
     }

--- a/src/_scss/pages/explorer/detail/sidebar/sidebar.scss
+++ b/src/_scss/pages/explorer/detail/sidebar/sidebar.scss
@@ -16,6 +16,12 @@
             @include flex-wrap(nowrap);
         }
     }
+    .usa-dt-quarter-picker__list li:first-child ul li:first-child {
+        border-radius: rem(30) 0 0 rem(30);
+    }
+    .usa-dt-quarter-picker__list li:last-child ul li:last-child {
+        border-radius: 0 rem(30) rem(30) 0;
+    }
     .usa-dt-quarter-picker__period-list-container {
         p {
             font-weight: 600;
@@ -23,6 +29,7 @@
         .usa-dt-quarter-picker__period-list .usa-dt-quarter-picker__list-item {
             // the generic period styles
             margin: rem(0) rem(1);
+            // background-color: $color-white;
             .usa-dt-quarter-picker__quarter {
                 width: rem(24);
                 font-weight: $font-bold;

--- a/src/_scss/pages/explorer/detail/sidebar/sidebar.scss
+++ b/src/_scss/pages/explorer/detail/sidebar/sidebar.scss
@@ -29,7 +29,7 @@
         .usa-dt-quarter-picker__period-list .usa-dt-quarter-picker__list-item {
             // the generic period styles
             margin: rem(0) rem(1);
-            // background-color: $color-white;
+            background-color: $color-white;
             .usa-dt-quarter-picker__quarter {
                 width: rem(24);
                 font-weight: $font-bold;
@@ -47,6 +47,18 @@
             // period representing three periods w/ two-digit integers (10-12)
             &.triple-period--extra-wide .usa-dt-quarter-picker__quarter {
                 width: rem(72);
+            }
+        }
+    }
+    .quarter-picker {
+        ul.quarter-picker__list {
+            button.quarter-picker__quarter {
+                &[disabled] {
+                    background-color: $color-gray;
+                    cursor: not-allowed;
+                    color: $color-gray-dark;
+                    opacity: 0.90;
+                }
             }
         }
     }

--- a/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
+++ b/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
@@ -10,7 +10,7 @@ import { Link } from 'react-router-dom';
 import Analytics from 'helpers/analytics/Analytics';
 
 import { Home } from 'components/sharedComponents/icons/Icons';
-import { lastCompletedQuarterInFY, lastPeriodByQuarter } from 'containers/explorer/detail/helpers/explorerQuarters';
+import { lastCompletedQuarterInFY, lastCompletedPeriodInFY } from 'containers/explorer/detail/helpers/explorerQuarters';
 import QuarterPickerWithFY from 'components/sharedComponents/QuarterPickerWithFY';
 import VerticalTrail from './VerticalTrail';
 
@@ -63,14 +63,14 @@ export default class ExplorerSidebar extends React.Component {
 
     pickedYear(year) {
         const lastQuarter = lastCompletedQuarterInFY(year);
-
+        const lastPeriod = lastCompletedPeriodInFY(year);
         // Log analytic event
         this.logTimePeriodEvent(lastQuarter.quarter, lastQuarter.year);
 
         if (year >= 2020) {
             this.props.setExplorerPeriod({
                 fy: `${lastQuarter.year}`,
-                period: `${lastPeriodByQuarter[lastQuarter.quarter]}`,
+                period: `${lastPeriod.period}`,
                 quarter: null
             });
         }

--- a/src/js/containers/explorer/detail/helpers/explorerQuarters.js
+++ b/src/js/containers/explorer/detail/helpers/explorerQuarters.js
@@ -173,9 +173,8 @@ export const mostRecentPeriod = () => {
     };
 };
 
-
 export const lastCompletedPeriodInFY = (fy) => {
-    // get the most recent available quarter and year
+    // get the most recent available period and year
     const current = mostRecentPeriod();
     const sanitizedFY = handlePotentialStrings(fy);
 
@@ -187,7 +186,7 @@ export const lastCompletedPeriodInFY = (fy) => {
             year: sanitizedFY
         };
     }
-    // otherwise, return the current year's quarter
+    // otherwise, return the current year's period
     return current;
 };
 

--- a/src/js/containers/explorer/detail/helpers/explorerQuarters.js
+++ b/src/js/containers/explorer/detail/helpers/explorerQuarters.js
@@ -150,3 +150,48 @@ export const defaultQuarters = () => {
     const current = mostRecentQuarter();
     return availableQuartersInFY(current.year);
 };
+
+
+export const mostRecentPeriod = () => {
+    // get current "fiscal period", which is three months ahead of the current month
+    const todayAdjusted = moment().add(3, 'months');
+    // determine what month that was
+    let period = todayAdjusted.month();
+
+    const year = FiscalYearHelper.defaultFiscalYear();
+
+    // now go back one additional month (so we go to the most recently closed month, rather than
+    // the active in-progress month)
+    period -= 1;
+    if (period === 0) {
+        period = 12;
+    }
+
+    return {
+        period,
+        year
+    };
+};
+
+
+export const lastCompletedPeriodInFY = (fy) => {
+    // get the most recent available quarter and year
+    const current = mostRecentPeriod();
+    const sanitizedFY = handlePotentialStrings(fy);
+
+    if (sanitizedFY < current.year) {
+        // user wants a previous year's periods
+        // since we are no longer on that year, it must be completed
+        return {
+            period: 12,
+            year: sanitizedFY
+        };
+    }
+    // otherwise, return the current year's quarter
+    return current;
+};
+
+export const defaultPeriod = () => {
+    const current = mostRecentPeriod();
+    return lastCompletedPeriodInFY(current.year);
+};

--- a/src/js/redux/reducers/explorer/explorerReducer.js
+++ b/src/js/redux/reducers/explorer/explorerReducer.js
@@ -4,7 +4,7 @@
  **/
 
 import { List, Record } from 'immutable';
-import { defaultQuarters, mostRecentPeriod } from 'containers/explorer/detail/helpers/explorerQuarters';
+import { defaultQuarters, defaultPeriod } from 'containers/explorer/detail/helpers/explorerQuarters';
 
 export const ActiveScreen = new Record({
     within: '', // within is the data type that the total is a slice WITHIN
@@ -14,7 +14,7 @@ export const ActiveScreen = new Record({
 });
 
 const initialQuarters = defaultQuarters();
-const initalPeriod = mostRecentPeriod();
+const initalPeriod = defaultPeriod();
 export const initialState = {
     root: 'object_class',
     fy: `${initialQuarters.year}`,

--- a/src/js/redux/reducers/explorer/explorerReducer.js
+++ b/src/js/redux/reducers/explorer/explorerReducer.js
@@ -4,7 +4,7 @@
  **/
 
 import { List, Record } from 'immutable';
-import { defaultQuarters, lastPeriodByQuarter } from 'containers/explorer/detail/helpers/explorerQuarters';
+import { defaultQuarters, defaultPeriod } from 'containers/explorer/detail/helpers/explorerQuarters';
 
 export const ActiveScreen = new Record({
     within: '', // within is the data type that the total is a slice WITHIN
@@ -14,12 +14,12 @@ export const ActiveScreen = new Record({
 });
 
 const initialQuarters = defaultQuarters();
-
+const initalPeriod = defaultPeriod();
 export const initialState = {
     root: 'object_class',
     fy: `${initialQuarters.year}`,
     quarter: initialQuarters.year >= 2020 ? null : `${Math.max(...initialQuarters.quarters)}`,
-    period: initialQuarters.year >= 2020 ? `${lastPeriodByQuarter[Math.max(...initialQuarters.quarters)]}` : null,
+    period: initialQuarters.year >= 2020 ? `${initalPeriod.period}` : null,
     active: new ActiveScreen(),
     trail: new List([]),
     table: {

--- a/src/js/redux/reducers/explorer/explorerReducer.js
+++ b/src/js/redux/reducers/explorer/explorerReducer.js
@@ -4,7 +4,7 @@
  **/
 
 import { List, Record } from 'immutable';
-import { defaultQuarters, defaultPeriod } from 'containers/explorer/detail/helpers/explorerQuarters';
+import { defaultQuarters, mostRecentPeriod } from 'containers/explorer/detail/helpers/explorerQuarters';
 
 export const ActiveScreen = new Record({
     within: '', // within is the data type that the total is a slice WITHIN
@@ -14,7 +14,7 @@ export const ActiveScreen = new Record({
 });
 
 const initialQuarters = defaultQuarters();
-const initalPeriod = defaultPeriod();
+const initalPeriod = mostRecentPeriod();
 export const initialState = {
     root: 'object_class',
     fy: `${initialQuarters.year}`,

--- a/tests/containers/explorer/detail/DetailContentContainer-test.jsx
+++ b/tests/containers/explorer/detail/DetailContentContainer-test.jsx
@@ -141,6 +141,25 @@ describe('DetailContentContainer', () => {
             expect(container.state().filters.fy).toEqual('1984');
             expect(container.state().filters.period).toEqual('5');
         });
+        it('should create a filterset that consists of the provided fiscal year and period', () => {
+            const container = shallow(
+                <DetailContentContainer
+                    {...mockActions}
+                    explorer={mockReducerRoot} />
+            );
+
+            container.instance().loadData = jest.fn();
+            
+            container.instance().componentDidUpdate({
+                explorer: Object.assign({}, mockReducerRoot, {
+                    period: '5'
+                })
+            });
+
+            container.instance().prepareRootRequest('agency', '1984', null, '5');
+            expect(container.state().filters.fy).toEqual('1984');
+            expect(container.state().filters.period).toEqual('5');
+        });
         it('should make a root-level API call with the provided subdivision type', () => {
             const container = shallow(
                 <DetailContentContainer

--- a/tests/redux/reducers/explorer/mockQuarterHelper.js
+++ b/tests/redux/reducers/explorer/mockQuarterHelper.js
@@ -2,3 +2,8 @@ export const defaultQuarters = () => ({
     quarters: [1, 2],
     year: 1984
 });
+
+export const defaultPeriod = () => ({
+    period: 5,
+    year: 1984
+});


### PR DESCRIPTION
**High level description:**

Fixes issues w/ period selection on the spending explorer, previously was not selecting the latest closed period, but the latest period in the latest closed quarter.

**JIRA Ticket:**
[DEV-5401](https://federal-spending-transparency.atlassian.net/browse/DEV-5401)

**Mockup:**
https://bahdigital.invisionapp.com/share/C8IADXT2BD4#/screens/296036477

The following are ALL required for the PR to be merged:

Author:
- [X] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR
- [X] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [X] Verified mobile/tablet/desktop/monitor responsiveness
- [X] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [X] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [X] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)

Reviewer(s):
- [x] Design review complete
- [x] Code review complete
