### PR TITLE
[DEV-6852] Warmfix Federal Account profile bug

### DIFF
--- a/src/js/components/account/AccountOverview.jsx
+++ b/src/js/components/account/AccountOverview.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { isEqual } from 'lodash';
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 
 import SankeyVisualization from './visualizations/sankey/SankeyVisualization';
@@ -51,7 +52,7 @@ export default class AccountOverview extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (prevProps.account.id !== this.props.account.id) {
+        if (!isEqual(prevProps.account, this.props.account)) {
             this.generateSummary(this.props.account);
         }
     }

--- a/tests/containers/account/AccountContainer-test.jsx
+++ b/tests/containers/account/AccountContainer-test.jsx
@@ -50,39 +50,30 @@ const stripModelId = (model) => {
 };
 
 describe('AccountContainer', () => {
+    afterEach(() => {
+        loadAccountSpy.reset();
+        loadFiscalYearSnapshotSpy.reset();
+    });
     it('should make an API call for the selected account on mount', async () => {
-        const mockRedux = {
-            account: mockReduxAccount
-        };
-
         const container = mount(<AccountContainer
-            submissionPeriods={[]}
             latestPeriod={{ year: 2020 }}
             match={parameters}
             setSelectedAccount={jest.fn()}
-            account={mockRedux} />);
+            account={mockReduxAccount} />);
 
         await container.instance().accountRequest.promise;
         await container.instance().fiscalYearSnapshotRequest.promise;
 
         expect(loadAccountSpy.callCount).toEqual(1);
         expect(loadFiscalYearSnapshotSpy.callCount).toEqual(1);
-
-        loadAccountSpy.reset();
-        loadFiscalYearSnapshotSpy.reset();
     });
 
-    it('should make an API call when the award ID parameter changes', async () => {
-        const mockRedux = {
-            account: mockReduxAccount
-        };
-
+    it('should make an API call when the account number parameter changes', async () => {
         const container = mount(<AccountContainer
-            submissionPeriods={[]}
             latestPeriod={{ year: 2020 }}
             match={parameters}
             setSelectedAccount={jest.fn()}
-            account={mockRedux} />);
+            account={mockReduxAccount} />);
 
         await container.instance().accountRequest.promise;
         await container.instance().fiscalYearSnapshotRequest.promise;
@@ -103,9 +94,39 @@ describe('AccountContainer', () => {
 
         expect(loadAccountSpy.callCount).toEqual(2);
         expect(loadFiscalYearSnapshotSpy.callCount).toEqual(2);
+    });
 
-        loadAccountSpy.reset();
-        loadFiscalYearSnapshotSpy.reset();
+    it('should not make an API call for FY Snapshot data if the latest FY is not available', async () => {
+        const container = mount(<AccountContainer
+            latestPeriod={{ year: null }}
+            match={parameters}
+            setSelectedAccount={jest.fn()}
+            account={mockReduxAccount} />);
+
+        await container.instance().accountRequest.promise;
+
+        expect(loadAccountSpy.callCount).toEqual(1);
+        expect(loadFiscalYearSnapshotSpy.callCount).toEqual(0);
+    });
+
+    it('should make an API call for FY Snapshot data when the latest FY becomes available', () => {
+        const container = shallow(<AccountContainer
+            latestPeriod={{ year: 1999 }}
+            match={parameters}
+            setSelectedAccount={jest.fn()}
+            account={mockReduxAccount} />);
+
+        const prevProps = {
+            latestPeriod: { year: null },
+            account: {
+                id: 123
+            },
+            match: parameters
+        };
+
+        container.instance().componentDidUpdate(prevProps);
+
+        expect(loadFiscalYearSnapshotSpy.callCount).toEqual(1);
     });
 
     describe('parseAccount', () => {
@@ -114,7 +135,6 @@ describe('AccountContainer', () => {
             const reduxAction = jest.fn();
 
             const container = shallow(<AccountContainer
-                submissionPeriods={[]}
                 latestPeriod={{ year: 2020 }}
                 setSelectedAccount={reduxAction} />);
             container.instance().parseAccount(mockAccount);


### PR DESCRIPTION
(warmfix version of #2391)

**High level description:**

Fixes a bug that sometimes prevented the overview data from displaying on initial load of the Federal Account profile page.

**Technical details:**

At first I went down a rabbit hole of refactoring and there is a lot that _could_ be improved with this page. The root of the problem was [here](https://github.com/fedspendingtransparency/usaspending-website/compare/fix/dev-6852-fed-account-bug?expand=1#diff-063e6d3c48538b3cd3ab557395678c9a5a2a726eaa432dab5c9fd3ea99cba8edL54). `AccountContainer` makes two API requests, one for the account overview info (internal id, name, etc) and one for the monetary values (budget authority, obligations, etc). They both are stored in the `account.account` object in redux. The bug occurred when `totals` was not populated in time for render. Now `componentDidUpdate` compares the whole `account` object instead of just the `id`. 

It also removes an unnecessary state variable (`currentAccountNumber`) from `AccountContainer` and ensures we show the loading state if the latest FY is loading.

**JIRA Ticket:**
[DEV-6852](https://federal-spending-transparency.atlassian.net/browse/DEV-6852)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR 
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations

Reviewer(s):
- [ ] Code review complete