### PR TITLE
DEV-6758 update toptier_code field

### DIFF
--- a/src/js/models/v2/aboutTheData/BaseAgencyRow.js
+++ b/src/js/models/v2/aboutTheData/BaseAgencyRow.js
@@ -10,7 +10,7 @@ const BaseAgencyRow = Object.create(CoreReportingRow);
 
 BaseAgencyRow.populate = function populate(data) {
     this.populateCore(data);
-    this.code = data.agency_code || '';
+    this.code = data.toptier_code || '';
     this._name = data.agency_name || '';
     this._abbreviation = data.abbreviation || '';
     this.name = (this._name && this._abbreviation)

--- a/src/js/models/v2/aboutTheData/PublicationOverviewRow.js
+++ b/src/js/models/v2/aboutTheData/PublicationOverviewRow.js
@@ -22,7 +22,7 @@ const DatesRow = {
     populate(fy, data, totals) {
         this._name = data.agency_name || '';
         this._abbreviation = data.abbreviation || '';
-        this._code = data.toptier_code || '';
+        this.code = data.toptier_code || '';
         this._budgetAuthority = data.current_total_budget_authority_amount || 0;
         this._federalTotal = totals
             .filter(({ fiscal_year: y }) => y === fy)

--- a/src/js/models/v2/aboutTheData/PublicationOverviewRow.js
+++ b/src/js/models/v2/aboutTheData/PublicationOverviewRow.js
@@ -1,6 +1,5 @@
 /**
- * DatesRow.js
- * Created by Lizzie Salita 11/20/20
+ * PublicationOverviewRow.js
  */
 
 import { formatMoney, formatNumber, calculatePercentage } from 'helpers/moneyFormatter';
@@ -23,7 +22,7 @@ const DatesRow = {
     populate(fy, data, totals) {
         this._name = data.agency_name || '';
         this._abbreviation = data.abbreviation || '';
-        this._code = data.agency_code || '';
+        this._code = data.toptier_code || '';
         this._budgetAuthority = data.current_total_budget_authority_amount || 0;
         this._federalTotal = totals
             .filter(({ fiscal_year: y }) => y === fy)

--- a/tests/containers/aboutTheData/mockData.js
+++ b/tests/containers/aboutTheData/mockData.js
@@ -28,7 +28,7 @@ export const mockAPI = {
                 {
                     agency_name: "Mock Agency",
                     abbreviation: "ABC",
-                    agency_code: "020",
+                    toptier_code: "020",
                     current_total_budget_authority_amount: 8000.72,
                     periods: [
                         {
@@ -45,7 +45,7 @@ export const mockAPI = {
                 {
                     agency_name: "Mock Agency",
                     abbreviation: "ABC",
-                    agency_code: "123",
+                    toptier_code: "123",
                     current_total_budget_authority_amount: 8000.72,
                     periods: [
                         {
@@ -93,7 +93,7 @@ export const mockAPI = {
                 {
                     agency_name: "Mock Agency",
                     abbreviation: "ABC",
-                    agency_code: "123",
+                    toptier_code: "123",
                     agency_id: 123,
                     current_total_budget_authority_amount: 8000.72,
                     recent_publication_date: "2020-01-10T11:59:21Z",
@@ -112,7 +112,7 @@ export const mockAPI = {
                 {
                     agency_name: "Mock Agency 2",
                     abbreviation: "XYZ",
-                    agency_code: "456",
+                    toptier_code: "456",
                     agency_id: 789,
                     current_total_budget_authority_amount: 8000.72,
                     recent_publication_date: null,


### PR DESCRIPTION
**High level description:**

Updates the name of an API field.

**Technical Details**
Also fixes a bug with links from the "Updates by Fiscal Year" tab (expecting `code` when field was `_code`)

**JIRA Ticket:**
[DEV-6758](https://federal-spending-transparency.atlassian.net/browse/DEV-6758), subtask of [DEV-6714](https://federal-spending-transparency.atlassian.net/browse/DEV-6714)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Updated Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations 
- [x] [API contract](https://github.com/fedspendingtransparency/usaspending-api/pull/2942) updated

Reviewer(s):
- [x] [API #2942](https://github.com/fedspendingtransparency/usaspending-api/pull/2942) merged concurrently
- [x] Code review complete
