### PR TITLE
[DEV-5551][DEV-5549] Fix wording and some award counts

### DIFF
--- a/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
+++ b/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
@@ -61,6 +61,13 @@ const SpendingByCFDA = () => {
         Analytics.event({ category: 'COVID-19 - Award Spending by CFDA', action: `${activeTab} - click` });
     };
 
+    // Keep track of previous tab to prevent duplicate requests in summary
+    const prevTabRef = useRef();
+    useEffect(() => {
+        prevTabRef.current = activeTab;
+    });
+    const prevTab = prevTabRef.current;
+
     useEffect(() => {
         if (defCodes && defCodes.length > 0) {
             // Make an API request for the count of CFDA for each award type
@@ -133,6 +140,7 @@ const SpendingByCFDA = () => {
                 // pass CFDA count to the summary section so we don't have to make the same API request again
                 resultsCount={tabCounts[activeTab]}
                 activeTab={activeTab}
+                prevTab={prevTab}
                 areCountsLoading={inFlight}
                 overviewData={overviewData}
                 assistanceOnly />

--- a/src/js/components/covid19/budgetCategories/BudgetCategories.jsx
+++ b/src/js/components/covid19/budgetCategories/BudgetCategories.jsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import kGlobalConstants from 'GlobalConstants';
 import BudgetCategoriesTableContainer from 'containers/covid19/budgetCategories/BudgetCategoriesTableContainer';
 import DateNote from 'components/covid19/DateNote';
@@ -12,7 +12,6 @@ import { fetchDisasterSpendingCount } from 'helpers/disasterHelper';
 import MoreOptionsTabs from 'components/sharedComponents/moreOptionsTabs/MoreOptionsTabs';
 import GlossaryLink from 'components/sharedComponents/GlossaryLink';
 import { scrollIntoView } from 'containers/covid19/helpers/scrollHelper';
-import { setBudgetCategoriesCount } from 'redux/actions/covid19/covid19Actions';
 import Analytics from 'helpers/analytics/Analytics';
 import OverviewData from '../OverviewData';
 import ReadMore from '../ReadMore';
@@ -40,7 +39,6 @@ const BudgetCategories = () => {
     const [count, setCount] = useState(null);
     const [inFlight, setInFlight] = useState(true);
     const moreOptionsTabsRef = useRef(null);
-    const dispatch = useDispatch();
 
     const { defCodes, overview } = useSelector((state) => state.covid19);
     const overviewData = [
@@ -86,7 +84,6 @@ const BudgetCategories = () => {
             countRequest.promise
                 .then((res) => {
                     setCount(res.data.count);
-                    dispatch(setBudgetCategoriesCount(res.data.count));
                 });
         }
     }, [activeTab, defCodes]);

--- a/src/js/containers/covid19/Covid19Container.jsx
+++ b/src/js/containers/covid19/Covid19Container.jsx
@@ -37,8 +37,13 @@ import {
     stickyHeaderHeight,
     dataDisclaimerHeight
 } from 'dataMapping/covid19/covid19';
-import { fetchDEFCodes, fetchOverview, fetchAllSubmissionDates } from 'helpers/disasterHelper';
-import { setDEFCodes, setOverview, setLatestSubmissionDate } from 'redux/actions/covid19/covid19Actions';
+import {
+    fetchDEFCodes,
+    fetchOverview,
+    fetchAllSubmissionDates,
+    fetchAwardAmounts
+} from 'helpers/disasterHelper';
+import { setDEFCodes, setOverview, setLatestSubmissionDate, setTotals } from 'redux/actions/covid19/covid19Actions';
 import { showModal } from 'redux/actions/modal/modalActions';
 import DataSourcesAndMethodology from 'components/covid19/DataSourcesAndMethodology';
 import OtherResources from 'components/covid19/OtherResources';
@@ -58,6 +63,7 @@ const Covid19Container = () => {
     const defCodesRequest = useRef(null);
     const overviewRequest = useRef(null);
     const lastSectionRef = useRef(null);
+    const awardAmountRequest = useRef(null);
     const dataDisclaimerBannerRef = useRef(null);
     const allSubmissionDatesRequest = useRef(null);
     const dispatch = useDispatch();
@@ -121,13 +127,38 @@ const Covid19Container = () => {
                 console.log(' Error Overview : ', e.message);
             }
         };
+        const getAllAwardTypesAmount = async () => {
+            const params = {
+                filter: {
+                    def_codes: defCodes.map((code) => code.code)
+                }
+            };
+            awardAmountRequest.current = fetchAwardAmounts(params);
+            awardAmountRequest.current.promise
+                .then((res) => {
+                    /* eslint-disable camelcase */
+                    // set totals in redux, we can use totals elsewhere to calculate unlinked data
+                    const totals = {
+                        obligation: res.data?.obligation,
+                        outlay: res.data?.outlay,
+                        awardCount: res.data?.award_count,
+                        faceValueOfLoan: res.data?.face_value_of_loan
+                    };
+                    dispatch(setTotals('', totals));
+                });
+        };
         if (defCodes.length) {
             getOverviewData();
+            getAllAwardTypesAmount();
             overviewRequest.current = null;
+            awardAmountRequest.current = null;
         }
         return () => {
             if (overviewRequest.current) {
                 overviewRequest.cancel();
+            }
+            if (awardAmountRequest.current) {
+                awardAmountRequest.cancel();
             }
         };
     }, [defCodes, dispatch]);

--- a/src/js/containers/covid19/Covid19Container.jsx
+++ b/src/js/containers/covid19/Covid19Container.jsx
@@ -135,14 +135,20 @@ const Covid19Container = () => {
             };
             awardAmountRequest.current = fetchAwardAmounts(params);
             awardAmountRequest.current.promise
-                .then((res) => {
-                    /* eslint-disable camelcase */
+                .then(({
+                    data: {
+                        obligation,
+                        outlay,
+                        award_count: awardCount,
+                        face_value_of_loan: faceValueOfLoan
+                    }
+                }) => {
                     // set totals in redux, we can use totals elsewhere to calculate unlinked data
                     const totals = {
-                        obligation: res.data?.obligation,
-                        outlay: res.data?.outlay,
-                        awardCount: res.data?.award_count,
-                        faceValueOfLoan: res.data?.face_value_of_loan
+                        obligation,
+                        outlay,
+                        awardCount,
+                        faceValueOfLoan
                     };
                     dispatch(setTotals('', totals));
                 });

--- a/src/js/containers/covid19/SummaryInsightsContainer.jsx
+++ b/src/js/containers/covid19/SummaryInsightsContainer.jsx
@@ -85,18 +85,24 @@ const SummaryInsightsContainer = ({
                 }
                 awardAmountRequest.current = fetchAwardAmounts(params);
                 awardAmountRequest.current.promise
-                    .then((res) => {
-                        setAwardObligations(res.data.obligation);
-                        setAwardOutlays(res.data.outlay);
-                        setNumberOfAwards(res.data.award_count);
+                    .then(({
+                        data: {
+                            obligation,
+                            outlay,
+                            award_count: awardCount,
+                            face_value_of_loan: faceValueOfLoan
+                        }
+                    }) => {
+                        setAwardObligations(obligation);
+                        setAwardOutlays(outlay);
+                        setNumberOfAwards(awardCount);
 
-                        /* eslint-disable camelcase */
                         // set totals in redux, we can use totals elsewhere to calculate unlinked data
                         const totals = {
-                            obligation: res.data?.obligation,
-                            outlay: res.data?.outlay,
-                            awardCount: res.data?.award_count,
-                            faceValueOfLoan: res.data?.face_value_of_loan
+                            obligation,
+                            outlay,
+                            awardCount,
+                            faceValueOfLoan
                         };
 
                         if (spendingByAgencyOnly) {

--- a/src/js/containers/covid19/assistanceListing/SpendingByCFDAContainer.jsx
+++ b/src/js/containers/covid19/assistanceListing/SpendingByCFDAContainer.jsx
@@ -201,8 +201,6 @@ const SpendingByCFDAContainer = ({ activeTab, scrollIntoView }) => {
                     Unknown CFDA Program (Unlinked Data)
                 </div>
             );
-
-            // TODO - DEV-5625 Remove placeholder 0s
             rows.push({
                 description: unlinkedName,
                 obligation: unlinkedData.obligation,

--- a/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
+++ b/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
@@ -140,7 +140,7 @@ const AwardSpendingAgencyTableContainer = (props) => {
         const unlinkedData = calculateUnlinkedTotals(spendingByAgencyTotals, totals);
 
         if (props.type === 'all') {
-            unlinkedName = 'Unknown Agency (Missing Linkage)';
+            unlinkedName = 'Unknown Agency (Unlinked Data)';
         } else {
             unlinkedName = 'Unknown Agency (Linked but Missing Funding Agency)';
         }

--- a/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
+++ b/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
@@ -156,9 +156,7 @@ const BudgetCategoriesTableContainer = (props) => {
     const request = useRef(null);
     const [unlinkedDataClass, setUnlinkedDataClass] = useState(false);
 
-    const budgetCategoriesCount = useSelector((state) => state.covid19.budgetCategoriesCount);
-    const overview = useSelector((state) => state.covid19.overview);
-    const defCodes = useSelector((state) => state.covid19.defCodes);
+    const { overview, defCodes, allAwardTypeTotals } = useSelector((state) => state.covid19);
 
     const clickedAgencyProfile = (agencyName) => {
         Analytics.event({
@@ -183,7 +181,7 @@ const BudgetCategoriesTableContainer = (props) => {
             totalBudgetaryResources: overview._totalBudgetAuthority,
             obligation: overview._totalObligations,
             outlay: overview._totalOutlays,
-            awardCount: budgetCategoriesCount
+            awardCount: allAwardTypeTotals.awardCount
         };
         const unlinkedData = calculateUnlinkedTotals(overviewTotals, totals);
 
@@ -286,7 +284,7 @@ const BudgetCategoriesTableContainer = (props) => {
         }
 
         setLoading(true);
-        if (defCodes && defCodes.length > 0 && spendingCategory && overview && budgetCategoriesCount) {
+        if (defCodes && defCodes.length > 0 && spendingCategory && overview && allAwardTypeTotals.awardCount) {
             const apiSortField = sort === 'name' ? budgetCategoriesNameSort[props.type] : snakeCase(sort);
             const params = {
                 filter: {
@@ -343,7 +341,7 @@ const BudgetCategoriesTableContainer = (props) => {
             fetchBudgetSpendingCallback();
         }
         changeCurrentPage(1);
-    }, [pageSize, sort, order, defCodes, overview, budgetCategoriesCount]);
+    }, [pageSize, sort, order, defCodes, overview, allAwardTypeTotals]);
 
     useEffect(() => {
         fetchBudgetSpendingCallback();

--- a/src/js/helpers/covid19Helper.js
+++ b/src/js/helpers/covid19Helper.js
@@ -164,10 +164,13 @@ export const getTotalSpendingAbbreviated = (totalSpending) => {
     return `${abbreviatedValue} ${unit.longLabel}`;
 };
 
-export const areCountsDefined = (counts) => Object.keys(counts).reduce((acc, tab) => {
-    if (acc === null) return acc;
-    return counts[tab];
-}, true);
+export const areCountsDefined = (counts) => {
+    const countTabs = Object.keys(counts);
+    if (countTabs.length === 0) {
+        return false;
+    }
+    return countTabs.reduce((acc, tab) => acc && counts[tab] !== null, true);
+};
 
 export const handleSort = (a, b) => {
     if (a.sortOrder < b.sortOrder) return -1;

--- a/src/js/redux/actions/covid19/covid19Actions.js
+++ b/src/js/redux/actions/covid19/covid19Actions.js
@@ -19,11 +19,6 @@ export const setLatestSubmissionDate = (latestSubmissionDate) => ({
 });
 
 export const setTotals = (awardType, totals) => ({
-    type: `SET_COVID_AWARD_AMOUNTS_${awardType}`,
+    type: `SET_COVID_AWARD_AMOUNTS${awardType && '_'}${awardType}`,
     totals
-});
-
-export const setBudgetCategoriesCount = (count) => ({
-    type: "SET_BUDGET_CATEGORIES_COUNT",
-    count
 });

--- a/src/js/redux/reducers/covid19/covid19Reducer.js
+++ b/src/js/redux/reducers/covid19/covid19Reducer.js
@@ -7,10 +7,10 @@ const initialState = {
     defCodes: [],
     overview: {},
     latestSubmissionDate: '',
+    allAwardTypeTotals: {},
     assistanceTotals: {},
     spendingByAgencyTotals: {},
-    recipientTotals: {},
-    budgetCategoriesCount: 0
+    recipientTotals: {}
 };
 
 const covid19Reducer = (state = initialState, action) => {
@@ -24,6 +24,9 @@ const covid19Reducer = (state = initialState, action) => {
         case 'SET_LATEST_SUBMISSION_DATE': {
             return Object.assign({}, state, { latestSubmissionDate: action.latestSubmissionDate });
         }
+        case 'SET_COVID_AWARD_AMOUNTS': {
+            return Object.assign({}, state, { allAwardTypeTotals: action.totals });
+        }
         case 'SET_COVID_AWARD_AMOUNTS_ASSISTANCE': {
             return Object.assign({}, state, { assistanceTotals: action.totals });
         }
@@ -32,9 +35,6 @@ const covid19Reducer = (state = initialState, action) => {
         }
         case 'SET_COVID_AWARD_AMOUNTS_RECIPIENT': {
             return Object.assign({}, state, { recipientTotals: action.totals });
-        }
-        case 'SET_BUDGET_CATEGORIES_COUNT': {
-            return Object.assign({}, state, { budgetCategoriesCount: action.count });
         }
         default: return state;
     }

--- a/tests/helpers/covid19Helper-test.js
+++ b/tests/helpers/covid19Helper-test.js
@@ -16,12 +16,15 @@ describe('Covid 19 Helper', () => {
         });
     });
     describe('areCountsDefined', () => {
-        it('should return null/falsy when count object has null', () => {
-            expect(areCountsDefined({ test: null, test2: 5 })).toBeFalsy();
+        it('should return false when count object has null', () => {
+            expect(areCountsDefined({ test: null, test2: 5 })).toEqual(false);
         });
-        it('should return truthy when count object is totally defined', () => {
-            expect(areCountsDefined({ test: 5, test2: 3 })).toBeTruthy();
+        it('should return true when count object is totally defined', () => {
+            expect(areCountsDefined({ test: 5, test2: 3 })).toEqual(true);
         });
+        it('should return true when last count is 0', () => {
+            expect(areCountsDefined({ test: 1, test2: 7, test3: 0 })).toEqual(true);
+        })
     });
 
     describe('calculateUnlinkedTotals', () => {

--- a/tests/redux/reducers/covid19/covid19Reducer-test.js
+++ b/tests/redux/reducers/covid19/covid19Reducer-test.js
@@ -4,7 +4,7 @@
  */
 
 import covid19Reducer from 'redux/reducers/covid19/covid19Reducer';
-import { setDEFCodes, setOverview, setLatestSubmissionDate, setTotals, setBudgetCategoriesCount } from 'redux/actions/covid19/covid19Actions';
+import { setDEFCodes, setOverview, setLatestSubmissionDate, setTotals } from 'redux/actions/covid19/covid19Actions';
 import { defCodes, overview } from './mockData';
 
 describe('Covid 19 Reducer', () => {
@@ -22,6 +22,17 @@ describe('Covid 19 Reducer', () => {
         let state = covid19Reducer(undefined, {});
         state = covid19Reducer(state, setLatestSubmissionDate('June 01, 1999'));
         expect(state.latestSubmissionDate).toEqual('June 01, 1999');
+    });
+    it('should SET_COVID_AWARD_AMOUNTS', () => {
+        let state = covid19Reducer(undefined, {});
+        state = covid19Reducer(state, setTotals('', {
+            awardCount: 26742,
+            obligation: 13458852480.17,
+            outlay: 367346004.33
+        }));
+        expect(state.allAwardTypeTotals).toEqual({
+            awardCount: 26742, obligation: 13458852480.17, outlay: 367346004.33
+        });
     });
     it('should SET_COVID_AWARD_AMOUNTS_ASSISTANCE', () => {
         let state = covid19Reducer(undefined, {});
@@ -58,10 +69,5 @@ describe('Covid 19 Reducer', () => {
         expect(state.recipientTotals).toEqual({
             awardCount: 526742, faceValueOfLoan: undefined, obligation: 213458852480.17, outlay: 8367346004.33
         });
-    });
-    it('should SET_BUDGET_CATEGORIES_COUNT', () => {
-        let state = covid19Reducer(undefined, {});
-        state = covid19Reducer(state, setBudgetCategoriesCount(12));
-        expect(state.budgetCategoriesCount).toEqual(12);
     });
 });


### PR DESCRIPTION
**High level description:**

Update unlinked text to match AC and use Award Count when determining missing awards.

**Technical details:**

Refactored some to minimize calls to `/api/v2/disaster/award/amount/` since the endpoint is causing a lot of trouble. Instead of multiple calls for the same endpoint there is one call to handle the "All Awards" tab across different visualizations and that one call is stored in the Redux store.

**JIRA Ticket:**
[DEV-5551](https://federal-spending-transparency.atlassian.net/browse/DEV-5551)
[DEV-5549](https://federal-spending-transparency.atlassian.net/browse/DEV-5549)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [x] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)

Reviewer(s):
- [ ] Code review complete
