### PR TITLE
[DEV-6739] About the Data Overview Table Reset to Page 1 on FY/Period change

### DIFF
--- a/src/js/containers/aboutTheData/AgenciesContainer.jsx
+++ b/src/js/containers/aboutTheData/AgenciesContainer.jsx
@@ -63,6 +63,11 @@ const AgenciesContainer = ({
     const verticalStickyClass = isVerticalSticky ? 'sticky-y-table' : '';
     const horizontalStickyClass = isHorizontalSticky ? 'sticky-x-table' : '';
     const tableRef = useRef(null);
+    const pageRef = useRef({ publications: null, submissions: null });
+    const { current: { publications: prevPublicationsPg, submissions: prevSubmissionsPg } } = pageRef;
+    useEffect(() => {
+        pageRef.current = { publications: publicationsPage, submissions: submissionsPage };
+    }, [submissionsPage, publicationsPage]);
 
     const handleScroll = throttle(() => {
         const { scrollLeft: horizontal, scrollTop: vertical } = tableRef.current;
@@ -194,30 +199,34 @@ const AgenciesContainer = ({
     }, [
         federalTotals,
         activeTab,
-        selectedFy,
-        selectedPeriod,
         submissionsPage,
         publicationsPage
     ]);
 
     useEffect(() => {
-        if (activeTab === 'submissions' && submissionsPage === 1 && allSubmissions.length) {
+        const shouldResetPg = (
+            (prevSubmissionsPg && prevPublicationsPg) &&
+            (selectedFy && selectedPeriod)
+        );
+        if (activeTab === 'submissions' && submissionsPage === 1 && shouldResetPg) {
             // re-fetch w/ new params
             fetchTableData(true);
         }
-        else if (activeTab === 'submissions') {
+        else if (activeTab === 'submissions' && shouldResetPg) {
             // reset to pg 1, triggering a refetch
             changeSubmissionsPg(1);
         }
-        else if (publicationsPage === 1 && allPublications.length) {
+        else if (activeTab === 'publications' && publicationsPage === 1 && shouldResetPg) {
             // re-fetch w/ new params
             fetchTableData(true);
         }
-        else {
+        else if (activeTab === 'publications' && shouldResetPg) {
             // reset to pg 1, triggering a refetch
             changePublicationsPg(1);
         }
     }, [
+        selectedFy,
+        selectedPeriod,
         submissionsSort,
         submissionsLimit,
         publicationsSort,

--- a/tests/containers/aboutTheData/AgenciesContainer-test.jsx
+++ b/tests/containers/aboutTheData/AgenciesContainer-test.jsx
@@ -177,6 +177,8 @@ test('when totals are defined and the sort field changes, one request is made', 
     });
     const submissionsRequest = jest.spyOn(aboutTheDataHelper, 'getAgenciesReportingData').mockClear().mockReturnValue(mockResponses.submissionsRequest);
     const { rerender } = render(<AgenciesContainer {...defaultProps} />);
+    expect(submissionsRequest).toHaveBeenCalledTimes(1);
+    submissionsRequest.mockClear();
     jest.spyOn(redux, 'useSelector').mockReturnValue({
         allSubmissions: [],
         submissionsSearchResults: [],
@@ -190,9 +192,10 @@ test('when totals are defined and the sort field changes, one request is made', 
             { submission_fiscal_year: 2020, submission_fiscal_month: 8 }
         ])
     });
+
     rerender(<AgenciesContainer {...defaultProps} />);
+
     return waitFor(() => {
-        // if you changes this to three the test will fail; once on mount, then only once more.
         expect(submissionsRequest).toHaveBeenCalledTimes(2);
     });
 });
@@ -213,6 +216,7 @@ test('when totals are defined and the order field changes, one request is made',
     });
     const submissionsRequest = jest.spyOn(aboutTheDataHelper, 'getAgenciesReportingData').mockClear().mockReturnValue(mockResponses.submissionsRequest);
     const { rerender } = render(<AgenciesContainer {...defaultProps} />);
+    submissionsRequest.mockClear();
     jest.spyOn(redux, 'useSelector').mockReturnValue({
         allSubmissions: [],
         submissionsSearchResults: [],
@@ -249,6 +253,7 @@ test('when totals are defined and the search term is defined, one request is mad
     });
     const submissionsRequest = jest.spyOn(aboutTheDataHelper, 'getAgenciesReportingData').mockClear().mockReturnValue(mockResponses.submissionsRequest);
     const { rerender } = render(<AgenciesContainer {...defaultProps} />);
+    submissionsRequest.mockClear();
     jest.spyOn(redux, 'useSelector').mockReturnValue({
         allSubmissions: [],
         submissionsSearchResults: [],


### PR DESCRIPTION
**High level description:**

Reset to page one on fy/period change.

**Technical details:**

A couple parts to this:

(1) get previous page # so we dont make duplicate requests on first render. (see line 207)
(2) Tests needed to be updated so that the rerender is always expected to also call submissionsRequest (see line 181, for instance)

**JIRA Ticket:**
[DEV-6739](https://federal-spending-transparency.atlassian.net/browse/DEV-6739)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A`  Design review complete `if applicable`
- [x] Code review complete
