### PR TITLE
[DEV-6739] Populate Percent of Total Federal Budget Column

### DIFF
--- a/src/js/containers/aboutTheData/AgenciesContainer.jsx
+++ b/src/js/containers/aboutTheData/AgenciesContainer.jsx
@@ -189,14 +189,10 @@ const AgenciesContainer = ({
 
     useEffect(() => {
         // FY or Period changes
-        if (!federalTotals.length) {
-            fetchTotals();
-        }
-        else if (selectedFy && selectedPeriod) {
+        if (selectedFy && selectedPeriod) {
             fetchTableData();
         }
     }, [
-        federalTotals,
         activeTab,
         submissionsPage,
         publicationsPage
@@ -207,7 +203,10 @@ const AgenciesContainer = ({
             (prevSubmissionsPg && prevPublicationsPg) &&
             (selectedFy && selectedPeriod)
         );
-        if (activeTab === 'submissions' && submissionsPage === 1 && shouldResetPg) {
+        if (selectedFy && selectedPeriod && !federalTotals.length) {
+            fetchTotals();
+        }
+        else if (activeTab === 'submissions' && submissionsPage === 1 && shouldResetPg) {
             // re-fetch w/ new params
             fetchTableData(true);
         }
@@ -224,6 +223,7 @@ const AgenciesContainer = ({
             changePublicationsPg(1);
         }
     }, [
+        federalTotals,
         selectedFy,
         selectedPeriod,
         submissionsSort,

--- a/src/js/containers/aboutTheData/AgenciesContainer.jsx
+++ b/src/js/containers/aboutTheData/AgenciesContainer.jsx
@@ -188,7 +188,7 @@ const AgenciesContainer = ({
     }, []);
 
     useEffect(() => {
-        // FY or Period changes
+        // Active tab or page number changes
         if (selectedFy && selectedPeriod) {
             fetchTableData();
         }


### PR DESCRIPTION
**High level description:**

Refactoring in 611cb3f broke the logic where we call `fetchTotals` and populate this column. SS:

![image](https://user-images.githubusercontent.com/12897813/108276723-45f0f200-7146-11eb-9ed8-3dea48df09ff.png)


**Technical details:**

See commit message

**JIRA Ticket:**
[DEV-6739](https://federal-spending-transparency.atlassian.net/browse/DEV-6739)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
