### PR TITLE
[DEV-6182] logging pageviews when a user changes their route via client side router

### DIFF
--- a/src/js/containers/AppContainer.jsx
+++ b/src/js/containers/AppContainer.jsx
@@ -10,6 +10,7 @@ import perflogger from 'redux-perf-middleware';
 import kGlobalConstants from 'GlobalConstants';
 import { BrowserRouter, Switch, Route, useLocation } from 'react-router-dom';
 
+import Analytics from 'helpers/analytics/Analytics';
 import storeSingleton from 'redux/storeSingleton';
 import withGlossaryListener from 'containers/glossary/GlossaryListener';
 import reducers from 'redux/reducers/index';
@@ -57,11 +58,22 @@ const ScrollToTop = () => {
     return null;
 };
 
+const LogPageView = () => {
+    const { pathname } = useLocation();
+
+    useEffect(() => {
+        Analytics.pageview(pathname);
+    }, [pathname]);
+
+    return null;
+};
+
 const AppContainer = () => (
     <Provider store={store}>
         <BrowserRouter>
             <Suspense fallback={<Loading isLoading includeHeader includeFooter />}>
                 <ScrollToTop />
+                <LogPageView />
                 <Switch>
                     {routes.map(({ path, component }) => (
                         <Route

--- a/src/js/helpers/analytics/Analytics.js
+++ b/src/js/helpers/analytics/Analytics.js
@@ -36,18 +36,11 @@ const Analytics = {
             args.nonInteraction || undefined
         );
     },
-    pageview(args) {
-        let path = args;
-        let title;
-        // Use the test tracker for non-prod environments
-        if (typeof args === 'object') {
-            ({ path, title } = args);
-        }
+    pageview(path) {
         this._execute(
             'send',
             'pageview',
-            path,
-            title
+            path
         );
     }
 };


### PR DESCRIPTION
**High level description:**
The custom router did this, we removed the functionality. Currently, all we do is log page views the first time the user loads the site.

**Technical details:**
When the component loads, we log the pathname

**JIRA Ticket:**
[DEV-6182](https://federal-spending-transparency.atlassian.net/browse/DEV-6182)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
`N/A` All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
