### PR TITLE
[DEV-5766] Advanced Search DEFC column

### DIFF
--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -127,7 +127,14 @@ export default class ResultsTable extends React.Component {
             && !this.props.results[rowIndex][column.columnName]) {
             props.value = '--';
         }
-
+        else if (column.columnName === 'DEFC') {
+            if (!this.props.results[rowIndex].def_codes) {
+                props.value = '--';
+            }
+            else {
+                props.value = this.props.results[rowIndex].def_codes;
+            }
+        }
         return React.createElement(
             cellClass,
             props

--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -132,7 +132,7 @@ export default class ResultsTable extends React.Component {
                 props.value = '--';
             }
             else {
-                props.value = this.props.results[rowIndex].def_codes;
+                props.value = this.props.results[rowIndex].def_codes.join(", ");
             }
         }
         return React.createElement(

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -17,8 +17,11 @@ import Analytics from 'helpers/analytics/Analytics';
 
 import { awardTypeGroups, subawardTypeGroups } from 'dataMapping/search/awardType';
 
-import { defaultColumns, defaultSort } from
-    'dataMapping/search/awardTableColumns';
+import {
+    defaultColumns,
+    defaultSort,
+    apiFieldByTableColumnName
+} from 'dataMapping/search/awardTableColumns';
 import { awardTableColumnTypes } from 'dataMapping/search/awardTableColumnTypes';
 import { measureTableHeader } from 'helpers/textMeasurement';
 
@@ -314,7 +317,12 @@ export class ResultsTableContainer extends React.Component {
         columnVisibility.forEach((field) => {
             if (!requestFields.includes(field)) {
                 // Prevent duplicates in the list of fields to request
-                requestFields.push(field);
+                if (Object.keys(apiFieldByTableColumnName).includes(field)) {
+                    requestFields.push(apiFieldByTableColumnName[field]);
+                }
+                else {
+                    requestFields.push(field);
+                }
             }
         });
 

--- a/src/js/dataMapping/search/awardTableColumns.jsx
+++ b/src/js/dataMapping/search/awardTableColumns.jsx
@@ -321,6 +321,10 @@ const covidOutlaysCol = {
     customWidth: covidColWidth
 };
 
+const covidDefCCol = {
+    title: 'DEFC'
+};
+
 const tabsWithCovidCols = [
     defaultContract,
     defaultGrant,
@@ -333,6 +337,7 @@ const tabsWithCovidCols = [
 if (kGlobalConstants.CARES_ACT_RELEASED) {
     // Insert columns for COVID-19
     tabsWithCovidCols.forEach((tab) => {
+        tab.splice(4, 0, covidDefCCol);
         tab.splice(5, 0, covidObligationsCol);
         tab.splice(6, 0, covidOutlaysCol);
     });
@@ -392,4 +397,8 @@ export const defaultSort = (type) => {
     };
 
     return columns[type];
+};
+
+export const apiFieldByTableColumnName = {
+    DEFC: 'def_codes'
 };

--- a/src/js/dataMapping/search/awardTableColumns.jsx
+++ b/src/js/dataMapping/search/awardTableColumns.jsx
@@ -337,9 +337,9 @@ const tabsWithCovidCols = [
 if (kGlobalConstants.CARES_ACT_RELEASED) {
     // Insert columns for COVID-19
     tabsWithCovidCols.forEach((tab) => {
-        tab.splice(4, 0, covidDefCCol);
-        tab.splice(5, 0, covidObligationsCol);
-        tab.splice(6, 0, covidOutlaysCol);
+        tab.splice(5, 0, covidDefCCol);
+        tab.splice(6, 0, covidObligationsCol);
+        tab.splice(7, 0, covidOutlaysCol);
     });
 }
 


### PR DESCRIPTION
**High level description:**

This new column surfaces only COVID DEFC (i.e., L, M, N, O, P). A follow-up ticket will allow all DEFC to be accessed

**Technical details:**

Created new column in ResultsTable.jsx that retrieves the def_codes from API

**JIRA Ticket:**
[DEV-5766](https://federal-spending-transparency.atlassian.net/browse/DEV-5766)

**Mockup:**
https://federal-spending-transparency.atlassian.net/browse/DEV-5766

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [`N/A`] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [`N/A`] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [`N/A`] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [`N/A`] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [`N/A`] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
