### PR TITLE
[DEV-6238] Advanced Search Hash Url (a) Loads search and (b) doesn't generate duplicate hash

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,6 @@ module.exports = {
         "<rootDir>/__mocks__/fileMock.js",
         "^(data-transparency-ui)$": "<rootDir>/node_modules/data-transparency-ui",
         "\\.(css|less|scss)$": "identity-obj-proxy",
-        "react-router-dom": "<rootDir>/tests/testResources/mockComponent.js",
         ".*GlobalConstants$": "<rootDir>/tests/testResources/mockGlobalConstants.js",
     },
     setupFilesAfterEnv: ["<rootDir>/tests/setup.js"],

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,8 @@ module.exports = {
         "<rootDir>/__mocks__/fileMock.js",
         "^(data-transparency-ui)$": "<rootDir>/node_modules/data-transparency-ui",
         "\\.(css|less|scss)$": "identity-obj-proxy",
-        ".*GlobalConstants$": "<rootDir>/tests/testResources/mockGlobalConstants.js"
+        "react-router-dom": "<rootDir>/tests/testResources/mockComponent.js",
+        ".*GlobalConstants$": "<rootDir>/tests/testResources/mockGlobalConstants.js",
     },
     setupFilesAfterEnv: ["<rootDir>/tests/setup.js"],
     transform: {
@@ -34,5 +35,6 @@ module.exports = {
     },
     transformIgnorePatterns: [
         "node_modules/(?!(data-transparency-ui))"
-    ]
+    ],
+    modulePaths: ["<rootDir>/tests/testResources"]
 };

--- a/tests/components/covid19/homepage/TotalAmount-test.jsx
+++ b/tests/components/covid19/homepage/TotalAmount-test.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-
 import TotalAmount from 'components/homepage/hero/TotalAmount';
+
+// import { render, screen } from '../../../testResources/test-utils';
+import { render, screen } from 'test-utils';
 
 const reallyBigNumber = 1000000000000;
 

--- a/tests/containers/search/SearchContainer-test.jsx
+++ b/tests/containers/search/SearchContainer-test.jsx
@@ -2,10 +2,12 @@
  * SearchContainer-test.jsx
  * Created by Kevin Li 6/2/17
  */
+import React from 'react';
+import { render, screen } from 'test-utils';
 import { Set } from 'immutable';
 
 import { initialState } from 'redux/reducers/search/searchFiltersReducer';
-import { parseRemoteFilters, areFiltersEqual } from 'containers/search/SearchContainer';
+import SearchContainer, { parseRemoteFilters } from 'containers/search/SearchContainer';
 
 import { mockFilters, mockRedux } from './mockSearchHashes';
 
@@ -14,16 +16,17 @@ import { mockFilters, mockRedux } from './mockSearchHashes';
 global.Promise = jest.requireActual('promise');
 
 // mock the child component by replacing it with a function that returns a null element
-jest.mock('components/search/SearchPage', () =>
-    jest.fn(() => null));
+// jest.mock('components/search/SearchPage', () => (
+//     jest.fn(() => null)
+// ));
 
 jest.mock('helpers/searchHelper', () => require('./filters/searchHelper'));
-jest.mock('helpers/fiscalYearHelper', () => require('./filters/fiscalYearHelper'));
+// jest.mock('helpers/fiscalYearHelper', () => require('./filters/fiscalYearHelper'));
 jest.mock('helpers/downloadHelper', () => require('./modals/fullDownload/downloadHelper'));
 
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
-    useParams: jest.fn().mockReturnValue({ environment: 'dev', service: 'fakeService' })
+    useParams: jest.fn().mockReturnValue({ hash: '123' })
 }));
 
 jest.mock('react-redux', () => {
@@ -55,5 +58,19 @@ describe('SearchContainer', () => {
             expect(parseRemoteFilters(mockFilters.filter).timePeriodFY).toEqual(expectedFilter);
         });
     });
+    // it('applied filters show a confirmation pill', () => {
+    //     const withAppliedFilters = {
+    //         ...mockRedux.appliedFilters,
+    //         timePeriodFY: new Set(["2021"])
+    //     };
+    //     render(<SearchContainer {...mockRedux} appliedFilters={withAppliedFilters} />);
+    //     expect(screen.queryByRole('listitem')).toBeFalsy();
+    // });
+    // condition x: url hash exists
+    // html exists showing confirmation pill
+    
+    // describe('a hashed url renders results and a confirmation pill', () => {
+
+    // });
 });
 

--- a/tests/containers/search/SearchContainer-test.jsx
+++ b/tests/containers/search/SearchContainer-test.jsx
@@ -3,48 +3,50 @@
  * Created by Kevin Li 6/2/17
  */
 import React from 'react';
-import { render, screen } from 'test-utils';
+import { render, waitFor } from '@testing-library/react';
 import { Set } from 'immutable';
+import { useParams } from 'react-router-dom';
 
-import { initialState } from 'redux/reducers/search/searchFiltersReducer';
 import SearchContainer, { parseRemoteFilters } from 'containers/search/SearchContainer';
 
 import { mockFilters, mockRedux } from './mockSearchHashes';
+import { restoreUrlHash } from './filters/searchHelper';
 
 // force Jest to use native Node promises
 // see: https://facebook.github.io/jest/docs/troubleshooting.html#unresolved-promises
 global.Promise = jest.requireActual('promise');
 
 // mock the child component by replacing it with a function that returns a null element
-// jest.mock('components/search/SearchPage', () => (
-//     jest.fn(() => null)
-// ));
+jest.mock('components/search/SearchPage', () => (
+    jest.fn(() => null)
+));
 
 jest.mock('helpers/searchHelper', () => require('./filters/searchHelper'));
 // jest.mock('helpers/fiscalYearHelper', () => require('./filters/fiscalYearHelper'));
 jest.mock('helpers/downloadHelper', () => require('./modals/fullDownload/downloadHelper'));
 
-jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useParams: jest.fn().mockReturnValue({ hash: '123' })
-}));
-
 jest.mock('react-redux', () => {
     const ActualReactRedux = jest.requireActual('react-redux');
     return {
         ...ActualReactRedux,
-        useDispatch: jest.fn(),
+        useDispatch: jest.fn(() => () => {}),
         useSelector: jest.fn().mockImplementation(() => {
             return mockRedux;
         })
+
     };
 });
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useParams: jest.fn().mockReturnValue({ urlHash: 'abc' })
+}));
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
 
 describe('SearchContainer', () => {
     describe('parseRemoteFilters', () => {
-        it('should return null if the versions do not match', () => {
+        test('should return null if the versions do not match', () => {
             const mockResponse = Object.assign({}, mockFilters, {
                 filter: {
                     version: -1000
@@ -53,24 +55,33 @@ describe('SearchContainer', () => {
 
             expect(parseRemoteFilters(mockResponse)).toEqual(null);
         });
-        it('should return an immutable data structure when versions match', () => {
+        test('should return an immutable data structure when versions match', () => {
             const expectedFilter = new Set(['1990']);
-            expect(parseRemoteFilters(mockFilters.filter).timePeriodFY).toEqual(expectedFilter);
+            const mock = {
+                ...mockFilters,
+                filter: {
+                    ...mockFilters.filter,
+                    filters: {
+                        ...mockFilters.filter.filters,
+                        timePeriodFY: ['1990']
+                    }
+                }
+            };
+            expect(parseRemoteFilters(mock.filter).timePeriodFY).toEqual(expectedFilter);
         });
     });
-    // it('applied filters show a confirmation pill', () => {
-    //     const withAppliedFilters = {
-    //         ...mockRedux.appliedFilters,
-    //         timePeriodFY: new Set(["2021"])
-    //     };
-    //     render(<SearchContainer {...mockRedux} appliedFilters={withAppliedFilters} />);
-    //     expect(screen.queryByRole('listitem')).toBeFalsy();
-    // });
-    // condition x: url hash exists
-    // html exists showing confirmation pill
-    
-    // describe('a hashed url renders results and a confirmation pill', () => {
-
-    // });
+    test('a non-hashed does not make a request to the api', async () => {
+        useParams.mockReturnValueOnce({ urlHash: null });
+        render(<SearchContainer {...mockRedux} />, {});
+        await waitFor(() => {
+            expect(restoreUrlHash).not.toHaveBeenCalled();
+        });
+    });
+    test('a hashed url makes a request to the api', async () => {
+        render(<SearchContainer {...mockRedux} />, {});
+        await waitFor(() => {
+            expect(restoreUrlHash).toHaveBeenCalledTimes(1);
+        });
+    });
 });
 

--- a/tests/containers/search/filters/searchHelper.js
+++ b/tests/containers/search/filters/searchHelper.js
@@ -135,7 +135,7 @@ export const generateUrlHash = () => (
     }
 );
 
-export const restoreUrlHash = () => (
+export const restoreUrlHash = jest.fn(() => (
     {
         promise: new Promise((resolve) => {
             process.nextTick(() => {
@@ -146,7 +146,7 @@ export const restoreUrlHash = () => (
         }),
         cancel: jest.fn()
     }
-);
+));
 
 export const fetchLastUpdate = () => (
     {

--- a/tests/testResources/test-utils.js
+++ b/tests/testResources/test-utils.js
@@ -1,0 +1,36 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable react/jsx-filename-extension */
+// test-utils.js
+import React from "react";
+import { render as rtlRender } from "@testing-library/react";
+import { createStore } from "redux";
+import { Provider } from "react-redux";
+import { BrowserRouter } from 'react-router-dom';
+
+// Import your own reducer
+import reducer from "../../src/js/redux/reducers/index";
+
+function render(
+    ui,
+    {
+        initialState,
+        store = createStore(reducer, initialState),
+        ...renderOptions
+    } = {}
+) {
+    function Wrapper({ children }) {
+        return (
+            <Provider store={store}>
+                <BrowserRouter>
+                    {children}
+                </BrowserRouter>
+            </Provider>
+        );
+    }
+    return rtlRender(ui, { wrapper: Wrapper, ...renderOptions });
+}
+
+// re-export everything
+export * from "@testing-library/react";
+// override render method
+export { render };


### PR DESCRIPTION
**High level description:**
- On Advanced Search in QAT, the hash url page (`/search/234qkd234`) was not loading the search
- On Advanced search in PROD, the hash url page was generating a duplicate hash for the same search

**Technical details:**
changing useEffect conditional logic:

- caller of generateHash updated to look at appliedFilters property in redux for source of truth
- caller of history.replace() updated to look at new previousProps ref & areAppliedFiltersEmpty prop in redux for source of truth

**JIRA Ticket:**
[DEV-6238](https://federal-spending-transparency.atlassian.net/browse/DEV-6238)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A`Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A`Verified mobile/tablet/desktop/monitor responsiveness
`N/A`Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A`[API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
