### PR TITLE
[DEV-6188] Recipient Profile Landing Page 'gathering your data' triggers every time a key is pressed after clicking tab

### DIFF
--- a/src/js/components/search/table/ResultsTableTabItem.jsx
+++ b/src/js/components/search/table/ResultsTableTabItem.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { formatNumber } from 'helpers/moneyFormatter';
+import { createOnKeyDownHandler } from 'helpers/keyboardEventsHelper';
 
 const propTypes = {
     label: PropTypes.string,
@@ -64,12 +65,13 @@ export default class ResultsTableTabItem extends React.Component {
             );
         }
         const className = `table-type-toggle${activeClass} ${this.props.className}${disabledClass}`;
+        const onKeyDownHandler = createOnKeyDownHandler(this.clickedTab);
         return (
             <div className={`table-type-toggle__wrapper${disabledClass}`}>
                 <div
                     className={className}
                     onClick={this.clickedTab}
-                    onKeyDown={this.clickedTab}
+                    onKeyDown={onKeyDownHandler}
                     role="menuitemradio"
                     aria-checked={this.props.active}
                     title={`Show ${this.props.label}`}


### PR DESCRIPTION
**High level description:**

When a tab is highlighted/selected on the recipient profile landing page, the API call triggers on every key press. This PR resolves the bug by preventing multiple API calls on each key press and only allowing the call to trigger when a user hits enter on the highlighted tab.

**Technical details:**

Added onKeyDownHandler to ResultsTableTabItem to ensure we are only fetching from API on 'enter'

**JIRA Ticket:**
[DEV-6188](https://federal-spending-transparency.atlassian.net/browse/DEV-6188)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [`N/A`] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [`N/A`] Added Unit Tests for methods in Container Components, reducers, helper functions, and models `if applicable`
- [`N/A`] All `componentWillReceiveProps` and `componentWillMount` in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3277](https://federal-spending-transparency.atlassian.net/browse/DEV-3277)
- [`N/A`] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [`N/A`] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [`N/A`] Design review complete `if applicable`
- [`N/A`] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
