### PR TITLE
[DEV-6748] Refactor Advanced Search to Utilize QueryParams Avoiding Re-Render

### DIFF
--- a/src/js/containers/search/SearchContainer.jsx
+++ b/src/js/containers/search/SearchContainer.jsx
@@ -7,7 +7,7 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { isCancel } from 'axios';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 
 import { filterStoreVersion, requiredTypes, initialState } from 'redux/reducers/search/searchFiltersReducer';
 import { restoreHashedFilters } from 'redux/actions/search/searchHashActions';
@@ -71,7 +71,10 @@ export const parseRemoteFilters = (data) => {
 };
 
 const SearchContainer = ({ history }) => {
-    const { urlHash } = useParams();
+    const { urlHash: pathHash } = useParams();
+    const { hash: queryHash } = SearchHelper.getObjFromQueryParams(useLocation().search);
+    const urlHash = pathHash || queryHash;
+
     const dispatch = useDispatch();
     const {
         filters: stagedFilters,
@@ -167,15 +170,24 @@ const SearchContainer = ({ history }) => {
             if (request.current) {
                 request.current.cancel();
             }
+            // clear selected filters so we don't fetch previous search
+            dispatch(resetAppliedFilters());
+            dispatch(clearAllFilters());
         };
     }, []);
 
     useEffect(() => {
         if (areAppliedFiltersEmpty && prevAreAppliedFiltersEmpty === false) {
             // all the filters were cleared, reset to a blank hash
-            history.replace('/search');
+            history.replace({
+                pathname: '/search',
+                search: ''
+            });
+            if (queryHash) {
+                setDownloadAvailable(false);
+            }
         }
-    }, [areAppliedFiltersEmpty]);
+    }, [areAppliedFiltersEmpty, urlHash]);
 
     const generateHash = useCallback(() => {
         // POST an API request to retrieve the Redux state
@@ -193,8 +205,10 @@ const SearchContainer = ({ history }) => {
         request.current.promise
             .then((res) => {
                 // update the URL with the received hash
-                const newHash = res.data.hash;
-                history.replace(`/search/${newHash}`);
+                history.push({
+                    pathname: `/search/`,
+                    search: `?${new URLSearchParams({ hash: res.data.hash }).toString()}`
+                });
                 setGenerateHashInFlight(false);
             })
             .catch((err) => {

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -122,19 +122,18 @@ export class ResultsTableContainer extends React.Component {
         // we can't hide the table entirely because the viewport is required to calculate the
         // row rendering
         this.loadColumns();
-        if (SearchHelper.isSearchHashReady(this.props.location.pathname)) {
+        if (SearchHelper.isSearchHashReady(this.props.location)) {
             this.pickDefaultTab();
         }
     }
 
     componentDidUpdate(prevProps) {
-        const filtersChanged = !SearchHelper.areFiltersEqual(prevProps.filters, this.props.filters);
-        if (filtersChanged && !this.props.noApplied) {
-            // filters changed, update the search object
+        if (prevProps.subaward !== this.props.subaward && !this.props.noApplied) {
+            // subaward toggle changed, update the search object
             this.pickDefaultTab();
         }
-        else if (prevProps.subaward !== this.props.subaward && !this.props.noApplied) {
-            // subaward toggle changed, update the search object
+        else if (SearchHelper.isSearchHashReady(this.props.location) && (this.props.location.search !== prevProps.location.search || prevProps.location.pathname !== this.props.location.pathname)) {
+            // hash is (a) defined and (b) new
             this.pickDefaultTab();
         }
     }

--- a/src/js/helpers/searchHelper.js
+++ b/src/js/helpers/searchHelper.js
@@ -177,7 +177,28 @@ export const areFiltersSelected = (filters) => !areFiltersEqual(filters);
 
 export const areFiltersDifferent = (a, b) => !areFiltersEqual(a, b);
 
-export const isSearchHashReady = (str) => str
-    .split('/search/')
-    .filter((s) => s && s !== "/search")
-    .length > 0;
+export const isSearchHashReady = ({ pathname, search }) => {
+    if (!pathname && !search) return false;
+    if (search) {
+        const params = new URLSearchParams(search);
+        for (const [key, value] of params.entries()) {
+            if (key === 'hash' && value) {
+                return true;
+            }
+        }
+        return false;
+    }
+    return pathname
+        .split('/search/')
+        .filter((s) => s && s !== "/search")
+        .length > 0;
+};
+
+export const getObjFromQueryParams = (str) => {
+    const params = new URLSearchParams(str);
+    const obj = {};
+    for (const [key, value] of params.entries()) {
+        obj[key] = value;
+    }
+    return obj;
+};

--- a/tests/containers/search/SearchContainer-test.jsx
+++ b/tests/containers/search/SearchContainer-test.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { Set } from 'immutable';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 import * as redux from 'react-redux';
 
 import SearchContainer, { parseRemoteFilters } from 'containers/search/SearchContainer';
@@ -22,6 +22,8 @@ global.Promise = jest.requireActual('promise');
 jest.mock('components/search/SearchPage', () => (
     jest.fn(() => null)
 ));
+
+jest.spyOn(URLSearchParams.prototype, 'toString').mockImplementation(() => 'str');
 
 jest.mock('helpers/searchHelper', () => ({
     ...jest.requireActual('helpers/searchHelper'),
@@ -41,7 +43,8 @@ jest.mock('react-redux', () => {
 
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
-    useParams: jest.fn().mockReturnValue({ urlHash: 'abc' })
+    useParams: jest.fn().mockReturnValue({ urlHash: 'abc' }),
+    useLocation: jest.fn().mockReturnValue({ search: '' })
 }));
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
@@ -71,7 +74,7 @@ test('parseRemoteFilters should return an immutable data structure when versions
     expect(parseRemoteFilters(mock.filter).timePeriodFY).toEqual(expectedFilter);
 });
 
-test('a non-hashed does not make a request to the api', async () => {
+test('a non-hashed url does not make a request to the api', async () => {
     useParams.mockReturnValueOnce({ urlHash: null });
     render(<SearchContainer />, {});
     await waitFor(() => {
@@ -80,7 +83,20 @@ test('a non-hashed does not make a request to the api', async () => {
     });
 });
 
-test('a hashed url makes a request to the api & sets loading state', async () => {
+test('a hashed url (in the pathname) makes a request to the api & sets loading state', async () => {
+    const setLoadingStateFn = jest.spyOn(appliedFilterActions, 'setAppliedFilterEmptiness');
+    render(<SearchContainer />, {});
+    await waitFor(() => {
+        expect(restoreUrlHash).toHaveBeenCalledTimes(1);
+        expect(setLoadingStateFn).toHaveBeenCalledWith(false);
+        expect(generateUrlHash).not.toHaveBeenCalled();
+    });
+});
+
+test('a hashed url (as a query param) makes a request to the api & sets loading state', async () => {
+    restoreUrlHash.mockClear();
+    useParams.mockReturnValueOnce({ urlHash: '' });
+    useLocation.mockReturnValueOnce({ search: '?hash=abc' });
     const setLoadingStateFn = jest.spyOn(appliedFilterActions, 'setAppliedFilterEmptiness');
     render(<SearchContainer />, {});
     await waitFor(() => {
@@ -94,7 +110,7 @@ test('when filters change (a) hash is generated, (b) loading is set & (c) url is
     restoreUrlHash.mockClear();
     useParams.mockReturnValueOnce({ urlHash: null });
     const setLoading = jest.spyOn(appliedFilterActions, 'setAppliedFilterEmptiness');
-    const mockReplace = jest.fn();
+    const mockPush = jest.fn();
     jest.spyOn(redux, 'useSelector').mockReturnValue({
         ...mockRedux,
         appliedFilters: {
@@ -105,11 +121,16 @@ test('when filters change (a) hash is generated, (b) loading is set & (c) url is
         }
     });
 
-    render(<SearchContainer history={{ replace: mockReplace }} />, {});
+    render(<SearchContainer history={{ push: mockPush }} />, {});
 
     await waitFor(() => {
         expect(generateUrlHash).toHaveBeenCalledTimes(1);
-        expect(mockReplace).toHaveBeenCalledTimes(1);
+        expect(mockPush).toHaveBeenCalledTimes(1);
+        expect(mockPush).toHaveBeenLastCalledWith({
+            pathname: '/search/',
+            // not ?hash=str because we aren't mocking out new URLSearchParams
+            search: '?str'
+        });
         expect(setLoading).toHaveBeenCalledWith(false);
         expect(restoreUrlHash).not.toHaveBeenCalled();
     });

--- a/tests/containers/search/table/ResultsTableContainer-test.jsx
+++ b/tests/containers/search/table/ResultsTableContainer-test.jsx
@@ -51,7 +51,7 @@ describe('ResultsTableContainer', () => {
         const newFilters = Object.assign({}, mockRedux.filters, {
             timePeriodFY: new Set(['1987'])
         });
-        container.setProps({ filters: newFilters });
+        container.setProps({ filters: newFilters, location: { pathname: '/search/456' } });
 
         await container.instance().tabCountRequest.promise;
 

--- a/tests/helpers/searchHelper-test.js
+++ b/tests/helpers/searchHelper-test.js
@@ -19,8 +19,20 @@ test('areFiltersEqual should return false when filters are selected', () => {
     })).toBeFalsy();
 });
 
-test('isSearchHashReady knows when theres a hash', () => {
-    expect(isSearchHashReady('/search')).toEqual(false);
-    expect(isSearchHashReady('/search/')).toEqual(false);
-    expect(isSearchHashReady('/search/test')).toEqual(true);
+test.each([
+    ['', false],
+    ['/?', false],
+    ['/?fy=2020&period=12&hash=', false],
+    ['/?fy=2020&period=12&hash=t', true]
+])('when input (a query param) is %s return value is %s', (input, rtrn) => {
+    expect(isSearchHashReady({ search: input })).toEqual(rtrn);
+});
+
+test.each([
+    ['', false],
+    ['/search', false],
+    ['/search/', false],
+    ['/search/test', true]
+])('when input (a pathname) is %s return value is %s', (input, rtrn) => {
+    expect(isSearchHashReady({ pathname: input })).toEqual(rtrn);
 });


### PR DESCRIPTION
**High level description:**

Download button not enabled on submit. Have to refresh.

Root cause of this is that onSubmit triggers a re-render because we update the url pathname. 

**Technical details:**
**3 files changed + tests in one commit:**

4c55bef

-- SearchContainer: (A) use useLocation.search & useParams to
expect a hash as a query param (/search/?hash=xyz) or in the
path (/search/:hash); (B) on "reset search" if using hash,
manually disable the download button (when not using hash, a
re-render/mount automatically sets); (C) clear all selected filters
on unmount to prevent previous search from rendering (bug in prod)

-- searchHelper: refactor isSearchHashReady
to expect an object w/ either pathname or search
containing a hash.

-- ResultsTableContainer: consumer of isSearchHashReady:

didMount handles case where it's in the pathname,
didUpdate handles case where its in the search keyspace.
Was able to remove obsolete condition as well where we're
looking at the filters directly to detect a change.

TESTS:
-- searchHelper: new tests for refactor of isSearchHashReady
-- SearchContainer: (a) refactored to mock for queryParams
and use history.push instead of history.replace; (b) new test
to confirm hash in query params works; (c) new expect() to confirm
new hashes are using query params.
-- ResultsTableContainer: updated test to pass new hash
to trigger new request

**JIRA Ticket:**
[DEV-6748](https://federal-spending-transparency.atlassian.net/browse/DEV-6748)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`
- [ ] Sandbox Tested

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
