### PR TITLE
[DEV-5489] Handle when user does not clear their own search in a Checkbox Tree

### DIFF
--- a/src/js/containers/search/SearchSidebarSubmitContainer.jsx
+++ b/src/js/containers/search/SearchSidebarSubmitContainer.jsx
@@ -10,7 +10,6 @@ import { connect } from 'react-redux';
 
 import * as appliedFilterActions from 'redux/actions/search/appliedFilterActions';
 import { clearAllFilters as clearStagedFilters } from 'redux/actions/search/searchFilterActions';
-import { setCheckedNaics, setUncheckedNaics } from 'redux/actions/search/naicsActions';
 import { resetMapLegendToggle } from 'redux/actions/search/mapLegendToggleActions';
 
 import { areFiltersEqual } from 'helpers/searchHelper';
@@ -107,7 +106,6 @@ export class SearchSidebarSubmitContainer extends React.Component {
     resetFilters() {
         this.props.clearStagedFilters();
         this.props.resetAppliedFilters();
-        this.props.resetNaicsTree();
         this.props.resetMapLegendToggle();
     }
 
@@ -130,11 +128,7 @@ export default connect(
         appliedFilters: state.appliedFilters.filters
     }),
     (dispatch) => ({
-        ...bindActionCreators(combinedActions, dispatch),
-        resetNaicsTree: () => {
-            dispatch(setCheckedNaics([]));
-            dispatch(setUncheckedNaics([]));
-        }
+        ...bindActionCreators(combinedActions, dispatch)
     })
 )(SearchSidebarSubmitContainer);
 

--- a/src/js/containers/search/filters/naics/NAICSCheckboxTree.jsx
+++ b/src/js/containers/search/filters/naics/NAICSCheckboxTree.jsx
@@ -178,6 +178,7 @@ export class NAICSCheckboxTree extends React.Component {
         if (this.request) {
             this.request.cancel();
         }
+        this.props.showNaicsTree();
     }
 
     onSearchChange = debounce(() => {

--- a/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
@@ -132,6 +132,7 @@ export class TASCheckboxTree extends React.Component {
         if (this.request) {
             this.request.cancel();
         }
+        this.props.showTasTree();
     }
 
     onExpand = (expandedValue, newExpandedArray, shouldFetchChildren, selectedNode) => {

--- a/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
@@ -133,6 +133,7 @@ export class PSCCheckboxTreeContainer extends React.Component {
         if (this.request) {
             this.request.cancel();
         }
+        this.props.showPscTree();
     }
 
     onExpand = (expandedValue, newExpandedArray, shouldFetchChildren, selectedNode) => {

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -679,15 +679,10 @@ export const showAllNodes = (tree) => tree
         ...node,
         className: '',
         children: node.children
-            ? node.children
-                .map((child) => ({
-                    ...child,
-                    className: '',
-                    children: child?.children?.length > 0 ? showAllNodes(child.children) : []
-                }))
-                .sort(sortNodesByValue)
+            ? showAllNodes(node.children)
             : []
-    }));
+    }))
+    .sort(sortNodesByValue);
 /**
  * @param checkedAncestorPaths 2d array, each item an ancestryPath with the last item in the array representing a checkedNode; ie, [[11, 1111, 111110]] to represented checked state for 111110
  * @param uncheckedAncestorPaths same as @param checkedAncestorPaths except for unchecked nodes

--- a/src/js/redux/reducers/search/naicsReducer.js
+++ b/src/js/redux/reducers/search/naicsReducer.js
@@ -99,6 +99,12 @@ export const naicsReducer = (state = initialState, action) => {
                 counts: new List(action.payload)
             };
         }
+        case 'CLEAR_SEARCH_FILTER_ALL': {
+            return {
+                ...initialState,
+                naics: new List(showAllNodes(state.naics.toJS()))
+            };
+        }
         default:
             return state;
     }

--- a/src/js/redux/reducers/search/pscReducer.js
+++ b/src/js/redux/reducers/search/pscReducer.js
@@ -103,7 +103,7 @@ export const pscReducer = (state = initialState, action) => {
         case 'CLEAR_SEARCH_FILTER_ALL': {
             return {
                 ...initialState,
-                psc: state.psc
+                psc: new List(showAllNodes(state.psc.toJS()))
             };
         }
         default:

--- a/src/js/redux/reducers/search/tasReducer.js
+++ b/src/js/redux/reducers/search/tasReducer.js
@@ -111,7 +111,7 @@ export const tasReducer = (state = initialState, action) => {
         case 'CLEAR_SEARCH_FILTER_ALL': {
             return {
                 ...initialState,
-                tas: state.tas
+                tas: new List(showAllNodes(state.tas.toJS()))
             };
         }
 

--- a/tests/containers/search/SearchSidebarSubmitContainer-test.jsx
+++ b/tests/containers/search/SearchSidebarSubmitContainer-test.jsx
@@ -188,19 +188,5 @@ describe('SearchSidebarSubmitContainer', () => {
             container.instance().resetFilters();
             expect(actions.resetAppliedFilters).toHaveBeenCalledTimes(1);
         });
-        it('should reset all naics redux namespace, checked and unchecked', () => {
-            const actions = Object.assign({}, mockActions, {
-                resetNaicsTree: jest.fn()
-            });
-
-            const container = shallow(
-                <SearchSidebarSubmitContainer
-                    {...mockRedux}
-                    {...actions} />
-            );
-            
-            container.instance().resetFilters();
-            expect(actions.resetNaicsTree).toHaveBeenCalledTimes(1);
-        });
     });
 });


### PR DESCRIPTION
NOTE: This PR contains #2165 

**High level description:**

Handle the case where:
  (a) performs a search in a checkbox tree
  (b) checks some results
  (c) submits the search without clearing it out  -- or -- (c2) resets the search filters w/o clearing out the checkbox tree search

**Technical details:**
- 62701ba when a user submits a search, that unMounts the component b/c we go to a new url; onUnmount, show all nodes in the tree
- e629f22 if a user selects `reset search` on the search page to clear out all filters, clear out checked expanded etc... and show all nodes in the tree

Code cleanup:
- e629f22 NAICS was not listening for the global `CLEAR_ALL_FILTERS` action type. Now we are
- 9f90602 `showAllNodes` was not recursive as much as it should've been. Making it more so.

**JIRA Ticket:**
[DEV-5489](https://federal-spending-transparency.atlassian.net/browse/DEV-5489)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
- [x] Down merge of #2165 complete