### PR TITLE
[DEV-6449] Count of Agency TAS in GTAS Not in File A using correct property on API response

### DIFF
--- a/src/js/models/v2/aboutTheData/BaseAgencyRow.js
+++ b/src/js/models/v2/aboutTheData/BaseAgencyRow.js
@@ -12,7 +12,8 @@ const BaseAgencyRow = {
         this._abbreviation = data.abbreviation || '';
         this._code = data.code || '';
         this._budgetAuthority = data.current_total_budget_authority_amount || 0;
-        this._discrepancyCount = data.discrepancy_count || 0;
+        // eslint-disable-next-line camelcase
+        this._discrepancyCount = data.tas_account_discrepancies_totals?.missing_tas_accounts_count || 0;
         this._obligationDifference = data.obligation_difference || 0;
         this._publicationDate = data.recent_publication_date || null;
         this.certified = data.recent_publication_date_certified || false;

--- a/tests/models/aboutTheData/BaseAgencyRow-test.js
+++ b/tests/models/aboutTheData/BaseAgencyRow-test.js
@@ -7,7 +7,7 @@ import BaseAgencyRow from 'models/v2/aboutTheData/BaseAgencyRow';
 import { mockAPI } from 'containers/aboutTheData/AgencyTableMapping';
 
 // TODO - update when API contracts are finalized
-const mockAgencyRow = { ...mockAPI.details.data.results[0], discrepancy_count: 2000 };
+const mockAgencyRow = { ...mockAPI.details.data.results[0] };
 
 const agencyRow = Object.create(BaseAgencyRow);
 agencyRow.populate(mockAgencyRow);
@@ -32,7 +32,7 @@ describe('BaseAgencyRow', () => {
         expect(agencyRow.obligationDifference).toEqual('$436,376,232,653');
     });
     it('should format the discrepancy count', () => {
-        expect(agencyRow.discrepancyCount).toEqual('2,000');
+        expect(agencyRow.discrepancyCount).toEqual('20');
     });
     it('should format the publication date', () => {
         expect(agencyRow.publicationDate).toEqual('01/10/2020');


### PR DESCRIPTION
**High level description:**
Was looking at the wrong property.

**Technical details:**
![image](https://user-images.githubusercontent.com/12897813/102101608-d5052500-3df8-11eb-8b8c-595d040e3db5.png)

**JIRA Ticket:**
[DEV-6449](https://federal-spending-transparency.atlassian.net/browse/DEV-6449)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A`Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A`Verified mobile/tablet/desktop/monitor responsiveness
`N/A`Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
