### PR TITLE
[DEV-6355] GA Pageview title logging bug

### DIFF
--- a/src/js/components/sharedComponents/metaTags/MetaTags.jsx
+++ b/src/js/components/sharedComponents/metaTags/MetaTags.jsx
@@ -43,9 +43,8 @@ export default class MetaTags extends React.Component {
             this.generateTags();
         }
         if (!isEqual(prevState.tags, this.state.tags)) {
-            if (this.props.og_title !== undefined) {
-                Analytics.pageview(this.props.og_url, this.props.og_title);
-            }
+            const pathname = new URL(this.props.og_url).pathname;
+            Analytics.pageview(pathname, this.props.og_title);
         }
     }
 

--- a/src/js/components/sharedComponents/metaTags/MetaTags.jsx
+++ b/src/js/components/sharedComponents/metaTags/MetaTags.jsx
@@ -5,7 +5,9 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import Analytics from 'helpers/analytics/Analytics';
 import { Helmet } from 'react-helmet';
+import { isEqual } from 'lodash';
 
 const propTypes = {
     og_url: PropTypes.string,
@@ -36,9 +38,14 @@ export default class MetaTags extends React.Component {
         this.generateTags();
     }
 
-    componentDidUpdate(prevProps) {
+    componentDidUpdate(prevProps, prevState) {
         if (prevProps !== this.props) {
             this.generateTags();
+        }
+        if (!isEqual(prevState.tags, this.state.tags)) {
+            if (this.props.og_title !== undefined) {
+                Analytics.pageview(this.props.og_url, this.props.og_title);
+            }
         }
     }
 

--- a/src/js/components/sharedComponents/metaTags/MetaTags.jsx
+++ b/src/js/components/sharedComponents/metaTags/MetaTags.jsx
@@ -36,15 +36,13 @@ export default class MetaTags extends React.Component {
 
     componentDidMount() {
         this.generateTags();
+        const pathname = new URL(this.props.og_url).pathname;
+        Analytics.pageview(pathname, this.props.og_title);
     }
 
-    componentDidUpdate(prevProps, prevState) {
+    componentDidUpdate(prevProps) {
         if (prevProps !== this.props) {
             this.generateTags();
-        }
-        if (!isEqual(prevState.tags, this.state.tags)) {
-            const pathname = new URL(this.props.og_url).pathname;
-            Analytics.pageview(pathname, this.props.og_title);
         }
     }
 

--- a/src/js/components/sharedComponents/metaTags/MetaTags.jsx
+++ b/src/js/components/sharedComponents/metaTags/MetaTags.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Analytics from 'helpers/analytics/Analytics';
 import { Helmet } from 'react-helmet';
-import { isEqual } from 'lodash';
 
 const propTypes = {
     og_url: PropTypes.string,

--- a/src/js/containers/AppContainer.jsx
+++ b/src/js/containers/AppContainer.jsx
@@ -10,7 +10,6 @@ import perflogger from 'redux-perf-middleware';
 import kGlobalConstants from 'GlobalConstants';
 import { BrowserRouter, Switch, Route, useLocation } from 'react-router-dom';
 
-import Analytics from 'helpers/analytics/Analytics';
 import storeSingleton from 'redux/storeSingleton';
 import withGlossaryListener from 'containers/glossary/GlossaryListener';
 import reducers from 'redux/reducers/index';
@@ -58,23 +57,12 @@ const ScrollToTop = () => {
     return null;
 };
 
-const LogPageView = () => {
-    const { pathname } = useLocation();
-
-    useEffect(() => {
-        Analytics.pageview(pathname);
-    }, [pathname]);
-
-    return null;
-};
-
 
 const AppContainer = () => (
     <Provider store={store}>
         <BrowserRouter>
             <Suspense fallback={<Loading isLoading includeHeader includeFooter />}>
                 <ScrollToTop />
-                <LogPageView />
                 <Switch>
                     {routes.filter((route) => !route.hide).map(({ path, component }) => (
                         <Route

--- a/src/js/helpers/analytics/Analytics.js
+++ b/src/js/helpers/analytics/Analytics.js
@@ -64,6 +64,10 @@ const Analytics = {
         }
         else {
             this._execute(
+                'set',
+                { title: pagename }
+            );
+            this._execute(
                 'send',
                 'pageview',
                 pathname

--- a/src/js/helpers/analytics/Analytics.js
+++ b/src/js/helpers/analytics/Analytics.js
@@ -51,13 +51,14 @@ const Analytics = {
             );
         }
     },
-    pageview(pathname) {
+    pageview(pathname, pagename) {
         if (kGlobalConstants.DEV || kGlobalConstants.QAT) {
             window.dataLayer = window.dataLayer || [];
             window.dataLayer.push({
                 event: 'pageview',
                 page: {
-                    url: pathname
+                    url: pathname,
+                    title: pagename
                 }
             });
         }


### PR DESCRIPTION
**High level description:**

This PR addresses the bug in production with GA logging mismatched page titles

**Technical details:**

Moving pageview firing logic to `MetaTags.jsx` so that the pageview event is fired only after the correct page title has been generated

**JIRA Ticket:**
[DEV-6355](https://federal-spending-transparency.atlassian.net/browse/DEV-6355)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [`N/A`] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [`N/A`] Verified mobile/tablet/desktop/monitor responsiveness
- [`N/A`] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [`N/A`] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [`N/A`] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [`N/A`] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [`N/A`] Design review complete `if applicable`
- [`N/A`] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
