### PR TITLE
[DEV-6852] Warmfix Federal Account profile bug

### DIFF
--- a/src/js/components/account/AccountOverview.jsx
+++ b/src/js/components/account/AccountOverview.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { isEqual } from 'lodash';
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 
 import SankeyVisualization from './visualizations/sankey/SankeyVisualization';
@@ -51,7 +52,7 @@ export default class AccountOverview extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (prevProps.account.id !== this.props.account.id) {
+        if (!isEqual(prevProps.account, this.props.account)) {
             this.generateSummary(this.props.account);
         }
     }

--- a/src/js/containers/account/AccountContainer.jsx
+++ b/src/js/containers/account/AccountContainer.jsx
@@ -64,6 +64,8 @@ export class AccountContainer extends React.Component {
             this.loadData();
         }
         if (!prevProps.latestPeriod?.year && this.props.latestPeriod?.year && this.props.account?.id) {
+            // The latest FY became available and we have the internal / database id required for
+            // the FY snapshot request
             this.loadFiscalYearSnapshot(this.props.account.id);
         }
     }

--- a/src/js/containers/account/AccountContainer.jsx
+++ b/src/js/containers/account/AccountContainer.jsx
@@ -107,7 +107,9 @@ export class AccountContainer extends React.Component {
     parseAccount(data) {
         const account = new FederalAccount(data);
         this.props.setSelectedAccount(account);
-        this.loadFiscalYearSnapshot(account.id);
+        if (this.props.latestPeriod.year) {
+            this.loadFiscalYearSnapshot(account.id);
+        }
     }
 
     loadFiscalYearSnapshot(id) {
@@ -115,35 +117,33 @@ export class AccountContainer extends React.Component {
             this.fiscalYearSnapshotRequest.cancel();
         }
 
-        if (this.props.latestPeriod.year) {
-            this.fiscalYearSnapshotRequest = AccountHelper.fetchFederalAccountFYSnapshot(
-                id,
-                this.props.latestPeriod.year
-            );
+        this.fiscalYearSnapshotRequest = AccountHelper.fetchFederalAccountFYSnapshot(
+            id,
+            this.props.latestPeriod.year
+        );
 
-            this.fiscalYearSnapshotRequest.promise
-                .then((res) => {
-                    this.fiscalYearSnapshotRequest = null;
+        this.fiscalYearSnapshotRequest.promise
+            .then((res) => {
+                this.fiscalYearSnapshotRequest = null;
 
-                    // update the redux store
-                    this.parseFYSnapshot(res.data);
+                // update the redux store
+                this.parseFYSnapshot(res.data);
 
+                this.setState({
+                    loading: false
+                });
+            })
+            .catch((err) => {
+                this.fiscalYearSnapshotRequest = null;
+
+                if (!isCancel(err)) {
                     this.setState({
                         loading: false
                     });
-                })
-                .catch((err) => {
-                    this.fiscalYearSnapshotRequest = null;
 
-                    if (!isCancel(err)) {
-                        this.setState({
-                            loading: false
-                        });
-
-                        console.log(err);
-                    }
-                });
-        }
+                    console.log(err);
+                }
+            });
     }
 
     parseFYSnapshot(data) {

--- a/src/js/containers/account/AccountContainer.jsx
+++ b/src/js/containers/account/AccountContainer.jsx
@@ -47,7 +47,6 @@ export class AccountContainer extends React.Component {
         super(props);
 
         this.state = {
-            currentAccountNumber: '',
             loading: true,
             validAccount: true
         };
@@ -57,29 +56,28 @@ export class AccountContainer extends React.Component {
     }
 
     componentDidMount() {
-        this.loadData(this.props.match.params.accountNumber);
+        this.loadData();
     }
 
     componentDidUpdate(prevProps) {
         if (prevProps.match.params.accountNumber !== this.props.match.params.accountNumber) {
-            this.loadData(this.props.match.params.accountNumber);
+            this.loadData();
         }
         if (!prevProps.latestSubmissionDate && this.props.latestSubmissionDate && this.props.account) {
             this.loadFiscalYearSnapshot(this.props.account.id);
         }
     }
 
-    loadData(accountNumber) {
+    loadData() {
         if (this.accountRequest) {
             this.accountRequest.cancel();
         }
 
         this.setState({
-            loading: true,
-            currentAccountNumber: accountNumber
+            loading: true
         });
 
-        this.accountRequest = AccountHelper.fetchFederalAccount(accountNumber);
+        this.accountRequest = AccountHelper.fetchFederalAccount(this.props.match.params.accountNumber);
 
         this.accountRequest.promise
             .then((res) => {
@@ -98,8 +96,7 @@ export class AccountContainer extends React.Component {
                 if (!isCancel(err)) {
                     this.setState({
                         loading: false,
-                        validAccount: false,
-                        currentAccountNumber: accountNumber
+                        validAccount: false
                     });
 
                     console.log(err);

--- a/src/js/containers/account/AccountContainer.jsx
+++ b/src/js/containers/account/AccountContainer.jsx
@@ -29,12 +29,12 @@ import LoadingAccount from 'components/account/LoadingAccount';
 require('pages/account/accountPage.scss');
 
 const propTypes = {
-    latestSubmissionDate: PropTypes.object,
     account: PropTypes.object,
     match: PropTypes.object,
     setSelectedAccount: PropTypes.func,
     submissionPeriods: SUBMISSION_PERIOD_PROPS,
-    latestPeriod: LATEST_PERIOD_PROPS
+    latestPeriod: LATEST_PERIOD_PROPS,
+    isFetchLatestFyLoading: PropTypes.bool
 };
 
 const combinedActions = Object.assign({},
@@ -63,7 +63,7 @@ export class AccountContainer extends React.Component {
         if (prevProps.match.params.accountNumber !== this.props.match.params.accountNumber) {
             this.loadData();
         }
-        if (!prevProps.latestSubmissionDate && this.props.latestSubmissionDate && this.props.account) {
+        if (!prevProps.latestPeriod?.year && this.props.latestPeriod?.year && this.props.account?.id) {
             this.loadFiscalYearSnapshot(this.props.account.id);
         }
     }
@@ -170,7 +170,7 @@ export class AccountContainer extends React.Component {
         if (!this.state.loading && !this.state.validAccount) {
             output = <InvalidAccount />;
         }
-        else if (!this.state.loading) {
+        else if (!this.state.loading && !this.props.isFetchLatestFyLoading) {
             output = <Account {...this.props} currentFiscalYear={`${this.props.latestPeriod.year}`} />;
         }
 

--- a/tests/containers/account/AccountContainer-test.jsx
+++ b/tests/containers/account/AccountContainer-test.jsx
@@ -50,39 +50,30 @@ const stripModelId = (model) => {
 };
 
 describe('AccountContainer', () => {
+    afterEach(() => {
+        loadAccountSpy.reset();
+        loadFiscalYearSnapshotSpy.reset();
+    });
     it('should make an API call for the selected account on mount', async () => {
-        const mockRedux = {
-            account: mockReduxAccount
-        };
-
         const container = mount(<AccountContainer
-            submissionPeriods={[]}
             latestPeriod={{ year: 2020 }}
             match={parameters}
             setSelectedAccount={jest.fn()}
-            account={mockRedux} />);
+            account={mockReduxAccount} />);
 
         await container.instance().accountRequest.promise;
         await container.instance().fiscalYearSnapshotRequest.promise;
 
         expect(loadAccountSpy.callCount).toEqual(1);
         expect(loadFiscalYearSnapshotSpy.callCount).toEqual(1);
-
-        loadAccountSpy.reset();
-        loadFiscalYearSnapshotSpy.reset();
     });
 
     it('should make an API call when the award ID parameter changes', async () => {
-        const mockRedux = {
-            account: mockReduxAccount
-        };
-
         const container = mount(<AccountContainer
-            submissionPeriods={[]}
             latestPeriod={{ year: 2020 }}
             match={parameters}
             setSelectedAccount={jest.fn()}
-            account={mockRedux} />);
+            account={mockReduxAccount} />);
 
         await container.instance().accountRequest.promise;
         await container.instance().fiscalYearSnapshotRequest.promise;
@@ -103,9 +94,19 @@ describe('AccountContainer', () => {
 
         expect(loadAccountSpy.callCount).toEqual(2);
         expect(loadFiscalYearSnapshotSpy.callCount).toEqual(2);
+    });
 
-        loadAccountSpy.reset();
-        loadFiscalYearSnapshotSpy.reset();
+    it('should not make an API call for FY Snapshot data if the latest FY is not available', async () => {
+        const container = mount(<AccountContainer
+            latestPeriod={{ year: null }}
+            match={parameters}
+            setSelectedAccount={jest.fn()}
+            account={mockReduxAccount} />);
+
+        await container.instance().accountRequest.promise;
+
+        expect(loadAccountSpy.callCount).toEqual(1);
+        expect(loadFiscalYearSnapshotSpy.callCount).toEqual(0);
     });
 
     describe('parseAccount', () => {
@@ -114,7 +115,6 @@ describe('AccountContainer', () => {
             const reduxAction = jest.fn();
 
             const container = shallow(<AccountContainer
-                submissionPeriods={[]}
                 latestPeriod={{ year: 2020 }}
                 setSelectedAccount={reduxAction} />);
             container.instance().parseAccount(mockAccount);

--- a/tests/containers/account/AccountContainer-test.jsx
+++ b/tests/containers/account/AccountContainer-test.jsx
@@ -68,7 +68,7 @@ describe('AccountContainer', () => {
         expect(loadFiscalYearSnapshotSpy.callCount).toEqual(1);
     });
 
-    it('should make an API call when the award ID parameter changes', async () => {
+    it('should make an API call when the account number parameter changes', async () => {
         const container = mount(<AccountContainer
             latestPeriod={{ year: 2020 }}
             match={parameters}
@@ -107,6 +107,26 @@ describe('AccountContainer', () => {
 
         expect(loadAccountSpy.callCount).toEqual(1);
         expect(loadFiscalYearSnapshotSpy.callCount).toEqual(0);
+    });
+
+    it('should make an API call for FY Snapshot data when the latest FY becomes available', () => {
+        const container = shallow(<AccountContainer
+            latestPeriod={{ year: 1999 }}
+            match={parameters}
+            setSelectedAccount={jest.fn()}
+            account={mockReduxAccount} />);
+
+        const prevProps = {
+            latestPeriod: { year: null },
+            account: {
+                id: 123
+            },
+            match: parameters
+        };
+
+        container.instance().componentDidUpdate(prevProps);
+
+        expect(loadFiscalYearSnapshotSpy.callCount).toEqual(1);
     });
 
     describe('parseAccount', () => {

--- a/tests/containers/account/AccountContainer-test.jsx
+++ b/tests/containers/account/AccountContainer-test.jsx
@@ -118,9 +118,7 @@ describe('AccountContainer', () => {
 
         const prevProps = {
             latestPeriod: { year: null },
-            account: {
-                id: 123
-            },
+            account: mockAccount,
             match: parameters
         };
 


### PR DESCRIPTION
(warmfix version of #2391)

**High level description:**

Fixes a bug that sometimes prevented the overview data from displaying on initial load of the Federal Account profile page.

**Technical details:**

At first I went down a rabbit hole of refactoring and there is a lot that _could_ be improved with this page. The root of the problem was [here](https://github.com/fedspendingtransparency/usaspending-website/compare/fix/dev-6852-fed-account-bug?expand=1#diff-063e6d3c48538b3cd3ab557395678c9a5a2a726eaa432dab5c9fd3ea99cba8edL54). `AccountContainer` makes two API requests, one for the account overview info (internal id, name, etc) and one for the monetary values (budget authority, obligations, etc). They both are stored in the `account.account` object in redux. The bug occurred when `totals` was not populated in time for render. Now `componentDidUpdate` compares the whole `account` object instead of just the `id`. 

It also removes an unnecessary state variable (`currentAccountNumber`) from `AccountContainer` and ensures we show the loading state if the latest FY is loading.

**JIRA Ticket:**
[DEV-6852](https://federal-spending-transparency.atlassian.net/browse/DEV-6852)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Provided instructions for testing in JIRA
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations

Reviewer(s):
- [x] Code review complete