### PR TITLE
[DEV-6108] Data dictionary listed twice bug

### DIFF
--- a/src/js/containers/Footer.jsx
+++ b/src/js/containers/Footer.jsx
@@ -112,9 +112,9 @@ const Footer = ({
                             </div>
                             <ul className="links">
                                 <li>
-                                    <a href="/download_center/data_dictionary">
+                                    <Link to="/download_center/data_dictionary">
                                         Data Dictionary
-                                    </a>
+                                    </Link>
                                 </li>
                                 <li>
                                     <FooterExternalLink
@@ -125,11 +125,6 @@ const Footer = ({
                                     <FooterExternalLink
                                         link="https://datalab.usaspending.gov"
                                         title="Data Lab" />
-                                </li>
-                                <li>
-                                    <Link to="/download_center/data_dictionary">
-                                        Data Dictionary
-                                    </Link>
                                 </li>
                                 <li>
                                     <FooterExternalLink


### PR DESCRIPTION
**High level description:**

This PR removes the second occurrence of data dictionary in the resources section so it correctly displays:
Data Dictionary
Data Model
Data Lab
Fiscal Data

**Technical details:**

Technical details for the knowledge of other developers.

**JIRA Ticket:**
[DEV-6108](https://federal-spending-transparency.atlassian.net/browse/DEV-6108)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [`N/A`] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [`N/A`] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [`N/A`] Verified mobile/tablet/desktop/monitor responsiveness
- [`N/A`] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [`N/A`] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [`N/A`] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [`N/A`] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [`N/A`] Design review complete `if applicable`
- [`N/A`] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
