### PR TITLE
dev-6486 final wording fix

### DIFF
--- a/src/js/components/search/visualizations/time/TimeVisualizationSection.jsx
+++ b/src/js/components/search/visualizations/time/TimeVisualizationSection.jsx
@@ -70,7 +70,7 @@ export default class TimeVisualizationSection extends React.Component {
         <>
             <div className="tooltip__title">Download data by {capitalize(this.props.data.visualizationPeriod === 'fiscal_year' ? 'year' : this.props.data.visualizationPeriod)}</div>
             <div className="tooltip__text">
-                Download a CSV of award spending data that matches your search criteria, broken down by year. For complete download results, click on the &quot;Download&quot; button on the top right of this page.
+                Download a CSV of award spending data that matches your search criteria, broken down by {this.props.data.visualizationPeriod === 'fiscal_year' ? 'year' : this.props.data.visualizationPeriod}. For complete download results, click on the &quot;Download&quot; button on the top right of this page.
             </div>
         </>
     );


### PR DESCRIPTION
Warmfix: https://federal-spending-transparency.atlassian.net/browse/DEV-6486 (QAT PR is https://github.com/fedspendingtransparency/usaspending-website/pull/2277)
Fix "broken down by year" to show year/quarter/month as appropriate.