### PR TITLE
[DEV-6355] Google Analytics Page Views for Dynamic Page Titles

### DIFF
--- a/src/js/components/bulkDownload/BulkDownloadPage.jsx
+++ b/src/js/components/bulkDownload/BulkDownloadPage.jsx
@@ -34,6 +34,13 @@ const propTypes = {
     dataTypes: PropTypes.array
 };
 
+const metaTagsByDataType = {
+    data_dictionary: dataDictionaryPageMetaTags,
+    awards: downloadAwardPageMetaTags,
+    accounts: downloadAccountPageMetaTags,
+    award_data_archive: downloadArchivePageMetaTags
+};
+
 export default class BulkDownloadPage extends React.Component {
     constructor(props) {
         super(props);
@@ -83,29 +90,25 @@ export default class BulkDownloadPage extends React.Component {
             <AwardDataContainer
                 clickedDownload={this.clickedDownload} />
         );
-        let metaTags = downloadAwardPageMetaTags;
         if (this.props.dataType === 'award_data_archive') {
             downloadDataContent = (
                 <AwardDataArchiveContainer />
             );
-            metaTags = downloadArchivePageMetaTags;
         }
         if (this.props.dataType === 'accounts') {
             downloadDataContent = (
                 <AccountDataContainer
                     clickedDownload={this.clickedDownload} />
             );
-            metaTags = downloadAccountPageMetaTags;
         }
         if (this.props.dataType === 'data_dictionary') {
             downloadDataContent = (
                 <DataDictionaryContainer />
             );
-            metaTags = dataDictionaryPageMetaTags;
         }
         return (
             <div className="usa-da-bulk-download-page">
-                <MetaTags {...metaTags} />
+                {Object.keys(metaTagsByDataType).includes(this.props.dataType) && <MetaTags {...metaTagsByDataType[this.props.dataType]} />}
                 <Header />
                 <StickyHeader>
                     <div className="sticky-header__title">

--- a/src/js/components/recipient/RecipientPage.jsx
+++ b/src/js/components/recipient/RecipientPage.jsx
@@ -49,7 +49,7 @@ export default class RecipientPage extends React.Component {
     hideChildRecipientModal = () => this.setState({ showChildRecipientModal: false });
 
     render() {
-        const { id, recipient } = this.props;
+        const { id, recipient, loading } = this.props;
         const slug = `recipient/${id}/${recipient.fy}`;
         let content = (
             <RecipientContent
@@ -65,7 +65,7 @@ export default class RecipientPage extends React.Component {
 
         return (
             <div className="usa-da-recipient-page">
-                {this.props.recipient.overview && <MetaTags {...recipientPageMetaTags(this.props.recipient.overview)} />}
+                {recipient.overview.id && !loading && <MetaTags {...recipientPageMetaTags(this.props.recipient.overview)} />}
                 <Header />
                 <StickyHeader>
                     <div className="sticky-header__title">
@@ -104,3 +104,10 @@ export default class RecipientPage extends React.Component {
 }
 
 RecipientPage.propTypes = propTypes;
+RecipientPage.defaultProps = {
+    loading: true,
+    error: false,
+    id: '',
+    recipient: {},
+    pickedFy: () => { }
+};

--- a/src/js/components/sharedComponents/metaTags/MetaTags.jsx
+++ b/src/js/components/sharedComponents/metaTags/MetaTags.jsx
@@ -3,7 +3,7 @@
  * Created by michaelbray on 5/25/17.
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation } from 'react-router-dom';
 
@@ -26,7 +26,7 @@ const defaultProps = {
     og_image: 'https://usaspending.gov/img/FacebookOG.png'
 };
 
-const isTitleLegit = (title = "USAspending.gov") => {
+const isCustomPageTitleDefined = (title = "USAspending.gov") => {
     if (title === "USAspending.gov") return false;
     if (title.split('|')[0] === ' ') return false;
     return true;
@@ -41,9 +41,6 @@ const MetaTags = ({
 }) => {
     const { pathname } = useLocation();
     const [tags, setTags] = useState([]);
-
-    const previousTitleRef = useRef(null);
-    const { current: previousTitle } = previousTitleRef;
 
     const generateTags = () => {
         const newTags = [];
@@ -85,9 +82,8 @@ const MetaTags = ({
     };
 
     useEffect(() => {
-        previousTitleRef.current = title;
         generateTags();
-        if (isTitleLegit(title) && title !== previousTitle) {
+        if (isCustomPageTitleDefined(title)) {
             Analytics.pageview(pathname, title);
         }
     }, [title]);

--- a/src/js/components/sharedComponents/metaTags/MetaTags.jsx
+++ b/src/js/components/sharedComponents/metaTags/MetaTags.jsx
@@ -3,8 +3,10 @@
  * Created by michaelbray on 5/25/17.
  */
 
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import { useLocation } from 'react-router-dom';
+
 import Analytics from 'helpers/analytics/Analytics';
 import { Helmet } from 'react-helmet';
 
@@ -24,76 +26,90 @@ const defaultProps = {
     og_image: 'https://usaspending.gov/img/FacebookOG.png'
 };
 
-export default class MetaTags extends React.Component {
-    constructor(props) {
-        super(props);
+const isTitleLegit = (title = "USAspending.gov") => {
+    if (title === "USAspending.gov") return false;
+    if (title.split('|')[0] === ' ') return false;
+    return true;
+};
 
-        this.state = {
-            tags: []
-        };
-    }
+const MetaTags = ({
+    og_url: url,
+    og_title: title,
+    og_description: description,
+    og_site_name: siteName,
+    og_image: image
+}) => {
+    const { pathname } = useLocation();
+    const [tags, setTags] = useState([]);
 
-    componentDidMount() {
-        this.generateTags();
-        const pathname = new URL(this.props.og_url).pathname;
-        Analytics.pageview(pathname, this.props.og_title);
-    }
+    const previousTitleRef = useRef(null);
+    const { current: previousTitle } = previousTitleRef;
 
-    componentDidUpdate(prevProps) {
-        if (prevProps !== this.props) {
-            this.generateTags();
-        }
-    }
+    const generateTags = () => {
+        const newTags = [];
 
-    generateTags() {
-        const tags = [];
-
-        if (this.props.og_url !== '') {
-            tags.push(<meta
+        if (url !== '') {
+            newTags.push(<meta
                 property="og:url"
-                content={this.props.og_url}
+                content={url}
                 key="og_url" />);
         }
-        if (this.props.og_title !== '') {
-            tags.push(<meta
+        if (title !== '') {
+            newTags.push(<meta
                 property="og:title"
-                content={this.props.og_title}
+                content={title}
                 key="og_title" />);
-            tags.push(<title key="title">{this.props.og_title}</title>);
+            newTags.push(<title key="title">{title}</title>);
         }
-        if (this.props.og_description !== '') {
-            tags.push(<meta
+        if (description !== '') {
+            newTags.push(<meta
                 name="description"
                 property="og:description"
-                content={this.props.og_description}
+                content={description}
                 key="og_description" />);
         }
-        if (this.props.og_site_name !== '') {
-            tags.push(<meta
+        if (siteName !== '') {
+            newTags.push(<meta
                 property="og:site_name"
-                content={this.props.og_site_name}
+                content={siteName}
                 key="og_site_name" />);
         }
-        if (this.props.og_image !== '') {
-            tags.push(<meta
+        if (image !== '') {
+            newTags.push(<meta
                 property="og:image"
-                content={this.props.og_image}
+                content={image}
                 key="og_image" />);
         }
 
-        this.setState({
-            tags
-        });
-    }
+        setTags(newTags);
+    };
 
-    render() {
-        return (
-            <Helmet>
-                {this.state.tags}
-            </Helmet>
-        );
-    }
-}
+    useEffect(() => {
+        previousTitleRef.current = title;
+        generateTags();
+        if (isTitleLegit(title) && title !== previousTitle) {
+            Analytics.pageview(pathname, title);
+        }
+    }, [title]);
+
+    useEffect(() => {
+        generateTags();
+    }, [
+        url,
+        title,
+        description,
+        siteName,
+        image
+    ]);
+
+    return (
+        <Helmet>
+            {tags}
+        </Helmet>
+    );
+};
 
 MetaTags.propTypes = propTypes;
 MetaTags.defaultProps = defaultProps;
+
+export default MetaTags;

--- a/src/js/containers/agency/AgencyContainer.jsx
+++ b/src/js/containers/agency/AgencyContainer.jsx
@@ -21,6 +21,7 @@ require('pages/agency/agencyPage.scss');
 const propTypes = {
     agency: PropTypes.object,
     setAgencyOverview: PropTypes.func,
+    resetAgency: PropTypes.func,
     match: PropTypes.object
 };
 
@@ -47,6 +48,10 @@ export class AgencyContainer extends React.Component {
         if (this.props.match.params.agencyId !== prevProps.match.params.agencyId) {
             this.loadAgencyOverview(this.props.match.params.agencyId);
         }
+    }
+
+    componentWillUnmount() {
+        this.props.resetAgency();
     }
 
     loadAgencyOverview(id) {

--- a/src/js/containers/recipient/RecipientContainer.jsx
+++ b/src/js/containers/recipient/RecipientContainer.jsx
@@ -21,6 +21,7 @@ require('pages/recipient/recipientPage.scss');
 const propTypes = {
     setRecipientOverview: PropTypes.func,
     setRecipientFiscalYear: PropTypes.func,
+    resetRecipient: PropTypes.func,
     recipient: PropTypes.object,
     match: PropTypes.object,
     history: PropTypes.object
@@ -67,6 +68,7 @@ export class RecipientContainer extends React.Component {
     componentWillUnmount() {
         // Reset the FY
         this.props.setRecipientFiscalYear('latest');
+        this.props.resetRecipient();
     }
 
     loadRecipientOverview(id, year) {

--- a/src/js/containers/state/StateContainer.jsx
+++ b/src/js/containers/state/StateContainer.jsx
@@ -22,6 +22,7 @@ require('pages/state/statePage.scss');
 const propTypes = {
     stateProfile: PropTypes.object,
     setStateOverview: PropTypes.func,
+    resetState: PropTypes.func,
     setStateFiscalYear: PropTypes.func,
     setStateCenter: PropTypes.func,
     match: PropTypes.object,
@@ -68,6 +69,10 @@ export class StateContainer extends React.Component {
         if (this.props.stateProfile.fy !== prevProps.stateProfile.fy) {
             this.loadStateOverview(this.props.match.params.stateId, this.props.stateProfile.fy);
         }
+    }
+
+    componentWillUnmount() {
+        this.props.resetState();
     }
 
     onClickFy(fy) {

--- a/src/js/redux/reducers/recipient/recipientReducer.js
+++ b/src/js/redux/reducers/recipient/recipientReducer.js
@@ -6,7 +6,7 @@
 import BaseRecipientOverview from 'models/v2/recipient/BaseRecipientOverview';
 
 const recipientOverview = Object.create(BaseRecipientOverview);
-recipientOverview.populate({});
+recipientOverview.populate({ name: ' ' });
 
 export const initialState = {
     id: '',
@@ -30,6 +30,8 @@ const recipientReducer = (state = initialState, action) => {
             return Object.assign({}, state, {
                 children: action.children
             });
+        case 'RESET_RECIPIENT':
+            return Object.assign({}, initialState);
         case 'RESET_AGENCY':
             return Object.assign({}, initialState);
         default:


### PR DESCRIPTION
**High level description:**
Fixes bug where previous state/recipient/agency/account page titles were logged under the url.

**Technical details:**

82b0665 using componentWillUnmount to clear out redux for agency, state, account & recipient pages
936aa98 using helper fn and prevProps to determine when to log a new page view (we have to wait for react and the API in some cases)
510111f removing let declarations resulting in unwanted side-effects

**JIRA Ticket:**
[DEV-6355](https://federal-spending-transparency.atlassian.net/browse/DEV-6355)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A`Verified mobile/tablet/desktop/monitor responsiveness
`N/A`Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A`Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A`[API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A`[Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A`Design review complete `if applicable`
`N/A`[API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
