### PR TITLE
[DEV-6220] fix month determining bug

### DIFF
--- a/src/js/containers/explorer/detail/helpers/explorerQuarters.js
+++ b/src/js/containers/explorer/detail/helpers/explorerQuarters.js
@@ -166,6 +166,9 @@ export const mostRecentPeriod = () => {
     if (period === 0) {
         period = 12;
     }
+    else if (period === -1) {
+        period = 11;
+    }
 
     return {
         period,

--- a/tests/containers/explorer/detail/helpers/explorerQuarters-test.js
+++ b/tests/containers/explorer/detail/helpers/explorerQuarters-test.js
@@ -187,3 +187,30 @@ describe('explorerQuarters', () => {
         });
     });
 });
+
+describe('mostRecentPeriod', () => {
+    it('should the latest closed fiscal period in a given fiscal year', () => {
+        mockDate('2020-06-01');
+        const output = explorerQuarters.defaultPeriod();
+        expect(output).toEqual({
+            period: 7,
+            year: 2020
+        });
+    });
+    it('should return the latest closed period even if the latest ended period has not closed yet', () => {
+        mockDate('2020-10-01');
+        const output = explorerQuarters.defaultPeriod();
+        expect(output).toEqual({
+            period: 11,
+            year: 2020
+        });
+    });
+    it('should return the last period of the fiscal year after it has closed', () => {
+        mockDate('2020-11-20');
+        const output = explorerQuarters.defaultPeriod();
+        expect(output).toEqual({
+            period: 12,
+            year: 2020
+        });
+    });
+});


### PR DESCRIPTION
**High level description:**

Fixes a bug where the  fiscal period was being determined incorrectly on the spending explorer page

**Technical details:**

Technical details for the knowledge of other developers.

**JIRA Ticket:**
[DEV-6220](https://federal-spending-transparency.atlassian.net/browse/DEV-6220)


The following are ALL required for the PR to be merged:

Author:
- [X] Linked to this PR in JIRA ticket
- [X] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR 
- [X] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [X] Verified mobile/tablet/desktop/monitor responsiveness
- [X] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)

Reviewer(s):
- [ ] Code review complete
