### PR TITLE
[DEV-4644] - Add 'unique award key' box to Additional Information section of award summary v2.0

### DIFF
--- a/src/_scss/pages/award/visualizations/_additionalInfo.scss
+++ b/src/_scss/pages/award/visualizations/_additionalInfo.scss
@@ -105,6 +105,9 @@
                           flex: 1;
                           font-weight: $font-light;
                           padding-left: rem(40);
+                          &.generated-id {
+                            word-break: break-word;
+                          }
                           .accordion-table__list {
                             list-style-type: none;
                             margin: 0;

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -52,7 +52,8 @@ import {
     faThLarge,
     faTimes,
     faUserTie,
-    faWindowRestore
+    faWindowRestore,
+    faFingerprint
 } from "@fortawesome/free-solid-svg-icons";
 import AppContainer from 'containers/AppContainer';
 
@@ -93,6 +94,7 @@ library.add(
     faExclamationCircle,
     faExternalLinkAlt,
     faExclamationTriangle,
+    faFingerprint,
     faHandHoldingMedical,
     faHandsHelping,
     faInfo,

--- a/src/js/components/award/shared/additionalInfo/Accordion.jsx
+++ b/src/js/components/award/shared/additionalInfo/Accordion.jsx
@@ -18,6 +18,8 @@ const propTypes = {
     globalToggle: PropTypes.bool
 };
 
+const awardIdField = 'Unique Award Key';
+
 export default class Accordion extends React.Component {
     constructor(props) {
         super(props);
@@ -96,7 +98,7 @@ export default class Accordion extends React.Component {
                     key={key}
                     className="accordion-row">
                     <div className="accordion-row__title">{key}</div>
-                    <div className="accordion-row__data">{data}</div>
+                    <div className={`accordion-row__data${key === awardIdField ? ' generated-id' : ''}`}>{data}</div>
                 </div>
             );
         });

--- a/src/js/components/award/shared/additionalInfo/AdditionalInfo.jsx
+++ b/src/js/components/award/shared/additionalInfo/AdditionalInfo.jsx
@@ -77,6 +77,12 @@ export default class AdditionalInfo extends React.Component {
         }
         const columnOne = [
             (<Accordion
+                key="UniqueAwardKey"
+                globalToggle={this.state.globalToggle}
+                accordionName="Unique Award Key"
+                accordionIcon="fingerprint"
+                accordionData={data.uniqueAwardKey} />),
+            (<Accordion
                 key="AgencyDetails"
                 globalToggle={this.state.globalToggle}
                 accordionName="Agency Details"
@@ -137,6 +143,12 @@ export default class AdditionalInfo extends React.Component {
         const { overview } = this.props;
         const data = this.data();
         const columnOne = [
+            (<Accordion
+                key="UniqueAwardKey"
+                globalToggle={this.state.globalToggle}
+                accordionName="Unique Award Key"
+                accordionIcon="fingerprint"
+                accordionData={data.uniqueAwardKey} />),
             (<Accordion
                 key="AgencyDetails"
                 globalToggle={this.state.globalToggle}

--- a/src/js/components/award/shared/overview/RelatedAwards.jsx
+++ b/src/js/components/award/shared/overview/RelatedAwards.jsx
@@ -133,7 +133,7 @@ export default class RelatedAwards extends React.Component {
     render() {
         const { overview } = this.props;
         const tooltipInfo = this.tooltipInfo();
-        const awardTitle = 'Parent Award';
+        const awardTitle = 'Parent Award Unique Key';
         let parentLink = 'N/A';
         if (overview.parentAwardDetails.piid && overview.parentAwardDetails.awardId) {
             parentLink = (

--- a/src/js/components/award/shared/overview/RelatedAwards.jsx
+++ b/src/js/components/award/shared/overview/RelatedAwards.jsx
@@ -133,14 +133,14 @@ export default class RelatedAwards extends React.Component {
     render() {
         const { overview } = this.props;
         const tooltipInfo = this.tooltipInfo();
-        const awardTitle = 'Parent Award Unique Key';
+        const awardTitle = 'Parent Award';
         let parentLink = 'N/A';
         if (overview.parentAwardDetails.piid && overview.parentAwardDetails.awardId) {
             parentLink = (
                 <Link
                     className="related-awards__link"
-                    href={`award/${overview.parentAwardDetails.awardId}`}>
-                    {overview.parentAwardDetails.piid}
+                    to={`/award/${overview.parentAwardDetails.awardId}`}>
+                    {overview.parentAwardDetails.awardId}
                 </Link>
             );
         }

--- a/src/js/dataMapping/award/additionalDetailsContract.js
+++ b/src/js/dataMapping/award/additionalDetailsContract.js
@@ -2,11 +2,7 @@
  * additionalDetails.js -> additonalDetailsContracts.js
  * Created by Kwadwo Opoku-Debrah 12/17/18
  */
-export const getSubmittingAgencyId = (generatedString, substring, piid) => {
-    const tempString = generatedString.substring(generatedString.indexOf(substring) + substring.length);
-    const parsedString = tempString.substring(0, tempString.indexOf(piid)).replaceAll('_', '');
-    return parsedString;
-};
+import { getSubmittingAgencyId } from "helpers/awardSummaryHelper";
 
 const additionalDetailsContracts = (awardData) => {
     const {
@@ -23,7 +19,7 @@ const additionalDetailsContracts = (awardData) => {
             'Unique Award Key': awardData.generatedId,
             'Award or IDV Flag': 'Contract Award',
             'Procurement Instrument Identifier (PIID)': awardData.piid,
-            'Submitting Agency Identifier Code': getSubmittingAgencyId(awardData.generatedId, awardData.piid, parentAwardDetails.piid),
+            'Submitting Agency Identifier Code': getSubmittingAgencyId(awardData.generatedId),
             'Parent Award ID (Parent PIID)': parentAwardDetails.piid,
             'Parent Agency Identifier Code': awardData.additionalDetails.idvAgencyId
         },

--- a/src/js/dataMapping/award/additionalDetailsContract.js
+++ b/src/js/dataMapping/award/additionalDetailsContract.js
@@ -15,7 +15,7 @@ const additionalDetailsContracts = (awardData) => {
         parentAwardDetails,
         periodOfPerformance,
         placeOfPerformance,
-        recipient,
+        recipient
     } = awardData;
     
     const data = {

--- a/src/js/dataMapping/award/additionalDetailsContract.js
+++ b/src/js/dataMapping/award/additionalDetailsContract.js
@@ -2,6 +2,11 @@
  * additionalDetails.js -> additonalDetailsContracts.js
  * Created by Kwadwo Opoku-Debrah 12/17/18
  */
+export const getSubmittingAgencyId = (generatedString, substring, piid) => {
+    var tempString = generatedString.substring(generatedString.indexOf(substring) + substring.length);
+    var parsedString = tempString.substring(0, tempString.indexOf(piid)).replaceAll('_','');
+    return parsedString;
+};
 
 const additionalDetailsContracts = (awardData) => {
     const {
@@ -18,7 +23,7 @@ const additionalDetailsContracts = (awardData) => {
             'Unique Award Key': awardData.generatedId,
             'Award or IDV Flag': 'Contract Award',
             'Procurement Instrument Identifier (PIID)': awardData.piid,
-            'Submitting Agency Identifier Code': parentAwardDetails.internalId,
+            'Submitting Agency Identifier Code': getSubmittingAgencyId(awardData.generatedId, awardData.piid, parentAwardDetails.piid),
             'Parent Award ID (Parent PIID)': parentAwardDetails.piid,
             'Parent Agency Identifier Code': awardData.additionalDetails.idvAgencyId
         },

--- a/src/js/dataMapping/award/additionalDetailsContract.js
+++ b/src/js/dataMapping/award/additionalDetailsContract.js
@@ -16,7 +16,7 @@ const additionalDetailsContracts = (awardData) => {
     const data = {
         uniqueAwardKey: {
             'Unique Award Key': awardData.generatedId,
-            'Award or IDV Flag': awardData.category,
+            'Award or IDV Flag': 'Contract Award',
             'Procurement Instrument Identifier (PIID)': awardData.piid,
             'Submitting Agency Identifier Code': parentAwardDetails.internalId,
             'Parent Award ID (Parent PIID)': parentAwardDetails.piid,

--- a/src/js/dataMapping/award/additionalDetailsContract.js
+++ b/src/js/dataMapping/award/additionalDetailsContract.js
@@ -3,8 +3,8 @@
  * Created by Kwadwo Opoku-Debrah 12/17/18
  */
 export const getSubmittingAgencyId = (generatedString, substring, piid) => {
-    var tempString = generatedString.substring(generatedString.indexOf(substring) + substring.length);
-    var parsedString = tempString.substring(0, tempString.indexOf(piid)).replaceAll('_','');
+    const tempString = generatedString.substring(generatedString.indexOf(substring) + substring.length);
+    const parsedString = tempString.substring(0, tempString.indexOf(piid)).replaceAll('_', '');
     return parsedString;
 };
 
@@ -17,7 +17,7 @@ const additionalDetailsContracts = (awardData) => {
         placeOfPerformance,
         recipient
     } = awardData;
-    
+
     const data = {
         uniqueAwardKey: {
             'Unique Award Key': awardData.generatedId,

--- a/src/js/dataMapping/award/additionalDetailsContract.js
+++ b/src/js/dataMapping/award/additionalDetailsContract.js
@@ -10,9 +10,18 @@ const additionalDetailsContracts = (awardData) => {
         parentAwardDetails,
         periodOfPerformance,
         placeOfPerformance,
-        recipient
+        recipient,
     } = awardData;
+    console.log(parentAwardDetails.idvAgencyId);
     const data = {
+        uniqueAwardKey: {
+            'Unique Award Key': awardData.generatedId,
+            'Award or IDV Flag': awardData.category,
+            'Procurement Instrument Identifier (PIID)': awardData.piid,
+            'Submitting Agency Identifier Code': parentAwardDetails.internalId,
+            'Parent Award ID (Parent PIID)': parentAwardDetails.piid,
+            'Parent Agency Identifier Code': awardData.additionalDetails.idvAgencyId
+        },
         agencyDetails: {
             'Awarding Agency': {
                 type: 'link',

--- a/src/js/dataMapping/award/additionalDetailsContract.js
+++ b/src/js/dataMapping/award/additionalDetailsContract.js
@@ -12,7 +12,7 @@ const additionalDetailsContracts = (awardData) => {
         placeOfPerformance,
         recipient,
     } = awardData;
-    console.log(parentAwardDetails.idvAgencyId);
+    
     const data = {
         uniqueAwardKey: {
             'Unique Award Key': awardData.generatedId,
@@ -67,6 +67,7 @@ const additionalDetailsContracts = (awardData) => {
             }
         },
         parentAwardDetails: {
+            'Parent Award Unique Key': parentAwardDetails.awardId,
             'Parent Award ID (Parent PIID)': {
                 type: 'link',
                 data: {

--- a/src/js/dataMapping/award/additionalDetailsFinancialAssistance.js
+++ b/src/js/dataMapping/award/additionalDetailsFinancialAssistance.js
@@ -36,8 +36,8 @@ const additionalDetailsFinancialAssistance = (awardData) => {
             'Record Type': isAwardAggregate(awardData.generatedId)
                 ? 'Financial Assistance, Aggregated'
                 : 'Financial Assistance, Non-Aggregated',
-            'Unique Record Identifier (URI)': awardData.uri,
-            ...getUriOrFain(awardData)
+            ...getUriOrFain(awardData),
+            'Awarding Sub-Agency Code': awardingAgency.subtierId
         },
         agencyDetails: {
             'Awarding Agency': {

--- a/src/js/dataMapping/award/additionalDetailsFinancialAssistance.js
+++ b/src/js/dataMapping/award/additionalDetailsFinancialAssistance.js
@@ -3,7 +3,7 @@
  * Created by Jonathan Hill 09/19/19
  */
 
-import { isAwardAggregate } from 'helpers/awardSummaryHelper';
+import { isAwardAggregate, getSubmittingAgencyId } from 'helpers/awardSummaryHelper';
 
 const getUriOrFain = ({
     generatedId,
@@ -37,7 +37,7 @@ const additionalDetailsFinancialAssistance = (awardData) => {
                 ? 'Financial Assistance, Aggregated'
                 : 'Financial Assistance, Non-Aggregated',
             ...getUriOrFain(awardData),
-            'Awarding Sub-Agency Code': awardingAgency.subtierId
+            'Awarding Sub-Agency Code': getSubmittingAgencyId(awardData.generatedId)
         },
         agencyDetails: {
             'Awarding Agency': {

--- a/src/js/dataMapping/award/additionalDetailsFinancialAssistance.js
+++ b/src/js/dataMapping/award/additionalDetailsFinancialAssistance.js
@@ -14,7 +14,7 @@ const getUriOrFain = ({
         return {
             // aggregate  awards are identified by their "Unique Record Identifier"
             'Unique Record Identifier (URI)': uri
-        }
+        };
     }
     // non aggregate awards are identified by their "FAIN"
     return {

--- a/src/js/dataMapping/award/additionalDetailsFinancialAssistance.js
+++ b/src/js/dataMapping/award/additionalDetailsFinancialAssistance.js
@@ -3,6 +3,24 @@
  * Created by Jonathan Hill 09/19/19
  */
 
+import { isAwardAggregate } from 'helpers/awardSummaryHelper';
+
+const getUriOrFain = ({
+    generatedId,
+    uri,
+    fain
+}) => {
+    if (isAwardAggregate(generatedId)) {
+        return {
+            // aggregate  awards are identified by their "Unique Record Identifier"
+            'Unique Record Identifier (URI)': uri
+        }
+    }
+    // non aggregate awards are identified by their "FAIN"
+    return {
+        'Federal Award Identification Number (FAIN)': fain
+    };
+};
 
 const additionalDetailsFinancialAssistance = (awardData) => {
     const {
@@ -13,6 +31,14 @@ const additionalDetailsFinancialAssistance = (awardData) => {
         recipient
     } = awardData;
     const data = {
+        uniqueAwardKey: {
+            'Unique Award Key': awardData.generatedId,
+            'Record Type': isAwardAggregate(awardData.generatedId)
+                ? 'Financial Assistance, Aggregated'
+                : 'Financial Assistance, Non-Aggregated',
+            'Unique Record Identifier (URI)': awardData.uri,
+            ...getUriOrFain(awardData)
+        },
         agencyDetails: {
             'Awarding Agency': {
                 type: 'link',

--- a/src/js/dataMapping/award/additionalDetailsIdv.js
+++ b/src/js/dataMapping/award/additionalDetailsIdv.js
@@ -39,6 +39,7 @@ const additionalDetails = (awardData) => {
             'Funding Office': awardData.fundingAgency.officeName
         },
         parentAwardDetails: {
+            'Parent Award Unique Key': parentAwardDetails.awardId,
             'Parent Award ID (Parent PIID)': {
                 type: 'link',
                 data: {

--- a/src/js/dataMapping/award/additionalDetailsIdv.js
+++ b/src/js/dataMapping/award/additionalDetailsIdv.js
@@ -12,7 +12,7 @@ const additionalDetails = (awardData) => {
     const data = {
         uniqueAwardKey: {
             'Unique Award Key': awardData.generatedId,
-            'Award or IDV Flag': awardData.category,
+            'Award or IDV Flag': 'Contract IDV',
             'Procurement Instrument Identifier (PIID)': awardData.piid,
             'Submitting Agency Identifier Code': awardData.additionalDetails.idvAgencyId,
             'Parent Award ID (Parent PIID)': parentAwardDetails.piid,

--- a/src/js/dataMapping/award/additionalDetailsIdv.js
+++ b/src/js/dataMapping/award/additionalDetailsIdv.js
@@ -10,6 +10,14 @@ const additionalDetails = (awardData) => {
         parentAwardDetails
     } = awardData;
     const data = {
+        uniqueAwardKey: {
+            'Unique Award Key': awardData.generatedId,
+            'Award or IDV Flag': awardData.category,
+            'Procurement Instrument Identifier (PIID)': awardData.piid,
+            'Submitting Agency Identifier Code': awardData.additionalDetails.idvAgencyId,
+            'Parent Award ID (Parent PIID)': parentAwardDetails.piid,
+            'Parent Agency Identifier Code': parentAwardDetails.agencyId
+        },
         agencyDetails: {
             'Awarding Agency': {
                 type: 'link',

--- a/src/js/dataMapping/award/additionalDetailsIdv.js
+++ b/src/js/dataMapping/award/additionalDetailsIdv.js
@@ -3,6 +3,8 @@
  * Created by Lizzie Salita 6/20/19
  */
 
+import { getSubmittingAgencyId } from "helpers/awardSummaryHelper";
+
 const additionalDetails = (awardData) => {
     const {
         recipient,
@@ -14,9 +16,7 @@ const additionalDetails = (awardData) => {
             'Unique Award Key': awardData.generatedId,
             'Award or IDV Flag': 'Contract IDV',
             'Procurement Instrument Identifier (PIID)': awardData.piid,
-            'Submitting Agency Identifier Code': awardData.additionalDetails.idvAgencyId,
-            'Parent Award ID (Parent PIID)': parentAwardDetails.piid,
-            'Parent Agency Identifier Code': parentAwardDetails.agencyId
+            'Submitting Agency Identifier Code': getSubmittingAgencyId(awardData.generatedId)
         },
         agencyDetails: {
             'Awarding Agency': {

--- a/src/js/helpers/awardSummaryHelper.js
+++ b/src/js/helpers/awardSummaryHelper.js
@@ -1,10 +1,10 @@
-import moment from "moment";
-import { apiRequest } from "./apiRequest";
-
 /**
  * awardSummaryHelper.js
  * Created by Lizzie Salita 8/16/19
 **/
+
+import moment from "moment";
+import { apiRequest } from "./apiRequest";
 
 export const fetchAwardFundingSummary = (awardId) => apiRequest({
     url: 'v2/awards/funding_rollup/',

--- a/src/js/helpers/awardSummaryHelper.js
+++ b/src/js/helpers/awardSummaryHelper.js
@@ -6,6 +6,24 @@
 import moment from "moment";
 import { apiRequest } from "./apiRequest";
 
+/**
+//  * https://github.com/fedspendingtransparency/data-act-documentation/blob/master/usaspending_api/what-is-an-award.mdhttps://github.com/fedspendingtransparency/data-act-documentation/blob/master/usaspending_api/what-is-an-award.md
+ * @param {String} awardId - human readable generated unique award ID
+ * @param {String} pid - PIID
+ * @returns {String} parsedString representing submitting agency ID code
+ */
+
+export const getSubmittingAgencyId = (awardId) => {
+    if (awardId) {
+        const splitAwardId = awardId.split("_");
+        if (splitAwardId.length >= 4) {
+            return awardId.split("_")[3];
+        }
+        return '--';
+    }
+    return '--';
+};
+
 export const fetchAwardFundingSummary = (awardId) => apiRequest({
     url: 'v2/awards/funding_rollup/',
     method: 'post',

--- a/src/js/models/v2/award/BaseParentAwardDetails.js
+++ b/src/js/models/v2/award/BaseParentAwardDetails.js
@@ -10,6 +10,7 @@ const parentAwardDetails = {
             : '';
         this.idvType = data.idv_type_description || '';
         this.idcType = data.type_of_idc_description || '';
+        this.idvAgencyId = data.referenced_idv_agency_iden || '';
         this.agencyId = data.agency_id || '';
         this.agencyName = data.agency_name || '';
         this.subAgencyId = data.sub_agency_id || '';

--- a/tests/helpers/awardSummaryHelper-test.js
+++ b/tests/helpers/awardSummaryHelper-test.js
@@ -3,11 +3,28 @@ import {
     isAwardFinancialAssistance,
     getAwardTypeByRecordtypeCountyAndState,
     isBadDates,
-    isUSAAward
+    isUSAAward,
+    getSubmittingAgencyId
 } from 'helpers/awardSummaryHelper';
 import moment from 'moment';
 
-describe('', () => {
+
+describe('awardSummaryHelper', () => {
+    describe('getSubmittingAgencyId', () => {
+        it('returns submitting agency ID when parent PIID is defined ', () => {
+            const mockAwardId = "CONT_AWD_DEAC5206NA25396_8900_ASDF";
+            expect(getSubmittingAgencyId(mockAwardId)).toEqual("8900");
+        });
+        it('returns submitting agency ID when parent PIID is undefined ', () => {
+            const mockAwardId = "CONT_AWD_DEAC5206NA25396_8900_-NONE-_-NONE-";
+            expect(getSubmittingAgencyId(mockAwardId)).toEqual("8900");
+        });
+        it('returns \'--\' when awardId is undefined ', () => {
+            const mockAwardId = null;
+            expect(getSubmittingAgencyId(mockAwardId)).toEqual("--");
+        });
+    });
+
     describe('isAwardAggregate', () => {
         it('returns true when string (ASST_AGG) is included in input ', () => {
             expect(isAwardAggregate("alskdjf_asdf_ASST_AGG_asdfa")).toEqual(true);


### PR DESCRIPTION
**High level description:**

This PR will implement adding a new component to the additional details section for all awards on awards pages, along with updating the text in the Related Awards section of the overview section and adding a new field in the parent award details section on the awards pages for contracts and idvs.

**Technical details:**

Added uniqueAwardKey component to all additionalDetails files for the different award types

**JIRA Ticket:**
[DEV-4644](https://federal-spending-transparency.atlassian.net/browse/DEV-4644)

**Mockup:**
https://bahdigital.invisionapp.com/share/ZCIACNTUDER#/screens

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [`N/A`] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [`N/A`] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [`N/A`] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [`N/A`] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
