### PR TITLE
DEV-6773 Agency Stats table default sort

### DIFF
--- a/src/js/containers/aboutTheData/AgencyDetailsContainer.jsx
+++ b/src/js/containers/aboutTheData/AgencyDetailsContainer.jsx
@@ -22,7 +22,7 @@ const propTypes = {
 
 const AgencyDetailsContainer = ({ modalClick, agencyName, agencyCode }) => {
     const [sortStatus, updateSort] = useState({
-        field: 'current_total_budget_authority_amount',
+        field: 'fiscal_year',
         direction: 'desc'
     });
     const [{ vertical: isVertialSticky, horizontal: isHorizontalSticky }, setIsSticky] = useState({

--- a/tests/containers/aboutTheData/AgencyDetailsContainer-test.jsx
+++ b/tests/containers/aboutTheData/AgencyDetailsContainer-test.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, waitFor, fireEvent, screen } from 'test-utils';
+import '@testing-library/jest-dom/extend-expect';
+import * as aboutTheDataHelper from 'helpers/aboutTheDataHelper';
+import AgencyDetailsContainer from 'containers/aboutTheData/AgencyDetailsContainer';
+import { mockReportingPeriodRow } from './mockData';
+
+const defaultProps = {
+    agencyName: 'Mock Agency (ABC)',
+    agencyCode: '123',
+    modalClick: jest.fn()
+};
+
+const mockResponse = {
+    promise: new Promise((resolve) => {
+        process.nextTick(() => {
+            resolve(mockReportingPeriodRow);
+        });
+    }),
+    cancel: () => {
+        console.log('cancel executed!');
+    }
+};
+
+test('makes a request for table data on mount', () => {
+    const tableRequest = jest.spyOn(aboutTheDataHelper, 'fetchAgency').mockReturnValue(mockResponse);
+
+    render(<AgencyDetailsContainer {...defaultProps} />);
+    expect(tableRequest).toHaveBeenCalledTimes(2); // once for each useEffect
+});
+
+test('when the sort field changes, a new request is made', () => {
+    const tableRequest = jest.spyOn(aboutTheDataHelper, 'fetchAgency').mockClear().mockReturnValue(mockResponse);
+    render(<AgencyDetailsContainer {...defaultProps} />);
+
+    fireEvent.click(screen.getByTitle('Sort table by descending Percent of Total Federal Budget'));
+    expect(tableRequest).toHaveBeenCalledTimes(3);
+});
+
+test('when the sort order changes, a new request is made', () => {
+    const tableRequest = jest.spyOn(aboutTheDataHelper, 'fetchAgency').mockClear().mockReturnValue(mockResponse);
+    render(<AgencyDetailsContainer {...defaultProps} />);
+
+    fireEvent.click(screen.getByTitle('Sort table by ascending Reporting Period'));
+
+    return waitFor(() => {
+        expect(tableRequest).toHaveBeenCalledTimes(3);
+    });
+});
+
+test('Indicates a default sort of descending Reporting Period', () => {
+    render(<AgencyDetailsContainer {...defaultProps} />);
+    expect(screen.getByTitle('Sort table by descending Reporting Period')).toHaveClass('table-header__icon_active');
+});

--- a/tests/containers/aboutTheData/mockData.js
+++ b/tests/containers/aboutTheData/mockData.js
@@ -132,3 +132,34 @@ export const mockAPI = {
         }
     }
 };
+
+export const mockReportingPeriodRow = {
+    data: {
+        page_metadata: {
+            page: 1,
+            hasNext: false,
+            hasPrevious: false,
+            limit: 10,
+            total: 2
+        },
+        results: [
+            {
+                fiscal_year: 2020,
+                fiscal_period: 12,
+                current_total_budget_authority_amount: 8000.72,
+                recent_publication_date: "2020-01-10T11:59:21Z",
+                recent_publication_date_certified: false,
+                tas_account_discrepancies_totals: {
+                    gtas_obligation_total: 55234,
+                    tas_accounts_total: 23923,
+                    tas_obligation_not_in_gtas_total: 343345,
+                    missing_tas_accounts_count: 20
+                },
+                percent_of_total_budgetary_resources: 2.189,
+                obligation_difference: 4000.00,
+                unlinked_contract_award_count: 20002,
+                unlinked_assistance_award_count: 10001,
+                assurance_statement_url: 'https://files.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2020/Q1/MockAgency(ABC)-Assurance_Statement.txt'}
+        ]
+    }
+};

--- a/tests/models/aboutTheData/BaseReportingPeriodRow-test.js
+++ b/tests/models/aboutTheData/BaseReportingPeriodRow-test.js
@@ -6,27 +6,11 @@
 import BaseReportingPeriodRow from 'models/v2/aboutTheData/BaseReportingPeriodRow';
 import CoreReportingRow from 'models/v2/aboutTheData/CoreReportingRow';
 
-export const mockReportingPeriodRow = {
-    fiscal_year: 2020,
-    fiscal_period: 12,
-    current_total_budget_authority_amount: 8000.72,
-    recent_publication_date: "2020-01-10T11:59:21Z",
-    recent_publication_date_certified: false,
-    tas_account_discrepancies_totals: {
-        gtas_obligation_total: 55234,
-        tas_accounts_total: 23923,
-        tas_obligation_not_in_gtas_total: 343345,
-        missing_tas_accounts_count: 20
-    },
-    percent_of_total_budgetary_resources: 2.189,
-    obligation_difference: 4000.00,
-    unlinked_contract_award_count: 20002,
-    unlinked_assistance_award_count: 10001,
-    assurance_statement_url: 'https://files.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2020/Q1/MockAgency(ABC)-Assurance_Statement.txt'
-};
+import { mockReportingPeriodRow } from '../../containers/aboutTheData/mockData';
 
+const mockResult = mockReportingPeriodRow.data.results[0];
 const reportingPeriodRow = Object.create(BaseReportingPeriodRow);
-reportingPeriodRow.populate(mockReportingPeriodRow);
+reportingPeriodRow.populate(mockResult);
 
 describe('BaseReportingPeriodRow', () => {
     it('should format the reporting period when the period corresponds to a quarter', () => {
@@ -34,7 +18,7 @@ describe('BaseReportingPeriodRow', () => {
     });
     it('should format the reporting period when the period does not correspond to a quarter', () => {
         const period7 = {
-            ...mockReportingPeriodRow,
+            ...mockResult,
             fiscal_period: 7
         };
         const reportingPeriodRowMod = Object.create(BaseReportingPeriodRow);
@@ -43,7 +27,7 @@ describe('BaseReportingPeriodRow', () => {
     });
     it('should correctly format period 02 to indicate it includes P01', () => {
         const period2 = {
-            ...mockReportingPeriodRow,
+            ...mockResult,
             fiscal_period: 2
         };
         const reportingPeriodRowMod = Object.create(BaseReportingPeriodRow);


### PR DESCRIPTION
**High level description:**

Changes the single Agency Submission Statistics table default sort to the Reporting Period column

**Technical details:**

Reporting Period column correlates to sorting by `fiscal_year`, [DEV-6771](https://federal-spending-transparency.atlassian.net/browse/DEV-6771) will add fiscal period as secondary sort on the backend.

**JIRA Ticket:**
[DEV-6773](https://federal-spending-transparency.atlassian.net/browse/DEV-6773)

**Mockup:**
https://bahdigital.invisionapp.com/share/5BIAFVV7KUX#/296054014_003__All-Statistics-To-SBA

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)


Reviewer(s):
- [x] Code review complete
