### PR TITLE
update "term" to match changed glossary URL Slug

### DIFF
--- a/src/js/components/covid19/AwardQuestions.jsx
+++ b/src/js/components/covid19/AwardQuestions.jsx
@@ -16,7 +16,7 @@ const AwardQuestion = () => (
         <div className="award-question__sub-section">
             <p className="award-question__sub-section_paragraph">
                 Award spending is a subset of total spending and refers to money given through <span className="glossary-term">contracts</span> <GlossaryLink currentUrl="disaster/covid-19" term="contract" /> or <span className="glossary-term">financial assistance</span> <GlossaryLink currentUrl="disaster/covid-19" term="financial-assistance" /> to individuals, organizations, businesses, or state, local, or tribal governments.
-                There are two main categories of awards: contracts and financial assistance. Loan spending is a type of financial assistance with two components: <span className="glossary-term">face value</span> <GlossaryLink currentUrl="disaster/covid-19" term="face-value" /> and <span className="glossary-term">subsidy cost</span> <GlossaryLink currentUrl="disaster/covid-19" term="subsidy-cost" />.
+                There are two main categories of awards: contracts and financial assistance. Loan spending is a type of financial assistance with two components: <span className="glossary-term">face value</span> <GlossaryLink currentUrl="disaster/covid-19" term="face-value-of-loan" /> and <span className="glossary-term">subsidy cost</span> <GlossaryLink currentUrl="disaster/covid-19" term="loan-subsidy-cost" />.
             </p>
             <ReadMore>
                 <p className="award-question__sub-section_paragraph">


### PR DESCRIPTION
Change glossary terms from 'Subsidy Cost' to 'Loan Subsidy Cost' and 'Face Value' to 'Face Value of Loan'. 

**Technical details:**

Change `term` parameter to `GlossaryLink` component to match `slug` field in database.  
**JIRA Ticket:**
[DEV-5758](https://federal-spending-transparency.atlassian.net/browse/DEV-5758)

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently
- [ ] Code review complete
