### PR TITLE
[DEV-6535] Handling partially defined urls (no fy or period urlParams)

### DIFF
--- a/src/js/components/aboutTheData/AboutTheDataPage.jsx
+++ b/src/js/components/aboutTheData/AboutTheDataPage.jsx
@@ -5,8 +5,8 @@
 
 import React, { useEffect, useState } from "react";
 import PropTypes from 'prop-types';
-import { useParams } from 'react-router-dom';
 import { TooltipComponent, TooltipWrapper, Tabs } from "data-transparency-ui";
+import { useParams } from "react-router-dom";
 
 import { getLatestPeriod } from "helpers/accountHelper";
 import Header from "containers/shared/HeaderContainer";
@@ -120,8 +120,8 @@ const AboutTheDataPage = ({
                         active={activeTab}
                         switchTab={handleSwitchTab}
                         types={[
-                            { internal: 'details', label: <TableTabLabel label="Statistics by Reporting Period" /> },
-                            { internal: 'dates', label: <TableTabLabel label="Updates by  Fiscal Year" /> }
+                            { internal: 'details', label: "Statistics by Reporting Period", labelComponent: <TableTabLabel label="Statistics by Reporting Period" /> },
+                            { internal: 'dates', label: "Updates by  Fiscal Year", labelComponent: <TableTabLabel label="Updates by  Fiscal Year" /> }
                         ]} />
                     <TimeFilters
                         submissionPeriods={submissionPeriods}
@@ -159,7 +159,10 @@ const AboutTheDataPage = ({
 };
 
 AboutTheDataPage.propTypes = {
-    history: PropTypes.object
+    history: PropTypes.object,
+    match: PropTypes.shape({
+        params: PropTypes.object
+    })
 };
 
 export default AboutTheDataPage;

--- a/src/js/components/aboutTheData/AboutTheDataPage.jsx
+++ b/src/js/components/aboutTheData/AboutTheDataPage.jsx
@@ -3,11 +3,12 @@
  * Created by Lizzie Salita 11/25/20
  */
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from 'prop-types';
-import { useParams } from "react-router-dom";
+import { useParams } from 'react-router-dom';
 import { TooltipComponent, TooltipWrapper, Tabs } from "data-transparency-ui";
 
+import { getLatestPeriod } from "helpers/accountHelper";
 import Header from "containers/shared/HeaderContainer";
 import Footer from "containers/Footer";
 import { getPeriodWithTitleById } from "helpers/aboutTheDataHelper";
@@ -15,6 +16,7 @@ import StickyHeader from "components/sharedComponents/stickyHeader/StickyHeader"
 import Note from "components/sharedComponents/Note";
 import AboutTheDataModal from "components/aboutTheData/AboutTheDataModal";
 import AgenciesContainer from 'containers/aboutTheData/AgenciesContainer';
+import { useLatestAccountData } from "containers/account/WithLatestFy";
 import { modalTitles, modalClassNames } from 'dataMapping/aboutTheData/modals';
 import TimeFilters from "./TimeFilters";
 
@@ -48,6 +50,7 @@ const AboutTheDataPage = ({
     history
 }) => {
     const { fy: urlFy, period: urlPeriod } = useParams();
+    const [dataAsOf, submissionPeriods] = useLatestAccountData();
     const [selectedFy, setSelectedFy] = useState(null);
     const [selectedPeriod, setSelectedPeriod] = useState(null);
 
@@ -64,6 +67,13 @@ const AboutTheDataPage = ({
         setShowModal('');
         setModalData(null);
     };
+
+    useEffect(() => {
+        if ((!urlFy || !urlPeriod) && submissionPeriods.length) {
+            const { year, period } = getLatestPeriod(submissionPeriods);
+            history.replace(`about-the-data/agencies/${year}/${period}`);
+        }
+    }, []);
 
     const updateUrl = (newFy, newPeriod) => {
         history.push({ pathname: `/about-the-data/agencies/${newFy}/${newPeriod}` });
@@ -114,6 +124,8 @@ const AboutTheDataPage = ({
                             { internal: 'dates', label: <TableTabLabel label="Updates by  Fiscal Year" /> }
                         ]} />
                     <TimeFilters
+                        submissionPeriods={submissionPeriods}
+                        dataAsOf={dataAsOf}
                         activeTab={activeTab}
                         onTimeFilterSelection={onTimeFilterSelection}
                         selectedPeriod={selectedPeriod}

--- a/src/js/components/aboutTheData/TimeFilters.jsx
+++ b/src/js/components/aboutTheData/TimeFilters.jsx
@@ -178,9 +178,9 @@ TimePeriodFilters.propTypes = {
         className: PropTypes.string
     }),
     selectedFy: PropTypes.string,
-    urlFy: PropTypes.string.isRequired,
+    urlPeriod: PropTypes.string,
+    urlFy: PropTypes.string,
     activeTab: PropTypes.string.isRequired,
-    urlPeriod: PropTypes.string.isRequired,
     onTimeFilterSelection: PropTypes.func,
     submissionPeriods: PropTypes.array,
     dataAsOf: PropTypes.object

--- a/src/js/components/aboutTheData/TimeFilters.jsx
+++ b/src/js/components/aboutTheData/TimeFilters.jsx
@@ -23,7 +23,6 @@ import {
     lastPeriods,
     cssOrderClassByPeriodId
 } from 'components/aboutTheData/dataMapping/timeFilters';
-import { useLatestAccountData } from "containers/account/WithLatestFy";
 import PeriodComponent from './PeriodComponent';
 
 const sortPeriods = ({ type: a }, { type: b }) => {
@@ -84,9 +83,10 @@ const TimePeriodFilters = ({
     selectedFy,
     urlFy,
     urlPeriod,
-    onTimeFilterSelection
+    onTimeFilterSelection,
+    submissionPeriods,
+    dataAsOf
 }) => {
-    const [dataAsOf, submissionPeriods] = useLatestAccountData();
     const latestPeriod = getLatestPeriod(submissionPeriods);
 
     const handleTimeChange = (fy, period, latestAvailable = latestPeriod) => {
@@ -181,7 +181,9 @@ TimePeriodFilters.propTypes = {
     urlFy: PropTypes.string.isRequired,
     activeTab: PropTypes.string.isRequired,
     urlPeriod: PropTypes.string.isRequired,
-    onTimeFilterSelection: PropTypes.func
+    onTimeFilterSelection: PropTypes.func,
+    submissionPeriods: PropTypes.array,
+    dataAsOf: PropTypes.object
 };
 
 export default TimePeriodFilters;

--- a/src/js/containers/router/RouterRoutes.js
+++ b/src/js/containers/router/RouterRoutes.js
@@ -169,6 +169,18 @@ export const routes = [
         exact: true
     },
     {
+        path: '/about-the-data/agencies',
+        component: AboutTheDataPage,
+        exact: true,
+        hide: !kGlobalConstants.DEV && !kGlobalConstants.QAT // Not DEV and not QAT === Production, so we hide
+    },
+    {
+        path: '/about-the-data/agencies/:fy',
+        component: AboutTheDataPage,
+        exact: true,
+        hide: !kGlobalConstants.DEV && !kGlobalConstants.QAT // Not DEV and not QAT === Production, so we hide
+    },
+    {
         path: '/about-the-data/agencies/:fy/:period',
         component: AboutTheDataPage,
         exact: true,

--- a/tests/components/aboutTheData/AboutTheDataPage-test.jsx
+++ b/tests/components/aboutTheData/AboutTheDataPage-test.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
+import moment from 'moment';
 
-import { render, screen, fireEvent } from '@test-utils';
+import { render, screen, fireEvent, waitFor } from '@test-utils';
 import AboutTheDataPage from 'components/aboutTheData/AboutTheDataPage';
 import * as accountHelpers from 'helpers/accountHelper';
+import * as helpers from "containers/account/WithLatestFy";
 import * as glossaryHelpers from 'helpers/glossaryHelper';
+import * as aboutTheDataHelpers from 'helpers/aboutTheDataHelper';
+import { mockAPI } from 'containers/aboutTheData/AgencyTableMapping';
 
 // latest fy of 2020; latest period is 12
 const mockPeriods = {
@@ -79,18 +83,27 @@ const mockGlossary = {
     }
 };
 
-jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useParams: jest.fn(() => ({ fy: '2020', period: '12' }))
-}));
-
 const mockPush = jest.fn();
+const mockReplace = jest.fn();
 
-const history = {
-    push: mockPush
+const defaultProps = {
+    history: {
+        push: mockPush,
+        replace: mockReplace
+    },
+    match: {
+        params: {
+            fy: '2020',
+            period: '12'
+        }
+    }
 };
 
 beforeEach(() => {
+    jest.spyOn(helpers, 'useLatestAccountData').mockReturnValue([
+        moment(),
+        mockPeriods.data.available_periods
+    ]);
     jest.spyOn(accountHelpers, 'fetchAllSubmissionDates').mockReturnValue({
         promise: Promise.resolve(mockPeriods),
         cancel: () => {
@@ -103,19 +116,45 @@ beforeEach(() => {
             console.log('cancel called');
         }
     });
-    render(<AboutTheDataPage history={history} />);
+    jest.spyOn(aboutTheDataHelpers, 'getTotalBudgetaryResources').mockReturnValue({
+        promise: Promise.resolve(mockAPI.totals),
+        cancel: () => {
+            console.log('cancel called');
+        }
+    });
+    jest.spyOn(aboutTheDataHelpers, 'getAgenciesReportingData').mockReturnValue({
+        promise: Promise.resolve(mockAPI.details),
+        cancel: () => {
+            console.log('cancel called');
+        }
+    });
+    jest.spyOn(aboutTheDataHelpers, 'getSubmissionPublicationDates').mockReturnValue({
+        promise: Promise.resolve(mockAPI.dates),
+        cancel: () => {
+            console.log('cancel called');
+        }
+    });
 });
 
 test('renders the details table first', async () => {
-    // only fires one api request
+    render(<AboutTheDataPage {...defaultProps} />);
     // shows the correct table
     const [table] = screen.getAllByText('Count of Agency TAS in GTAS Not in File A');
     expect(table).toBeDefined();
 });
 
 test('on tab change updates the table view', async () => {
+    // shows the other table
+    render(<AboutTheDataPage {...defaultProps} />);
     const tab = screen.getAllByText('Updates by Fiscal Year');
     fireEvent.click(tab[0]);
     const table = screen.getByText('FY 2020 Q4');
     expect(table).toBeDefined();
+});
+
+test('redirects about-the-data/agencies to url w/ latest fy and period in params', async () => {
+    render(<AboutTheDataPage {...defaultProps} match={{ params: {} }} />);
+    return waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith('about-the-data/agencies/2020/12');
+    });
 });

--- a/tests/components/aboutTheData/AboutTheDataPage-test.jsx
+++ b/tests/components/aboutTheData/AboutTheDataPage-test.jsx
@@ -119,4 +119,3 @@ test('on tab change updates the table view', async () => {
     const table = screen.getByText('FY 2020 Q4');
     expect(table).toBeDefined();
 });
-

--- a/tests/components/aboutTheData/TimeFilters-test.jsx
+++ b/tests/components/aboutTheData/TimeFilters-test.jsx
@@ -5,6 +5,7 @@ import TimeFilters from 'components/aboutTheData/TimeFilters';
 import * as accountHelpers from 'helpers/accountHelper';
 import * as glossaryHelpers from 'helpers/glossaryHelper';
 import { mockGlossary, mockSubmissions } from '../../mockData';
+import moment from 'moment';
 
 const defaultProps = {
     urlPeriod: '12',
@@ -12,7 +13,9 @@ const defaultProps = {
     activeTab: 'details', // or dates
     onTimeFilterSelection: jest.fn(),
     selectedPeriod: null,
-    selectedFy: null
+    selectedFy: null,
+    submissionPeriods: mockSubmissions,
+    dataAsOf: null
 };
 
 const q4Fy2020 = {
@@ -47,14 +50,12 @@ test('Publication Dates table does not show period picker', async () => {
 test('Validates fiscal year from url', async () => {
     // bad fiscal year:
     const mockOnTimeSelection = jest.fn();
-    render(<TimeFilters {...defaultProps} onTimeFilterSelection={mockOnTimeSelection} urlFy="1990" />);
-    await waitForElementToBeRemoved(screen.queryByText('Loading fiscal years...'));
+    render(<TimeFilters {...defaultProps} dataAsOf={moment()} onTimeFilterSelection={mockOnTimeSelection} urlFy="1990" />);
     expect(mockOnTimeSelection).toHaveBeenCalledWith("2020", { className: "last-period-per-quarter", id: "12", title: "Q4 P12" });
 });
 
 test('Validates period from url', async () => {
     const mockOnTimeSelection = jest.fn();
-    render(<TimeFilters {...defaultProps} onTimeFilterSelection={mockOnTimeSelection} urlFy="2020" urlPeriod="13" />);
-    await waitForElementToBeRemoved(screen.queryByText('Loading fiscal years...'));
+    render(<TimeFilters {...defaultProps} dataAsOf={moment()} onTimeFilterSelection={mockOnTimeSelection} urlFy="2020" urlPeriod="13" />);
     expect(mockOnTimeSelection).toHaveBeenCalledWith("2020", { className: "last-period-per-quarter", id: "12", title: "Q4 P12" });
 });


### PR DESCRIPTION
**High level description:**
Redirecting `about-the-data/agencies` to a url with the latest fy and period selected

**Technical details:**

f2e79ee - Adds new paths for the about-the-data page component
5327882 -- TimeFilters refactor to take submissionPeriods and dataAsOf as props
- AboutTheDataPage passes props ☝
- AboutTheDataPage useEffect to look for impartial urls

Note on test coverage:

Trying to mock out react-router-dom didnt go well.
The helper the useEffect relies on is tested
and should be adequate for our coverage. That said,
ideally we should have a test for this. I'm considering
it a "nice to have" for now.

**JIRA Ticket:**
[DEV-6535](https://federal-spending-transparency.atlassian.net/browse/DEV-6535)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` (SEE NOTE ABOVE ☝️) Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A`  [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A`  Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
