### PR TITLE
[DEV-6378] Update currentPage to 1 when searchTerm Changes (About the Data Search when paginated)

### DIFF
--- a/tests/containers/aboutTheData/AgenciesContainer-test.jsx
+++ b/tests/containers/aboutTheData/AgenciesContainer-test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from 'test-utils';
+import { render, waitFor } from 'test-utils';
 
 import * as redux from 'react-redux';
 import { List } from 'immutable';
@@ -71,7 +71,8 @@ test('when totals are defined, request for totals are not made and only one for 
     const submissionsRequest = jest.spyOn(aboutTheDataHelper, 'getAgenciesReportingData').mockReturnValue(mockResponses.submissionsRequest);
     jest.spyOn(redux, 'useSelector').mockReturnValue({
         allSubmissions: [],
-        searchResults: [[], []],
+        submissionsSearchResults: [],
+        publicationsSearchResults: [],
         searchTerm: '',
         allPublications: [],
         federalTotals: [1],
@@ -90,7 +91,8 @@ test('when totals are defined, request for totals are not made and only one for 
 test('when totals are defined and the active tab changes, one request is made', () => {
     jest.spyOn(redux, 'useSelector').mockReturnValue({
         allSubmissions: [],
-        searchResults: [[], []],
+        submissionsSearchResults: [],
+        publicationsSearchResults: [],
         searchTerm: '',
         allPublications: [],
         federalTotals: [1],
@@ -114,7 +116,8 @@ test('when totals are defined and the active tab changes, one request is made', 
 test('when totals are defined and the fy changes, one request is made', () => {
     jest.spyOn(redux, 'useSelector').mockReturnValue({
         allSubmissions: [],
-        searchResults: [[], []],
+        submissionsSearchResults: [],
+        publicationsSearchResults: [],
         searchTerm: '',
         allPublications: [],
         federalTotals: [1],
@@ -137,7 +140,8 @@ test('when totals are defined and the fy changes, one request is made', () => {
 test('when totals are defined and the period changes, one request is made', () => {
     jest.spyOn(redux, 'useSelector').mockReturnValue({
         allSubmissions: [],
-        searchResults: [[], []],
+        submissionsSearchResults: [],
+        publicationsSearchResults: [],
         searchTerm: '',
         allPublications: [],
         federalTotals: [1],
@@ -160,7 +164,8 @@ test('when totals are defined and the period changes, one request is made', () =
 test('when totals are defined and the sort field changes, one request is made', () => {
     jest.spyOn(redux, 'useSelector').mockReturnValue({
         allSubmissions: [],
-        searchResults: [[], []],
+        submissionsSearchResults: [],
+        publicationsSearchResults: [],
         searchTerm: '',
         allPublications: [],
         federalTotals: [1],
@@ -174,7 +179,8 @@ test('when totals are defined and the sort field changes, one request is made', 
     const { rerender } = render(<AgenciesContainer {...defaultProps} />);
     jest.spyOn(redux, 'useSelector').mockReturnValue({
         allSubmissions: [],
-        searchResults: [[], []],
+        submissionsSearchResults: [],
+        publicationsSearchResults: [],
         searchTerm: '',
         allPublications: [],
         federalTotals: [1],
@@ -194,7 +200,8 @@ test('when totals are defined and the sort field changes, one request is made', 
 test('when totals are defined and the order field changes, one request is made', () => {
     jest.spyOn(redux, 'useSelector').mockReturnValue({
         allSubmissions: [],
-        searchResults: [[], []],
+        submissionsSearchResults: [],
+        publicationsSearchResults: [],
         searchTerm: '',
         allPublications: [],
         federalTotals: [1],
@@ -208,7 +215,8 @@ test('when totals are defined and the order field changes, one request is made',
     const { rerender } = render(<AgenciesContainer {...defaultProps} />);
     jest.spyOn(redux, 'useSelector').mockReturnValue({
         allSubmissions: [],
-        searchResults: [[], []],
+        submissionsSearchResults: [],
+        publicationsSearchResults: [],
         searchTerm: '',
         allPublications: [],
         federalTotals: [1],
@@ -228,7 +236,8 @@ test('when totals are defined and the order field changes, one request is made',
 test('when totals are defined and the search term is defined, one request is made', () => {
     jest.spyOn(redux, 'useSelector').mockReturnValue({
         allSubmissions: [],
-        searchResults: [[], []],
+        submissionsSearchResults: [],
+        publicationsSearchResults: [],
         searchTerm: '',
         allPublications: [],
         federalTotals: [1],
@@ -242,7 +251,8 @@ test('when totals are defined and the search term is defined, one request is mad
     const { rerender } = render(<AgenciesContainer {...defaultProps} />);
     jest.spyOn(redux, 'useSelector').mockReturnValue({
         allSubmissions: [],
-        searchResults: [[], []],
+        submissionsSearchResults: [],
+        publicationsSearchResults: [],
         searchTerm: 'test',
         allPublications: [],
         federalTotals: [1],


### PR DESCRIPTION
**High level description:**

Change signature of `getTableData()` to accept boolean input, by default false, which indicates wherether we should `goToFirst` page.

Tests were failing b/c previous implementation was creating duplicate API calls and breaking tests.

**Technical details:**

cb6477f

**JIRA Ticket:**
[DEV-6378](https://federal-spending-transparency.atlassian.net/browse/DEV-6378)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
