### PR TITLE
[DEV-5971] using the funding agency for the site description rather than the awarding agency

### DIFF
--- a/src/js/helpers/metaTagHelper.js
+++ b/src/js/helpers/metaTagHelper.js
@@ -88,12 +88,12 @@ export const awardPageMetaTags = ({
     recipient: { _name: recipientName },
     _dateSigned: dateSigned,
     generatedId: id,
-    awardingAgency: { officeName: agencyName }
+    fundingAgency: { toptierName: agencyName }
 }) => ({
     og_url: `${productionURL}award/${id}`,
     og_title: `${awardType.toUpperCase()} to ${recipientName} | USAspending.gov`,
     og_description:
-        `View a summary page of this ${dateSigned.format('YYYY')} ${awardType.toUpperCase()} to ${recipientName} from ${agencyName}.`,
+        `View a summary page of this ${dateSigned.format('YYYY')} ${awardType.toUpperCase()} to ${recipientName} from the ${agencyName}.`,
     og_site_name: siteName,
     og_image: `${productionURL}${imgDirectory}${facebookImage}`
 });


### PR DESCRIPTION
**High level description:**
Description for award summary page now refers to the funding rather than awarding agency.

**Technical details:**
Using different property on redux store `award.overview.fundingAgency.toptierName`

**JIRA Ticket:**
[DEV-5971](https://federal-spending-transparency.atlassian.net/browse/DEV-5971)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
