### PR TITLE
Dev-4400 Date Picker Bug

### DIFF
--- a/src/js/components/sharedComponents/DatePicker.jsx
+++ b/src/js/components/sharedComponents/DatePicker.jsx
@@ -103,6 +103,17 @@ export default class DatePicker extends React.Component {
             // have to hold a reference to the bound function in order to cancel the listener later
             window.addEventListener('keyup', this.escapeEvent);
         }
+        else if (this.state.showDatePicker) {
+            /**
+             * Given a user updates the month in the date picker to a month that does not include the date selected,
+             * we must focus on another element within the datepicker or a user will not be able to outside click to
+             * hide the datepicker.
+             */
+            this.datepicker.focus();
+            // we want to close the date picker on escape key
+            // have to hold a reference to the bound function in order to cancel the listener later
+            window.addEventListener('keyup', this.escapeEvent);
+        }
         else {
             // date picker is now closed, stop listening for this event
             window.removeEventListener('keyup', this.escapeEvent);

--- a/src/js/components/sharedComponents/DatePicker.jsx
+++ b/src/js/components/sharedComponents/DatePicker.jsx
@@ -89,9 +89,15 @@ export default class DatePicker extends React.Component {
     }
 
     datePickerChangeEvent() {
-        if (this.state.showDatePicker) {
+        const selectedDay = this.datepicker.dayPicker.querySelector('.DayPicker-Day--selected');
+        /**
+         * Given a user updates the month in the date picker to a month that does not include the date selected,
+         * there will not be a selected day class and will err, therefore if there is no selected day in the current
+         * month in the day picker we will not focus it.
+         */
+        if (this.state.showDatePicker && selectedDay) {
             // focus on the date picker
-            this.datepicker.dayPicker.querySelector('.DayPicker-Day--selected').focus();
+            selectedDay.focus();
 
             // we want to close the date picker on escape key
             // have to hold a reference to the bound function in order to cancel the listener later


### PR DESCRIPTION
**Do Not Merge**

- [x] https://github.com/fedspendingtransparency/usaspending-website/pull/2380 has been merged.

**High level description:**

Fixes an error in the date picker on the advanced search page where if a user updates the month to not include the currently selected date and tries open the date picker will break the page.

**Technical details:**

> • Check for selected day element before focusing on it.

**JIRA Ticket:**
[DEV-4400](https://federal-spending-transparency.atlassian.net/browse/DEV-4400)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
