### PR TITLE
[DEV-6815] Adding Share Icon to About The Data Pg

### DIFF
--- a/src/js/components/aboutTheData/AboutTheDataPage.jsx
+++ b/src/js/components/aboutTheData/AboutTheDataPage.jsx
@@ -9,6 +9,7 @@ import { TooltipComponent, TooltipWrapper, Tabs } from "data-transparency-ui";
 import { useLocation } from "react-router-dom";
 
 import Header from "containers/shared/HeaderContainer";
+import ShareIcon from "components/sharedComponents/stickyHeader/ShareIcon";
 import Footer from "containers/Footer";
 import { getPeriodWithTitleById } from "helpers/aboutTheDataHelper";
 import StickyHeader from "components/sharedComponents/stickyHeader/StickyHeader";
@@ -42,9 +43,15 @@ TableTabLabel.propTypes = {
 
 const message = "All numeric figures in this table are calculated based on the set of TAS owned by each agency, as opposed to the set of TAS that the agency directly reported to USAspending.gov. In the vast majority of cases, these are exactly the same (upwards of 95% of TAS—with these TAS representing over 99% of spending—are submitted and owned by the same agency). This display decision is consistent with our practice throughout the website of grouping TAS by the owning agency rather than the reporting agency. While reporting agencies are not identified in this table, they are available in the Custom Account Download in the reporting_agency_name field.";
 
+const emailDetails = {
+    subject: 'Agency Submission Statistics | USAspending.gov',
+    body: ''
+};
+
 const AboutTheDataPage = ({
     history
 }) => {
+    const { search } = useLocation();
     const query = new URLSearchParams(useLocation().search);
     const urlFy = query.get('fy');
     const urlPeriod = query.get('period');
@@ -111,6 +118,9 @@ const AboutTheDataPage = ({
             <StickyHeader>
                 <div className="sticky-header__title">
                     <h1 tabIndex={-1}>Agency Submission Statistics</h1>
+                </div>
+                <div className="sticky-header__toolbar">
+                    <ShareIcon slug={`submission-statistics/${search}`} email={emailDetails} />
                 </div>
             </StickyHeader>
             <main id="main-content" className="main-content">


### PR DESCRIPTION
**High level description:**

Adds the share icon to the page header

Screenshots:

![image](https://user-images.githubusercontent.com/12897813/108237776-3b1e6900-7116-11eb-848d-4d9840a68f38.png)
![image](https://user-images.githubusercontent.com/12897813/108237790-3f4a8680-7116-11eb-8015-d95f381b0fd3.png)
![image](https://user-images.githubusercontent.com/12897813/108237799-42457700-7116-11eb-9f50-61e1d1d303d7.png)


**Technical details:**

Reusing existing component and styles.

**JIRA Ticket:**
[DEV-6815](https://federal-spending-transparency.atlassian.net/browse/DEV-6815)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A`  Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
