### PR TITLE
Hotfix Budget Category table Federal Account links

### DIFF
--- a/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
+++ b/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
@@ -253,7 +253,7 @@ const BudgetCategoriesTableContainer = (props) => {
                     <Link
                         className="federal-account-profile__link"
                         onClick={clickedFedAcctProfile.bind(null, `${budgetCategoryRow.name}`)}
-                        href={`/federal_account/${code}`}>
+                        to={`/federal_account/${code}`}>
                         {budgetCategoryRow.name}
                     </Link>
                 );


### PR DESCRIPTION
**High level description:**

Fixes Federal Account links in the Budget Category table on the COVID profile page.

The following are ALL required for the PR to be merged:

Reviewer(s):
- [ ] Code review complete
