### PR TITLE
Bug-6364 Custom Account Download FY Period Quarter Picker

### DIFF
--- a/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
+++ b/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
@@ -173,11 +173,11 @@ export class BulkDownloadPageContainer extends React.Component {
             params.filters.budget_subfunction = formState.budgetSubfunction.code;
         }
 
-        if (formState.period !== '') {
-            params.filters.period = formState.period;
+        if (formState.period !== 0 && !formState.period) {
+            params.filters.quarter = formState.quarter;
         }
         else {
-            params.filters.quarter = formState.quarter;
+            params.filters.period = formState.period;
         }
 
         this.requestDownload(params, 'accounts');

--- a/tests/containers/bulkDownload/BulkDownloadPageContainer-test.jsx
+++ b/tests/containers/bulkDownload/BulkDownloadPageContainer-test.jsx
@@ -365,7 +365,8 @@ describe('BulkDownloadPageContainer', () => {
 
             expect(requestDownload).toHaveBeenCalledWith(expectedParams, 'accounts');
         });
-        it('should exclude the quarter param when the period key is defined', () => {
+
+        it('should use the quarter property when the period key is null', () => {
             const container = shallow(<BulkDownloadPageContainer
                 {...{
                     ...accountsRedux,
@@ -373,7 +374,44 @@ describe('BulkDownloadPageContainer', () => {
                         ...accountsRedux.bulkDownload,
                         accounts: {
                             ...accountsRedux.bulkDownload.accounts,
-                            quarter: '',
+                            quarter: '4',
+                            period: null
+                        }
+                    }
+                }}
+                {...mockActions} />);
+
+            const expectedParams = {
+                account_level: 'treasury_account',
+                filters: {
+                    budget_function: '300',
+                    budget_subfunction: '123',
+                    agency: '123',
+                    federal_account: '212',
+                    submission_types: ['account_balances'],
+                    fy: '1989',
+                    quarter: '4',
+                    def_codes: ["L", "M", "N", "O", "P"]
+                },
+                file_format: 'csv'
+            };
+
+            const requestDownload = jest.fn();
+            container.instance().requestDownload = requestDownload;
+
+            container.instance().startAccountDownload();
+
+            expect(requestDownload).toHaveBeenCalledWith(expectedParams, 'accounts');
+        });
+        it('should use the period property when the quarter key is null', () => {
+            const container = shallow(<BulkDownloadPageContainer
+                {...{
+                    ...accountsRedux,
+                    bulkDownload: {
+                        ...accountsRedux.bulkDownload,
+                        accounts: {
+                            ...accountsRedux.bulkDownload.accounts,
+                            quarter: null,
                             period: '5'
                         }
                     }


### PR DESCRIPTION
**High level description:**

Custom Account Download FY Period Quarter Picker is fully functional.

**Technical details:**

The `period` and `quarter` property are being stored as null values. This updates the logic to falsey.

**JIRA Ticket:**
[DEV-6364](https://federal-spending-transparency.atlassian.net/browse/DEV-6364)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [N/A] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [N/A] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
