### PR TITLE
DEV-6488 Agency Submission Statistics refactor (part 1)

### DIFF
--- a/src/_scss/pages/aboutTheData/agencyDetailsPage.scss
+++ b/src/_scss/pages/aboutTheData/agencyDetailsPage.scss
@@ -114,7 +114,6 @@
       }
 
       .heading-container {
-          padding-left: rem(20);
           .header {
             margin-top: rem(10);
             margin-bottom: 0;
@@ -146,10 +145,9 @@
             width: 100%;
             @include display(inline-flex);
             @include flex-wrap(wrap);
-            margin-top: rem(0);
+            margin-bottom: rem(30);
             @media (max-width: $tablet-screen) {
                 margin-top: rem(10);
-                margin-bottom: rem(30);
             }
             .more-info-note {
               margin: 0;

--- a/src/_scss/pages/aboutTheData/agencyDetailsPage.scss
+++ b/src/_scss/pages/aboutTheData/agencyDetailsPage.scss
@@ -7,13 +7,15 @@
       @include display(flex);
       @include flex-wrap(wrap);
       @include flex-direction(column);
-      margin: rem(40) rem(20);
+      margin: rem(40) auto;
       background: $color-white;
       border-radius: 0.5rem 0.5rem 0 0;
       padding: 0 rem(20);
       width: 100%;
       max-width: 160rem;
-      margin: auto;
+      .usda-message {
+        background-color: $color-white;
+      }
       .table-container,
         .table-controls {
           width: 100%;
@@ -182,9 +184,10 @@
         .default-note {
           font-style: italic;
           margin: 0;
-          padding-top: rem(30);
+          padding: rem(30) rem(15);
           letter-spacing: 0;
           line-height: rem(22);
+          max-width: rem(873);
         }
     }
   }

--- a/src/_scss/pages/aboutTheData/agencyDetailsPage.scss
+++ b/src/_scss/pages/aboutTheData/agencyDetailsPage.scss
@@ -31,9 +31,6 @@
               @include display(flex);
             }
           }
-          .usa-dt-picker__list {
-            max-width: rem(500);
-          }
         }
         .table-container  {
           height: rem(500);
@@ -110,13 +107,12 @@
       .agency-table-download {
         a {
           color: $color-primary;
-          text-decoration: underline;
         }
         .usa-button-link__download-icon {
           padding-right: rem(10);
         }
       }
-  
+
       .heading-container {
           padding-left: rem(20);
           .header {
@@ -146,7 +142,7 @@
             letter-spacing: 0;
             line-height: rem(59);
           }
-          .lower-details {
+          .agency-info {
             width: 100%;
             @include display(inline-flex);
             @include flex-wrap(wrap);
@@ -154,9 +150,6 @@
             @media (max-width: $tablet-screen) {
                 margin-top: rem(10);
                 margin-bottom: rem(30);
-            }
-            .usa-button-link {
-              text-decoration: underline;   
             }
             .more-info-note {
               margin: 0;
@@ -166,7 +159,7 @@
               line-height: rem(18);
             }
 
-            .agency-info-group {
+            .agency-info__group {
                 &:first-of-type {
                   padding-right: rem(60);
                 }
@@ -178,22 +171,12 @@
                     margin: rem(5) 0;
                 }
 
-                .agency-website {
+                .agency-info__website {
                     font-size: rem(14);
                     line-height: rem(20);
                     margin: rem(14) 0;
-                    a {
-                      text-decoration: underline;
-                    }
-                    a:visited {
-                      color: $color-primary;
-                    }
-                    svg.svg-inline--fa {
-                      font-size: rem(14);
-                      width: 0.8em;
-                    }
+                    @import 'components/externalLink';
                 }
-
             }
           }
       }
@@ -207,4 +190,3 @@
         }
     }
   }
-  

--- a/src/js/components/aboutTheData/AgencyDetailsPage.jsx
+++ b/src/js/components/aboutTheData/AgencyDetailsPage.jsx
@@ -1,0 +1,114 @@
+/**
+ * AgencyDetailsPage.jsx
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { agencyPageMetaTags } from 'helpers/metaTagHelper';
+import { fetchAgencyOverview } from 'helpers/agencyV2Helper';
+
+import MetaTags from 'components/sharedComponents/metaTags/MetaTags';
+import Header from 'containers/shared/HeaderContainer';
+import Footer from 'containers/Footer';
+import StickyHeader from 'components/sharedComponents/stickyHeader/StickyHeader';
+import Note from 'components/sharedComponents/Note';
+import AgencyDetailsContainer from 'containers/aboutTheData/AgencyDetailsContainer';
+import { modalTitles, modalClassNames } from 'dataMapping/aboutTheData/modals';
+import AboutTheDataModal from './AboutTheDataModal';
+
+require('pages/aboutTheData/agenciesDetailPage.scss');
+
+const message = 'All numeric figures in this table are calculated based on the set of TAS owned by each agency, as opposed to the set of TAS that the agency directly reported to USAspending.gov. In the vast majority of cases, these are exactly the same (upwards of 95% of TAS—with these TAS representing over 99% of spending—are submitted and owned by the same agency). This display decision is consistent with our practice throughout the website of grouping TAS by the owning agency rather than the reporting agency. While reporting agencies are not identified in this table, they are available in the Custom Account Download in the reporting_agency_name field.';
+
+const propTypes = {
+    agencyCode: PropTypes.string
+};
+
+const AgencyDetailsPage = () => {
+    const { agencyCode } = useParams();
+    // TODO - write agency overview data model
+    const [agencyOverview, setAgencyOverview] = useState({ name: '', toptier_code: '', website: '' });
+    const [showModal, setShowModal] = useState('');
+    const [modalAgency, setModalAgency] = useState('');
+
+    const modalClick = (modalType, agencyName) => {
+        setShowModal(modalType);
+        setModalAgency(agencyName);
+    };
+    const closeModal = () => setShowModal('');
+
+    useEffect(() => {
+        // request overview for agency
+        const agencyOverviewRequest = fetchAgencyOverview(agencyCode);
+        agencyOverviewRequest.promise
+            .then((res) => {
+                // TODO - parse the response using our data model
+                setAgencyOverview(res.data);
+            }).catch((err) => {
+                console.error(err);
+            });
+    }, [agencyCode]);
+
+    return (
+        <div className="usa-da__about-the-data__agencies-page">
+            <MetaTags {...agencyPageMetaTags} />
+            <Header />
+            <StickyHeader>
+                <div className="sticky-header__title">
+                    <h1 tabIndex={-1}>
+                        Agency Submission Data
+                    </h1>
+                </div>
+            </StickyHeader>
+            <main id="main-content" className="main-content">
+                <div className="heading-container">
+                    <div className="back-link">
+                        <a href="/about-the-data/agencies"><FontAwesomeIcon icon="angle-left" />&nbsp;Back to All Agencies</a>
+                    </div>
+                    <h2 className="header">Submission Data</h2>
+                    <h2 className="sub-header">{agencyOverview.name}</h2>
+                    <div className="lower-details">
+                        <div className="agency-info-group">
+                            <h5>Agency Contact Information</h5>
+                            <div className="more-info-note">Contact this Agency with questions about their submissions</div>
+                            <div className="agency-website">
+                                <Link to={agencyOverview.website}>
+                                    {agencyOverview.website}
+                                    <FontAwesomeIcon icon="external-link-alt" />
+                                </Link>
+                            </div>
+                        </div>
+                        <div className="agency-info-group">
+                            <h5>Agency Profile Page</h5>
+                            <div className="more-info-note">Learn more about this Agency&#39;s spending</div>
+                            <div className="agency-website">
+                                <Link to={`/agency/${agencyOverview.toptier_code}`}>
+                                    {agencyOverview.name}
+                                </Link>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <AgencyDetailsContainer agencyName={agencyOverview.name} modalClick={modalClick} />
+                <Note message={message} />
+                <AboutTheDataModal
+                    mounted={!!showModal.length}
+                    type={showModal}
+                    className={modalClassNames[showModal]}
+                    title={modalTitles[showModal]}
+                    agencyName={modalAgency}
+                    fiscalYear={2020}
+                    fiscalPeriod={8}
+                    closeModal={closeModal}
+                    totalObligationsNotInGTAS={45999} />
+            </main>
+            <Footer />
+        </div>
+    );
+};
+
+AgencyDetailsPage.propTypes = propTypes;
+export default AgencyDetailsPage;

--- a/src/js/components/aboutTheData/AgencyDetailsPage.jsx
+++ b/src/js/components/aboutTheData/AgencyDetailsPage.jsx
@@ -69,8 +69,7 @@ const AgencyDetailsPage = () => {
                     <div className="back-link">
                         <a href="/about-the-data/agencies"><FontAwesomeIcon icon="angle-left" />&nbsp;Back to All Agencies</a>
                     </div>
-                    <h2 className="header">Submission Data</h2>
-                    <h2 className="sub-header">{agencyOverview.name}</h2>
+                    <h2 className="header">{agencyOverview.name}</h2>
                     <div className="agency-info">
                         <div className="agency-info__group">
                             <h5>Agency Contact Information</h5>

--- a/src/js/components/aboutTheData/AgencyDetailsPage.jsx
+++ b/src/js/components/aboutTheData/AgencyDetailsPage.jsx
@@ -30,9 +30,7 @@ const AgencyDetailsPage = () => {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');
-    const initialAgency = Object.create(BaseAgencyOverview);
-    initialAgency.populate();
-    const [agencyOverview, setAgencyOverview] = useState(Object.create(initialAgency));
+    const [agencyOverview, setAgencyOverview] = useState(null);
     const [showModal, setShowModal] = useState('');
     const [modalAgency, setModalAgency] = useState('');
 

--- a/src/js/components/aboutTheData/AgencyDetailsPage.jsx
+++ b/src/js/components/aboutTheData/AgencyDetailsPage.jsx
@@ -17,9 +17,10 @@ import StickyHeader from 'components/sharedComponents/stickyHeader/StickyHeader'
 import Note from 'components/sharedComponents/Note';
 import AgencyDetailsContainer from 'containers/aboutTheData/AgencyDetailsContainer';
 import { modalTitles, modalClassNames } from 'dataMapping/aboutTheData/modals';
+import ExternalLink from 'components/sharedComponents/ExternalLink';
 import AboutTheDataModal from './AboutTheDataModal';
 
-require('pages/aboutTheData/agenciesDetailPage.scss');
+require('pages/aboutTheData/agencyDetailsPage.scss');
 
 const message = 'All numeric figures in this table are calculated based on the set of TAS owned by each agency, as opposed to the set of TAS that the agency directly reported to USAspending.gov. In the vast majority of cases, these are exactly the same (upwards of 95% of TAS—with these TAS representing over 99% of spending—are submitted and owned by the same agency). This display decision is consistent with our practice throughout the website of grouping TAS by the owning agency rather than the reporting agency. While reporting agencies are not identified in this table, they are available in the Custom Account Download in the reporting_agency_name field.';
 
@@ -70,21 +71,18 @@ const AgencyDetailsPage = () => {
                     </div>
                     <h2 className="header">Submission Data</h2>
                     <h2 className="sub-header">{agencyOverview.name}</h2>
-                    <div className="lower-details">
-                        <div className="agency-info-group">
+                    <div className="agency-info">
+                        <div className="agency-info__group">
                             <h5>Agency Contact Information</h5>
                             <div className="more-info-note">Contact this Agency with questions about their submissions</div>
-                            <div className="agency-website">
-                                <Link to={agencyOverview.website}>
-                                    {agencyOverview.website}
-                                    <FontAwesomeIcon icon="external-link-alt" />
-                                </Link>
+                            <div className="agency-info__website">
+                                <ExternalLink url={agencyOverview.website} />
                             </div>
                         </div>
-                        <div className="agency-info-group">
+                        <div className="agency-info__group">
                             <h5>Agency Profile Page</h5>
                             <div className="more-info-note">Learn more about this Agency&#39;s spending</div>
-                            <div className="agency-website">
+                            <div className="agency-info__website">
                                 <Link to={`/agency/${agencyOverview.toptier_code}`}>
                                     {agencyOverview.name}
                                 </Link>

--- a/src/js/components/aboutTheData/AgencyDetailsPage.jsx
+++ b/src/js/components/aboutTheData/AgencyDetailsPage.jsx
@@ -4,11 +4,11 @@
 
 import React, { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { LoadingMessage, ErrorMessage } from 'data-transparency-ui';
 
 import { agencyPageMetaTags } from 'helpers/metaTagHelper';
-import { fetchAgencyOverview } from 'helpers/agencyV2Helper';
+import { mockFetchAgencyOverview } from 'helpers/agencyV2Helper';
 
 import MetaTags from 'components/sharedComponents/metaTags/MetaTags';
 import Header from 'containers/shared/HeaderContainer';
@@ -17,6 +17,7 @@ import StickyHeader from 'components/sharedComponents/stickyHeader/StickyHeader'
 import Note from 'components/sharedComponents/Note';
 import AgencyDetailsContainer from 'containers/aboutTheData/AgencyDetailsContainer';
 import { modalTitles, modalClassNames } from 'dataMapping/aboutTheData/modals';
+import BaseAgencyOverview from 'models/v2/agencyV2/BaseAgencyOverview';
 import ExternalLink from 'components/sharedComponents/ExternalLink';
 import AboutTheDataModal from './AboutTheDataModal';
 
@@ -24,14 +25,14 @@ require('pages/aboutTheData/agencyDetailsPage.scss');
 
 const message = 'All numeric figures in this table are calculated based on the set of TAS owned by each agency, as opposed to the set of TAS that the agency directly reported to USAspending.gov. In the vast majority of cases, these are exactly the same (upwards of 95% of TAS—with these TAS representing over 99% of spending—are submitted and owned by the same agency). This display decision is consistent with our practice throughout the website of grouping TAS by the owning agency rather than the reporting agency. While reporting agencies are not identified in this table, they are available in the Custom Account Download in the reporting_agency_name field.';
 
-const propTypes = {
-    agencyCode: PropTypes.string
-};
-
 const AgencyDetailsPage = () => {
     const { agencyCode } = useParams();
-    // TODO - write agency overview data model
-    const [agencyOverview, setAgencyOverview] = useState({ name: '', toptier_code: '', website: '' });
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(false);
+    const [errorMessage, setErrorMessage] = useState('');
+    const initialAgency = Object.create(BaseAgencyOverview);
+    initialAgency.populate();
+    const [agencyOverview, setAgencyOverview] = useState(Object.create(initialAgency));
     const [showModal, setShowModal] = useState('');
     const [modalAgency, setModalAgency] = useState('');
 
@@ -42,14 +43,19 @@ const AgencyDetailsPage = () => {
     const closeModal = () => setShowModal('');
 
     useEffect(() => {
-        // request overview for agency
-        const agencyOverviewRequest = fetchAgencyOverview(agencyCode);
+        // TODO - replace mock API request
+        const agencyOverviewRequest = mockFetchAgencyOverview(agencyCode);
         agencyOverviewRequest.promise
             .then((res) => {
-                // TODO - parse the response using our data model
-                setAgencyOverview(res.data);
+                const agency = Object.create(BaseAgencyOverview);
+                agency.populate(res.data);
+                setAgencyOverview(agency);
+                setLoading(false);
             }).catch((err) => {
                 console.error(err);
+                setErrorMessage(err.message);
+                setLoading(false);
+                setError(true);
             });
     }, [agencyCode]);
 
@@ -65,32 +71,42 @@ const AgencyDetailsPage = () => {
                 </div>
             </StickyHeader>
             <main id="main-content" className="main-content">
-                <div className="heading-container">
-                    <div className="back-link">
-                        <a href="/about-the-data/agencies"><FontAwesomeIcon icon="angle-left" />&nbsp;Back to All Agencies</a>
-                    </div>
-                    <h2 className="header">{agencyOverview.name}</h2>
-                    <div className="agency-info">
-                        <div className="agency-info__group">
-                            <h5>Agency Contact Information</h5>
-                            <div className="more-info-note">Contact this Agency with questions about their submissions</div>
-                            <div className="agency-info__website">
-                                <ExternalLink url={agencyOverview.website} />
+                {loading && <LoadingMessage />}
+                {error && <ErrorMessage description={errorMessage} />}
+                {(!loading && !error) && (
+                    <>
+                        <div className="heading-container">
+                            <div className="back-link">
+                                <a href="/about-the-data/agencies"><FontAwesomeIcon icon="angle-left" />&nbsp;Back to All Agencies</a>
+                            </div>
+                            <h2 className="header">{agencyOverview.name}</h2>
+                            <div className="agency-info">
+                                {agencyOverview.website && (
+                                    <div className="agency-info__group">
+                                        <h5>Agency Contact Information</h5>
+                                        <div className="more-info-note">Contact this Agency with questions about their submissions</div>
+                                        <div className="agency-info__website">
+                                            <ExternalLink url={agencyOverview.website} />
+                                        </div>
+                                    </div>
+                                )}
+                                {agencyOverview.id && (
+                                    <div className="agency-info__group">
+                                        <h5>Agency Profile Page</h5>
+                                        <div className="more-info-note">Learn more about this Agency&#39;s spending</div>
+                                        <div className="agency-info__website">
+                                            <Link to={`/agency/${agencyOverview.id}`}>
+                                                {agencyOverview.name}
+                                            </Link>
+                                        </div>
+                                    </div>
+                                )}
                             </div>
                         </div>
-                        <div className="agency-info__group">
-                            <h5>Agency Profile Page</h5>
-                            <div className="more-info-note">Learn more about this Agency&#39;s spending</div>
-                            <div className="agency-info__website">
-                                <Link to={`/agency/${agencyOverview.toptier_code}`}>
-                                    {agencyOverview.name}
-                                </Link>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <AgencyDetailsContainer agencyName={agencyOverview.name} modalClick={modalClick} />
-                <Note message={message} />
+                        <AgencyDetailsContainer agencyName={agencyOverview.name} modalClick={modalClick} />
+                        <Note message={message} />
+                    </>
+                )}
                 <AboutTheDataModal
                     mounted={!!showModal.length}
                     type={showModal}
@@ -107,5 +123,4 @@ const AgencyDetailsPage = () => {
     );
 };
 
-AgencyDetailsPage.propTypes = propTypes;
 export default AgencyDetailsPage;

--- a/src/js/containers/aboutTheData/AgencyDetailsContainer.jsx
+++ b/src/js/containers/aboutTheData/AgencyDetailsContainer.jsx
@@ -202,7 +202,6 @@ const mockAPIResponse = {
 };
 
 const propTypes = {
-    // agencyCode: PropTypes.string,
     agencyName: PropTypes.string,
     modalClick: PropTypes.func
 };

--- a/src/js/containers/aboutTheData/AgencyDetailsContainer.jsx
+++ b/src/js/containers/aboutTheData/AgencyDetailsContainer.jsx
@@ -1,29 +1,14 @@
-import React, { useRef, useEffect, useState } from 'react';
-import { useParams, withRouter, Link } from "react-router-dom";
-import { useDispatch, connect } from "react-redux";
+/**
+ * AgencyDetailsContainer.jsx
+ */
+
+import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Table, TooltipComponent, TooltipWrapper } from "data-transparency-ui";
+import { Table, TooltipComponent, TooltipWrapper } from 'data-transparency-ui';
 import { throttle } from 'lodash';
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-import { agencyPageMetaTags } from 'helpers/metaTagHelper';
-import { fetchAgencyOverview } from 'helpers/agencyHelper';
-import { setAgencyOverview } from 'redux/actions/agency/agencyActions';
-import AgencyOverviewModel from 'models/agency/AgencyOverviewModel';
-import * as agencyActions from 'redux/actions/agency/agencyActions';
-import { bindActionCreators } from 'redux';
-
-import MetaTags from 'components/sharedComponents/metaTags/MetaTags';
-import Header from 'containers/shared/HeaderContainer';
-import Footer from 'containers/Footer';
-import StickyHeader from 'components/sharedComponents/stickyHeader/StickyHeader';
-import Note from 'components/sharedComponents/Note';
 import AgencyDownloadLinkCell from 'components/aboutTheData/AgencyDownloadLinkCell';
 import CellWithModal from 'components/aboutTheData/CellWithModal';
-import AboutTheDataModal from "components/aboutTheData/AboutTheDataModal";
-import { modalTitles, modalClassNames } from 'dataMapping/aboutTheData/modals';
-
-require('pages/aboutTheData/agenciesDetailPage.scss');
 
 const Tooltip = ({ title }) => (
     <TooltipComponent title={title}>
@@ -216,20 +201,15 @@ const mockAPIResponse = {
     ]
 };
 
-const message = "All numeric figures in this table are calculated based on the set of TAS owned by each agency, as opposed to the set of TAS that the agency directly reported to USAspending.gov. In the vast majority of cases, these are exactly the same (upwards of 95% of TAS—with these TAS representing over 99% of spending—are submitted and owned by the same agency). This display decision is consistent with our practice throughout the website of grouping TAS by the owning agency rather than the reporting agency. While reporting agencies are not identified in this table, they are available in the Custom Account Download in the reporting_agency_name field.";
-
 const propTypes = {
-    agency: PropTypes.object,
-    agencyId: PropTypes.string
+    // agencyCode: PropTypes.string,
+    agencyName: PropTypes.string,
+    modalClick: PropTypes.func
 };
 
-export const AgenciesDetailContainer = (props) => {
-    const [sortStatus, updateSort] = useState({ field: "", direction: "asc" });
+const AgencyDetailsContainer = ({ modalClick, agencyName }) => {
+    const [sortStatus, updateSort] = useState({ field: '', direction: 'asc' });
     const [{ vertical: isVertialSticky, horizontal: isHorizontalSticky }, setIsSticky] = useState({ vertical: false, horizontal: false });
-    const { agencyId } = useParams();
-    const [showModal, setShowModal] = useState('');
-    const [modalAgency, setModalAgency] = useState('');
-    const dispatch = useDispatch();
     const tableRef = useRef(null);
     const handleScroll = throttle(() => {
         const { scrollLeft: horizontal, scrollTop: vertical } = tableRef.current;
@@ -239,12 +219,6 @@ export const AgenciesDetailContainer = (props) => {
     const handleUpdateSort = (field, direction) => {
         updateSort({ field, direction });
     };
-
-    const modalClick = (modalType, agencyName) => {
-        setShowModal(modalType);
-        setModalAgency(agencyName);
-    };
-    const closeModal = () => setShowModal('');
 
     const verticalStickyClass = isVertialSticky ? 'sticky-y-table' : '';
     const horizontalStickyClass = isHorizontalSticky ? 'sticky-x-table' : '';
@@ -262,8 +236,8 @@ export const AgenciesDetailContainer = (props) => {
         }) => [
             (<div className="generic-cell-content">{ fiscalYear }</div>),
             (<div className="generic-cell-content">{ total }</div>),
-            (<CellWithModal data={recentUpdate} openModal={modalClick} modalType="publicationDates" agencyName={props.agency.overviewname} />),
-            (<CellWithModal data={missingTasCount} openModal={modalClick} modalType="missingAccountBalance" agencyName={props.agency.overviewname} />),
+            (<CellWithModal data={recentUpdate} openModal={modalClick} modalType="publicationDates" agencyName={agencyName} />),
+            (<CellWithModal data={missingTasCount} openModal={modalClick} modalType="missingAccountBalance" agencyName={agencyName} />),
             (<div className="generic-cell-content">{ obligationDiff }</div>),
             (<div className="generic-cell-content">{ unlinkedCont }</div>),
             (<div className="generic-cell-content">{ unlinkedAsst }</div>),
@@ -271,111 +245,17 @@ export const AgenciesDetailContainer = (props) => {
         ]
     );
 
-    const onClick = (e) => {
-        e.persist();
-        if (e?.target) {
-            dispatch(showModal(e.target.parentNode.getAttribute('data-href') || e.target.getAttribute('data-href') || e.target.value));
-        }
-    };
-
-    useEffect(() => {
-        // request overview for agency
-        const agencyOverviewRequest = fetchAgencyOverview(agencyId);
-        agencyOverviewRequest.promise
-            .then((res) => {
-                // parse the response using our data model
-                const agency = new AgencyOverviewModel(Object.assign({}, res.data.results, {
-                    agency_id: agencyId
-                }), true);
-                // store the data model object in Redux
-                dispatch(setAgencyOverview(agency));
-            }).catch((err) => {
-                console.error(err);
-            });
-    }, [agencyId]);
-
     return (
-        <div className="usa-da__about-the-data__agencies-page">
-            <MetaTags {...agencyPageMetaTags} />
-            <Header />
-            <StickyHeader>
-                <div className="sticky-header__title">
-                    <h1 tabIndex={-1}>
-                        Agency Submission Data
-                    </h1>
-                </div>
-            </StickyHeader>
-            <main id="main-content" className="main-content">
-                <div className="heading-container">
-                    <div className="back-link">
-                        <a href="/about-the-data/agencies"><FontAwesomeIcon icon="angle-left" />&nbsp;Back to All Agencies</a>
-                    </div>
-                    <h2 className="header">Submission Data</h2>
-                    <h2 className="sub-header">{props.agency.overview.name}</h2>
-                    <div className="lower-details">
-                        <div className="agency-info-group">
-                            <h5>Agency Contact Information</h5>
-                            <div className="more-info-note">Contact this Agency with questions about their submissions</div>
-                            <div className="agency-website">
-                                <button
-                                    className="usa-button-link"
-                                    role="link"
-                                    value={props.agency.overview.website}
-                                    onClick={onClick}>
-                                    {props.agency.overview.website}
-                                    <span
-                                        data-href={props.agency.overview.website}
-                                        className="usa-button-link__icon">
-                                        <FontAwesomeIcon
-                                            data-href={props.agency.overview.website}
-                                            icon="external-link-alt" />
-                                    </span>
-                                </button>
-                            </div>
-                        </div>
-                        <div className="agency-info-group">
-                            <h5>Agency Profile Page</h5>
-                            <div className="more-info-note">Learn more about this Agency&#39;s spending</div>
-                            <div className="agency-website">
-                                <Link to={`/agency/${agencyId}`}>
-                                    {props.agency.overview.name}
-                                </Link>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div className="table-container" ref={tableRef} onScroll={handleScroll}>
-                    <Table
-                        rows={rows}
-                        classNames={`usda-table-w-grid ${verticalStickyClass} ${horizontalStickyClass}`}
-                        columns={columns}
-                        updateSort={handleUpdateSort}
-                        currentSort={sortStatus} />
-                </div>
-                <Note message={message} />
-                <AboutTheDataModal
-                    mounted={!!showModal.length}
-                    type={showModal}
-                    className={modalClassNames[showModal]}
-                    title={modalTitles[showModal]}
-                    agencyName={modalAgency}
-                    fiscalYear={2020}
-                    fiscalPeriod={8}
-                    closeModal={closeModal}
-                    totalObligationsNotInGTAS={45999} />
-            </main>
-            <Footer />
+        <div className="table-container" ref={tableRef} onScroll={handleScroll}>
+            <Table
+                rows={rows}
+                classNames={`usda-table-w-grid ${verticalStickyClass} ${horizontalStickyClass}`}
+                columns={columns}
+                updateSort={handleUpdateSort}
+                currentSort={sortStatus} />
         </div>
     );
 };
 
-AgenciesDetailContainer.propTypes = propTypes;
-
-
-const AgencyDetailContainerWithRouter = withRouter(AgenciesDetailContainer);
-export default connect(
-    (state) => ({
-        agency: state.agency
-    }),
-    (dispatch) => bindActionCreators(agencyActions, dispatch)
-)(AgencyDetailContainerWithRouter);
+AgencyDetailsContainer.propTypes = propTypes;
+export default AgencyDetailsContainer;

--- a/src/js/containers/router/RouterRoutes.js
+++ b/src/js/containers/router/RouterRoutes.js
@@ -31,7 +31,7 @@ const AgencyProfileV2 = React.lazy(() => import('containers/agency/v2/AgencyCont
 const Covid19Container = React.lazy(() => import('containers/covid19/Covid19Container').then((comp) => comp));
 const DataSourcesAndMethodologiesPage = React.lazy(() => import('components/covid19/DataSourcesAndMethodologiesPage').then((comp) => comp));
 const AboutTheDataPage = React.lazy(() => import('components/aboutTheData/AboutTheDataPage').then((comp) => comp));
-const AgenciesDetailContainer = React.lazy(() => import('containers/aboutTheData/AgenciesDetailContainer').then((comp) => comp));
+const AgencyDetailsPage = React.lazy(() => import('components/aboutTheData/AgencyDetailsPage').then((comp) => comp));
 const ErrorPage = React.lazy(() => import('components/errorPage/ErrorPage').then((comp) => comp));
 
 // /* eslint-disable import/prefer-default-export */
@@ -175,8 +175,8 @@ export const routes = [
         hide: !kGlobalConstants.DEV && !kGlobalConstants.QAT // Not DEV and not QAT === Production, so we hide
     },
     {
-        path: '/about-the-data/agency/:agencyId',
-        component: AgenciesDetailContainer,
+        path: '/about-the-data/agency/:agencyCode',
+        component: AgencyDetailsPage,
         exact: true,
         hide: !kGlobalConstants.DEV && !kGlobalConstants.QAT // Not DEV and not QAT === Production, so we hide
     },

--- a/src/js/helpers/agencyV2Helper.js
+++ b/src/js/helpers/agencyV2Helper.js
@@ -1,5 +1,5 @@
 /**
- * agencyHelper.js
+ * agencyV2Helper.js
  * Created by Lizzie Salita 5/26/20
  */
 
@@ -19,4 +19,8 @@ export const fetchSpendingByCategory = (agencyId, type, params) => apiRequest({
 
 export const fetchBudgetaryResources = (agencyId) => apiRequest({
     url: `v2/agency/${agencyId}/budgetary_resources/`
+});
+
+export const fetchAgencyOverview = (code, fy) => apiRequest({
+    url: `v2/agency/${code}/${fy || ''}`
 });

--- a/src/js/helpers/agencyV2Helper.js
+++ b/src/js/helpers/agencyV2Helper.js
@@ -40,5 +40,6 @@ export const mockFetchAgencyOverview = () => ({
                 data: mockAgency
             });
         }, 500);
-    })
+    }),
+    cancel() {}
 });

--- a/src/js/helpers/agencyV2Helper.js
+++ b/src/js/helpers/agencyV2Helper.js
@@ -22,5 +22,23 @@ export const fetchBudgetaryResources = (agencyId) => apiRequest({
 });
 
 export const fetchAgencyOverview = (code, fy) => apiRequest({
-    url: `v2/agency/${code}/${fy || ''}`
+    url: `v2/agency/${code}/${fy ? `?fiscal_year=${fy}` : ''}`
+});
+
+export const mockAgency = {
+    name: 'Mock Agency',
+    id: '456',
+    website: 'https://home.treasury.gov/',
+    code: '020',
+    abbreviation: 'ABC'
+};
+
+export const mockFetchAgencyOverview = () => ({
+    promise: new Promise((resolve) => {
+        window.setTimeout(() => {
+            resolve({
+                data: mockAgency
+            });
+        }, 500);
+    })
 });

--- a/src/js/helpers/agencyV2Helper.js
+++ b/src/js/helpers/agencyV2Helper.js
@@ -42,21 +42,3 @@ export const mockFetchAgencyOverview = () => ({
         }, 500);
     })
 });
-
-export const mockAgency = {
-    name: 'Mock Agency',
-    id: '456',
-    website: 'https://home.treasury.gov/',
-    code: '020',
-    abbreviation: 'ABC'
-};
-
-export const mockFetchAgencyOverview = () => ({
-    promise: new Promise((resolve) => {
-        window.setTimeout(() => {
-            resolve({
-                data: mockAgency
-            });
-        }, 500);
-    })
-});

--- a/src/js/models/v2/agencyV2/BaseAgencyOverview.js
+++ b/src/js/models/v2/agencyV2/BaseAgencyOverview.js
@@ -1,0 +1,19 @@
+/**
+ * BaseAgencyOverview.js
+ * Created by Lizzie Salita 12/3/20
+ */
+
+const BaseAgencyOverview = {
+    populate(data) {
+        this._name = data?.name || '';
+        this._abbreviation = data?.abbreviation || '';
+        this.website = data?.website || '';
+        this.id = data?.id || '';
+    },
+    get name() {
+        const abbreviation = this._abbreviation ? ` (${this._abbreviation})` : '';
+        return `${this._name}${abbreviation}`;
+    }
+};
+
+export default BaseAgencyOverview;

--- a/tests/models/agency/BaseAgencyOverview-test.js
+++ b/tests/models/agency/BaseAgencyOverview-test.js
@@ -1,0 +1,25 @@
+/**
+ * BaseAgencyOverview-test.js
+ * Created by Lizzie Salita 12/4/20
+ */
+
+import BaseAgencyOverview from 'models/v2/agencyV2/BaseAgencyOverview';
+import { mockAgency } from 'helpers/agencyV2Helper';
+
+const agencyOverview = Object.create(BaseAgencyOverview);
+agencyOverview.populate(mockAgency);
+
+describe('BaseAgencyOverview', () => {
+    it('should format the agency name', () => {
+        expect(agencyOverview.name).toEqual('Mock Agency (ABC)');
+    });
+    it('should handle an agency with no abbreviation', () => {
+        const missingAbbrev = {
+            ...mockAgency,
+            abbreviation: ''
+        };
+        const agencyOverviewMod = Object.create(BaseAgencyOverview);
+        agencyOverviewMod.populate(missingAbbrev);
+        expect(agencyOverviewMod.name).toEqual('Mock Agency');
+    });
+});


### PR DESCRIPTION
**High level description:**

Refactors the single Agency Submission Statistics page in preparation for API integration. 

**Technical details:**
- Separates the Agency page UI from the table container
- Adds a mock API request to populate agency name, website, and profile page url based on the toptier code url parameter
  - Uses mock data since the `id` property still needs to be added to `v2/agency/{toptier_code}` response (to link to v1 agency profile pages)
- Minor styling updates

**JIRA Ticket:**
[DEV-6488](https://federal-spending-transparency.atlassian.net/browse/DEV-6488)

**Mockup:**
https://bahdigital.invisionapp.com/share/D5IAFOD4YUN#/296052487_003__Publication-Dates-To-SBA

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- N/A [API contract](https://github.com/fedspendingtransparency/usaspending-api/blob/dev/usaspending_api/api_contracts/contracts/v2/agency/toptier_code.md) updated - created [DEV-6505](https://federal-spending-transparency.atlassian.net/browse/DEV-6505)

Reviewer(s):
- [x] Code review complete
