### PR TITLE
[DEV-4976] updating key on award object in Referenced Awards Container from counts to idvDetails

### DIFF
--- a/src/js/containers/award/idv/ReferencedAwardsContainer.jsx
+++ b/src/js/containers/award/idv/ReferencedAwardsContainer.jsx
@@ -75,17 +75,17 @@ export class ReferencedAwardsContainer extends React.Component {
     }
 
     componentDidMount() {
-        if (this.props.award.id && this.props.award.counts) {
+        if (this.props.award.id && this.props.award.idvDetails) {
             this.pickDefaultTab();
         }
     }
 
     componentDidUpdate(prevProps) {
-        if ((this.props.award.id !== prevProps.award.id || !isEqual(this.props.award.counts, prevProps.award.counts)) && this.props.award.counts) {
+        if ((this.props.award.id !== prevProps.award.id || !isEqual(this.props.award.idvDetails, prevProps.award.idvDetails)) && this.props.award.idvDetails) {
             this.pickDefaultTab();
         }
 
-        if (this.props.tableType !== prevProps.tableType && this.props.award.counts) this.loadResults();
+        if (this.props.tableType !== prevProps.tableType && this.props.award.idvDetails) this.loadResults();
     }
 
     componentWillUnmount() {
@@ -136,7 +136,7 @@ export class ReferencedAwardsContainer extends React.Component {
     }
 
     pickDefaultTab() {
-        const { counts } = this.props.award;
+        const { idvDetails: counts } = this.props.award;
         const tableKeys = tableTypes.map((type) => type.internal);
         const tableCounts = pick(counts, tableKeys);
         const defaultTab = findKey(tableCounts, (count) => count !== 0);
@@ -199,7 +199,7 @@ export class ReferencedAwardsContainer extends React.Component {
         return (
             <ReferencedAwardsSection
                 {...this.state}
-                counts={this.props.award.counts}
+                counts={this.props.award.idvDetails}
                 switchTab={this.switchTab}
                 changePage={this.changePage}
                 updateSort={this.updateSort}

--- a/tests/containers/award/mockAward.js
+++ b/tests/containers/award/mockAward.js
@@ -33,7 +33,7 @@ export const mockRedux = {
         id: '1234',
         category: 'idv',
         overview: mockIdv,
-        counts: {
+        idvDetails: {
             idvs: 45,
             contracts: 52
         }


### PR DESCRIPTION
**High level description:**
The referenced awards container expects `this.props.award.counts` to be defined, then makes at network request to populate the `Orders Under this IDV` table.

This key on the award object was changed so it is now never defined.

This PR updates the container to look for `this.props.award.idvDetails` instead of `this.props.award.counts`.

**Technical details:**
Updates methods to look at `idvDetails` instead of `counts`. Updates mockData as well.

**JIRA Ticket:**
[DEV-4976](https://federal-spending-transparency.atlassian.net/browse/DEV-4976)

(@BrianZito found this bug when working this ticket)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A`Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A`Verified mobile/tablet/desktop/monitor responsiveness
`N/A`Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A`All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A`[API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A`[Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A`Design review complete `if applicable`
`N/A`[API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
