### PR TITLE
DEV-6577 Hotfix reset info banner

### DIFF
--- a/src/js/components/sharedComponents/header/Header.jsx
+++ b/src/js/components/sharedComponents/header/Header.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Cookies from 'js-cookie';
 import { Link } from 'react-router-dom';
-import { isBefore, isAfter, startOfToday } from 'date-fns';
 
 import GlossaryContainer from 'containers/glossary/GlossaryContainer';
 import GlobalModalContainer from 'containers/globalModal/GlobalModalContainer';
@@ -18,16 +17,7 @@ const clickedHeaderLink = (route) => {
     });
 };
 
-// COVID banner before 1/4/21 after 1/13/21
-let cookie = 'usaspending_covid_release';
-if (isAfter(startOfToday(), new Date(2021, 0, 3)) && isBefore(startOfToday(), new Date(2021, 0, 8))) {
-    // pre-migration banner 1/4/21 through 1/7/21
-    cookie = 'usaspending_maintenance_warn';
-}
-else if (isAfter(startOfToday(), new Date(2021, 0, 7)) && isBefore(startOfToday(), new Date(2021, 0, 14))) {
-    // migration banner 1/8/21 through 1/13/21
-    cookie = 'usaspending_maintenance';
-}
+const cookie = 'usaspending_covid_release';
 
 export default class Header extends React.Component {
     constructor(props) {

--- a/src/js/components/sharedComponents/header/InfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/InfoBanner.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { isBefore, isAfter, startOfToday } from 'date-fns';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -21,28 +20,13 @@ export default class InfoBanner extends React.Component {
     }
 
     render() {
-        // Show the COVID banner before 1/4/21 after 1/13/21
-        let title = 'New to USAspending: COVID-19 Spending Data';
-        let content = (
+        const title = 'New to USAspending: COVID-19 Spending Data';
+        const content = (
             <p>
             USAspending now has spending data from federal agencies related to the Coronavirus Aid, Relief, and Economic Security (CARES) Act and other COVID-19 appropriations.
                 <button onClick={this.props.triggerModal}> Learn more</button> about the new data and features, or <Link to="/disaster/covid-19">visit the profile page</Link> to explore and download the data today!
             </p>
         );
-        if (isAfter(startOfToday(), new Date(2021, 0, 3)) && isBefore(startOfToday(), new Date(2021, 0, 8))) {
-            // Show the pre-migration banner 1/4/21 through 1/7/21
-            title = 'Maintenance Update:';
-            content = (
-                <p data-testid="pre-migration-message">USAspending daily data refreshes will be paused temporarily starting Saturday January 9, 2021 for planned maintenance. Daily updates are estimated to resume on January 14, 2021 at which time the data will be made current. Please contact the Service Desk with any questions.</p>
-            );
-        }
-        else if (isAfter(startOfToday(), new Date(2021, 0, 7)) && isBefore(startOfToday(), new Date(2021, 0, 14))) {
-            // Show the migration banner 1/8/21 through 1/13/21
-            title = 'Maintenance Update:';
-            content = (
-                <p data-testid="migration-message">USAspending daily data refreshes have been temporarily paused for planned maintenance. All data on the website is current as of January 8, 2021. Daily updates are estimated to resume on January 14, 2021 at which time the data will be made current. Please contact the Service Desk with any questions.</p>
-            );
-        }
 
         return (
             <div className="info-banner">

--- a/tests/components/sharedComponents/InfoBanner-test.jsx
+++ b/tests/components/sharedComponents/InfoBanner-test.jsx
@@ -7,19 +7,12 @@ import React from 'react';
 import InfoBanner from 'components/sharedComponents/header/InfoBanner';
 import { render, screen, fireEvent } from '@test-utils';
 
-const nativeDate = Date.now;
-
 const closeBanner = jest.fn();
 const triggerModal = jest.fn();
 const mockProps = {
     closeBanner,
     triggerModal
 };
-
-afterAll(() => {
-    // restore the native date function
-    Date.now = nativeDate;
-});
 
 describe('InfoBanner', () => {
     it('should render the dismiss button', () => {
@@ -32,59 +25,9 @@ describe('InfoBanner', () => {
         expect(closeBanner).toHaveBeenCalled();
     });
     describe('COVID-19 banner', () => {
-        it('should display before 1/4/21', () => {
-            // mock date 12/31/20
-            Date.now = () => new Date(2020, 11, 31);
-            render(<InfoBanner {...mockProps} />);
-            expect(screen.queryByText('New to USAspending: COVID-19 Spending Data')).toBeTruthy();
-        });
         it('should display again on 1/14/21', () => {
-            // mock date 1/14/21
-            Date.now = () => new Date(2021, 0, 14);
             render(<InfoBanner {...mockProps} />);
             expect(screen.queryByText('New to USAspending: COVID-19 Spending Data')).toBeTruthy();
-        });
-        it('should not display between 1/4/21 and 1/14/21', () => {
-            // mock date 1/4/21
-            Date.now = () => new Date(2021, 0, 4);
-            render(<InfoBanner {...mockProps} />);
-            expect(screen.queryByText('New to USAspending: COVID-19 Spending Data')).toBeFalsy();
-        });
-    });
-    describe('Pre-migration banner', () => {
-        it('should not display before 1/4/21', () => {
-            // mock date 1/3/21
-            Date.now = () => new Date(2021, 0, 3);
-            render(<InfoBanner {...mockProps} />);
-            expect(screen.queryByTestId('pre-migration-message')).toBeFalsy();
-        });
-        it('should not display after 1/8/21', () => {
-            Date.now = () => new Date(2021, 0, 8);
-            render(<InfoBanner {...mockProps} />);
-            expect(screen.queryByTestId('pre-migration-message')).toBeFalsy();
-        });
-        it('should display between 1/4/21 and 1/8/21', () => {
-            Date.now = () => new Date(2021, 0, 4);
-            render(<InfoBanner {...mockProps} />);
-            expect(screen.queryByTestId('pre-migration-message')).toBeTruthy();
-        });
-    });
-    describe('Migration banner', () => {
-        it('should not display before 1/8/21', () => {
-            // mock date 1/7/21
-            Date.now = () => new Date(2021, 0, 7);
-            render(<InfoBanner {...mockProps} />);
-            expect(screen.queryByTestId('migration-message')).toBeFalsy();
-        });
-        it('should display on 1/8/21', () => {
-            Date.now = () => new Date(2021, 0, 8);
-            render(<InfoBanner {...mockProps} />);
-            expect(screen.queryByTestId('migration-message')).toBeTruthy();
-        });
-        it('should not display on 1/14/21', () => {
-            Date.now = () => new Date(2021, 0, 14);
-            render(<InfoBanner {...mockProps} />);
-            expect(screen.queryByTestId('migration-message')).toBeFalsy();
         });
     });
 });


### PR DESCRIPTION
**High level description:**

Since the migration was completed a day early, change the sitewide banner back to the COVID-19 message.

**Technical details:**

Also went ahead and removed the date logic since it is no longer necessary.

**JIRA Ticket:**
[DEV-6577](https://federal-spending-transparency.atlassian.net/browse/DEV-6577)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Updated Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations [React Testing Library](react-testing-library.md)

Reviewer(s):
- [x] Code review complete
