### PR TITLE
Hotfix DEV-6575 map error

### DIFF
--- a/src/js/components/search/visualizations/geo/MapWrapper.jsx
+++ b/src/js/components/search/visualizations/geo/MapWrapper.jsx
@@ -420,8 +420,7 @@ export default class MapWrapper extends React.Component {
             let value = this.props.data.values[index];
             if (isNaN(value)) value = 0;
             // determine the group index
-            let group = Math.floor(scale.scale(value));
-            if (group.toString().startsWith('-')) group = 0;
+            const group = scale.scale(value);
             // add it to the filter list
             filterValues[group].push(location);
         });

--- a/src/js/helpers/mapHelper.js
+++ b/src/js/helpers/mapHelper.js
@@ -4,7 +4,7 @@
  */
 
 import { min, max } from 'lodash';
-import { scaleLinear } from 'd3-scale';
+import { scaleQuantize } from 'd3-scale';
 import kGlobalConstants from 'GlobalConstants';
 import { apiRequest } from './apiRequest';
 
@@ -407,14 +407,13 @@ export const calculateRange = (data) => {
     minValue = Math.floor(minValue / units.unit);
     maxValue = Math.ceil(maxValue / units.unit);
 
-    // determine the current step values, round it to something divisible by
-    const step = Math.ceil((maxValue - minValue) / 6);
-    maxValue = minValue + (6 * step);
-
     const segments = [];
-    const scale = scaleLinear().domain([minValue * units.unit, maxValue * units.unit]).range([0, 6]);
-    for (let i = 1; i <= 6; i++) {
-        segments.push(scale.invert(i));
+    const scale = scaleQuantize()
+        .domain([minValue * units.unit, maxValue * units.unit])
+        .range([0, 1, 2, 3, 4, 5])
+        .nice();
+    for (let i = 0; i <= 5; i++) {
+        segments.push(scale.invertExtent(i)[1]);
     }
 
     return {

--- a/tests/helpers/mapHelper-test.js
+++ b/tests/helpers/mapHelper-test.js
@@ -1,0 +1,34 @@
+/**
+ * mapHelper-test.js
+ * Created by Lizzie Salita 12/30/20
+ */
+
+import * as MapHelper from 'helpers/mapHelper';
+
+describe('Map helper functions', () => {
+    describe('calculateRange', () => {
+        const mockValues = [1, 3, 5, 11, 18];
+        const { scale, segments, units } = MapHelper.calculateRange(mockValues);
+        const mockLgValues = [0, 1000, 5000, 6000, 12000];
+        const result = MapHelper.calculateRange(mockLgValues);
+        it('should sort values into the correct bucket', () => {
+            expect(scale(14)).toEqual(4); // A value of 14 should fall into the 4th "bucket"
+            expect(scale(1)).toEqual(0);
+            expect(result.scale(8001)).toEqual(4);
+        });
+        it('should return an array of segments for each map color', () => {
+            expect(segments.length).toEqual(MapHelper.visualizationColors.length);
+        });
+        it('should return an array of segments with the upper range for each bucket', () => {
+            expect(segments).toEqual([3, 6, 9, 12, 15, 18]);
+            expect(result.segments).toEqual([2000, 4000, 6000, 8000, 10000, 12000]);
+        });
+        it('should calculate units for large values', () => {
+            expect(units.unit).toEqual(1);
+            expect(result.units.unit).toEqual(1000);
+        });
+        it('should handle a max value that exactly equals the upper range of the largest bucket', () => {
+            expect(result.scale(12000)).toEqual(5);
+        });
+    });
+});


### PR DESCRIPTION
**High level description:**

Fixes a bug where in rare edge cases, the Advanced Search map would throw an error resulting in a blank screen. E.g. https://www.usaspending.gov/search/13bd5bf59da6f9c844a8b20bc364895a. 

**Technical details:**

`MapWrapper` groups dollar values into 6 ranges represented by different colors on the map using the helper function `calculateRanges`. 

Old (flawed) approach: 

1. Determine the upper bound for our legend by rounding up the maximum dollar value in our data to an integer that is divisible by 6 * `unit` for the range of values (thousand, million, etc.)
2. Use d3 `scaleLinear` to convert each dollar value to a floating point number between 0 and 6
3. Use `Math.floor` to round down to the index of an array representing that bucket
4. Push the corresponding location to the array at the given index

This falls apart when the maximum dollar value in the data is a nice round number that is divisible by 6 * `unit` ($1,200,000 at the link above) and matches the upper bound used for the domain. In this case, `scaleLinear` will give us `6` as the index (which is correct), but there are only 6 buckets (the highest index of which is `5`).

Solution:
We were implementing what d3 `scaleQuantize` is designed to do; switch from `scaleLinear` to `scaleQuantize`. See https://github.com/d3/d3-scale/blob/master/README.md#quantize-scales

**JIRA Ticket:**
[DEV-6575](https://federal-spending-transparency.atlassian.net/browse/DEV-6575)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)

Reviewer(s):
- [ ] Code review complete
