### PR TITLE
[DEV-5590] Adding Special Treemap Cell to Spending Explorer to make Truncated Results Proportional

### DIFF
--- a/src/js/components/explorer/detail/DetailContent.jsx
+++ b/src/js/components/explorer/detail/DetailContent.jsx
@@ -189,6 +189,7 @@ export default class DetailContent extends React.Component {
             }
 
             header = (<DetailHeader
+                activeSubdivision={this.props.active.subdivision}
                 isLoading={this.props.isLoading}
                 within={lastFilter.within}
                 title={lastFilter.title}

--- a/src/js/components/explorer/detail/header/DetailHeader.jsx
+++ b/src/js/components/explorer/detail/header/DetailHeader.jsx
@@ -18,6 +18,7 @@ import TruncationWarning from './TruncationWarning';
 
 const propTypes = {
     within: PropTypes.string,
+    activeSubdivision: PropTypes.string,
     fy: PropTypes.string,
     lastUpdate: PropTypes.string,
     total: PropTypes.number,
@@ -110,7 +111,7 @@ const DetailHeader = (props) => {
     let truncationWarning = null;
     if (props.isTruncated) {
         truncationWarning = (
-            <TruncationWarning />
+            <TruncationWarning activeSubdivision={props.activeSubdivision} />
         );
     }
 

--- a/src/js/components/explorer/detail/header/TruncationWarning.jsx
+++ b/src/js/components/explorer/detail/header/TruncationWarning.jsx
@@ -4,23 +4,37 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
+import { startCase } from 'lodash';
+
 import { InfoCircle } from 'components/sharedComponents/icons/Icons';
 import { Link } from 'react-router-dom';
 
-const TruncationWarning = () => (
+const TruncationWarning = ({
+    activeSubdivision = 'award'
+}) => (
     <div className="truncation-warning detail-header__truncation">
         <div className="truncation-warning__icon">
             <InfoCircle alt="Information" />
         </div>
         <div className="truncation-warning__message">
             <div className="truncation-warning__title">
-                Award Display Limit
+                {startCase(activeSubdivision)} Display Limit
             </div>
             <div className="truncation-warning__detail">
-                Only the 500 awards with the highest amounts are shown. For further research on individual awards, visit our <Link to="/search">Advanced Search</Link>.
+                Only the 500 {startCase(activeSubdivision)}s with the highest amounts are shown.
+                {activeSubdivision === 'award' && (
+                    <>
+                        For further research on individual awards, visit our <Link to="/search">Advanced Search</Link>.
+                    </>
+                )}
             </div>
         </div>
     </div>
 );
+
+TruncationWarning.propTypes = {
+    activeSubdivision: PropTypes.string
+};
 
 export default TruncationWarning;

--- a/src/js/components/explorer/detail/visualization/ExplorerVisualization.jsx
+++ b/src/js/components/explorer/detail/visualization/ExplorerVisualization.jsx
@@ -90,6 +90,7 @@ export default class ExplorerVisualization extends React.Component {
         let visualization = (
             <div className={`treemap-loading-transition ${loadingTreemapClass}`}>
                 <ExplorerTreemap
+                    activeSubdivision={this.props.active.subdivision}
                     isLoading={this.props.isLoading}
                     width={this.state.width}
                     data={this.props.data}

--- a/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
+++ b/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
@@ -57,10 +57,7 @@ export default class ExplorerTreemap extends React.Component {
     }
 
     buildVirtualChart(props) {
-        const dataForTree = props.data.toJS()
-            .sort((a, b) => b.amount - a.amount)
-            .filter((item) => item.amount >= 0)
-            .slice(0, 500);
+        const dataForTree = props.data.toJS();
 
         const total = props.total;
         // remove the negative values from the data because they can't be displayed in the treemap

--- a/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
+++ b/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
@@ -8,9 +8,11 @@ import PropTypes from 'prop-types';
 
 import { hierarchy, treemap, treemapBinary } from 'd3-hierarchy';
 import { scaleLinear } from 'd3-scale';
-import { remove } from 'lodash';
 
+import { appendCellForDataOutsideTree } from 'helpers/explorerHelper';
 import { measureTreemapHeader, measureTreemapValue } from 'helpers/textMeasurement';
+
+
 import LoadingSpinner from 'components/sharedComponents/LoadingSpinner';
 import TreemapCell from 'components/sharedComponents/TreemapCell';
 
@@ -22,7 +24,8 @@ const propTypes = {
     goDeeper: PropTypes.func,
     showTooltip: PropTypes.func,
     hideTooltip: PropTypes.func,
-    goToUnreported: PropTypes.func
+    goToUnreported: PropTypes.func,
+    activeSubdivision: PropTypes.object
 };
 
 const defaultProps = {
@@ -54,19 +57,18 @@ export default class ExplorerTreemap extends React.Component {
     }
 
     buildVirtualChart(props) {
-        const data = props.data.toJS();
-
-        // remove the negative values from the data because they can't be displayed in the treemap
-        remove(data, (v) => v.amount <= 0);
+        const dataForTree = props.data.toJS()
+            .sort((a, b) => b.amount - a.amount)
+            .slice(0, 500);
 
         const total = props.total;
+        // remove the negative values from the data because they can't be displayed in the treemap
+        const data = appendCellForDataOutsideTree(dataForTree, total, props.activeSubdivision)
+            .filter((item) => item.amount >= 0);
 
         // parse the inbound data into D3's treemap hierarchy structure
-        const treemapData = hierarchy({
-            children: data
-        })
-            .sum((d) => d.amount) // tell D3 how to extract the monetary value out of the object
-            .sort((a, b) => b.height - a.height || b.value - a.value); // sort the objects
+        const treemapData = hierarchy({ children: data })
+            .sum((d) => d.amount); // tell D3 how to extract the monetary value out of the object
 
         // set up a function for generating the treemap of the specified size and style
         const tree = treemap()

--- a/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
+++ b/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
@@ -9,7 +9,6 @@ import PropTypes from 'prop-types';
 import { hierarchy, treemap, treemapBinary } from 'd3-hierarchy';
 import { scaleLinear } from 'd3-scale';
 
-import { appendCellForDataOutsideTree } from 'helpers/explorerHelper';
 import { measureTreemapHeader, measureTreemapValue } from 'helpers/textMeasurement';
 
 
@@ -57,12 +56,9 @@ export default class ExplorerTreemap extends React.Component {
     }
 
     buildVirtualChart(props) {
-        const dataForTree = props.data.toJS();
+        const data = props.data.toJS();
 
         const total = props.total;
-        // remove the negative values from the data because they can't be displayed in the treemap
-        const data = appendCellForDataOutsideTree(dataForTree, total, props.activeSubdivision)
-            .sort((a, b) => b.amount - a.amount);
 
         // parse the inbound data into D3's treemap hierarchy structure
         const treemapData = hierarchy({ children: data })

--- a/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
+++ b/src/js/components/explorer/detail/visualization/treemap/ExplorerTreemap.jsx
@@ -59,12 +59,13 @@ export default class ExplorerTreemap extends React.Component {
     buildVirtualChart(props) {
         const dataForTree = props.data.toJS()
             .sort((a, b) => b.amount - a.amount)
+            .filter((item) => item.amount >= 0)
             .slice(0, 500);
 
         const total = props.total;
         // remove the negative values from the data because they can't be displayed in the treemap
         const data = appendCellForDataOutsideTree(dataForTree, total, props.activeSubdivision)
-            .filter((item) => item.amount >= 0);
+            .sort((a, b) => b.amount - a.amount);
 
         // parse the inbound data into D3's treemap hierarchy structure
         const treemapData = hierarchy({ children: data })

--- a/src/js/containers/explorer/detail/DetailContentContainer.jsx
+++ b/src/js/containers/explorer/detail/DetailContentContainer.jsx
@@ -217,6 +217,7 @@ export class DetailContentContainer extends React.Component {
 
         let isTruncated = false;
         let parsedResults = ExplorerHelper.truncateDataForTreemap(data.results);
+
         if (request.subdivision === 'award') {
             // link to award page using new human readable id
             parsedResults = parsedResults.map((obj) => ({ ...obj, id: encodeURIComponent(obj.generated_unique_award_id) }));
@@ -228,6 +229,9 @@ export class DetailContentContainer extends React.Component {
             // message
             isTruncated = Math.abs(total - resultTotal) > 10;
         }
+
+        parsedResults = ExplorerHelper.appendCellForDataOutsideTree(parsedResults, total, request.subdivision)
+            .sort((a, b) => b.amount - a.amount);
 
         // build the trail item of the last applied filter using the request object
         const trailItem = Object.assign({}, request, {

--- a/src/js/containers/explorer/detail/DetailContentContainer.jsx
+++ b/src/js/containers/explorer/detail/DetailContentContainer.jsx
@@ -225,6 +225,8 @@ export class DetailContentContainer extends React.Component {
 
             // allow a $10 leeway to account for JS float bugs before triggering a truncation
             // message
+            // parsedResults are not really what we pass to the treemap. They're fully populated aka well over 500 for recipients.
+            debugger;
             isTruncated = Math.abs(total - resultTotal) > 10;
         }
 

--- a/src/js/containers/explorer/detail/DetailContentContainer.jsx
+++ b/src/js/containers/explorer/detail/DetailContentContainer.jsx
@@ -216,17 +216,16 @@ export class DetailContentContainer extends React.Component {
         const total = data.total;
 
         let isTruncated = false;
-        let parsedResults = data.results;
-
-        if (request.subdivision === 'award' || request.subdivision === 'recipient') {
-            const resultTotal = data.results.reduce((sum, item) => sum + item.amount, 0);
+        let parsedResults = ExplorerHelper.truncateDataForTreemap(data.results);
+        if (request.subdivision === 'award') {
             // link to award page using new human readable id
             parsedResults = parsedResults.map((obj) => ({ ...obj, id: encodeURIComponent(obj.generated_unique_award_id) }));
+        }
 
+        if (request.subdivision === 'award' || request.subdivision === 'recipient') {
+            const resultTotal = parsedResults.reduce((sum, item) => sum + item.amount, 0);
             // allow a $10 leeway to account for JS float bugs before triggering a truncation
             // message
-            // parsedResults are not really what we pass to the treemap. They're fully populated aka well over 500 for recipients.
-            debugger;
             isTruncated = Math.abs(total - resultTotal) > 10;
         }
 

--- a/src/js/containers/explorer/detail/DetailContentContainer.jsx
+++ b/src/js/containers/explorer/detail/DetailContentContainer.jsx
@@ -218,14 +218,8 @@ export class DetailContentContainer extends React.Component {
         let isTruncated = false;
         let parsedResults = data.results;
 
-        // set a safety limit of 1,000 cells to prevent the browser from crashing due to too many
-        // DOM elements
-        if (data.results.length > 1000) {
-            parsedResults = data.results.slice(0, 1000);
-        }
-        if (request.subdivision === 'award') {
-            const resultTotal = data.results
-                .reduce((sum, item) => sum + item.amount, 0);
+        if (request.subdivision === 'award' || request.subdivision === 'recipient') {
+            const resultTotal = data.results.reduce((sum, item) => sum + item.amount, 0);
             // link to award page using new human readable id
             parsedResults = parsedResults.map((obj) => ({ ...obj, id: encodeURIComponent(obj.generated_unique_award_id) }));
 

--- a/src/js/helpers/apiRequest.js
+++ b/src/js/helpers/apiRequest.js
@@ -13,7 +13,8 @@ const localUrl = `http://localhost:8000/api/`;
 const getBaseUrl = (params) => {
     if (params.isMocked) return mockUrl;
     if (params.isLocal) return localUrl;
-    return kGlobalConstants.API;
+    // return kGlobalConstants.API;
+    return 'https://api.usaspending.gov/api';
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/js/helpers/apiRequest.js
+++ b/src/js/helpers/apiRequest.js
@@ -13,8 +13,7 @@ const localUrl = `http://localhost:8000/api/`;
 const getBaseUrl = (params) => {
     if (params.isMocked) return mockUrl;
     if (params.isLocal) return localUrl;
-    // return kGlobalConstants.API;
-    return 'https://api.usaspending.gov/api';
+    return kGlobalConstants.API;
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/js/helpers/explorerHelper.js
+++ b/src/js/helpers/explorerHelper.js
@@ -2,6 +2,7 @@
  * explorerHelper.js
  * Created by Kevin Li 8/16/17
  */
+import { startCase } from 'lodash';
 
 import { apiRequest } from './apiRequest';
 
@@ -11,3 +12,21 @@ export const fetchBreakdown = (params) => apiRequest({
     method: 'post',
     data: params
 });
+
+/**
+ * @param {Array} rawData an array of objects from api representing spending explorer tree cells
+ * @param {Int} total integer representing total spending amount for selected criteria
+ * @param {String} activeSubdivision string indicating the selected activeSubdivision: award/recipient/etc...
+ */
+export const appendCellForDataOutsideTree = (dataForTree, overallTotal, activeSubdivision) => {
+    const totalNotShown = overallTotal - dataForTree.reduce((sum, item) => sum + item.amount, 0);
+    return [{
+        id: 'N/A',
+        link: false,
+        code: "N/A",
+        type: '',
+        name: `Sum of all ${startCase(activeSubdivision)}s after Top 500`,
+        amount: totalNotShown
+    }]
+        .concat(dataForTree);
+};

--- a/src/js/helpers/explorerHelper.js
+++ b/src/js/helpers/explorerHelper.js
@@ -24,7 +24,7 @@ export const fetchBreakdown = (params) => apiRequest({
 export const appendCellForDataOutsideTree = (dataForTree, overallTotal, activeSubdivision) => {
     const totalNotShown = overallTotal - dataForTree.reduce((sum, item) => sum + item.amount, 0);
     return [{
-        id: 'N/A',
+        id: null,
         link: false,
         code: "N/A",
         type: '',

--- a/src/js/helpers/explorerHelper.js
+++ b/src/js/helpers/explorerHelper.js
@@ -14,9 +14,12 @@ export const fetchBreakdown = (params) => apiRequest({
 });
 
 /**
- * @param {Array} rawData an array of objects from api representing spending explorer tree cells
+ * @param {Array} dataForTree an array of objects from api representing spending explorer tree cells
  * @param {Int} total integer representing total spending amount for selected criteria
- * @param {String} activeSubdivision string indicating the selected activeSubdivision: award/recipient/etc...
+ * @param {String} activeSubdivision string indicating the selected activeSubdivision: award/
+ *  recipient/etc...
+ * @returns {Array} the dataForTree array with new object appended representing total spending data
+ * not shown
  */
 export const appendCellForDataOutsideTree = (dataForTree, overallTotal, activeSubdivision) => {
     const totalNotShown = overallTotal - dataForTree.reduce((sum, item) => sum + item.amount, 0);
@@ -30,3 +33,8 @@ export const appendCellForDataOutsideTree = (dataForTree, overallTotal, activeSu
     }]
         .concat(dataForTree);
 };
+
+export const truncateDataForTreemap = (data, limit = 500) => data
+    .sort((a, b) => b.amount - a.amount)
+    .filter((item) => item.amount >= 0)
+    .slice(0, limit);

--- a/tests/containers/explorer/detail/DetailContentContainer-test.jsx
+++ b/tests/containers/explorer/detail/DetailContentContainer-test.jsx
@@ -212,7 +212,7 @@ describe('DetailContentContainer', () => {
         });
     });
     describe('parseData', () => {
-        it('should set the isTruncated state to true only at the award level', () => {
+        it('should set the isTruncated state to true at the award/recipient level', () => {
             const container = shallow(<DetailContentContainer
                 {...mockActions}
                 explorer={mockReducerRoot} />);
@@ -224,8 +224,17 @@ describe('DetailContentContainer', () => {
 
             container.instance().parseData(mockAwardResponse, request);
             expect(container.state().isTruncated).toBeTruthy();
+
+
+            const request2 = {
+                within: 'agency',
+                subdivision: 'recipient'
+            };
+
+            container.instance().parseData(mockAwardResponse, request2);
+            expect(container.state().isTruncated).toBeTruthy();
         });
-        it('should never set the isTruncated state to true if not at the award level', () => {
+        it('should never set the isTruncated state to true if not at the award/recipient level', () => {
             const container = shallow(<DetailContentContainer
                 {...mockActions}
                 explorer={mockReducerRoot} />);
@@ -267,24 +276,6 @@ describe('DetailContentContainer', () => {
 
             container.instance().parseData(mockAward, request);
             expect(container.state().isTruncated).toBeFalsy();
-        });
-
-        it('should limit the API response to the first 1,000 items as a safety check', () => {
-            const container = shallow(<DetailContentContainer
-                {...mockActions}
-                explorer={mockReducerRoot} />);
-
-            const request = {
-                within: 'recipient',
-                subdivision: 'award'
-            };
-
-            const mockAPI = Object.assign({}, mockAPI, {
-                results: new Array(15000).fill('filler', 0, 15000)
-            });
-
-            container.instance().parseData(mockAPI, request);
-            expect(container.state().data.count()).toEqual(1000);
         });
 
         it('should encode generated_unique_award_ids w/ special characters', () => {

--- a/tests/containers/explorer/detail/mockExplorerHelper.js
+++ b/tests/containers/explorer/detail/mockExplorerHelper.js
@@ -12,3 +12,4 @@ export const fetchBreakdown = () => ({
 });
 
 export const truncateDataForTreemap = (data) => data;
+export const appendCellForDataOutsideTree = (data) => data;

--- a/tests/containers/explorer/detail/mockExplorerHelper.js
+++ b/tests/containers/explorer/detail/mockExplorerHelper.js
@@ -10,3 +10,5 @@ export const fetchBreakdown = () => ({
     }),
     cancel: jest.fn()
 });
+
+export const truncateDataForTreemap = (data) => data;

--- a/tests/helpers/explorerHelper-test.js
+++ b/tests/helpers/explorerHelper-test.js
@@ -1,10 +1,30 @@
-import { appendCellForDataOutsideTree } from '../../src/js/helpers/explorerHelper';;
+import {
+    appendCellForDataOutsideTree,
+    truncateDataForTreemap
+} from '../../src/js/helpers/explorerHelper';
 
-describe('appendCellForDataOutsideTree', () => {
-    it('appends an object to the existing array correctly representing the difference between overall total and the total for the tree', () => {
-        const dataForTree = [{ amount: 1 }, { amount: 2 }];
-        const dataForTreeWithAppendedCell = appendCellForDataOutsideTree(dataForTree, 10, 'award');
-        expect(dataForTreeWithAppendedCell[0].amount).toEqual(7);
-        expect(dataForTreeWithAppendedCell[0].name).toEqual('Sum of all Awards after Top 500');
+describe('explorerHelper', () => {
+    describe('appendCellForDataOutsideTree', () => {
+        it('appends an object to the existing array correctly representing the difference between overall total and the total for the tree', () => {
+            const dataForTree = [{ amount: 1 }, { amount: 2 }];
+            const dataForTreeWithAppendedCell = appendCellForDataOutsideTree(dataForTree, 10, 'award');
+            expect(dataForTreeWithAppendedCell[0].amount).toEqual(7);
+            expect(dataForTreeWithAppendedCell[0].name).toEqual('Sum of all Awards after Top 500');
+        });
+    });
+    describe('truncateDataForTreemap', () => {
+        it('returns an array of maximum 500 items, sorted on the amount property, with no negative values', () => {
+            const dataForTree = new Array(1000).fill().map((item, i) => ({ amount: Math.random(i) }));
+            const truncatedData = truncateDataForTreemap(dataForTree);
+            const isInDescendingOrder = (
+                truncatedData[100].amount > truncatedData[101].amount &&
+                truncatedData[50].amount > truncatedData[51].amount &&
+                truncatedData[498].amount > truncatedData[499].amount
+            );
+
+            expect(isInDescendingOrder).toEqual(true);
+            expect(truncatedData.length).toEqual(500);
+        });
     });
 });
+

--- a/tests/helpers/explorerHelper-test.js
+++ b/tests/helpers/explorerHelper-test.js
@@ -1,0 +1,10 @@
+import { appendCellForDataOutsideTree } from '../../src/js/helpers/explorerHelper';;
+
+describe('appendCellForDataOutsideTree', () => {
+    it('appends an object to the existing array correctly representing the difference between overall total and the total for the tree', () => {
+        const dataForTree = [{ amount: 1 }, { amount: 2 }];
+        const dataForTreeWithAppendedCell = appendCellForDataOutsideTree(dataForTree, 10, 'award');
+        expect(dataForTreeWithAppendedCell[0].amount).toEqual(7);
+        expect(dataForTreeWithAppendedCell[0].name).toEqual('Sum of all Awards after Top 500');
+    });
+});


### PR DESCRIPTION
**High level description:**
When we truncate results on the treemap (we limit it at 500 cells in the treemap), we are adding a new cell representing all other cells outside the top 500. This ensures that the top 500 display the proper proportions relative to the overall total.

**Technical details:**
-  Truncating results at container level
- Also truncating results for recipients
- New helper to append special representational cell
- Tests added as well

**JIRA Ticket:**
[DEV-5590](https://federal-spending-transparency.atlassian.net/browse/DEV-5590)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
