### PR TITLE
DEV-6593 About the Data tooltips bug

### DIFF
--- a/src/_scss/pages/aboutTheData/aboutTheData.scss
+++ b/src/_scss/pages/aboutTheData/aboutTheData.scss
@@ -56,4 +56,25 @@
             margin-right: rem(5);
         }
     }
+    .usda-table {
+        thead {
+            th {
+                .wide {
+                    .tooltip-spacer {
+                        width: 600px !important;
+                    }
+                    &.wide_left {
+                        .tooltip-spacer {
+                            left: -408px !important;
+                        }
+                    }
+                    &.wide-right {
+                        .tooltip-spacer {
+                            right: 408px !important;
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/_scss/pages/aboutTheData/aboutTheData.scss
+++ b/src/_scss/pages/aboutTheData/aboutTheData.scss
@@ -68,7 +68,7 @@
                             left: -408px !important;
                         }
                     }
-                    &.wide-right {
+                    &.wide_right {
                         .tooltip-spacer {
                             right: 408px !important;
                         }

--- a/src/js/containers/aboutTheData/AgencyTableMapping.jsx
+++ b/src/js/containers/aboutTheData/AgencyTableMapping.jsx
@@ -8,18 +8,20 @@ import PropTypes from 'prop-types';
 import { TooltipComponent, TooltipWrapper } from 'data-transparency-ui';
 import { columnTooltips } from 'components/aboutTheData/dataMapping/tooltipContentMapping';
 
-const Tooltip = ({ title, position = 'right' }) => (
+const Tooltip = ({ title, position = 'right', className = '' }) => (
     <TooltipWrapper
         icon="info"
+        className={className}
         tooltipPosition={position}
         tooltipComponent={
-            <TooltipComponent title={title}>{columnTooltips[title]}</TooltipComponent>
+            <TooltipComponent className={title} title={title}>{columnTooltips[title]}</TooltipComponent>
         } />
 );
 
 Tooltip.propTypes = {
     title: PropTypes.string.isRequired,
-    position: PropTypes.oneOf(['left', 'right'])
+    position: PropTypes.oneOf(['left', 'right']),
+    className: PropTypes.string
 };
 
 export const agenciesTableColumns = {
@@ -99,13 +101,13 @@ export const agenciesTableColumns = {
         {
             title: 'unlinked_contract_award_count',
             displayName: 'Number of Unlinked Contract Awards',
-            icon: <Tooltip title="Number of Unlinked Contract Awards" />,
+            icon: <Tooltip title="Number of Unlinked Contract Awards" className="wide wide_right" />,
             right: true
         },
         {
             title: 'unlinked_assistance_award_count',
             displayName: 'Number of Unlinked Assistance Awards',
-            icon: <Tooltip title="Number of Unlinked Assistance Awards" position="left" />,
+            icon: <Tooltip title="Number of Unlinked Assistance Awards" position="left" className="wide wide_left" />,
             right: true
         },
         {
@@ -146,13 +148,13 @@ export const agencyDetailsColumns = [
     {
         title: 'unlinked_cont_award_count',
         displayName: 'Number of Unlinked Contract Awards',
-        icon: <Tooltip title="Number of Unlinked Contract Awards" />,
+        icon: <Tooltip title="Number of Unlinked Contract Awards" className="wide wide_right" />,
         right: true
     },
     {
         title: 'unlinked_asst_award_count',
         displayName: 'Number of Unlinked Assistance Awards',
-        icon: <Tooltip title="Number of Unlinked Assistance Awards" position="left" />,
+        icon: <Tooltip title="Number of Unlinked Assistance Awards" position="left" className="wide wide_left" />,
         right: true
     },
     {


### PR DESCRIPTION
**High level description:**

Prevents Unlinked Award column tooltips from getting cut off at the bottom of About the Data tables by making them wider.

**Technical details:**

The component library `wide` prop fills available space based on the width of the container. In this case, the width of the column itself caused the tooltip to actually get narrower when using that prop. This change overrides the width with USAS css using the `className` prop.

**JIRA Ticket:**
[DEV-6593](https://federal-spending-transparency.atlassian.net/browse/DEV-6593)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness

Reviewer(s):
- [x] Code review complete
