### PR TITLE
making sitemapscript configurable for different environments

### DIFF
--- a/scripts/sitemaps/buildSitemap.js
+++ b/scripts/sitemaps/buildSitemap.js
@@ -5,7 +5,7 @@ const axios = require('axios');
 const path = require('path');
 const tunnel = require('tunnel');
 
-const siteUrl = process.env.SITE_URL;
+const siteUrl = process.env.SITE_URL || 'https://www.usaspending.gov';
 const xmlStart = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
 const indexedSitemapXmlStart = `<?xml version="1.0" encoding="UTF-8"?>

--- a/scripts/sitemaps/buildSitemap.js
+++ b/scripts/sitemaps/buildSitemap.js
@@ -5,7 +5,7 @@ const axios = require('axios');
 const path = require('path');
 const tunnel = require('tunnel');
 
-const siteUrl = 'https://www.usaspending.gov';
+const siteUrl = process.env.SITE_URL;
 const xmlStart = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
 const indexedSitemapXmlStart = `<?xml version="1.0" encoding="UTF-8"?>

--- a/scripts/sitemaps/pages.js
+++ b/scripts/sitemaps/pages.js
@@ -26,7 +26,7 @@ const recipientRequestObject = {
     updatedFrequency: 'daily',
     priority: '0.8',
     isAsync: true,
-    url: 'https://api.usaspending.gov:443/api/v2/recipient/duns/',
+    url: `${process.env.API_URL}/api/v2/recipient/duns/`,
     method: 'post',
     requestObject: {
         name: 'recipient',
@@ -37,7 +37,7 @@ const recipientRequestObject = {
         award_type: "all"
     },
     accessor: 'id',
-    clientRoute: 'https://www.usaspending.gov/recipient'
+    clientRoute: `${process.env.SITE_URL}/recipient`
 };
 
 const awardPageInfo = {
@@ -45,7 +45,7 @@ const awardPageInfo = {
     updatedFrequency: 'daily',
     priority: '0.9',
     isAsync: true,
-    url: 'https://api.usaspending.gov:443/api/v2/search/spending_by_award/',
+    url: `${process.env.API_URL}/api/v2/search/spending_by_award/`,
     method: 'post',
     requestObject: {
         filters: {
@@ -71,7 +71,7 @@ const awardPageInfo = {
         subawards: false
     },
     accessor: 'generated_internal_id',
-    clientRoute: 'https://www.usaspending.gov/award'
+    clientRoute: `${process.env.SITE_URL}/award`
 };
 
 const federalAccountPageInfo = {
@@ -79,7 +79,7 @@ const federalAccountPageInfo = {
     updatedFrequency: 'daily',
     priority: '0.7',
     isAsync: true,
-    url: 'https://api.usaspending.gov:443/api/v2/federal_accounts/',
+    url: `${process.env.API_URL}/api/v2/federal_accounts/`,
     method: 'post',
     accessor: 'account_number',
     requestObject: {
@@ -88,7 +88,7 @@ const federalAccountPageInfo = {
         limit: 100,
         filters: { fy: "2019" }
     },
-    clientRoute: 'https://www.usaspending.gov/federal_account'
+    clientRoute: `${process.env.SITE_URL}/federal_account`
 };
 
 const createPaginatedPages = (defaultObj, numberOfPages) => {
@@ -121,10 +121,10 @@ const pages = [
         updatedFrequency: 'daily',
         priority: '0.5',
         // all states
-        url: 'https://api.usaspending.gov:443/api/v2/recipient/state/',
+        url: `${process.env.API_URL}/api/v2/recipient/state/`,
         method: 'get',
         accessor: 'fips',
-        clientRoute: 'https://www.usaspending.gov/state'
+        clientRoute: `${process.env.SITE_URL}/state`
     },
     {
         name: 'agency',
@@ -132,10 +132,10 @@ const pages = [
         updatedFrequency: 'monthly',
         priority: '0.5',
         // all agencies
-        url: 'https://api.usaspending.gov:443/api/v2/references/toptier_agencies/',
+        url: `${process.env.API_URL}/api/v2/references/toptier_agencies/`,
         method: 'get',
         accessor: 'agency_id',
-        clientRoute: 'https://www.usaspending.gov/agency'
+        clientRoute: `${process.env.SITE_URL}/agency`
     },
     [
         // all federal accounts

--- a/scripts/sitemaps/pages.js
+++ b/scripts/sitemaps/pages.js
@@ -1,5 +1,8 @@
 const moment = require('moment');
 
+const apiUrl = process.env.API_URL || 'https://api.usaspending.gov:443';
+const siteUrl = process.env.SITE_URL || 'https://www.usaspending.gov';
+
 const routes = [
     // no longer importing these from RouterRoutes because the many import statements in that file completely mess up babel
     '/',
@@ -26,7 +29,7 @@ const recipientRequestObject = {
     updatedFrequency: 'daily',
     priority: '0.8',
     isAsync: true,
-    url: `${process.env.API_URL}/api/v2/recipient/duns/`,
+    url: `${apiUrl}/api/v2/recipient/duns/`,
     method: 'post',
     requestObject: {
         name: 'recipient',
@@ -37,7 +40,7 @@ const recipientRequestObject = {
         award_type: "all"
     },
     accessor: 'id',
-    clientRoute: `${process.env.SITE_URL}/recipient`
+    clientRoute: `${siteUrl}/recipient`
 };
 
 const awardPageInfo = {
@@ -45,7 +48,7 @@ const awardPageInfo = {
     updatedFrequency: 'daily',
     priority: '0.9',
     isAsync: true,
-    url: `${process.env.API_URL}/api/v2/search/spending_by_award/`,
+    url: `${apiUrl}/api/v2/search/spending_by_award/`,
     method: 'post',
     requestObject: {
         filters: {
@@ -71,7 +74,7 @@ const awardPageInfo = {
         subawards: false
     },
     accessor: 'generated_internal_id',
-    clientRoute: `${process.env.SITE_URL}/award`
+    clientRoute: `${siteUrl}/award`
 };
 
 const federalAccountPageInfo = {
@@ -79,7 +82,7 @@ const federalAccountPageInfo = {
     updatedFrequency: 'daily',
     priority: '0.7',
     isAsync: true,
-    url: `${process.env.API_URL}/api/v2/federal_accounts/`,
+    url: `${apiUrl}/api/v2/federal_accounts/`,
     method: 'post',
     accessor: 'account_number',
     requestObject: {
@@ -88,7 +91,7 @@ const federalAccountPageInfo = {
         limit: 100,
         filters: { fy: "2019" }
     },
-    clientRoute: `${process.env.SITE_URL}/federal_account`
+    clientRoute: `${siteUrl}/federal_account`
 };
 
 const createPaginatedPages = (defaultObj, numberOfPages) => {
@@ -121,10 +124,10 @@ const pages = [
         updatedFrequency: 'daily',
         priority: '0.5',
         // all states
-        url: `${process.env.API_URL}/api/v2/recipient/state/`,
+        url: `${apiUrl}/api/v2/recipient/state/`,
         method: 'get',
         accessor: 'fips',
-        clientRoute: `${process.env.SITE_URL}/state`
+        clientRoute: `${siteUrl}/state`
     },
     {
         name: 'agency',
@@ -132,10 +135,10 @@ const pages = [
         updatedFrequency: 'monthly',
         priority: '0.5',
         // all agencies
-        url: `${process.env.API_URL}/api/v2/references/toptier_agencies/`,
+        url: `${apiUrl}/api/v2/references/toptier_agencies/`,
         method: 'get',
         accessor: 'agency_id',
-        clientRoute: `${process.env.SITE_URL}/agency`
+        clientRoute: `${siteUrl}/agency`
     },
     [
         // all federal accounts


### PR DESCRIPTION
**High level description:**

Sitemaps are only generated for prod currently. looking to make the process configurable so we can deploy sitemap files and test bot crawling in lower environments as well.

**Technical details:**

The defaults will keep the script running as normal in production without any additional changes to pipeline code. However, once [this pr](https://github.com/fedspendingtransparency/usaspending-config/pull/1018) is merged in as well, we will be able to select the environment and the backend API independently of one another and generate / deploy a sitemap suitable for the configuration.

**JIRA Ticket:**
[OPS-1678](https://federal-spending-transparency.atlassian.net/browse/OPS-1678)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [N/A] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [N/A] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [N/A] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] API merged concurrently `if applicable`
- [x] Code review complete
