### PR TITLE
Bug Dev-4478 Advanced Search Download Availability

### DIFF
--- a/src/js/containers/search/SearchContainer.jsx
+++ b/src/js/containers/search/SearchContainer.jsx
@@ -153,13 +153,6 @@ const SearchContainer = ({ history }) => {
     }, [appliedFilters, generateHashInFlight]);
 
     const setDownloadAvailability = useCallback(() => {
-        if (SearchHelper.areFiltersEqual(stagedFilters, appliedFilters)) {
-            // don't make an API call when it's a blank state
-            setDownloadAvailable(false);
-            setDownloadInFlight(false);
-            return;
-        }
-
         setDownloadInFlight(true);
 
         const operation = new SearchAwardsOperation();


### PR DESCRIPTION
**High level description:**

Fixes a bug that would not check for download availability.

**Technical details:**

> • Removes a check for if filters are equal within the check for download availability. The check for download availability is only called once and that effect is already checking if the filters are equal, so the check in the function is a dup.

**JIRA Ticket:**
[DEV-4478](https://federal-spending-transparency.atlassian.net/browse/DEV-4478)

- [x] Code review complete
