### PR TITLE
[DEV-5734] Covid tooltips text fixes

### DIFF
--- a/src/js/components/covid19/Covid19Tooltips.jsx
+++ b/src/js/components/covid19/Covid19Tooltips.jsx
@@ -25,7 +25,7 @@ export const AwardSpendingAgencyTT = () => (
                     <strong> Loan Subsidy Cost does have direct budgetary impact and is factored into obligations and outlays when it is positive.</strong> Subsidy costs can be positive (indicating that the government is likely to lose money on the loan) or negative (indicating that the government is likely to make money on the loan). Loan Subsidy Cost should never be larger in absolute value terms than the Face Value of Loans itself. Administrative costs of running the loan or loan guarantee program itself are excluded from Loan Subsidy Cost calculations.
                 </li>
                 <li>
-                    The ‘Face Value of Loans’ column represents the amount that agencies have directly issued (for direct loans) or facilitated by compensating the lender if the borrower defaults (for loan guarantees).From a budget perspective, Face Value of Loans is not considered federal spending, since it does not in itself represent a long-term cost to the government. As a result, <strong>Face Value of Loans is not included in any obligation or outlay figure.</strong>
+                    The ‘Face Value of Loans’ column represents the amount that agencies have directly issued (for direct loans) or facilitated by compensating the lender if the borrower defaults (for loan guarantees). From a budget perspective, Face Value of Loans is not considered federal spending, since it does not in itself represent a long-term cost to the government. As a result, <strong>Face Value of Loans is not included in any obligation or outlay figure.</strong>
                 </li>
             </ul>
         </div>
@@ -57,7 +57,7 @@ export const AwardSpendingCfdaTT = () => (
                     <strong> Loan Subsidy Cost does have direct budgetary impact and is factored into obligations and outlays when it is positive.</strong> Subsidy costs can be positive (indicating that the government is likely to lose money on the loan) or negative (indicating that the government is likely to make money on the loan). Loan Subsidy Cost should never be larger in absolute value terms than the Face Value of Loans itself. Administrative costs of running the loan or loan guarantee program itself are excluded from Loan Subsidy Cost calculations.
                 </li>
                 <li>
-                    The ‘Face Value of Loans’ column represents the amount that agencies have directly issued (for direct loans) or facilitated by compensating the lender if the borrower defaults (for loan guarantees).From a budget perspective, Face Value of Loans is not considered federal spending, since it does not in itself represent a long-term cost to the government. As a result, <strong>Face Value of Loans is not included in any obligation or outlay figure.</strong>
+                    The ‘Face Value of Loans’ column represents the amount that agencies have directly issued (for direct loans) or facilitated by compensating the lender if the borrower defaults (for loan guarantees). From a budget perspective, Face Value of Loans is not considered federal spending, since it does not in itself represent a long-term cost to the government. As a result, <strong>Face Value of Loans is not included in any obligation or outlay figure.</strong>
                 </li>
             </ul>
         </div>
@@ -69,7 +69,10 @@ export const AwardSpendingTT = () => (
         <h2 className="tooltip__title">Award Spending</h2>
         <div className="tooltip__text">
             <p>
-                Award Spending refers to money given through contracts or financial assistance to individuals, organizations, businesses, or state, local, or tribal governments. It stands in contrast to Total Spending, also known as Account Spending, which refers to the totality of agency obligations and outlays, including agency expenses.
+                Award Spending refers to money given through contracts or financial assistance to individuals, organizations, businesses, or state, local, or tribal governments.
+            </p><br />
+            <p>
+                Award Spending stands in contrast to Total Spending, also known as Account Spending, which refers to the totality of agency obligations and outlays, including agency expenses.
             </p>
         </div>
     </div>
@@ -100,7 +103,7 @@ export const SpendingByRecipientTT = () => (
                     <strong> Loan Subsidy Cost does have direct budgetary impact and is factored into obligations and outlays when it is positive.</strong> Subsidy costs can be positive (indicating that the government is likely to lose money on the loan) or negative (indicating that the government is likely to make money on the loan). Loan Subsidy Cost should never be larger in absolute value terms than the Face Value of Loans itself. Administrative costs of running the loan or loan guarantee program itself are excluded from Loan Subsidy Cost calculations.
                 </li>
                 <li>
-                    The ‘Face Value of Loans’ column represents the amount that agencies have directly issued (for direct loans) or facilitated by compensating the lender if the borrower defaults (for loan guarantees).From a budget perspective, Face Value of Loans is not considered federal spending, since it does not in itself represent a long-term cost to the government. As a result, <strong>Face Value of Loans is not included in any obligation or outlay figure.</strong>
+                    The ‘Face Value of Loans’ column represents the amount that agencies have directly issued (for direct loans) or facilitated by compensating the lender if the borrower defaults (for loan guarantees). From a budget perspective, Face Value of Loans is not considered federal spending, since it does not in itself represent a long-term cost to the government. As a result, <strong>Face Value of Loans is not included in any obligation or outlay figure.</strong>
                 </li>
             </ul>
         </div>
@@ -149,7 +152,7 @@ export const SpendingTypesTT = () => (
             <p>
                 From a budget perspective, Face Value of Loans is not considered federal spending, since it does not in itself represent a long-term cost to the government.
                 As a result, <strong>Face Value of Loans is not included in any obligation or outlay figure.</strong> However,
-                <strong> Loan Subsidy Cost does have direct budgetary impact and is factored into obligations and outlays when it is positive.</strong>
+                <strong> Loan Subsidy Cost does have direct budgetary impact and is factored into obligations and outlays when it is positive. </strong>
                 Subsidy costs can be positive (indicating that the government is likely to lose money on the loan) or negative (indicating that the government is likely to make money on the loan).
                 Loan Subsidy Cost should never be larger in absolute value terms than the Face Value of Loans itself. Administrative costs of running the loan or loan guarantee program itself are excluded from Loan Subsidy Cost calculations.
             </p>


### PR DESCRIPTION
**High level description:**

PR for fixing spacing issues in tooltip contents.

**Technical details:**

spaces after periods in award spending sections, splitting award spending into 2 paragraphs to replicate total spending

**JIRA Ticket:**
[DEV-5734](https://federal-spending-transparency.atlassian.net/browse/DEV-5734)

**Mockup:**
https://bahdigital.invisionapp.com/share/KWIAE7IT4H2#/screens

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [`N/A`] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [`N/A`] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [`N/A`] Verified mobile/tablet/desktop/monitor responsiveness
- [`N/A`] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [`N/A`] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [`N/A`] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [`N/A`] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [`N/A`] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [`N/A`] Design review complete `if applicable`
- [`N/A`] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
