### PR TITLE
[DEV-6291] Updating footer Links

### DIFF
--- a/src/js/containers/Footer.jsx
+++ b/src/js/containers/Footer.jsx
@@ -115,33 +115,6 @@ const Footer = ({
                         </div>
                         <div className="link-group">
                             <div className="group-title">
-                                Resources
-                            </div>
-                            <ul className="links">
-                                <li>
-                                    <Link to="/download_center/data_dictionary">
-                                        Data Dictionary
-                                    </Link>
-                                </li>
-                                <li>
-                                    <FooterExternalLink
-                                        link="https://fiscal.treasury.gov/data-transparency/DAIMS-current.html"
-                                        title="Data Model" />
-                                </li>
-                                <li>
-                                    <FooterExternalLink
-                                        link="https://datalab.usaspending.gov"
-                                        title="Data Lab" />
-                                </li>
-                                <li>
-                                    <FooterExternalLink
-                                        link="http://fiscaldata.treasury.gov/"
-                                        title="Fiscal Data" />
-                                </li>
-                            </ul>
-                        </div>
-                        <div className="link-group">
-                            <div className="group-title">
                                 Developers
                             </div>
                             <ul className="links">
@@ -154,6 +127,24 @@ const Footer = ({
                                     <FooterExternalLink
                                         link="https://github.com/fedspendingtransparency/usaspending-website/tree/master"
                                         title="Explore the Code" />
+                                </li>
+                                <li>
+                                    <FooterExternalLink
+                                        link="https://github.com/fedspendingtransparency/usaspending-website/releases"
+                                        title="Release Notes" />
+                                </li>
+                            </ul>
+                        </div>
+                        <div className="link-group">
+                            <div className="group-title">
+                                    Our Sites
+                            </div>
+                            <ul className="links">
+                                <li>
+                                    <a target="_blank" rel="noopener noreferrer" href="https://datalab.usaspending.gov/">Data Lab</a>
+                                </li>
+                                <li>
+                                    <a target="_blank" rel="noopener noreferrer" href="https://fiscaldata.treasury.gov/">Fiscal Data</a>
                                 </li>
                             </ul>
                         </div>


### PR DESCRIPTION
**High level description:**
Re-organizing/deleting links in footer.

**Technical details:**

994d190
- Removing the Resources tab
- Add our sites as the last option in footer w/ links to fiscal data
and data lab
- Under developers tab, adding release notes

**JIRA Ticket:**
[DEV-6291](https://federal-spending-transparency.atlassian.net/browse/DEV-6291)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
