### PR TITLE
[BRUS2DTI-419] Add new ENV to specify DTI

### DIFF
--- a/src/js/GlobalConstants.js
+++ b/src/js/GlobalConstants.js
@@ -11,7 +11,7 @@ const filesServerUrlByEnv = {
     qat: `https://files-nonprod.${isDti ? 'dti.' : ''}usaspending.gov`,
     staging: `https://files-staging.${isDti ? 'dti.' : ''}usaspending.gov`,
     prod: `https://files.${isDti ? 'dti.' : ''}usaspending.gov`
-}
+};
 
 const globalConstants = {
     API: process.env.USASPENDING_API,

--- a/src/js/GlobalConstants.js
+++ b/src/js/GlobalConstants.js
@@ -18,7 +18,8 @@ const globalConstants = {
     // Phase 1 release
     CARES_ACT_RELEASED: true,
     // Phase 2 release
-    CARES_ACT_RELEASED_2: true
+    CARES_ACT_RELEASED_2: true,
+    FILES_SERVER_BASE_URL: process.env.FILES_SERVER_BASE_URL
 };
 
 module.exports = globalConstants;

--- a/src/js/GlobalConstants.js
+++ b/src/js/GlobalConstants.js
@@ -3,6 +3,16 @@
  * Created by Maxwell Kendall 7/8/19
 */
 
+// This can be updated to remove "isDti" after DTI migration
+const isDti = process.env.USASPENDING_API.indexOf('.dti.') > -1;
+const filesServerUrlByEnv = {
+    dev: `https://files-nonprod.${isDti ? 'dti.' : ''}usaspending.gov`,
+    sandbox: `https://files-nonprod.${isDti ? 'dti.' : ''}usaspending.gov`,
+    qat: `https://files-nonprod.${isDti ? 'dti.' : ''}usaspending.gov`,
+    staging: `https://files-staging.${isDti ? 'dti.' : ''}usaspending.gov`,
+    prod: `https://files.${isDti ? 'dti.' : ''}usaspending.gov`
+}
+
 const globalConstants = {
     API: process.env.USASPENDING_API,
     LOCAL_ROOT: "",
@@ -15,11 +25,11 @@ const globalConstants = {
     FISCAL_YEAR: 2017,
     MAPBOX_TOKEN: process.env.MAPBOX_TOKEN,
     QAT: (process.env.ENV === 'qat'),
+    FILES_SERVER_BASE_URL: filesServerUrlByEnv[process.env.ENV],
     // Phase 1 release
     CARES_ACT_RELEASED: true,
     // Phase 2 release
-    CARES_ACT_RELEASED_2: true,
-    FILES_SERVER_BASE_URL: process.env.FILES_SERVER_BASE_URL
+    CARES_ACT_RELEASED_2: true
 };
 
 module.exports = globalConstants;

--- a/src/js/components/about/DataQuality.jsx
+++ b/src/js/components/about/DataQuality.jsx
@@ -63,7 +63,7 @@ export default class DataQuality extends React.Component {
                         raw quarterly submission files, including Quarterly Assurance Statements from Senior Accountable Officials of each agency about known data quality issues, are&nbsp;
                         <a
                             target="_blank"
-                            href={`https://files${kGlobalConstants.DEV ? '-nonprod' : ''}.usaspending.gov/agency_submissions/`}
+                            href={`${kGlobalConstants.FILES_SERVER_BASE_URL}/agency_submissions/`}
                             rel="noopener noreferrer"
                             aria-label="Raw quarterly submission files">
                             available here

--- a/src/js/components/bulkDownload/accounts/AccountDataContent.jsx
+++ b/src/js/components/bulkDownload/accounts/AccountDataContent.jsx
@@ -151,7 +151,7 @@ export default class AccountDataContent extends React.Component {
                             . Federal account data is essentially a &ldquo;roll-up&rdquo; of multiple treasury account data.
                         </p>
                         <p>
-                            The files available are categorized by type, according to the scope of spending they cover. More information on the different file types can be found in our <a href={`https://files${kGlobalConstants.DEV ? '-nonprod' : ''}.usaspending.gov/docs/Custom+Account+Data+Dictionary.xlsx`}>Custom Account Data Dictionary</a>.
+                            The files available are categorized by type, according to the scope of spending they cover. More information on the different file types can be found in our <a href={`${kGlobalConstants.FILES_SERVER_BASE_URL}/docs/Custom+Account+Data+Dictionary.xlsx`}>Custom Account Data Dictionary</a>.
                         </p>
                     </div>
                     <div className="download-info__section">

--- a/src/js/dataMapping/navigation/menuOptions.jsx
+++ b/src/js/dataMapping/navigation/menuOptions.jsx
@@ -90,7 +90,7 @@ export const downloadOptions = [
     {
         label: 'Agency Submission Files',
         type: 'snapshots',
-        url: `https://files${kGlobalConstants.DEV ? '-nonprod' : ''}.usaspending.gov/agency_submissions/`,
+        url: `${kGlobalConstants.FILES_SERVER_BASE_URL}/agency_submissions/`,
         code: 'submission',
         description: 'Raw, unadulterated data submitted by federal agencies in compliance with the DATA Act.',
         callToAction: 'Download Raw Files',
@@ -101,7 +101,7 @@ export const downloadOptions = [
     {
         label: 'Database Download',
         type: '',
-        url: `https://files${kGlobalConstants.DEV ? '-nonprod' : ''}.usaspending.gov/database_download/`,
+        url: `${kGlobalConstants.FILES_SERVER_BASE_URL}/database_download/`,
         code: 'database',
         description: 'Our entire database available as a download – the most complete download option available for advanced users.',
         callToAction: 'Explore Database Download',
@@ -112,7 +112,7 @@ export const downloadOptions = [
     {
         label: 'API',
         type: '',
-        url: 'https://api.usaspending.gov',
+        url: kGlobalConstants.API.replace("api/", ""),
         code: 'api',
         description: 'An automated way for advanced users to access all the data behind USAspending.gov. Accessible documentation includes tutorials, best practices, and more.',
         callToAction: 'Explore Our API',

--- a/src/js/models/v2/state/BaseStateProfile.js
+++ b/src/js/models/v2/state/BaseStateProfile.js
@@ -52,7 +52,7 @@ const BaseStateProfile = {
     },
     get flag() {
         if (this.id) {
-            return `https://files${kGlobalConstants.DEV ? '-nonprod' : ''}.usaspending.gov/state_flags/${this.id}.png`;
+            return `${kGlobalConstants.FILES_SERVER_BASE_URL}/state_flags/${this.id}.png`;
         }
         return '';
     },

--- a/tests/models/state/BaseStateProfile-test.js
+++ b/tests/models/state/BaseStateProfile-test.js
@@ -70,7 +70,7 @@ describe('BaseStateProfile', () => {
     });
     describe('State flag image', () => {
         it('should determine the filename based on FIPS', () => {
-            expect(state.flag).toEqual(`https://files${kGlobalConstants.DEV ? '-nonprod' : ''}.usaspending.gov/state_flags/06.png`);
+            expect(state.flag).toEqual(`${kGlobalConstants.FILES_SERVER_BASE_URL}/state_flags/06.png`);
         });
     });
 });

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -125,7 +125,10 @@ module.exports = {
             'process.env': {
                 ENV: process.env.ENV
                     ? JSON.stringify(process.env.ENV)
-                    : JSON.stringify('dev')
+                    : JSON.stringify('dev'),
+                FILES_SERVER_BASE_URL: process.env.FILES_SERVER_BASE_URL
+                    ? JSON.stringify(process.env.FILES_SERVER_BASE_URL)
+                    : JSON.stringify('https://files-nonprod.usaspending.gov')
             }
         })
     ]

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -125,10 +125,7 @@ module.exports = {
             'process.env': {
                 ENV: process.env.ENV
                     ? JSON.stringify(process.env.ENV)
-                    : JSON.stringify('dev'),
-                FILES_SERVER_BASE_URL: process.env.FILES_SERVER_BASE_URL
-                    ? JSON.stringify(process.env.FILES_SERVER_BASE_URL)
-                    : JSON.stringify('https://files-nonprod.usaspending.gov')
+                    : JSON.stringify('dev')
             }
         })
     ]


### PR DESCRIPTION
**High level description:**

To support the DTI migration hard coded links links to S3 resources have been updated to support specifying DTI in the URL.

**Technical details:**

Added a new ENV for `FILES_SERVER_BASE_URL` to specify the S3 resources URL. This removes the need to check `ENV` each time the S3 link is referenced and also allows for us to specify DTI as part of the server URL to support migration efforts. 

Currently labeled as `do not merge` until config PRs are made and merged.

**JIRA Ticket:**
[BRUS2DTI-419](https://federal-spending-transparency.atlassian.net/browse/BRUS2DTI-419)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)

Reviewer(s):
- [x] Code review complete
