### PR TITLE
DEV-6420 & DEV-6414 COVID Budget Category table resiliency

### DIFF
--- a/src/_scss/layouts/default/header/_warning.scss
+++ b/src/_scss/layouts/default/header/_warning.scss
@@ -76,7 +76,7 @@
                 position: fixed;
                 // right underneath the site header @ 66px
                 top: rem(66);
-                z-index: 3;
+                z-index: 4;
                 left: 0;
             }
         }

--- a/src/js/containers/covid19/Covid19Container.jsx
+++ b/src/js/containers/covid19/Covid19Container.jsx
@@ -127,24 +127,20 @@ const Covid19Container = () => {
                 }
             };
             awardAmountRequest.current = fetchAwardAmounts(params);
-            awardAmountRequest.current.promise
-                .then(({
-                    data: {
-                        obligation,
-                        outlay,
-                        award_count: awardCount,
-                        face_value_of_loan: faceValueOfLoan
-                    }
-                }) => {
-                    // set totals in redux, we can use totals elsewhere to calculate unlinked data
-                    const totals = {
-                        obligation,
-                        outlay,
-                        awardCount,
-                        faceValueOfLoan
-                    };
-                    dispatch(setTotals('', totals));
-                });
+            try {
+                const { data } = await awardAmountRequest.current.promise;
+                // set totals in redux, we can use totals elsewhere to calculate unlinked data
+                const totals = {
+                    obligation: data.obligation,
+                    outlay: data.outlay,
+                    awardCount: data.award_count,
+                    faceValueOfLoan: data.face_value_of_loan
+                };
+                dispatch(setTotals('', totals));
+            }
+            catch (e) {
+                console.log(' Error Amounts : ', e.message);
+            }
         };
         if (defCodes.length) {
             getOverviewData();

--- a/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
+++ b/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
@@ -181,8 +181,7 @@ const BudgetCategoriesTableContainer = (props) => {
         const overviewTotals = {
             totalBudgetaryResources: overview._totalBudgetAuthority,
             obligation: overview._totalObligations,
-            outlay: overview._totalOutlays,
-            awardCount: allAwardTypeTotals.awardCount
+            outlay: overview._totalOutlays
         };
         const unlinkedData = calculateUnlinkedTotals(overviewTotals, totals);
 
@@ -194,9 +193,6 @@ const BudgetCategoriesTableContainer = (props) => {
         }
         else if (props.type === 'object_class' && spendingCategory === 'total_spending') {
             unlinkedName = 'Unknown Object Class (Unlinked Data)';
-        }
-        else if (spendingCategory === 'award_spending') {
-            unlinkedName = 'Number of Unlinked Awards';
         }
 
         if (unlinkedName && unlinkedData && overview) {
@@ -290,7 +286,7 @@ const BudgetCategoriesTableContainer = (props) => {
         }
 
         setLoading(true);
-        if (defCodes && defCodes.length > 0 && spendingCategory && overview && allAwardTypeTotals.awardCount) {
+        if (defCodes && defCodes.length > 0 && spendingCategory && overview) {
             const apiSortField = sort === 'name' ? budgetCategoriesNameSort[props.type] : snakeCase(sort);
             const params = {
                 filter: {


### PR DESCRIPTION
**High level description:**

Fix one API request error preventing the rest of the COVID-19 Budget Categories table data from loading and remove the "Unlinked Awards" row from the Award Spending view.

**Technical details:**

- Added a try/catch block to the award amounts request to match the format of other requests
- Removes the check for total award count (populated by the endpoint that was 504-ing) that was previously required to load table data
- Also fixes a z-index issue that was causing the loading message to display on top of the sticky banner

**JIRA Tickets:**
- [DEV-6420](https://federal-spending-transparency.atlassian.net/browse/DEV-6420)
- [DEV-6414](https://federal-spending-transparency.atlassian.net/browse/DEV-6414)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA tickets
- [x] Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- N/A Verified mobile/tablet/desktop/monitor responsiveness
- N/A Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Code review complete
