### PR TITLE
Warmfix DEV-6441 homepage links to files.usaspending.gov

### DIFF
--- a/src/js/components/homepage/download/DownloadDetail.jsx
+++ b/src/js/components/homepage/download/DownloadDetail.jsx
@@ -24,7 +24,7 @@ const propTypes = {
     url: PropTypes.string.isRequired,
     newTab: PropTypes.bool,
     externalLink: PropTypes.bool,
-    filesLink: PropTypes.bool
+    internalDomain: PropTypes.bool
 };
 
 export default class DownloadDetail extends React.Component {
@@ -63,7 +63,7 @@ export default class DownloadDetail extends React.Component {
                 </button>
             );
         }
-        else if (this.props.filesLink) {
+        else if (this.props.internalDomain) {
             link = (
                 <a
                     className="download-detail__link"

--- a/src/js/components/homepage/download/DownloadDetail.jsx
+++ b/src/js/components/homepage/download/DownloadDetail.jsx
@@ -23,7 +23,8 @@ const propTypes = {
     callToAction: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
     newTab: PropTypes.bool,
-    externalLink: PropTypes.bool
+    externalLink: PropTypes.bool,
+    filesLink: PropTypes.bool
 };
 
 export default class DownloadDetail extends React.Component {
@@ -60,6 +61,17 @@ export default class DownloadDetail extends React.Component {
                     onClick={this.redirect}>
                     {this.props.callToAction}
                 </button>
+            );
+        }
+        else if (this.props.filesLink) {
+            link = (
+                <a
+                    className="download-detail__link"
+                    href={this.props.url}
+                    {...linkProps}
+                    onClick={clickedHomepageLink.bind(null, this.props.url)}>
+                    {this.props.callToAction}
+                </a>
             );
         }
 

--- a/src/js/dataMapping/navigation/menuOptions.jsx
+++ b/src/js/dataMapping/navigation/menuOptions.jsx
@@ -96,7 +96,7 @@ export const downloadOptions = [
         callToAction: 'Download Raw Files',
         newTab: true,
         enabled: true,
-        filesLink: true
+        internalDomain: true
     },
     {
         label: 'Database Download',
@@ -107,7 +107,7 @@ export const downloadOptions = [
         callToAction: 'Explore Database Download',
         newTab: true,
         enabled: true,
-        filesLink: true
+        internalDomain: true
     },
     {
         label: 'API',
@@ -118,7 +118,7 @@ export const downloadOptions = [
         callToAction: 'Explore Our API',
         newTab: true,
         enabled: true,
-        externalLink: false
+        internalDomain: true
     },
     {
         label: 'Data Dictionary',

--- a/src/js/dataMapping/navigation/menuOptions.jsx
+++ b/src/js/dataMapping/navigation/menuOptions.jsx
@@ -96,7 +96,7 @@ export const downloadOptions = [
         callToAction: 'Download Raw Files',
         newTab: true,
         enabled: true,
-        externalLink: false
+        filesLink: true
     },
     {
         label: 'Database Download',
@@ -107,7 +107,7 @@ export const downloadOptions = [
         callToAction: 'Explore Database Download',
         newTab: true,
         enabled: true,
-        externalLink: false
+        filesLink: true
     },
     {
         label: 'API',


### PR DESCRIPTION
**High level description:**

Fixes three homepage links in the download section.

**Technical details:**

Adds another prop to the `DownloadDetail` component to denote an internal link at a different domain (files.usaspending.gov, api.usaspending.gov).

**JIRA Ticket:**
[DEV-6441](https://federal-spending-transparency.atlassian.net/browse/DEV-6441)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Code review complete
