### PR TITLE
[DEV-5570] IDV Aggregate Award Amounts now includes grand child (Was only looking at children)

### DIFF
--- a/src/js/models/v2/award/BaseAwardAmounts.js
+++ b/src/js/models/v2/award/BaseAwardAmounts.js
@@ -7,8 +7,8 @@ import * as MoneyFormatter from 'helpers/moneyFormatter';
 import { defCodes } from 'dataMapping/covid19/covid19';
 
 const getCovid19Totals = (arr) => arr
-    .filter((obj) => defCodes.includes(obj.code))
-    .reduce((acc, obj) => acc + obj.amount, 0);
+    .filter((obj) => defCodes.includes(obj?.code))
+    .reduce((acc, obj) => acc + obj?.amount, 0);
 
 const BaseAwardAmounts = {
     populateBase(data) {
@@ -33,8 +33,14 @@ const BaseAwardAmounts = {
         this._baseExercisedOptions = parseFloat(
             data.child_award_base_exercised_options_val + data.grandchild_award_base_exercised_options_val
         ) || 0;
-        this._fileCOutlay = getCovid19Totals(data.child_account_outlays_by_defc);
-        this._fileCObligated = getCovid19Totals(data.child_account_obligations_by_defc);
+        this._fileCOutlay = getCovid19Totals(
+            data.child_account_outlays_by_defc
+                .concat(data.grandchild_account_outlays_by_defc)
+        );
+        this._fileCObligated = getCovid19Totals(
+            data.child_account_obligations_by_defc
+                .concat(data.grandchild_account_obligations_by_defc)
+        );
     },
     populateIdv(data) {
         this._totalObligation = data._totalObligation;

--- a/src/js/models/v2/award/BaseAwardAmounts.js
+++ b/src/js/models/v2/award/BaseAwardAmounts.js
@@ -8,7 +8,7 @@ import { defCodes } from 'dataMapping/covid19/covid19';
 
 const getCovid19Totals = (arr) => arr
     .filter((obj) => defCodes.includes(obj?.code))
-    .reduce((acc, obj) => acc + obj?.amount, 0);
+    .reduce((acc, obj) => acc + obj?.amount || 0, 0);
 
 const BaseAwardAmounts = {
     populateBase(data) {

--- a/tests/models/award/BaseAwardAmounts-test.js
+++ b/tests/models/award/BaseAwardAmounts-test.js
@@ -155,6 +155,10 @@ describe('BaseAwardAmounts', () => {
         it('should format the amount overspent with units', () => {
             expect(awardAmountsOverspent.overspendingAbbreviated).toEqual('$2.5 M');
         });
+        it('should aggregate child/grandchild file-c award amounts', () => {
+            expect(awardAmounts._fileCObligated).toEqual(100);
+            expect(awardAmounts._fileCOutlay).toEqual(100);
+        });
     });
     describe('IDVs - Non Aggregated Award Amounts', () => {
         it('should successfully return spending data for the IDV itself (non-combined)', () => {

--- a/tests/models/award/mockAwardApi.js
+++ b/tests/models/award/mockAwardApi.js
@@ -447,7 +447,9 @@ export const mockAwardAmounts = {
     child_award_total_obligation: 811660.51,
     grandchild_award_total_obligation: 811660.51,
     child_account_obligations_by_defc: [],
-    child_account_outlays_by_defc: []
+    child_account_outlays_by_defc: [],
+    grandchild_account_obligations_by_defc: [{ code: 'N', amount: 100 }],
+    grandchild_account_outlays_by_defc: [{ code: 'N', amount: 100 }]
 };
 
 export const mockReferencedAwards = {


### PR DESCRIPTION
**High level description:**
Quick fix for demo of bug in prod. Including `grandchild_*` in calculation of defc award amounts.

**Technical details:**

![image](https://user-images.githubusercontent.com/12897813/94020899-6aa49180-fd81-11ea-8982-8046e5cff3d3.png)

We were ignoring the grandchild property in this response ☝️ 

-  `concat()` child and grandchild arrays in award amount model. 
- adds test

**JIRA Ticket:**
[DEV-5570](https://federal-spending-transparency.atlassian.net/browse/DEV-5570)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A`Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A`Verified mobile/tablet/desktop/monitor responsiveness
`N/A`Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A`All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A`[API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A`[Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A`Design review complete `if applicable`
`N/A`[API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
