### PR TITLE
Hotfix DEV-6558, DEV-6576, DEV-6577 migration banners

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8271,6 +8271,11 @@
                 "whatwg-url": "^8.0.0"
             }
         },
+        "date-fns": {
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
+            "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
+        },
         "debug": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
         "d3-scale": "^1.0.4",
         "d3-time": "^1.0.11",
         "data-transparency-ui": "github:fedspendingtransparency/data-transparency-ui#v1.3.3",
+        "date-fns": "^2.16.1",
         "file-loader": "^3.0.1",
         "fixed-data-table": "0.6.3",
         "history": "^4.6.1",

--- a/src/js/components/sharedComponents/header/Header.jsx
+++ b/src/js/components/sharedComponents/header/Header.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Cookies from 'js-cookie';
 import { Link } from 'react-router-dom';
+import { isBefore, isAfter, startOfToday } from 'date-fns';
 
 import GlossaryContainer from 'containers/glossary/GlossaryContainer';
 import GlobalModalContainer from 'containers/globalModal/GlobalModalContainer';
@@ -17,7 +18,16 @@ const clickedHeaderLink = (route) => {
     });
 };
 
-export const CovidHomepageCookie = 'usaspending_covid_release';
+// COVID banner before 1/4/21 after 1/13/21
+let cookie = 'usaspending_covid_release';
+if (isAfter(startOfToday(), new Date(2021, 0, 3)) && isBefore(startOfToday(), new Date(2021, 0, 8))) {
+    // pre-migration banner 1/4/21 through 1/7/21
+    cookie = 'usaspending_maintenance_warn';
+}
+else if (isAfter(startOfToday(), new Date(2021, 0, 7)) && isBefore(startOfToday(), new Date(2021, 0, 14))) {
+    // migration banner 1/8/21 through 1/13/21
+    cookie = 'usaspending_maintenance';
+}
 
 export default class Header extends React.Component {
     constructor(props) {
@@ -36,7 +46,7 @@ export default class Header extends React.Component {
     }
     setShowInfoBanner() {
         // check if the info banner cookie exists
-        if (!Cookies.get(CovidHomepageCookie)) {
+        if (!Cookies.get(cookie)) {
             // cookie does not exist, show the banner
             this.setState({
                 showInfoBanner: true
@@ -56,9 +66,9 @@ export default class Header extends React.Component {
             mainFocus.focus();
         }
     }
-    closeBanner(bannerType, cookieName) {
+    closeBanner(bannerType) {
         // set a cookie to hide the banner in the future if banner is closed
-        Cookies.set(cookieName, 'hide', { expires: 730 });
+        Cookies.set(cookie, 'hide', { expires: 730 });
         this.setState({
             [bannerType]: false
         });

--- a/src/js/components/sharedComponents/header/InfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/InfoBanner.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Analytics from 'helpers/analytics/Analytics';
 import { Link } from 'react-router-dom';
 import { isBefore, isAfter, startOfToday } from 'date-fns';
 
@@ -21,13 +20,6 @@ export default class InfoBanner extends React.Component {
 
     bannerClosed() {
         this.props.closeBanner('showInfoBanner', CovidHomepageCookie);
-    }
-
-    clickedBannerLink = () => {
-        Analytics.event({
-            category: 'Banner - Link',
-            action: 'https://www.whitehouse.gov/wp-content/uploads/2020/04/Implementation-Guidance-for-Supplemental-Funding-Provided-in-Response.pdf'
-        });
     }
 
     render() {

--- a/src/js/components/sharedComponents/header/InfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/InfoBanner.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Analytics from 'helpers/analytics/Analytics';
 import { Link } from 'react-router-dom';
+import { isBefore, isAfter, startOfToday } from 'date-fns';
 
-import kGlobalConstants from 'GlobalConstants';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { CovidHomepageCookie } from './Header';
@@ -31,42 +31,32 @@ export default class InfoBanner extends React.Component {
     }
 
     render() {
-        const content = kGlobalConstants.CARES_ACT_RELEASED_2 ? (
-        <>
-            <div className="info-banner__alert-text">
-                <p className="info-banner__title-text">New to USAspending: COVID-19 Spending Data</p>
+        let content;
+        let title;
+        if (isBefore(startOfToday(), new Date(2021, 0, 4)) || isAfter(startOfToday(), new Date(2021, 0, 14))) {
+            // Show the COVID banner before 1/4/21 after 1/14/21
+            title = 'New to USAspending: COVID-19 Spending Data';
+            content = (
                 <p>
-                    USAspending now has spending data from federal agencies related to the Coronavirus Aid, Relief, and Economic Security (CARES) Act and other COVID-19 appropriations.
+                USAspending now has spending data from federal agencies related to the Coronavirus Aid, Relief, and Economic Security (CARES) Act and other COVID-19 appropriations.
                     <button onClick={this.props.triggerModal}> Learn more</button> about the new data and features, or <Link to="/disaster/covid-19">visit the profile page</Link> to explore and download the data today!
                 </p>
-            </div>
-            <button
-                className="info-banner__close-button"
-                title="Dismiss message"
-                aria-label="Dismiss message"
-                onClick={this.bannerClosed}>
-                <FontAwesomeIcon size="lg" alt="Dismiss message" icon="times" />
-            </button>
-        </>
-        ) :
-            (
-            <>
-                <div className="info-banner__alert-text">
-                    <p className="info-banner__title-text">New to USAspending: Preliminary COVID-19 Spending Data</p>
-                    <p>
-                        USAspending now has preliminary spending data from federal agencies related to the Coronavirus Aid, Relief, and Economic Security (CARES) Act and other COVID-19 appropriations.
-                        <button onClick={this.props.triggerModal}> Learn more</button> about the new data and features, or check out <Link to="/disaster/covid-19">a preliminary version of the COVID-19 Spending profile page </Link> to explore and download the data.
-                    </p>
-                </div>
-                <button
-                    className="info-banner__close-button"
-                    title="Dismiss message"
-                    aria-label="Dismiss message"
-                    onClick={this.bannerClosed}>
-                    <FontAwesomeIcon size="lg" alt="Dismiss message" icon="times" />
-                </button>
-            </>
             );
+        }
+        else if (isAfter(startOfToday(), new Date(2021, 0, 4)) && isBefore(startOfToday(), new Date(2021, 0, 8))) {
+            // Show the pre-migration banner 1/4/21 through 1/7/21
+            title = 'Maintenance Update:';
+            content = (
+                <p>USAspending daily data refreshes will be paused temporarily starting Saturday January 9, 2021 for planned maintenance. Daily updates are estimated to resume on January 14, 2021 at which time the data will be made current. Please contact the Service Desk with any questions.</p>
+            );
+        }
+        else if (isAfter(startOfToday(), new Date(2021, 0, 8)) && isBefore(startOfToday(), new Date(2021, 0, 14))) {
+            // Show the migration banner 1/8/21 through 1/13/21
+            title = 'Maintenance Update:';
+            content = (
+                <p>USAspending daily data refreshes have been temporarily paused for planned maintenance. All data on the website is current as of January 8, 2021. Daily updates are estimated to resume on January 14, 2021 at which time the data will be made current. Please contact the Service Desk with any questions.</p>
+            );
+        }
 
         return (
             <div className="info-banner">
@@ -74,7 +64,19 @@ export default class InfoBanner extends React.Component {
                     <span className="info-banner__info-circle">
                         <FontAwesomeIcon size="lg" icon="info-circle" />
                     </span>
-                    {content}
+                    <>
+                        <div className="info-banner__alert-text">
+                            <p className="info-banner__title-text">{title}</p>
+                            {content}
+                        </div>
+                        <button
+                            className="info-banner__close-button"
+                            title="Dismiss message"
+                            aria-label="Dismiss message"
+                            onClick={this.bannerClosed}>
+                            <FontAwesomeIcon size="lg" alt="Dismiss message" icon="times" />
+                        </button>
+                    </>
                 </div>
             </div>
         );

--- a/src/js/components/sharedComponents/header/InfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/InfoBanner.jsx
@@ -23,30 +23,26 @@ export default class InfoBanner extends React.Component {
     }
 
     render() {
-        let content;
-        let title;
-        if (isBefore(startOfToday(), new Date(2021, 0, 4)) || isAfter(startOfToday(), new Date(2021, 0, 14))) {
-            // Show the COVID banner before 1/4/21 after 1/14/21
-            title = 'New to USAspending: COVID-19 Spending Data';
-            content = (
-                <p>
-                USAspending now has spending data from federal agencies related to the Coronavirus Aid, Relief, and Economic Security (CARES) Act and other COVID-19 appropriations.
-                    <button onClick={this.props.triggerModal}> Learn more</button> about the new data and features, or <Link to="/disaster/covid-19">visit the profile page</Link> to explore and download the data today!
-                </p>
-            );
-        }
-        else if (isAfter(startOfToday(), new Date(2021, 0, 4)) && isBefore(startOfToday(), new Date(2021, 0, 8))) {
+        // Show the COVID banner before 1/4/21 after 1/13/21
+        let title = 'New to USAspending: COVID-19 Spending Data';
+        let content = (
+            <p>
+            USAspending now has spending data from federal agencies related to the Coronavirus Aid, Relief, and Economic Security (CARES) Act and other COVID-19 appropriations.
+                <button onClick={this.props.triggerModal}> Learn more</button> about the new data and features, or <Link to="/disaster/covid-19">visit the profile page</Link> to explore and download the data today!
+            </p>
+        );
+        if (isAfter(startOfToday(), new Date(2021, 0, 3)) && isBefore(startOfToday(), new Date(2021, 0, 8))) {
             // Show the pre-migration banner 1/4/21 through 1/7/21
             title = 'Maintenance Update:';
             content = (
-                <p>USAspending daily data refreshes will be paused temporarily starting Saturday January 9, 2021 for planned maintenance. Daily updates are estimated to resume on January 14, 2021 at which time the data will be made current. Please contact the Service Desk with any questions.</p>
+                <p data-testid="pre-migration-message">USAspending daily data refreshes will be paused temporarily starting Saturday January 9, 2021 for planned maintenance. Daily updates are estimated to resume on January 14, 2021 at which time the data will be made current. Please contact the Service Desk with any questions.</p>
             );
         }
-        else if (isAfter(startOfToday(), new Date(2021, 0, 8)) && isBefore(startOfToday(), new Date(2021, 0, 14))) {
+        else if (isAfter(startOfToday(), new Date(2021, 0, 7)) && isBefore(startOfToday(), new Date(2021, 0, 14))) {
             // Show the migration banner 1/8/21 through 1/13/21
             title = 'Maintenance Update:';
             content = (
-                <p>USAspending daily data refreshes have been temporarily paused for planned maintenance. All data on the website is current as of January 8, 2021. Daily updates are estimated to resume on January 14, 2021 at which time the data will be made current. Please contact the Service Desk with any questions.</p>
+                <p data-testid="migration-message">USAspending daily data refreshes have been temporarily paused for planned maintenance. All data on the website is current as of January 8, 2021. Daily updates are estimated to resume on January 14, 2021 at which time the data will be made current. Please contact the Service Desk with any questions.</p>
             );
         }
 

--- a/src/js/components/sharedComponents/header/InfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/InfoBanner.jsx
@@ -5,8 +5,6 @@ import { isBefore, isAfter, startOfToday } from 'date-fns';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { CovidHomepageCookie } from './Header';
-
 const propTypes = {
     closeBanner: PropTypes.func,
     triggerModal: PropTypes.func
@@ -19,7 +17,7 @@ export default class InfoBanner extends React.Component {
     }
 
     bannerClosed() {
-        this.props.closeBanner('showInfoBanner', CovidHomepageCookie);
+        this.props.closeBanner('showInfoBanner');
     }
 
     render() {

--- a/tests/components/sharedComponents/InfoBanner-test.jsx
+++ b/tests/components/sharedComponents/InfoBanner-test.jsx
@@ -1,0 +1,90 @@
+/**
+ * InfoBanner-test.jsx
+ * Created by Lizzie Salita 12/31/20
+ */
+
+import React from 'react';
+import InfoBanner from 'components/sharedComponents/header/InfoBanner';
+import { render, screen, fireEvent } from '@test-utils';
+
+const nativeDate = Date.now;
+
+const closeBanner = jest.fn();
+const triggerModal = jest.fn();
+const mockProps = {
+    closeBanner,
+    triggerModal
+};
+
+afterAll(() => {
+    // restore the native date function
+    Date.now = nativeDate;
+});
+
+describe('InfoBanner', () => {
+    it('should render the dismiss button', () => {
+        render(<InfoBanner {...mockProps} />);
+        expect(screen.queryByTitle('Dismiss message')).toBeTruthy();
+    });
+    it('should close the banner on click', () => {
+        render(<InfoBanner {...mockProps} />);
+        fireEvent.click(screen.getByTitle('Dismiss message'));
+        expect(closeBanner).toHaveBeenCalled();
+    });
+    describe('COVID-19 banner', () => {
+        it('should display before 1/4/21', () => {
+            // mock date 12/31/20
+            Date.now = () => new Date(2020, 11, 31);
+            render(<InfoBanner {...mockProps} />);
+            expect(screen.queryByText('New to USAspending: COVID-19 Spending Data')).toBeTruthy();
+        });
+        it('should display again on 1/14/21', () => {
+            // mock date 1/14/21
+            Date.now = () => new Date(2021, 0, 14);
+            render(<InfoBanner {...mockProps} />);
+            expect(screen.queryByText('New to USAspending: COVID-19 Spending Data')).toBeTruthy();
+        });
+        it('should not display between 1/4/21 and 1/14/21', () => {
+            // mock date 1/4/21
+            Date.now = () => new Date(2021, 0, 4);
+            render(<InfoBanner {...mockProps} />);
+            expect(screen.queryByText('New to USAspending: COVID-19 Spending Data')).toBeFalsy();
+        });
+    });
+    describe('Pre-migration banner', () => {
+        it('should not display before 1/4/21', () => {
+            // mock date 1/3/21
+            Date.now = () => new Date(2021, 0, 3);
+            render(<InfoBanner {...mockProps} />);
+            expect(screen.queryByTestId('pre-migration-message')).toBeFalsy();
+        });
+        it('should not display after 1/8/21', () => {
+            Date.now = () => new Date(2021, 0, 8);
+            render(<InfoBanner {...mockProps} />);
+            expect(screen.queryByTestId('pre-migration-message')).toBeFalsy();
+        });
+        it('should display between 1/4/21 and 1/8/21', () => {
+            Date.now = () => new Date(2021, 0, 4);
+            render(<InfoBanner {...mockProps} />);
+            expect(screen.queryByTestId('pre-migration-message')).toBeTruthy();
+        });
+    });
+    describe('Migration banner', () => {
+        it('should not display before 1/8/21', () => {
+            // mock date 1/7/21
+            Date.now = () => new Date(2021, 0, 7);
+            render(<InfoBanner {...mockProps} />);
+            expect(screen.queryByTestId('migration-message')).toBeFalsy();
+        });
+        it('should display on 1/8/21', () => {
+            Date.now = () => new Date(2021, 0, 8);
+            render(<InfoBanner {...mockProps} />);
+            expect(screen.queryByTestId('migration-message')).toBeTruthy();
+        });
+        it('should not display on 1/14/21', () => {
+            Date.now = () => new Date(2021, 0, 14);
+            render(<InfoBanner {...mockProps} />);
+            expect(screen.queryByTestId('migration-message')).toBeFalsy();
+        });
+    });
+});


### PR DESCRIPTION
**High level description:**

Sets up the following sitewide banners:

- Pre-migration message on 1/4
- Maintenance message on 1/8
- Switch back to the current COVID banner on 1/14

**Technical details:**

- Uses a new library, `date-fns` to handle date logic (since `moment.js` is considered a legacy project)
- Changes the cookie each time the banner updates so it will re-appear to users who have previously closed the old banner
- Removes phased COVID release logic

**JIRA Ticket:**
Pre-migration message [DEV-6558](https://federal-spending-transparency.atlassian.net/browse/DEV-6588), Maintenance message [DEV-6576](https://federal-spending-transparency.atlassian.net/browse/DEV-6576), change back to COVID banner [DEV-6577](https://federal-spending-transparency.atlassian.net/browse/DEV-6577).
Split into separate tickets for testing purposes.

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)

Reviewer(s):
- [x] Code review complete
