### PR TITLE
removing VOLUME directive from the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,4 @@ RUN npm ci
 
 COPY . /node-workspace
 
-VOLUME /node-workspace
-
 RUN mkdir /test-results


### PR DESCRIPTION
**High level description:**

removing unused volume from dockerfile

**Technical details:**

We do not use the volume mount when building the application  (we instead mount a volume at /node-workspace/public) and removing the creation of the volume during the docker build process reduces the build time significantly.

Reviewer(s):
- [ ] Code review complete
