### PR TITLE
remove npm i

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ COPY package-lock.json /node-workspace
 
 WORKDIR /node-workspace
 
-RUN npm i -g npm@6.14.6
-
 RUN npm ci
 
 COPY . /node-workspace


### PR DESCRIPTION
Given we bumped node to v12, we do not need to install a specific version of npm anymore since node v12 comes with npm v6.12 and npm install alias was created in npm v6.9. 

https://nodejs.org/en/blog/release/v12.13.0/ 
https://npm.community/t/release-npm-6-9-0/5911

- [ ] Code review complete
