### PR TITLE
[DEV-6609] Ensuring Fiscal Year for Account Data is Accurate in drop downs, tables, and Network Calls

### DIFF
--- a/src/js/components/aboutTheData/AboutTheDataPage.jsx
+++ b/src/js/components/aboutTheData/AboutTheDataPage.jsx
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
 import { TooltipComponent, TooltipWrapper, Tabs } from "data-transparency-ui";
 import { useParams } from "react-router-dom";
 
-import { getLatestPeriod } from "helpers/accountHelper";
 import Header from "containers/shared/HeaderContainer";
 import Footer from "containers/Footer";
 import { getPeriodWithTitleById } from "helpers/aboutTheDataHelper";

--- a/src/js/components/aboutTheData/AboutTheDataPage.jsx
+++ b/src/js/components/aboutTheData/AboutTheDataPage.jsx
@@ -47,7 +47,7 @@ const AboutTheDataPage = ({
     history
 }) => {
     const { fy: urlFy, period: urlPeriod } = useParams();
-    const [dataAsOf, submissionPeriods] = useLatestAccountData();
+    const [, submissionPeriods, { year: latestFy, period: latestPeriod }] = useLatestAccountData();
     const [selectedFy, setSelectedFy] = useState(null);
     const [selectedPeriod, setSelectedPeriod] = useState(null);
 
@@ -66,9 +66,8 @@ const AboutTheDataPage = ({
     };
 
     useEffect(() => {
-        if ((!urlFy || !urlPeriod) && submissionPeriods.length) {
-            const { year, period } = getLatestPeriod(submissionPeriods);
-            history.replace(`about-the-data/agencies/${year}/${period}`);
+        if ((!urlFy || !urlPeriod) && submissionPeriods.size && latestFy && latestPeriod) {
+            history.replace(`about-the-data/agencies/${latestFy}/${latestPeriod}`);
         }
     }, []);
 
@@ -130,7 +129,8 @@ const AboutTheDataPage = ({
                         ]} />
                     <TimeFilters
                         submissionPeriods={submissionPeriods}
-                        dataAsOf={dataAsOf}
+                        latestFy={latestFy}
+                        latestPeriod={latestPeriod}
                         activeTab={activeTab}
                         onTimeFilterSelection={onTimeFilterSelection}
                         selectedPeriod={selectedPeriod}

--- a/src/js/components/aboutTheData/TimeFilters.jsx
+++ b/src/js/components/aboutTheData/TimeFilters.jsx
@@ -8,9 +8,9 @@ import PropTypes from 'prop-types';
 import { Picker } from "data-transparency-ui";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import moment from "moment";
+import { List } from "immutable";
 
 import { allFiscalYears } from "helpers/fiscalYearHelper";
-import { getLatestPeriod } from "helpers/accountHelper";
 import {
     getPeriodWithTitleById,
     getSelectedPeriodTitle,
@@ -85,23 +85,22 @@ const TimePeriodFilters = ({
     urlPeriod,
     onTimeFilterSelection,
     submissionPeriods,
-    dataAsOf
+    latestFy,
+    latestPeriod
 }) => {
-    const latestPeriod = getLatestPeriod(submissionPeriods);
-
     const handleTimeChange = (fy, period, latestAvailable = latestPeriod) => {
         onTimeFilterSelection(fy, getPeriodWithTitleById(period, latestAvailable));
     };
 
     useEffect(() => {
         // when latest account data is ready or the url changes, set the active time periods
-        if (dataAsOf) {
-            const availablePeriodsInFy = submissionPeriods.filter(({ submission_fiscal_year: y }) => parseInt(urlFy, 10) === y);
+        if (submissionPeriods.size && latestFy && latestPeriod) {
+            const availablePeriodsInFy = submissionPeriods.toJS().filter(({ submission_fiscal_year: y }) => parseInt(urlFy, 10) === y);
             if (availablePeriodsInFy.length) {
                 // fy selection is valid but what about the period? 🤔
                 const validPeriod = isPeriodVisible(availablePeriodsInFy, urlPeriod)
                     ? urlPeriod
-                    : `${latestPeriod.period}`;
+                    : `${latestPeriod}`;
 
                 const selectablePeriod = isPeriodSelectable(availablePeriodsInFy, validPeriod)
                     ? validPeriod
@@ -111,10 +110,10 @@ const TimePeriodFilters = ({
             }
             else {
                 // invalid time selection, use the latest available fy/period 👌
-                handleTimeChange(`${latestPeriod.year}`, `${latestPeriod.period}`);
+                handleTimeChange(`${latestFy}`, `${latestPeriod}`);
             }
         }
-    }, [dataAsOf, urlFy, urlPeriod]);
+    }, [submissionPeriods, urlFy, urlPeriod, latestPeriod, latestFy]);
 
     const generatePeriodDropdown = (fy, periods) => (
         parsePeriods(fy, periods)
@@ -145,8 +144,8 @@ const TimePeriodFilters = ({
                                 FY <FontAwesomeIcon icon="spinner" size="sm" alt="FY Loading ..." spin />
                             </div>
                         )}
-                    options={dataAsOf
-                        ? allFiscalYears(2017, dataAsOf.year()).map((year) => ({ name: `FY ${year}`, value: `${year}`, onClick: onTimeFilterSelection }))
+                    options={latestFy
+                        ? allFiscalYears(2017, latestFy).map((year) => ({ name: `FY ${year}`, value: `${year}`, onClick: onTimeFilterSelection }))
                         : [{ name: 'Loading fiscal years...', value: null, onClick: () => { } }]
                     } />
             </div>
@@ -177,12 +176,14 @@ TimePeriodFilters.propTypes = {
         title: PropTypes.string.isRequired,
         className: PropTypes.string
     }),
+    latestPeriod: PropTypes.number,
+    latestFy: PropTypes.number,
     selectedFy: PropTypes.string,
     urlPeriod: PropTypes.string,
     urlFy: PropTypes.string,
     activeTab: PropTypes.string.isRequired,
     onTimeFilterSelection: PropTypes.func,
-    submissionPeriods: PropTypes.array,
+    submissionPeriods: PropTypes.instanceOf(List),
     dataAsOf: PropTypes.object
 };
 

--- a/src/js/components/account/Account.jsx
+++ b/src/js/components/account/Account.jsx
@@ -19,7 +19,7 @@ import SearchResults from './SearchResults';
 
 const propTypes = {
     account: PropTypes.object,
-    currentFiscalYear: PropTypes.object
+    currentFiscalYear: PropTypes.string
 };
 
 export default class Account extends React.Component {

--- a/src/js/components/agency/AgencyContent.jsx
+++ b/src/js/components/agency/AgencyContent.jsx
@@ -8,10 +8,9 @@ import PropTypes from 'prop-types';
 import { find } from 'lodash';
 
 import { scrollToY } from 'helpers/scrollToHelper';
-import { convertDateToQuarter } from 'helpers/fiscalYearHelper';
 
 import GlossaryButtonWrapperContainer from 'containers/glossary/GlossaryButtonWrapperContainer';
-import WithLatestFy from 'containers/account/WithLatestFy';
+import { useLatestAccountData } from 'containers/account/WithLatestFy';
 import ObjectClassContainer from 'containers/agency/visualizations/ObjectClassContainer';
 import ObligatedContainer from 'containers/agency/visualizations/ObligatedContainer';
 import FederalAccountContainer from 'containers/agency/visualizations/FederalAccountContainer';
@@ -44,14 +43,14 @@ const agencySections = [
 const propTypes = {
     agency: PropTypes.object,
     isTreasury: PropTypes.bool,
-    dataAsOf: PropTypes.object
+    latestSubmissionDate: PropTypes.object
 };
 
 const AgencyContent = ({
     agency,
-    isTreasury,
-    dataAsOf
+    isTreasury
 }) => {
+    const [asOfDate, , { year: latestFy, quarter: latestQuarter }] = useLatestAccountData();
     const [activeSection, setActiveSection] = useState('overview');
 
     const jumpToSection = (section = '') => {
@@ -76,12 +75,12 @@ const AgencyContent = ({
         setActiveSection(section);
     };
 
-    const asOfDate = dataAsOf
-        ? dataAsOf.format("MMMM D, YYYY")
+    const parsedAsOfDate = asOfDate
+        ? asOfDate.format("MMMM D, YYYY")
         : "";
 
-    const activeFy = dataAsOf
-        ? `${dataAsOf.year()}`
+    const parsedLatestFy = latestFy
+        ? `${latestFy}`
         : "";
 
     let disclaimer = null;
@@ -104,27 +103,27 @@ const AgencyContent = ({
                 <div className="agency-padded-content overview">
                     <GlossaryButtonWrapperContainer
                         child={AgencyOverview}
-                        activeFy={activeFy}
-                        asOfDate={asOfDate}
+                        activeFy={parsedLatestFy}
+                        asOfDate={parsedAsOfDate}
                         agency={agency.overview} />
                 </div>
                 <div className="agency-padded-content data">
                     <ObligatedContainer
                         agencyName={agency.overview.name}
-                        activeFY={activeFy}
-                        activeQuarter={convertDateToQuarter(dataAsOf)}
+                        activeFY={parsedLatestFy}
+                        activeQuarter={latestQuarter}
                         id={agency.id}
-                        asOfDate={asOfDate} />
+                        asOfDate={parsedAsOfDate} />
                     <ObjectClassContainer
                         id={agency.id}
-                        activeFY={activeFy}
+                        activeFY={parsedLatestFy}
                         displayedTotalObligation={agency.overview.obligatedAmount}
-                        asOfDate={asOfDate} />
+                        asOfDate={parsedAsOfDate} />
                     <FederalAccountContainer
                         id={agency.id}
-                        activeFY={activeFy}
+                        activeFY={parsedLatestFy}
                         obligatedAmount={agency.overview.obligatedAmount}
-                        asOfDate={asOfDate} />
+                        asOfDate={parsedAsOfDate} />
                     {disclaimer}
                 </div>
                 <FooterLinkToAdvancedSearchContainer
@@ -137,8 +136,4 @@ const AgencyContent = ({
 
 AgencyContent.propTypes = propTypes;
 
-export default (props) => (
-    <WithLatestFy propName="dataAsOf">
-        <AgencyContent {...props} />
-    </WithLatestFy>
-);
+export default AgencyContent;

--- a/src/js/components/covid19/DateNote.jsx
+++ b/src/js/components/covid19/DateNote.jsx
@@ -5,12 +5,13 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
+
+import { useLatestAccountData } from 'containers/account/WithLatestFy';
 
 const propTypes = { styles: PropTypes.object };
 
 const DateNote = ({ styles }) => {
-    const date = useSelector((state) => state.account.dataAsOf);
+    const [date] = useLatestAccountData();
     if (!date) return null;
     return (
         <div style={{ ...styles }} className="covid__date-note">

--- a/src/js/components/sharedComponents/pickers/FYPicker.jsx
+++ b/src/js/components/sharedComponents/pickers/FYPicker.jsx
@@ -18,7 +18,7 @@ const propTypes = {
     iconColor: PropTypes.string,
     iconSize: PropTypes.string,
     sortFn: PropTypes.func,
-    latestFy: PropTypes.object,
+    latestFy: PropTypes.number,
     isLoading: PropTypes.bool
 };
 

--- a/src/js/components/sharedComponents/pickers/FYPicker.jsx
+++ b/src/js/components/sharedComponents/pickers/FYPicker.jsx
@@ -69,7 +69,7 @@ const FYPicker = ({
 
     const getActiveYears = () => {
         if (latestFy) {
-            return FiscalYearHelper.allFiscalYears(earliestFY, latestFy.year())
+            return FiscalYearHelper.allFiscalYears(earliestFY, latestFy)
                 .sort(sortFn)
                 .map((year) => (
                     <li key={year} className="fy-picker__list-item">

--- a/src/js/containers/account/AccountContainer.jsx
+++ b/src/js/containers/account/AccountContainer.jsx
@@ -25,10 +25,17 @@ import LoadingAccount from 'components/account/LoadingAccount';
 require('pages/account/accountPage.scss');
 
 const propTypes = {
-    currentFiscalYear: PropTypes.string,
+    latestSubmissionDate: PropTypes.object,
     account: PropTypes.object,
     match: PropTypes.object,
-    setSelectedAccount: PropTypes.func
+    setSelectedAccount: PropTypes.func,
+    submissionPeriods: PropTypes.arrayOf(PropTypes.object),
+    latestPeriod: PropTypes.shape({
+        year: PropTypes.number,
+        quarter: PropTypes.number,
+        period: PropTypes.number,
+        latestSubmissionDate: PropTypes.object // moment obj
+    })
 };
 
 const combinedActions = Object.assign({},
@@ -58,7 +65,7 @@ export class AccountContainer extends React.Component {
         if (prevProps.match.params.accountNumber !== this.props.match.params.accountNumber) {
             this.loadData(this.props.match.params.accountNumber);
         }
-        if (!prevProps.currentFiscalYear && this.props.currentFiscalYear && this.props.account) {
+        if (!prevProps.latestSubmissionDate && this.props.latestSubmissionDate && this.props.account) {
             this.loadFiscalYearSnapshot(this.props.account.id);
         }
     }
@@ -112,11 +119,9 @@ export class AccountContainer extends React.Component {
             this.fiscalYearSnapshotRequest.cancel();
         }
 
-        const { currentFiscalYear } = this.props;
-
         this.fiscalYearSnapshotRequest = AccountHelper.fetchFederalAccountFYSnapshot(
             id,
-            currentFiscalYear
+            this.props.latestPeriod.year
         );
 
         this.fiscalYearSnapshotRequest.promise
@@ -168,7 +173,7 @@ export class AccountContainer extends React.Component {
             output = <InvalidAccount />;
         }
         else if (!this.state.loading) {
-            output = <Account {...this.props} />;
+            output = <Account {...this.props} currentFiscalYear={`${this.props.latestPeriod.year}`} />;
         }
 
         return output;
@@ -185,7 +190,7 @@ export default connect(
     }),
     (dispatch) => bindActionCreators(combinedActions, dispatch)
 )((props) => (
-    <WithLatestFy propName="currentFiscalYear" format="YYYY">
+    <WithLatestFy>
         <AccountContainerWithRouter {...props} />
     </WithLatestFy>
 ));

--- a/src/js/containers/account/WithLatestFy.jsx
+++ b/src/js/containers/account/WithLatestFy.jsx
@@ -1,51 +1,82 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { isCancel } from 'axios';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { setAccountDataAsOfDate, setSubmissionPeriods } from 'redux/actions/account/accountActions';
-import { getLatestPeriodAsMoment, fetchAllSubmissionDates } from 'helpers/accountHelper';
+import { setSubmissionPeriods } from 'redux/actions/account/accountActions';
+import { getLatestPeriodAsMoment, getLatestPeriod, fetchAllSubmissionDates } from 'helpers/accountHelper';
 
-const WithLatestFy = ({
-    children,
-    propName = 'dataAsOf',
-    format = null
-}) => {
-    const { dataAsOf, submissionPeriods } = useSelector((state) => state.account);
-    const request = useRef();
+// TODO: Refactor existing consumers of WithLatestFy to use this custom hook
+export const useLatestAccountData = () => {
     const dispatch = useDispatch();
+    const { submissionPeriods } = useSelector((state) => state.account);
+    const [{ latestMoment, latestPeriod }, setLatestData] = useState({ latestPeriod: getLatestPeriod([]), latestMoment: null });
+    const request = useRef();
 
     useEffect(() => {
-        if (!dataAsOf) {
+        if (!submissionPeriods.size) {
             request.current = fetchAllSubmissionDates();
             request.current.promise
                 .then(({ data: { available_periods: periods } }) => {
                     dispatch(setSubmissionPeriods(periods));
-                    dispatch(setAccountDataAsOfDate(getLatestPeriodAsMoment(periods)));
+                    getLatestPeriodAsMoment(periods);
+                    setLatestData({
+                        latestMoment: getLatestPeriodAsMoment(periods),
+                        latestPeriod: getLatestPeriod(periods)
+                    });
                     request.current = null;
                 })
                 .catch((e) => {
-                    console.error('Error fetching active periods: ', e);
-                    request.current = null;
+                    if (!isCancel(e)) {
+                        console.error('Error fetching active periods: ', e);
+                        request.current = null;
+                    }
                 });
+        }
+        else if (!latestMoment || !latestPeriod) {
+            setLatestData({
+                latestMoment: getLatestPeriodAsMoment(submissionPeriods.toJS()),
+                latestPeriod: getLatestPeriod(submissionPeriods.toJS())
+            });
         }
 
         return () => {
             if (request.current) {
+                console.info('cancelling request, fetchAllSubmissionDates');
                 request.current.cancel();
             }
         };
-    }, []);
+    }, [dispatch, submissionPeriods]);
+
+    return [
+        latestMoment,
+        submissionPeriods,
+        latestPeriod
+    ];
+};
+
+const WithLatestFy = ({
+    children,
+    propName = 'latestSubmissionDate',
+    format = null
+}) => {
+    const [latestPeriodAsMoment, submissionPeriods, latestPeriod] = useLatestAccountData();
 
     if (format) {
         return React.cloneElement(children, {
-            [propName]: dataAsOf !== null
-                ? dataAsOf.format(format)
-                : dataAsOf,
-            submissionPeriods: submissionPeriods.toJS()
+            [propName]: latestPeriodAsMoment
+                ? latestPeriodAsMoment.format(format)
+                : latestPeriodAsMoment,
+            submissionPeriods: submissionPeriods.toJS(),
+            latestPeriod
         });
     }
 
-    return React.cloneElement(children, { [propName]: dataAsOf, submissionPeriods: submissionPeriods.toJS() });
+    return React.cloneElement(children, {
+        [propName]: latestPeriodAsMoment,
+        submissionPeriods: submissionPeriods.toJS(),
+        latestPeriod
+    });
 };
 
 WithLatestFy.propTypes = {
@@ -55,34 +86,3 @@ WithLatestFy.propTypes = {
 };
 
 export default WithLatestFy;
-
-// TODO: Refactor existing consumers of WithLatestFy to use this custom hook
-export const useLatestAccountData = () => {
-    const { dataAsOf, submissionPeriods } = useSelector((state) => state.account);
-    const request = useRef();
-    const dispatch = useDispatch();
-
-    useEffect(() => {
-        if (!dataAsOf) {
-            request.current = fetchAllSubmissionDates();
-            request.current.promise
-                .then(({ data: { available_periods: periods } }) => {
-                    dispatch(setSubmissionPeriods(periods));
-                    dispatch(setAccountDataAsOfDate(getLatestPeriodAsMoment(periods)));
-                    request.current = null;
-                })
-                .catch((e) => {
-                    console.error('Error fetching active periods: ', e);
-                    request.current = null;
-                });
-        }
-
-        return () => {
-            if (request.current) {
-                request.current.cancel();
-            }
-        };
-    }, []);
-
-    return [dataAsOf, submissionPeriods.toJS()];
-};

--- a/src/js/containers/account/filters/AccountTimePeriodContainer.jsx
+++ b/src/js/containers/account/filters/AccountTimePeriodContainer.jsx
@@ -16,6 +16,8 @@ import * as FiscalYearHelper from 'helpers/fiscalYearHelper';
 import WithLatestFy from 'containers/account/WithLatestFy';
 import TimePeriod from 'components/search/filters/timePeriod/TimePeriod';
 
+import { LATEST_PERIOD_PROPS } from "propTypes";
+
 const startYear = FiscalYearHelper.earliestFederalAccountYear;
 
 const propTypes = {
@@ -25,7 +27,8 @@ const propTypes = {
     filterTimePeriodFY: PropTypes.instanceOf(Immutable.Set),
     filterTimePeriodStart: PropTypes.string,
     filterTimePeriodEnd: PropTypes.string,
-    latestFy: PropTypes.object
+    submissionPeriods: PropTypes.arrayOf(PropTypes.object),
+    latestPeriod: LATEST_PERIOD_PROPS
 };
 
 export class AccountTimePeriodContainer extends React.Component {
@@ -42,13 +45,13 @@ export class AccountTimePeriodContainer extends React.Component {
     }
 
     componentDidMount() {
-        if (this.props.latestFy) {
+        if (this.props.latestPeriod.year) {
             this.generateTimePeriods();
         }
     }
 
     componentDidUpdate(prevProps) {
-        if (!prevProps.latestFy && this.props.latestFy) {
+        if (!prevProps.latestPeriod.year && this.props.latestPeriod.year) {
             this.generateTimePeriods();
         }
     }
@@ -56,7 +59,7 @@ export class AccountTimePeriodContainer extends React.Component {
     generateTimePeriods() {
         this.setState({
             timePeriods: FiscalYearHelper
-                .allFiscalYears(startYear, this.props.latestFy.year())
+                .allFiscalYears(startYear, this.props.latestPeriod.year)
                 .map((int) => String(int))
         });
     }
@@ -85,6 +88,7 @@ export class AccountTimePeriodContainer extends React.Component {
         return (
             <TimePeriod
                 {...this.props}
+                latestFy={this.props.latestPeriod.year}
                 activeTab={this.props.filterTimePeriodType}
                 timePeriods={this.state.timePeriods}
                 updateFilter={this.updateFilter}
@@ -107,7 +111,7 @@ export default connect(
         ...bindActionCreators(accountFilterActions, dispatch)
     })
 )((props) => (
-    <WithLatestFy propName="latestFy">
+    <WithLatestFy>
         <AccountTimePeriodContainer {...props} />
     </WithLatestFy>
 ));

--- a/src/js/containers/accountLanding/AccountLandingContainer.jsx
+++ b/src/js/containers/accountLanding/AccountLandingContainer.jsx
@@ -15,6 +15,7 @@ import WithLatestFy from 'containers/account/WithLatestFy';
 import AccountLandingContent from 'components/accountLanding/AccountLandingContent';
 
 import BaseFederalAccountLandingRow from 'models/accountLanding/BaseFederalAccountLandingRow';
+import { LATEST_PERIOD_PROPS } from 'propTypes';
 
 require('pages/accountLanding/accountLandingPage.scss');
 
@@ -44,13 +45,13 @@ export class AccountLandingContainer extends React.Component {
     }
 
     componentDidMount() {
-        if (this.props.fy) {
+        if (this.props.latestPeriod.year) {
             this.showColumns();
         }
     }
 
     componentDidUpdate(prevProps) {
-        if (!prevProps.fy && this.props.fy) {
+        if (!prevProps.latestPeriod.year && this.props.latestPeriod.year) {
             this.showColumns();
         }
     }
@@ -98,7 +99,7 @@ export class AccountLandingContainer extends React.Component {
     }
 
     showColumns() {
-        const { fy } = this.props;
+        const { year: fy } = this.props.latestPeriod;
         const columns = [];
         const sortOrder = AccountsTableFields.defaultSortDirection;
 
@@ -141,7 +142,7 @@ export class AccountLandingContainer extends React.Component {
             page: this.state.pageNumber,
             limit: pageSize,
             filters: {
-                fy: this.props.fy
+                fy: `${this.props.latestPeriod.year}`
             }
         };
 
@@ -206,11 +207,12 @@ export class AccountLandingContainer extends React.Component {
 }
 
 AccountLandingContainer.propTypes = {
-    fy: PropTypes.string
+    submissionPeriods: PropTypes.arrayOf(PropTypes.object),
+    latestPeriod: LATEST_PERIOD_PROPS
 };
 
 export default () => (
-    <WithLatestFy propName="fy" format="YYYY">
+    <WithLatestFy>
         <AccountLandingContainer />
     </WithLatestFy>
 );

--- a/src/js/containers/agency/visualizations/ObligatedContainer.jsx
+++ b/src/js/containers/agency/visualizations/ObligatedContainer.jsx
@@ -35,11 +35,16 @@ export class ObligatedContainer extends React.PureComponent {
     }
 
     componentDidMount() {
-        this.loadData(this.props.id, this.props.activeFY);
+        if (this.props.activeFY && this.props.id) {
+            this.loadData(this.props.id, this.props.activeFY);
+        }
     }
 
     componentDidUpdate(prevProps) {
-        if (this.props.id !== prevProps.id || this.props.activeFY !== prevProps.activeFY) {
+        if (
+            (this.props.id !== prevProps.id || this.props.activeFY !== prevProps.activeFY) &&
+            this.props.id && this.props.activeFY
+        ) {
             this.loadData(this.props.id, this.props.activeFY);
         }
     }

--- a/src/js/containers/covid19/Covid19Container.jsx
+++ b/src/js/containers/covid19/Covid19Container.jsx
@@ -41,9 +41,7 @@ import {
     fetchOverview,
     fetchAwardAmounts
 } from 'helpers/disasterHelper';
-import { getLatestPeriodAsMoment, fetchAllSubmissionDates } from 'helpers/accountHelper';
 import { setDEFCodes, setOverview, setTotals } from 'redux/actions/covid19/covid19Actions';
-import { setAccountDataAsOfDate as setLatestSubmissionDate } from 'redux/actions/account/accountActions';
 import { showModal } from 'redux/actions/modal/modalActions';
 import DataSourcesAndMethodology from 'components/covid19/DataSourcesAndMethodology';
 import OtherResources from 'components/covid19/OtherResources';
@@ -64,7 +62,6 @@ const Covid19Container = () => {
     const lastSectionRef = useRef(null);
     const awardAmountRequest = useRef(null);
     const dataDisclaimerBannerRef = useRef(null);
-    const allSubmissionDatesRequest = useRef(null);
     const dispatch = useDispatch();
     const defCodes = useSelector((state) => state.covid19.defCodes, isEqual);
     const [isBannerSticky, , , setBannerStickyOnScroll] = useDynamicStickyClass(dataDisclaimerBannerRef, getStickyBreakPointForCovidBanner(Cookies.get('usaspending_covid_homepage')));
@@ -157,26 +154,6 @@ const Covid19Container = () => {
             }
         };
     }, [defCodes, dispatch]);
-
-    useEffect(() => {
-        const getAllSubmissionDates = async () => {
-            allSubmissionDatesRequest.current = fetchAllSubmissionDates();
-            try {
-                const data = await allSubmissionDatesRequest.current.promise;
-                dispatch(setLatestSubmissionDate(getLatestPeriodAsMoment(data.data.available_periods)));
-            }
-            catch (e) {
-                console.log(' Error Submission Periods : ', e.message);
-            }
-        };
-        getAllSubmissionDates();
-        allSubmissionDatesRequest.current = null;
-        return () => {
-            if (allSubmissionDatesRequest.current) {
-                allSubmissionDatesRequest.cancel();
-            }
-        };
-    }, []);
 
     const handleExternalLinkClick = (url) => {
         dispatch(showModal(url));

--- a/src/js/helpers/accountHelper.js
+++ b/src/js/helpers/accountHelper.js
@@ -41,22 +41,6 @@ export const fetchAllSubmissionDates = () => apiRequest({
     url: 'v2/references/submission_periods/'
 });
 
-export const getLatestPeriod = (availablePeriods, fy = null) => availablePeriods
-    .filter((s) => {
-        if (fy) {
-            return s.submission_fiscal_year === parseInt(fy, 10);
-        }
-        return true;
-    })
-    .map((s) => ({
-        revealDate: moment.utc(s.submission_reveal_date),
-        asOfDate: moment.utc(s.period_end_date),
-        period: s.submission_fiscal_month,
-        year: s.submission_fiscal_year
-    }))
-    .sort(({ revealDate: a }, { revealDate: b }) => b.valueOf() - a.valueOf())
-    .find(({ revealDate: s }) => moment(s).isSameOrBefore(moment()));
-
 export const getSubmissionDeadlines = (fiscalYear, fiscalPeriod, submissionPeriods) => {
     if (!submissionPeriods.length) return null;
     const submissionPeriod = submissionPeriods
@@ -65,5 +49,45 @@ export const getSubmissionDeadlines = (fiscalYear, fiscalPeriod, submissionPerio
     return { submissionDueDate: submissionPeriod.submission_due_date, certificationDueDate: submissionPeriod.certification_due_date };
 };
 
-export const getLatestPeriodAsMoment = (availablePeriods) => getLatestPeriod(availablePeriods).asOfDate;
+export const getLatestPeriod = (availablePeriods, fy = null) => {
+    if (availablePeriods.length) {
+        return availablePeriods
+            .filter((s) => {
+                if (fy) {
+                    return s.submission_fiscal_year === parseInt(fy, 10);
+                }
+                return true;
+            })
+            .map((s) => ({
+                revealDate: moment.utc(s.submission_reveal_date),
+                asOfDate: moment.utc(s.period_end_date),
+                period: s.submission_fiscal_month,
+                year: s.submission_fiscal_year,
+                quarter: s.submission_fiscal_quarter
+            }))
+            .sort(({ revealDate: a }, { revealDate: b }) => b.valueOf() - a.valueOf())
+            .find(({ revealDate: s }) => moment(s).isSameOrBefore(moment()));
+    }
+
+    return {
+        revealDate: null,
+        asOfDate: null,
+        period: null,
+        year: null,
+        quarter: null
+    };
+};
+
+export const getLatestPeriodAsMoment = (availablePeriods) => {
+    if (availablePeriods.length) {
+        return getLatestPeriod(availablePeriods).asOfDate;
+    }
+    return {
+        revealDate: null,
+        asOfDate: null,
+        period: null,
+        year: null,
+        quarter: null
+    };
+};
 

--- a/src/js/propTypes/index.js
+++ b/src/js/propTypes/index.js
@@ -131,3 +131,10 @@ export const globalModalProps = PropTypes.shape({
     url: PropTypes.string,
     modal: PropTypes.oneOf(['redirect', '', 'covid', 'covid-data-disclaimer'])
 });
+
+export const LATEST_PERIOD_PROPS = PropTypes.shape({
+    year: PropTypes.number,
+    quarter: PropTypes.number,
+    period: PropTypes.number,
+    latestSubmissionDate: PropTypes.object // moment obj
+})

--- a/src/js/propTypes/index.js
+++ b/src/js/propTypes/index.js
@@ -137,4 +137,4 @@ export const LATEST_PERIOD_PROPS = PropTypes.shape({
     quarter: PropTypes.number,
     period: PropTypes.number,
     latestSubmissionDate: PropTypes.object // moment obj
-})
+});

--- a/src/js/redux/actions/account/accountActions.js
+++ b/src/js/redux/actions/account/accountActions.js
@@ -12,17 +12,6 @@ export const resetAccount = () => ({
     type: 'RESET_ACCOUNT'
 });
 
-/**
- * setAccountDataAsOfDate
- * @param {Object} payload: moment representing the latest submission period
- * @returns {Object}: like every redux action creator --> an object w/ a type property and one or more
- * other properties which will constitute the new redux state.
- */
-export const setAccountDataAsOfDate = (payload) => ({
-    type: 'SET_ACCOUNT_DATA_AS_OF',
-    payload
-});
-
 export const setSubmissionPeriods = (submissionPeriods) => ({
     type: 'SET_SUBMISSION_PERIODS',
     submissionPeriods

--- a/src/js/redux/reducers/account/accountReducer.js
+++ b/src/js/redux/reducers/account/accountReducer.js
@@ -43,7 +43,6 @@ export const initialState = {
         }
     },
     totalSpending: 0,
-    dataAsOf: null, // will be a moment obj
     submissionPeriods: new List()
 };
 
@@ -151,12 +150,6 @@ const accountReducer = (state = initialState, action) => {
         }
         case 'RESET_ACCOUNT': {
             return Object.assign({}, initialState);
-        }
-        case 'SET_ACCOUNT_DATA_AS_OF': {
-            return {
-                ...state,
-                dataAsOf: action.payload
-            };
         }
         case 'SET_SUBMISSION_PERIODS': {
             return {

--- a/tests/components/aboutTheData/AboutTheDataPage-test.jsx
+++ b/tests/components/aboutTheData/AboutTheDataPage-test.jsx
@@ -1,64 +1,21 @@
 import React from 'react';
+import { List } from 'immutable';
 import moment from 'moment';
-
 import { render, screen, fireEvent, waitFor } from '@test-utils';
+
 import AboutTheDataPage from 'components/aboutTheData/AboutTheDataPage';
 import * as accountHelpers from 'helpers/accountHelper';
 import * as helpers from "containers/account/WithLatestFy";
 import * as glossaryHelpers from 'helpers/glossaryHelper';
 import * as aboutTheDataHelpers from 'helpers/aboutTheDataHelper';
 import { mockAPI } from 'containers/aboutTheData/AgencyTableMapping';
+import { mockSubmissions } from '../../mockData';
 
 // latest fy of 2020; latest period is 12
-const mockPeriods = {
-    data: {
-        available_periods: [{
-            period_start_date: "2020-09-01T00:00:00Z", period_end_date: "2020-09-30T00:00:00Z", submission_start_date: "2020-10-19T00:00:00Z", submission_due_date: "2020-11-17T00:00:00Z", certification_due_date: "2020-11-17T00:00:00Z", submission_reveal_date: "2020-11-17T00:00:00Z", submission_fiscal_year: 2020, submission_fiscal_quarter: 4, submission_fiscal_month: 12, is_quarter: false
-        }, {
-            period_start_date: "2020-07-01T00:00:00Z", period_end_date: "2020-09-30T00:00:00Z", submission_start_date: "2020-10-19T00:00:00Z", submission_due_date: "2020-11-17T00:00:00Z", certification_due_date: "2020-11-17T00:00:00Z", submission_reveal_date: "2020-11-17T00:00:00Z", submission_fiscal_year: 2020, submission_fiscal_quarter: 4, submission_fiscal_month: 12, is_quarter: true
-        }, {
-            period_start_date: "2020-08-01T00:00:00Z", period_end_date: "2020-08-31T00:00:00Z", submission_start_date: "2020-09-18T00:00:00Z", submission_due_date: "2020-09-30T00:00:00Z", certification_due_date: "2020-11-17T00:00:00Z", submission_reveal_date: "2020-09-30T00:00:00Z", submission_fiscal_year: 2020, submission_fiscal_quarter: 4, submission_fiscal_month: 11, is_quarter: false
-        }, {
-            period_start_date: "2020-07-01T00:00:00Z", period_end_date: "2020-07-31T00:00:00Z", submission_start_date: "2020-08-19T00:00:00Z", submission_due_date: "2020-08-29T00:00:00Z", certification_due_date: "2020-11-17T00:00:00Z", submission_reveal_date: "2020-08-29T00:00:00Z", submission_fiscal_year: 2020, submission_fiscal_quarter: 4, submission_fiscal_month: 10, is_quarter: false
-        }, {
-            period_start_date: "2020-06-01T00:00:00Z", period_end_date: "2020-06-30T00:00:00Z", submission_start_date: "2020-07-17T00:00:00Z", submission_due_date: "2020-07-31T00:00:00Z", certification_due_date: "2020-08-15T00:00:00Z", submission_reveal_date: "2020-07-31T00:00:00Z", submission_fiscal_year: 2020, submission_fiscal_quarter: 3, submission_fiscal_month: 9, is_quarter: false
-        }, {
-            period_start_date: "2020-04-01T00:00:00Z", period_end_date: "2020-06-30T00:00:00Z", submission_start_date: "2020-07-17T00:00:00Z", submission_due_date: "2020-08-15T00:00:00Z", certification_due_date: "2020-08-15T00:00:00Z", submission_reveal_date: "2020-08-15T00:00:00Z", submission_fiscal_year: 2020, submission_fiscal_quarter: 3, submission_fiscal_month: 9, is_quarter: true
-        }, {
-            period_start_date: "2020-05-01T00:00:00Z", period_end_date: "2020-05-31T00:00:00Z", submission_start_date: "2020-07-17T00:00:00Z", submission_due_date: "2020-07-31T00:00:00Z", certification_due_date: "2020-08-15T00:00:00Z", submission_reveal_date: "2020-07-31T00:00:00Z", submission_fiscal_year: 2020, submission_fiscal_quarter: 3, submission_fiscal_month: 8, is_quarter: false
-        }, {
-            period_start_date: "2020-04-01T00:00:00Z", period_end_date: "2020-04-30T00:00:00Z", submission_start_date: "2020-07-17T00:00:00Z", submission_due_date: "2020-07-31T00:00:00Z", certification_due_date: "2020-08-15T00:00:00Z", submission_reveal_date: "2020-07-31T00:00:00Z", submission_fiscal_year: 2020, submission_fiscal_quarter: 3, submission_fiscal_month: 7, is_quarter: false
-        }, {
-            period_start_date: "2020-01-01T00:00:00Z", period_end_date: "2020-03-31T00:00:00Z", submission_start_date: "2020-04-17T00:00:00Z", submission_due_date: "2020-05-16T00:00:00Z", certification_due_date: "2020-05-16T00:00:00Z", submission_reveal_date: "2020-05-16T00:00:00Z", submission_fiscal_year: 2020, submission_fiscal_quarter: 2, submission_fiscal_month: 6, is_quarter: true
-        }, {
-            period_start_date: "2019-10-01T00:00:00Z", period_end_date: "2019-12-31T00:00:00Z", submission_start_date: "2020-01-17T00:00:00Z", submission_due_date: "2020-02-15T00:00:00Z", certification_due_date: "2020-02-15T00:00:00Z", submission_reveal_date: "2020-02-15T00:00:00Z", submission_fiscal_year: 2020, submission_fiscal_quarter: 1, submission_fiscal_month: 3, is_quarter: true
-        }, {
-            period_start_date: "2019-07-01T00:00:00Z", period_end_date: "2019-09-30T00:00:00Z", submission_start_date: "2019-10-18T00:00:00Z", submission_due_date: "2019-11-15T00:00:00Z", certification_due_date: "2019-11-15T00:00:00Z", submission_reveal_date: "2019-11-15T00:00:00Z", submission_fiscal_year: 2019, submission_fiscal_quarter: 4, submission_fiscal_month: 12, is_quarter: true
-        }, {
-            period_start_date: "2019-04-01T00:00:00Z", period_end_date: "2019-06-30T00:00:00Z", submission_start_date: "2019-07-19T00:00:00Z", submission_due_date: "2019-08-15T00:00:00Z", certification_due_date: "2019-08-15T00:00:00Z", submission_reveal_date: "2019-08-15T00:00:00Z", submission_fiscal_year: 2019, submission_fiscal_quarter: 3, submission_fiscal_month: 9, is_quarter: true
-        }, {
-            period_start_date: "2019-01-01T00:00:00Z", period_end_date: "2019-03-31T00:00:00Z", submission_start_date: "2019-04-19T00:00:00Z", submission_due_date: "2019-05-16T00:00:00Z", certification_due_date: "2019-05-16T00:00:00Z", submission_reveal_date: "2019-05-16T00:00:00Z", submission_fiscal_year: 2019, submission_fiscal_quarter: 2, submission_fiscal_month: 6, is_quarter: true
-        }, {
-            period_start_date: "2018-10-01T00:00:00Z", period_end_date: "2018-12-31T00:00:00Z", submission_start_date: "2019-02-21T00:00:00Z", submission_due_date: "2019-03-21T00:00:00Z", certification_due_date: "2019-03-21T00:00:00Z", submission_reveal_date: "2019-03-21T00:00:00Z", submission_fiscal_year: 2019, submission_fiscal_quarter: 1, submission_fiscal_month: 3, is_quarter: true
-        }, {
-            period_start_date: "2018-07-01T00:00:00Z", period_end_date: "2018-09-30T00:00:00Z", submission_start_date: "2018-10-19T00:00:00Z", submission_due_date: "2018-11-15T00:00:00Z", certification_due_date: "2018-11-15T00:00:00Z", submission_reveal_date: "2018-11-15T00:00:00Z", submission_fiscal_year: 2018, submission_fiscal_quarter: 4, submission_fiscal_month: 12, is_quarter: true
-        }, {
-            period_start_date: "2018-04-01T00:00:00Z", period_end_date: "2018-06-30T00:00:00Z", submission_start_date: "2018-07-19T00:00:00Z", submission_due_date: "2018-08-15T00:00:00Z", certification_due_date: "2018-08-15T00:00:00Z", submission_reveal_date: "2018-08-15T00:00:00Z", submission_fiscal_year: 2018, submission_fiscal_quarter: 3, submission_fiscal_month: 9, is_quarter: true
-        }, {
-            period_start_date: "2018-01-01T00:00:00Z", period_end_date: "2018-03-31T00:00:00Z", submission_start_date: "2018-04-19T00:00:00Z", submission_due_date: "2018-05-16T00:00:00Z", certification_due_date: "2018-05-16T00:00:00Z", submission_reveal_date: "2018-05-16T00:00:00Z", submission_fiscal_year: 2018, submission_fiscal_quarter: 2, submission_fiscal_month: 6, is_quarter: true
-        }, {
-            period_start_date: "2017-10-01T00:00:00Z", period_end_date: "2017-12-31T00:00:00Z", submission_start_date: "2018-01-19T00:00:00Z", submission_due_date: "2018-02-15T00:00:00Z", certification_due_date: "2018-02-15T00:00:00Z", submission_reveal_date: "2018-02-15T00:00:00Z", submission_fiscal_year: 2018, submission_fiscal_quarter: 1, submission_fiscal_month: 3, is_quarter: true
-        }, {
-            period_start_date: "2017-07-01T00:00:00Z", period_end_date: "2017-09-30T00:00:00Z", submission_start_date: "2017-10-06T00:00:00Z", submission_due_date: "2017-12-01T00:00:00Z", certification_due_date: "2017-12-01T00:00:00Z", submission_reveal_date: "2017-12-01T00:00:00Z", submission_fiscal_year: 2017, submission_fiscal_quarter: 4, submission_fiscal_month: 12, is_quarter: true
-        }, {
-            period_start_date: "2017-04-01T00:00:00Z", period_end_date: "2017-06-30T00:00:00Z", submission_start_date: "2017-07-19T00:00:00Z", submission_due_date: "2017-08-15T00:00:00Z", certification_due_date: "2017-08-15T00:00:00Z", submission_reveal_date: "2017-08-15T00:00:00Z", submission_fiscal_year: 2017, submission_fiscal_quarter: 3, submission_fiscal_month: 9, is_quarter: true
-        }, {
-            period_start_date: "2017-01-01T00:00:00Z", period_end_date: "2017-03-31T00:00:00Z", submission_start_date: "2017-04-19T00:00:00Z", submission_due_date: "2017-05-20T00:00:00Z", certification_due_date: "2017-05-20T00:00:00Z", submission_reveal_date: "2017-05-20T00:00:00Z", submission_fiscal_year: 2017, submission_fiscal_quarter: 2, submission_fiscal_month: 6, is_quarter: true
-        }, {
-            period_start_date: "2016-10-01T00:00:00Z", period_end_date: "2016-12-31T00:00:00Z", submission_start_date: "2017-01-19T00:00:00Z", submission_due_date: "2017-02-20T00:00:00Z", certification_due_date: "2017-02-20T00:00:00Z", submission_reveal_date: "2017-02-20T00:00:00Z", submission_fiscal_year: 2017, submission_fiscal_quarter: 1, submission_fiscal_month: 3, is_quarter: true
-        }]
-    }
+const q4Fy2020 = {
+    period_start_date: "2020-09-01T00:00:00Z", period_end_date: "2020-09-30T00:00:00Z", submission_start_date: "2020-10-19T00:00:00Z", submission_due_date: "2020-11-17T00:00:00Z", certification_due_date: "2020-11-17T00:00:00Z", submission_reveal_date: "2020-11-17T00:00:00Z", submission_fiscal_year: 2020, submission_fiscal_quarter: 4, submission_fiscal_month: 12, is_quarter: false
 };
+const mockPeriods = new List([mockSubmissions, q4Fy2020]);
 
 const mockGlossary = {
     data: {
@@ -100,12 +57,13 @@ const defaultProps = {
 };
 
 beforeEach(() => {
-    jest.spyOn(helpers, 'useLatestAccountData').mockReturnValue([
+    jest.spyOn(helpers, "useLatestAccountData").mockReturnValue([
         moment(),
-        mockPeriods.data.available_periods
+        mockPeriods,
+        { year: 2020, period: 12 }
     ]);
     jest.spyOn(accountHelpers, 'fetchAllSubmissionDates').mockReturnValue({
-        promise: Promise.resolve(mockPeriods),
+        promise: Promise.resolve(mockSubmissions),
         cancel: () => {
             console.log('cancel called');
         }

--- a/tests/components/aboutTheData/TimeFilters-test.jsx
+++ b/tests/components/aboutTheData/TimeFilters-test.jsx
@@ -1,11 +1,16 @@
 import React from 'react';
+import { List } from 'immutable';
+import { render, screen } from '@test-utils';
 
-import { render, screen, waitForElementToBeRemoved } from '@test-utils';
 import TimeFilters from 'components/aboutTheData/TimeFilters';
 import * as accountHelpers from 'helpers/accountHelper';
 import * as glossaryHelpers from 'helpers/glossaryHelper';
 import { mockGlossary, mockSubmissions } from '../../mockData';
-import moment from 'moment';
+
+const q4Fy2020 = {
+    period_start_date: "2020-09-01T00:00:00Z", period_end_date: "2020-09-30T00:00:00Z", submission_start_date: "2020-10-19T00:00:00Z", submission_due_date: "2020-11-17T00:00:00Z", certification_due_date: "2020-11-17T00:00:00Z", submission_reveal_date: "2020-11-17T00:00:00Z", submission_fiscal_year: 2020, submission_fiscal_quarter: 4, submission_fiscal_month: 12, is_quarter: false
+};
+const mockPeriods = new List([...mockSubmissions, q4Fy2020]);
 
 const defaultProps = {
     urlPeriod: '12',
@@ -14,12 +19,8 @@ const defaultProps = {
     onTimeFilterSelection: jest.fn(),
     selectedPeriod: null,
     selectedFy: null,
-    submissionPeriods: mockSubmissions,
+    submissionPeriods: mockPeriods,
     dataAsOf: null
-};
-
-const q4Fy2020 = {
-    period_start_date: "2020-09-01T00:00:00Z", period_end_date: "2020-09-30T00:00:00Z", submission_start_date: "2020-10-19T00:00:00Z", submission_due_date: "2020-11-17T00:00:00Z", certification_due_date: "2020-11-17T00:00:00Z", submission_reveal_date: "2020-11-17T00:00:00Z", submission_fiscal_year: 2020, submission_fiscal_quarter: 4, submission_fiscal_month: 12, is_quarter: false
 };
 
 beforeEach(() => {
@@ -50,12 +51,12 @@ test('Publication Dates table does not show period picker', async () => {
 test('Validates fiscal year from url', async () => {
     // bad fiscal year:
     const mockOnTimeSelection = jest.fn();
-    render(<TimeFilters {...defaultProps} dataAsOf={moment()} onTimeFilterSelection={mockOnTimeSelection} urlFy="1990" />);
+    render(<TimeFilters {...defaultProps} onTimeFilterSelection={mockOnTimeSelection} latestFy={2020} latestPeriod={12} urlFy="1990" />);
     expect(mockOnTimeSelection).toHaveBeenCalledWith("2020", { className: "last-period-per-quarter", id: "12", title: "Q4 P12" });
 });
 
 test('Validates period from url', async () => {
     const mockOnTimeSelection = jest.fn();
-    render(<TimeFilters {...defaultProps} dataAsOf={moment()} onTimeFilterSelection={mockOnTimeSelection} urlFy="2020" urlPeriod="13" />);
+    render(<TimeFilters {...defaultProps} onTimeFilterSelection={mockOnTimeSelection} latestFy={2020} latestPeriod={12} urlFy="2020" urlPeriod="13" />);
     expect(mockOnTimeSelection).toHaveBeenCalledWith("2020", { className: "last-period-per-quarter", id: "12", title: "Q4 P12" });
 });

--- a/tests/containers/account/AccountContainer-test.jsx
+++ b/tests/containers/account/AccountContainer-test.jsx
@@ -56,6 +56,8 @@ describe('AccountContainer', () => {
         };
 
         const container = mount(<AccountContainer
+            submissionPeriods={[]}
+            latestPeriod={{ year: 2020 }}
             match={parameters}
             setSelectedAccount={jest.fn()}
             account={mockRedux} />);
@@ -76,6 +78,8 @@ describe('AccountContainer', () => {
         };
 
         const container = mount(<AccountContainer
+            submissionPeriods={[]}
+            latestPeriod={{ year: 2020 }}
             match={parameters}
             setSelectedAccount={jest.fn()}
             account={mockRedux} />);
@@ -109,7 +113,10 @@ describe('AccountContainer', () => {
             const expected = new FederalAccount(mockAccount);
             const reduxAction = jest.fn();
 
-            const container = shallow(<AccountContainer setSelectedAccount={reduxAction} />);
+            const container = shallow(<AccountContainer
+                submissionPeriods={[]}
+                latestPeriod={{ year: 2020 }}
+                setSelectedAccount={reduxAction} />);
             container.instance().parseAccount(mockAccount);
             expect(reduxAction).toHaveBeenCalledTimes(1);
 
@@ -135,6 +142,8 @@ describe('AccountContainer', () => {
             const reduxAction = jest.fn();
 
             const container = shallow(<AccountContainer
+                submissionPeriods={[]}
+                latestPeriod={{ year: 2020 }}
                 setSelectedAccount={reduxAction}
                 account={initialModel} />);
 
@@ -160,6 +169,8 @@ describe('AccountContainer', () => {
             const reduxAction = jest.fn();
 
             const container = shallow(<AccountContainer
+                submissionPeriods={[]}
+                latestPeriod={{ year: 2020 }}
                 setSelectedAccount={reduxAction}
                 account={initialModel} />);
 

--- a/tests/containers/account/filters/AccountTimePeriodContainer-test.jsx
+++ b/tests/containers/account/filters/AccountTimePeriodContainer-test.jsx
@@ -19,7 +19,7 @@ const defaultFilters = {
     filterTimePeriodFY: new Set(),
     filterTimePeriodStart: null,
     filterTimePeriodEnd: null,
-    latestFy: moment()
+    latestPeriod: { year: 2020 }
 };
 
 describe('AccountTimePeriodContainer', () => {

--- a/tests/containers/accountLanding/AccountLandingContainer-test.jsx
+++ b/tests/containers/accountLanding/AccountLandingContainer-test.jsx
@@ -13,7 +13,7 @@ import { mockData, mockParsed } from './mockFederalAccounts';
 
 jest.mock('helpers/accountLandingHelper', () => require('./accountLandingHelper'));
 jest.mock('react-redux', () => ({
-    useSelector: (cb) => (cb({ account: { dataAsOf: null } })),
+    useSelector: (cb) => (cb({ account: { latestSubmissionDate: null } })),
     useDispatch: (cb) => () => cb()
 }));
 
@@ -21,12 +21,14 @@ jest.mock('react-redux', () => ({
 jest.mock('components/accountLanding/AccountLandingContent', () =>
     jest.fn(() => null));
 
-const fy = `${FiscalYearHelper.currentFiscalYear()}`;
+const latestPeriod = {
+    year: 2020
+};
 
 describe('AccountLandingContainer', () => {
     it('should make an API request on mount', async () => {
         // mount the container
-        const container = mount(<AccountLandingContainer fy={fy} />);
+        const container = mount(<AccountLandingContainer latestPeriod={latestPeriod} />);
         const parseAccounts = jest.fn();
         container.instance().parseAccounts = parseAccounts;
 
@@ -37,7 +39,7 @@ describe('AccountLandingContainer', () => {
 
     describe('showColumns', () => {
         it('should build the table', () => {
-            const container = shallow(<AccountLandingContainer fy={fy} />);
+            const container = shallow(<AccountLandingContainer latestPeriod={latestPeriod} />);
 
             container.instance().showColumns();
 
@@ -61,7 +63,7 @@ describe('AccountLandingContainer', () => {
                 {
                     columnName: "budgetaryResources",
                     defaultDirection: "desc",
-                    displayName: `${fy} Budgetary Resources`
+                    displayName: `2020 Budgetary Resources`
                 }
             ];
 
@@ -71,9 +73,7 @@ describe('AccountLandingContainer', () => {
 
     describe('setSearchString', () => {
         it('should update the setAccountSearchString state value to the provided input', () => {
-            const container = shallow(
-                <AccountLandingContainer fy={fy} />
-            );
+            const container = shallow(<AccountLandingContainer latestPeriod={latestPeriod} />);
 
             container.instance().fetchAccounts = jest.fn();
 
@@ -81,9 +81,7 @@ describe('AccountLandingContainer', () => {
             expect(container.state().searchString).toEqual('test');
         });
         it('should trigger a fetch operation after setRecipientSearchString gets a value', () => {
-            const container = shallow(
-                <AccountLandingContainer fy={fy} />
-            );
+            const container = shallow(<AccountLandingContainer latestPeriod={latestPeriod} />);
 
             container.instance().fetchAccounts = jest.fn();
 
@@ -94,7 +92,7 @@ describe('AccountLandingContainer', () => {
 
     describe('parseAccounts', () => {
         it('should parse the API response and update the container state', () => {
-            const container = shallow(<AccountLandingContainer fy={fy} />);
+            const container = shallow(<AccountLandingContainer latestPeriod={latestPeriod} />);
 
             container.instance().parseAccounts(mockData.data);
             expect(container.state().results).toEqual(mockParsed);
@@ -103,7 +101,7 @@ describe('AccountLandingContainer', () => {
 
     describe('updateSort', () => {
         it('should update the container state and reset the page number to 1', () => {
-            const container = shallow(<AccountLandingContainer fy={fy} />);
+            const container = shallow(<AccountLandingContainer latestPeriod={latestPeriod} />);
 
             // change the sort order
             container.instance().updateSort('managing_agency', 'asc');
@@ -119,7 +117,7 @@ describe('AccountLandingContainer', () => {
 
     describe('onChangePage', () => {
         it('should update the page number when in range', () => {
-            const container = shallow(<AccountLandingContainer fy={fy} />);
+            const container = shallow(<AccountLandingContainer latestPeriod={latestPeriod} />);
             // Give the container enough items for two pages
             container.setState({
                 totalItems: 75
@@ -130,7 +128,7 @@ describe('AccountLandingContainer', () => {
             expect(container.state().pageNumber).toEqual(2);
         });
         it('should not update the page number when out of range', () => {
-            const container = shallow(<AccountLandingContainer fy={fy} />);
+            const container = shallow(<AccountLandingContainer latestPeriod={latestPeriod} />);
             // Give the container enough items for two pages
             container.setState({
                 totalItems: 75

--- a/tests/containers/covid19/homepage/CovidHighlights-test.jsx
+++ b/tests/containers/covid19/homepage/CovidHighlights-test.jsx
@@ -19,7 +19,8 @@ const defaultProps = {
     setCovidOverview: () => {},
     setCovidDefCodes: () => {},
     completeIncrement: () => {},
-    defCodes: []
+    defCodes: [],
+    submissionPeriods: []
 };
 
 describe('CovidHighlights', () => {

--- a/tests/redux/reducers/account/accountReducer-test.js
+++ b/tests/redux/reducers/account/accountReducer-test.js
@@ -480,13 +480,6 @@ describe('accountReducer', () => {
             expect(state.filters).toEqual(secondState);
         });
     });
-    describe('SET_ACCOUNT_DATA_AS_OF', () => {
-        it('should SET_ACCOUNT_DATA_AS_OF', () => {
-            let state = accountReducer(undefined, {});
-            state = accountReducer(state, { type: 'SET_ACCOUNT_DATA_AS_OF', payload: 'June 01, 1999' });
-            expect(state.dataAsOf).toEqual('June 01, 1999');
-        });
-    });
     it('should SET_SUBMISSION_PERIODS', () => {
         const action = {
             type: 'SET_SUBMISSION_PERIODS',


### PR DESCRIPTION
**High level description:**
This has been attempted by me twice. I made some mistakes and am now taking all of @jonhill13 's advice on his initial review of this.

-  Update redux to just have `submissionPeriods` from [the endpoint](https://api.usaspending.gov/api/v2/references/submission_periods/). I kept this in the `redux.account` key space because this data is strictly related to account data.
- In all the various places where account data is displayed, use redux as the source of truth and leverage existing unit-tested helpers to extract the following details: (a) the calendar date of the most recent submissions (this data is accurate as of...), (b) the latest Fiscal Year; (c) the latest fiscal period; (d) t he. latest fiscal quarter. 

**Technical details:**
This PR will be much easier to review if you reference the commits. There are three. Each are elaborate, specifying the technical details in the commit message:

bd39df4 Refactoring redux

9f2b692 Refactoring consumers of redux property to make use of new redux structure and leverage existing helpers

ab85bb5 Update tests to utilize correct props.

**JIRA Ticket:**
[DEV-6609](https://federal-spending-transparency.atlassian.net/browse/DEV-6609)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`
- [x] Smoke Tested in Sandbox
 
Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
