### PR TITLE
dev-6486 remove "10,000 results" wording from tip

### DIFF
--- a/src/js/components/search/visualizations/time/TimeVisualizationSection.jsx
+++ b/src/js/components/search/visualizations/time/TimeVisualizationSection.jsx
@@ -70,7 +70,7 @@ export default class TimeVisualizationSection extends React.Component {
         <>
             <div className="tooltip__title">Download data by {capitalize(this.props.data.visualizationPeriod === 'fiscal_year' ? 'year' : this.props.data.visualizationPeriod)}</div>
             <div className="tooltip__text">
-                Download a CSV of award spending that matches your search criteria, broken down by {this.props.data.visualizationPeriod === 'fiscal_year' ? 'year' : this.props.data.visualizationPeriod}. For complete download results, click on the “Download” button in the top right of this page.
+                Download a CSV of award spending data that matches your search criteria, broken down by year. For complete download results, click on the &quot;Download&quot; button on the top right of this page.
             </div>
         </>
     );

--- a/src/js/components/search/visualizations/time/TimeVisualizationSection.jsx
+++ b/src/js/components/search/visualizations/time/TimeVisualizationSection.jsx
@@ -70,7 +70,7 @@ export default class TimeVisualizationSection extends React.Component {
         <>
             <div className="tooltip__title">Download data by {capitalize(this.props.data.visualizationPeriod === 'fiscal_year' ? 'year' : this.props.data.visualizationPeriod)}</div>
             <div className="tooltip__text">
-                Download a CSV of award spending that matches your search criteria, broken down by {this.props.data.visualizationPeriod === 'fiscal_year' ? 'year' : this.props.data.visualizationPeriod}. Note that only the first 10,000 results will be returned. For complete download results, click on the “Download” button in the top right of this page.
+                Download a CSV of award spending that matches your search criteria, broken down by {this.props.data.visualizationPeriod === 'fiscal_year' ? 'year' : this.props.data.visualizationPeriod}. For complete download results, click on the “Download” button in the top right of this page.
             </div>
         </>
     );


### PR DESCRIPTION
**High level description:**

Update wording for Adv Search Time tab tooltip to "Download a CSV of award spending data that matches your search criteria, broken down by year. For complete download results, click on the “Download” button on the top right of this page."

**Technical details:**

none

**JIRA Ticket:**
[DEV-6486]https://federal-spending-transparency.atlassian.net/browse/DEV-6486)

**Mockup:**
none

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Design review complete `if applicable`
- [x] Code review complete
