### PR TITLE
[DEV-6269] Quick Follow Up for Agency and Account Pg

### DIFF
--- a/src/js/components/account/Account.jsx
+++ b/src/js/components/account/Account.jsx
@@ -19,7 +19,7 @@ import SearchResults from './SearchResults';
 
 const propTypes = {
     account: PropTypes.object,
-    fy: PropTypes.string
+    currentFiscalYear: PropTypes.object
 };
 
 export default class Account extends React.Component {
@@ -32,7 +32,7 @@ export default class Account extends React.Component {
                 <main
                     id="main-content"
                     className="main-content">
-                    <AccountOverview account={this.props.account} fy={this.props.fy} />
+                    <AccountOverview account={this.props.account} currentFiscalYear={this.props.currentFiscalYear} />
                     <div className="filter-results">
                         <SearchSidebar />
                         <SearchResults />

--- a/src/js/components/account/AccountOverview.jsx
+++ b/src/js/components/account/AccountOverview.jsx
@@ -11,7 +11,7 @@ import SankeyVisualization from './visualizations/sankey/SankeyVisualization';
 
 const propTypes = {
     account: PropTypes.object,
-    fy: PropTypes.string
+    currentFiscalYear: PropTypes.string
 };
 
 export default class AccountOverview extends React.Component {
@@ -180,7 +180,7 @@ ${authority} has been obligated.`;
                     </div>
                 </div>
 
-                <h3>FY {this.props.fy} Snapshot</h3>
+                <h3>FY {this.props.currentFiscalYear ? `${this.props.currentFiscalYear} Snapshot` : ''}</h3>
                 <hr
                     className="results-divider"
                     ref={(div) => {

--- a/src/js/components/account/AccountOverview.jsx
+++ b/src/js/components/account/AccountOverview.jsx
@@ -74,7 +74,7 @@ export default class AccountOverview extends React.Component {
 
     generateSummary(account) {
         // determine the current fiscal year and get the associated values
-        const { fy } = this.props;
+        const { currentFiscalYear: fy } = this.props;
         const fiscalYearAvailable = account.totals.available;
         const summary = {
             flow: `No data is available for the current fiscal year (FY ${fy}).`,

--- a/src/js/components/agency/overview/AgencyOverview.jsx
+++ b/src/js/components/agency/overview/AgencyOverview.jsx
@@ -5,9 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
 import { capitalize, throttle } from 'lodash';
-import { convertQuarterToDate } from 'helpers/fiscalYearHelper';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 
@@ -18,7 +16,9 @@ import { Glossary } from 'components/sharedComponents/icons/Icons';
 import HorizontalBarItem from '../visualizations/obligated/HorizontalBarItem';
 
 const propTypes = {
-    agency: PropTypes.object
+    agency: PropTypes.object,
+    activeFy: PropTypes.string,
+    asOfDate: PropTypes.string
 };
 
 export default class AgencyOverview extends React.PureComponent {
@@ -31,7 +31,6 @@ export default class AgencyOverview extends React.PureComponent {
             mission: '',
             website: '',
             congressionalJustificationUrl: '',
-            asOfDate: '',
             formattedBudgetAuthority: '',
             percentageElement: '',
             visualizationWidth: 0,
@@ -106,13 +105,6 @@ export default class AgencyOverview extends React.PureComponent {
 
         const federalBudget = agency.federalBudget;
 
-        const fy = parseInt(agency.activeFY, 10);
-        const quarter = parseInt(agency.activeFQ, 10);
-
-        // Generate "as of" date
-        const endOfQuarter = convertQuarterToDate(quarter, fy);
-        const asOfDate = moment(endOfQuarter, "YYYY-MM-DD").format("MMMM D, YYYY");
-
         // Generate Budget Authority string
         const budgetAuthorityAmount = MoneyFormatter
             .calculateUnitForSingleValue(budgetAuthority);
@@ -139,7 +131,6 @@ export default class AgencyOverview extends React.PureComponent {
             mission,
             website,
             cjUrl,
-            asOfDate,
             formattedBudgetAuthority,
             percentageElement,
             visualizationWidth
@@ -222,12 +213,12 @@ export default class AgencyOverview extends React.PureComponent {
                             <a href={`agency/${this.props.agency.id}?glossary=budgetary-resources`}>
                                 <Glossary />
                             </a>
-                            for FY {this.props.agency.activeFY}
+                            for FY {this.props.activeFy}
                         </h4>
                         <div className="budget-authority-date">
                             <em>
-                                FY {this.props.agency.activeFY} data reported
-                                through {this.state.asOfDate}
+                                FY {this.props.activeFy} data reported
+                                through {this.props.asOfDate}
                             </em>
                         </div>
                         <div className="authority-amount">
@@ -235,7 +226,7 @@ export default class AgencyOverview extends React.PureComponent {
                         </div>
                         <div className="authority-statement">
                             This is {this.state.percentageElement} of the total U.S.
-                            federal budgetary resources for FY {this.props.agency.activeFY}.
+                            federal budgetary resources for FY {this.props.activeFy}.
                         </div>
                         <svg className="horizontal-bar">
                             <g>

--- a/src/js/containers/agency/visualizations/ObligatedContainer.jsx
+++ b/src/js/containers/agency/visualizations/ObligatedContainer.jsx
@@ -39,7 +39,7 @@ export class ObligatedContainer extends React.PureComponent {
     }
 
     componentDidUpdate(prevProps) {
-        if (this.props.id !== prevProps.id) {
+        if (this.props.id !== prevProps.id || this.props.activeFY !== prevProps.activeFY) {
             this.loadData(this.props.id, this.props.activeFY);
         }
     }

--- a/src/js/helpers/fiscalYearHelper.js
+++ b/src/js/helpers/fiscalYearHelper.js
@@ -72,7 +72,9 @@ export const convertQuarterToDate = (qtr, year) => {
 export const convertDateToQuarter = (date) => {
     // Returns the fiscal quarter that the date falls in
     let quarter = 0;
-    const month = moment(date).month();
+    const month = moment.isMoment(date)
+        ? date.month()
+        : moment(date).month();
 
     if (month >= 9 && month <= 11) {
         quarter = 1;


### PR DESCRIPTION
**High level description:**
-  Missed a place we were using active FY in the federal account page.
-  Implementing for the agency page. Misunderstood tony about the APIs response for agency detail data.

**Technical details:**
- 59dc79c using existing prop on federal account detail pg
- e40bc97 reusing WithLatestFy container in agency page

**JIRA Ticket:**
[DEV-6269](https://federal-spending-transparency.atlassian.net/browse/DEV-6269)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A`Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A`Verified mobile/tablet/desktop/monitor responsiveness
`N/A`Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A`Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A`[API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A`[Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A`Design review complete `if applicable`
`N/A`[API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
