### PR TITLE
[DEV-2698] Fixing some Tooltip Styling issues 

### DIFF
--- a/src/_scss/components/tooltips/_customTooltipContent.scss
+++ b/src/_scss/components/tooltips/_customTooltipContent.scss
@@ -72,7 +72,8 @@
     }
 }
 
-.homepage__covid-19-tt {
+.homepage__covid-19-tt,
+.covid-profile-tt {
     @include display(flex);
     @include flex-direction(column);
     @include justify-content(center);
@@ -84,9 +85,12 @@
     h2 {
         text-align: center;
         font-size: rem(16);
-        padding: 0;
     }
-
+    
+    &.homepage__covid-19-tt h2 {
+        padding: 0;
+        margin: 0;
+    }
     p {
         font-size: rem(14);
         a {

--- a/src/_scss/components/tooltips/_index.scss
+++ b/src/_scss/components/tooltips/_index.scss
@@ -22,4 +22,8 @@
     .tooltip__content {
         @import './customTooltipContent';
     }
+
+    .tooltip .tooltip__interior .tooltip-pointer.bottom {
+        top: rem(-8);
+    }
 }

--- a/src/_scss/components/visualizations/tooltip/_arrow.scss
+++ b/src/_scss/components/visualizations/tooltip/_arrow.scss
@@ -15,7 +15,7 @@
     }
     &.right {
         left: auto;
-        right: rem(7);
+        right: rem(-9);
         &:after {
             transform: rotate(225deg);
         }

--- a/src/_scss/components/visualizations/tooltip/_arrow.scss
+++ b/src/_scss/components/visualizations/tooltip/_arrow.scss
@@ -71,4 +71,7 @@
             transform: rotate(225deg);
         }
     }
+    &.bottom {
+        top: rem(-8);
+    }
 }

--- a/src/_scss/layouts/search/header/_downloadButton.scss
+++ b/src/_scss/layouts/search/header/_downloadButton.scss
@@ -75,7 +75,7 @@
 
             &.right {
                 top: rem(32);
-                right: rem(9);
+                right: rem(-8);
             }
         }
     }

--- a/src/_scss/layouts/tabbedSearch/header/_downloadTooltip.scss
+++ b/src/_scss/layouts/tabbedSearch/header/_downloadTooltip.scss
@@ -73,7 +73,7 @@
 
         &.right {
             top: rem(32);
-            right: rem(9);
+            right: rem(-8);
         }
     }
 }

--- a/src/_scss/pages/award/shared/contractGrantsActivity.scss
+++ b/src/_scss/pages/award/shared/contractGrantsActivity.scss
@@ -84,6 +84,7 @@
             display: inline-flex;
             align-items: center;
             justify-content: space-around;
+            width: 100%;
             .pagination-text {
               font-style: italic;
             }

--- a/src/_scss/pages/award/shared/contractGrantsActivity.scss
+++ b/src/_scss/pages/award/shared/contractGrantsActivity.scss
@@ -60,9 +60,6 @@
           .tooltip-pointer {
             height: 1.6rem;
             width: 1.6rem;
-            &.bottom {
-              top: rem(-8);
-            }
           }
           .tooltip__content {
             .tooltip__message {

--- a/src/_scss/pages/covid19/visualizations/_amounts.scss
+++ b/src/_scss/pages/covid19/visualizations/_amounts.scss
@@ -19,6 +19,10 @@
     pointer-events: visible;
   }
   .tooltip-wrapper {
+    display: none;
+    @include media($medium-screen) {
+      @include display(flex);
+    }
     .tooltip__content {
       .tooltip__message {
         .tooltip__text {

--- a/src/_scss/pages/covid19/visualizations/_amounts.scss
+++ b/src/_scss/pages/covid19/visualizations/_amounts.scss
@@ -51,6 +51,7 @@
       @include display(inline-flex);
       @include align-items(center);
       @include justify-content(space-around);
+      width: 100%;
     }
   }
   .line__obligation {

--- a/src/js/components/covid19/AmountsVisualization.jsx
+++ b/src/js/components/covid19/AmountsVisualization.jsx
@@ -38,6 +38,8 @@ const propTypes = {
     width: PropTypes.number
 };
 
+const stickyHeaderHeight = 66;
+
 const AmountsVisualization = ({
     overviewData,
     width = null
@@ -105,15 +107,23 @@ const AmountsVisualization = ({
     const setMouseData = throttle((e) => {
         const browser = window.navigator.userAgent;
         if (browser.includes('Chrome')) {
+            // vertical offsets from trial/error. Not sure which element's height requires this?
+            const verticalOffset = window.innerWidth >= 1600
+                ? 40
+                : 80;
             setMouseValue({
                 x: e.clientX - document.getElementById('amounts-viz_id').getBoundingClientRect().left,
-                y: e.clientY - document.getElementById('amounts-viz_id').getBoundingClientRect().top - 40
+                y: e.clientY - document.getElementById('amounts-viz_id').getBoundingClientRect().top - verticalOffset
             });
         }
         else if (browser.includes('Firefox') || browser.includes('Safari')) {
+            // vertical offsets from trial/error. Not sure which element's height requires this?
+            const verticalOffset = window.innerWidth >= 1600
+                ? 0 + stickyHeaderHeight
+                : 29.5 + stickyHeaderHeight;
             setMouseValue({
                 x: e.clientX - document.getElementById('amounts-viz_id').getBoundingClientRect().left,
-                y: e.clientY - document.getElementById('amounts-viz_id').getBoundingClientRect().top - 66 - 29.5
+                y: e.clientY - document.getElementById('amounts-viz_id').getBoundingClientRect().top - verticalOffset
             });
         }
         else {
@@ -632,8 +642,14 @@ const AmountsVisualization = ({
             }
             tooltipElement={<Tooltip />} />
     });
-    const displayTooltip = (e) => setShowTooltip(e.target.getAttribute('data-id'));
-    const hideTooltip = () => setShowTooltip('');
+
+    const displayTooltip = (e) => {
+        setShowTooltip(e.target.getAttribute('data-id'));
+    };
+
+    const hideTooltip = () => {
+        setShowTooltip('');
+    };
 
     const dateNoteStyles = {
         position: 'absolute',
@@ -662,7 +678,9 @@ const AmountsVisualization = ({
                     width={defaultTooltipWidth}
                     controlledProps={{
                         isControlled: true,
-                        isVisible: !!showTooltip
+                        isVisible: !!showTooltip,
+                        showTooltip: () => {},
+                        closeTooltip: () => {}
                     }} />
             }
             {

--- a/src/js/components/covid19/AmountsVisualization.jsx
+++ b/src/js/components/covid19/AmountsVisualization.jsx
@@ -110,10 +110,16 @@ const AmountsVisualization = ({
                 y: e.clientY - document.getElementById('amounts-viz_id').getBoundingClientRect().top - 40
             });
         }
-        else {
+        else if (browser.includes('Firefox') || browser.includes('Safari')) {
             setMouseValue({
                 x: e.clientX - document.getElementById('amounts-viz_id').getBoundingClientRect().left,
                 y: e.clientY - document.getElementById('amounts-viz_id').getBoundingClientRect().top - 66 - 29.5
+            });
+        }
+        else {
+            setMouseValue({
+                x: e.offsetX || e.clientX,
+                y: e.offsetY || e.clientY
             });
         }
     }, 100);

--- a/src/js/components/covid19/AmountsVisualization.jsx
+++ b/src/js/components/covid19/AmountsVisualization.jsx
@@ -24,7 +24,8 @@ import {
     labelTextAdjustment,
     heightOfRemainingBalanceLines,
     defaultTooltipWidth,
-    tooltipMapping
+    tooltipMapping,
+    stickyHeaderHeight
 } from 'dataMapping/covid19/covid19';
 import {
     calculateUnits,
@@ -37,8 +38,6 @@ const propTypes = {
     overviewData: PropTypes.object,
     width: PropTypes.number
 };
-
-const stickyHeaderHeight = 66;
 
 const AmountsVisualization = ({
     overviewData,

--- a/src/js/components/covid19/AmountsVisualization.jsx
+++ b/src/js/components/covid19/AmountsVisualization.jsx
@@ -108,7 +108,7 @@ const AmountsVisualization = ({
             setMouseValue({
                 x: e.clientX - document.getElementById('amounts-viz_id').getBoundingClientRect().left,
                 y: e.clientY - document.getElementById('amounts-viz_id').getBoundingClientRect().top - 40
-            })
+            });
         }
         else {
             setMouseValue({

--- a/src/js/components/covid19/AmountsVisualization.jsx
+++ b/src/js/components/covid19/AmountsVisualization.jsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
-import { upperFirst } from 'lodash';
+import { upperFirst, throttle } from 'lodash';
 import { scaleLinear } from 'd3-scale';
 import DateNote from 'components/covid19/DateNote';
 import ResultsTableLoadingMessage from 'components/search/table/ResultsTableLoadingMessage';
@@ -102,21 +102,21 @@ const AmountsVisualization = ({
             setScale(() => s);
         }
     }, [width, overviewData]);
-    const setMouseData = (e) => {
-        let mousePosition = { x: e.offsetX || e.clientX, y: e.offsetY || e.clientY };
-        if (window.navigator.userAgent.indexOf("Firefox") !== -1) {
-            mousePosition.x = e.clientX - document.getElementById('amounts-viz_id').getBoundingClientRect().left;
-            mousePosition.y = e.clientY - document.getElementById('amounts-viz_id').getBoundingClientRect().top - 66 - 29.5;
+    const setMouseData = throttle((e) => {
+        const browser = window.navigator.userAgent;
+        if (browser.includes('Chrome')) {
+            setMouseValue({
+                x: e.clientX - document.getElementById('amounts-viz_id').getBoundingClientRect().left,
+                y: e.clientY - document.getElementById('amounts-viz_id').getBoundingClientRect().top - 40
+            })
         }
-        if (window.navigator.userAgent.indexOf("Safari") !== -1) {
-            mousePosition.x = e.clientX - document.getElementById('amounts-viz_id').getBoundingClientRect().left;
-            mousePosition.y = e.clientY - document.getElementById('amounts-viz_id').getBoundingClientRect().top - 66 - 29.5;
+        else {
+            setMouseValue({
+                x: e.clientX - document.getElementById('amounts-viz_id').getBoundingClientRect().left,
+                y: e.clientY - document.getElementById('amounts-viz_id').getBoundingClientRect().top - 66 - 29.5
+            });
         }
-        if (window.navigator.userAgent.indexOf("Chrome") !== -1) {
-            mousePosition = { x: e.offsetX || e.clientX, y: e.offsetY || e.clientY };
-        }
-        setMouseValue(mousePosition);
-    };
+    }, 100);
     useEffect(() => {
         document.getElementById('amounts-viz_id').addEventListener('mousemove', setMouseData);
         return () => document.getElementById('amounts-viz_id').removeEventListener('mousemove', setMouseData);

--- a/src/js/components/covid19/Covid19Tooltips.jsx
+++ b/src/js/components/covid19/Covid19Tooltips.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const AwardSpendingAgencyTT = () => (
-    <div className="homepage__covid-19-tt">
+    <div className="covid-profile-tt">
         <h2 className="tooltip__title">Award Spending by Agency</h2>
         <div className="tooltip__text ul-override">
             <p>
@@ -33,7 +33,7 @@ export const AwardSpendingAgencyTT = () => (
 );
 
 export const AwardSpendingCfdaTT = () => (
-    <div className="homepage__covid-19-tt">
+    <div className="covid-profile-tt">
         <h2 className="tooltip__title">Award Spending by CFDA Program (Assistance Listing)</h2>
         <div className="tooltip__text ul-override">
             <p>
@@ -65,7 +65,7 @@ export const AwardSpendingCfdaTT = () => (
 );
 
 export const AwardSpendingTT = () => (
-    <div className="homepage__covid-19-tt">
+    <div className="covid-profile-tt">
         <h2 className="tooltip__title">Award Spending</h2>
         <div className="tooltip__text">
             <p>
@@ -79,7 +79,7 @@ export const AwardSpendingTT = () => (
 );
 
 export const SpendingByRecipientTT = () => (
-    <div className="homepage__covid-19-tt">
+    <div className="covid-profile-tt">
         <h2 className="tooltip__title">Award Spending by Recipient</h2>
         <div className="tooltip__text ul-override">
             <p>
@@ -161,7 +161,7 @@ export const SpendingTypesTT = () => (
 );
 
 export const TotalSpendingTT = () => (
-    <div className="homepage__covid-19-tt">
+    <div className="covid-profile-tt">
         <h2 className="tooltip__title"> Total Spending</h2>
         <div className="tooltip__text">
             <p>

--- a/src/js/containers/covid19/homepage/CovidHighlights.jsx
+++ b/src/js/containers/covid19/homepage/CovidHighlights.jsx
@@ -293,6 +293,9 @@ export class CovidHighlights extends React.Component {
                                 <div style={{ width: '20px' }}>
                                     <TooltipWrapper
                                         icon="info"
+                                        offsetAdjustments={{
+                                            top: 0
+                                        }}
                                         tooltipComponent={<HomePageTooltip />} />
                                 </div>
                             </span>


### PR DESCRIPTION
**High level description:**
After updating the component library tooltip, there were some styling issues:

- COIVD Profile Viz tooltips
- Covid Profile Section Headers
- Spending Explorer tooltips 

Also cleaned up the home page tooltip.

**Technical details:**
- Biggest change is to the positioning of the Covid Profile Viz tooltips
- All other changes are trivial styling changes / html class name changes

**JIRA Ticket:**
[DEV-2698](https://federal-spending-transparency.atlassian.net/browse/DEV-2698)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A`Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Adequately tested in Sandbox
- [x] Code review complete
