### PR TITLE
[DEV-5936] When $0, remove "Non-Federal Funding" labels from Award Summary > Award Amounts chart

### DIFF
--- a/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmountsSection/charts/AwardAmountsChart.jsx
@@ -424,6 +424,7 @@ const AwardAmountsChart = ({
     const renderChartByAwardType = (awardAmounts = awardOverview, type = awardType, scenario = spendingScenario) => {
         const isNormal = scenario === 'normal';
         if (asstAwardTypesWithSimilarAwardAmountData.includes(type) && isNormal) {
+            const isNffZero = awardAmounts._nonFederalFunding === 0;
             const showFileC = awardAmounts._fileCObligated > 0 && isCaresActReleased;
             const chartProps = {
                 denominator: {
@@ -449,23 +450,25 @@ const AwardAmountsChart = ({
                     text: 'Obligated Amount',
                     color: obligatedColor
                 },
-                numerator2: {
-                    className: awardAmounts._nonFederalFunding > 0 ? `asst-non-federal-funding` : `asst-nff-zero`,
-                    labelSortOrder: 1,
-                    labelPosition: 'bottom',
-                    // fudging this for to get the correct tooltip position.
-                    rawValue: awardAmounts._nonFederalFunding + awardAmounts._totalObligation,
-                    denominatorValue: awardAmounts._totalFunding,
-                    lineOffset: lineOffsetsBySpendingCategory.nonFederalFunding,
-                    barWidthOverrides: {
-                        applyToLine: true,
-                        rawValue: awardAmounts._nonFederalFunding,
-                        denominatorValue: awardAmounts._totalFunding
-                    },
-                    value: awardAmounts.nonFederalFundingAbbreviated,
-                    color: nonFederalFundingColor,
-                    text: "Non Federal Funding",
-                    tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'nonFederalFunding', awardAmounts)
+                ...isNffZero ? {} : {
+                    numerator2: {
+                        className: awardAmounts._nonFederalFunding > 0 ? `asst-non-federal-funding` : `asst-nff-zero`,
+                        labelSortOrder: 1,
+                        labelPosition: 'bottom',
+                        // fudging this for to get the correct tooltip position.
+                        rawValue: awardAmounts._nonFederalFunding + awardAmounts._totalObligation,
+                        denominatorValue: awardAmounts._totalFunding,
+                        lineOffset: lineOffsetsBySpendingCategory.nonFederalFunding,
+                        barWidthOverrides: {
+                            applyToLine: true,
+                            rawValue: awardAmounts._nonFederalFunding,
+                            denominatorValue: awardAmounts._totalFunding
+                        },
+                        value: awardAmounts.nonFederalFundingAbbreviated,
+                        color: nonFederalFundingColor,
+                        text: "Non Federal Funding",
+                        tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory(awardType, 'nonFederalFunding', awardAmounts)
+                    }
                 }
             };
             if (showFileC) {


### PR DESCRIPTION
**High level description:**
Remove the "Non-Federal Funding" label in the Award Amounts chart in the Award Summary page* if and only if it is $0*.

**Technical details:**

Added conditional in chartProps list to only display non-federal funding when awardAmounts._nonFederalFunding is not equal to zero. This field will not render if it is zero.

**JIRA Ticket:**
[DEV-5936](https://federal-spending-transparency.atlassian.net/browse/DEV-5936)

**Mockup:**
screenshot in JIRA link

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [`N/A`] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [`N/A`] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [`N/A`] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [`N/A`] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [`N/A`] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
