### PR TITLE
[DEV-6805] About the data row and modal date discrepancy

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 // TODO: [DEV-5897] USAS Front End Test Configuration Update: Functional Components & Redux
 // Update test configuration to make testing react functional components easier.
+process.env.TZ = 'America/New_York';
 
 module.exports = {
     rootDir: ".",

--- a/src/js/containers/aboutTheData/modals/PublicationDatesContainer.jsx
+++ b/src/js/containers/aboutTheData/modals/PublicationDatesContainer.jsx
@@ -8,12 +8,13 @@ import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Table, Pagination } from 'data-transparency-ui';
 import { isCancel } from 'axios';
+
 import { publicationDatesColumns } from 'dataMapping/aboutTheData/modals';
 import {
     formatPublicationDates,
-    dateFormattedMonthDayYear,
     fetchPublishDates,
-    convertDatesToMilliseconds
+    convertDatesToMilliseconds,
+    renderDeadline
 } from 'helpers/aboutTheDataHelper';
 import { pageAndSort } from 'helpers/pageAndSortHelper';
 import { fetchAllSubmissionDates, getSubmissionDeadlines } from 'helpers/accountHelper';
@@ -126,8 +127,8 @@ const PublicationDatesContainer = ({
                     {column.displayName}
                 </div>
                 <div className="publication-dates__column-header-sub-title">
-                    <i>{`Deadline: ${column.title === 'publication_date' ?
-                        dateFormattedMonthDayYear(submissionDeadlines?.submissionDueDate) || '--' : dateFormattedMonthDayYear(submissionDeadlines?.certificationDueDate) || '--'}`}
+                    <i>
+                        Deadline: {renderDeadline(column.title, submissionDeadlines)}
                     </i>
                 </div>
             </div>

--- a/src/js/helpers/aboutTheDataHelper.js
+++ b/src/js/helpers/aboutTheDataHelper.js
@@ -5,6 +5,7 @@
 
 import { useState } from 'react';
 import { stringify } from 'querystring';
+import { format } from 'date-fns';
 
 import { calculatePercentage, formatMoney, formatNumber, formatMoneyWithPrecision } from 'helpers/moneyFormatter';
 import {
@@ -148,22 +149,14 @@ export const fetchMockUnlinkedData = () => ({
     cancel: () => {}
 });
 
-export const dateFormattedMonthDayYear = (date) => {
-    if (!date) return null;
-    const newDate = new Date(date);
-    const month = (newDate.getUTCMonth() + 1).toString().length === 1 ? `0${newDate.getUTCMonth() + 1}` : newDate.getUTCMonth() + 1;
-    const dayOfTheMonth = (newDate.getUTCDate()).toString().length === 1 ? `0${newDate.getUTCDate()}` : newDate.getUTCDate();
-    return `${month}/${dayOfTheMonth}/${newDate.getUTCFullYear()}`;
-};
-
 export const formatPublicationDates = (dates) => dates.map((date) => {
     let publicationDate = '--';
     let certificationDate = '--';
     if (date.publication_date) {
-        publicationDate = dateFormattedMonthDayYear(date.publication_date);
+        publicationDate = format(new Date(date.publication_date), 'MM/dd/yyyy');
     }
     if (date.certification_date) {
-        certificationDate = dateFormattedMonthDayYear(date.certification_date);
+        certificationDate = format(new Date(date.certification_date), 'MM/dd/yyyy');
     }
     return [publicationDate, certificationDate];
 });
@@ -218,3 +211,13 @@ export const formatUnlinkedDataRows = (data, type) => ([
 ]);
 
 export const showQuarterText = (period) => [3, 6, 9, 12].includes(period);
+
+export const renderDeadline = (title, deadlines) => {
+    if (title === 'publication_date' && deadlines?.submissionDueDate) {
+        return format(new Date(deadlines.submissionDueDate), 'MM/dd/yyyy');
+    }
+    if (title !== 'publication_date' && deadlines?.certificationDueDate) {
+        return format(new Date(deadlines.certificationDueDate), 'MM/dd/yyyy');
+    }
+    return '--';
+};

--- a/tests/helpers/aboutTheDataHelper-test.js
+++ b/tests/helpers/aboutTheDataHelper-test.js
@@ -1,5 +1,5 @@
 import {
-    dateFormattedMonthDayYear,
+    renderDeadline,
     formatPublicationDates,
     formatMissingAccountBalancesData,
     showQuarterText,
@@ -29,17 +29,6 @@ const mockPeriods = {
 };
 
 describe('About The Data Helper', () => {
-    describe('dateFormattedMonthDayYear', () => {
-        it('should return null if falsy is passed', () => {
-            expect(dateFormattedMonthDayYear('')).toBeNull();
-        });
-        it('should format the month of the date if a date is passed', () => {
-            expect(dateFormattedMonthDayYear('2020-05-31T00:00:00Z')).toBe('05/31/2020');
-        });
-        it('should format the day of the date if a date is passed', () => {
-            expect(dateFormattedMonthDayYear('2020-05-01T00:00:00Z')).toBe('05/01/2020');
-        });
-    });
     describe('formatPublicationDates', () => {
         const mockData = [
             {
@@ -62,10 +51,30 @@ describe('About The Data Helper', () => {
             expect(data[2][1]).toBe('--');
         });
         it('should format dates if they exist', () => {
-            expect(data[0][0]).toBe('05/01/2020');
-            expect(data[1][0]).toBe('08/01/2020');
-            expect(data[1][1]).toBe('08/31/2020');
+            // or, 5hr offset America/New_York UTC-05:000
+            expect(new Date().getTimezoneOffset()).toBe(300);
+            expect(data[0][0]).toBe('04/30/2020');
+            expect(data[1][0]).toBe('07/31/2020');
+            expect(data[1][1]).toBe('08/30/2020');
         });
+    });
+    test.each([
+        ['publication_date', '2020-05-01T00:00:00Z', { submissionDueDate: '2020-05-01T00:00:00Z' }, '04/30/2020'],
+        ['certification_date', '2020-05-01T00:00:00Z', { certificationDueDate: '2020-05-01T00:00:00Z' }, '04/30/2020'],
+        ['publication_date', '2020-05-01T00:00:00Z', { submissionDueDate: null }, '--'],
+        ['certification_date', '2020-05-01T00:00:00Z', { certificationDueDate: null }, '--'],
+        ['publication_date', '2020-05-01T00:00:00Z', { submissionDueDate: '' }, '--'],
+        ['certification_date', '2020-05-01T00:00:00Z', { certificationDueDate: '' }, '--'],
+        ['publication_date', null, {}, '--'],
+        ['certification_date', null, {}, '--']
+    ])('renderDeadline: for title %s when deadline is %s returns %s', (title, timestamp, obj, rtrn) => {
+        expect(new Date().getTimezoneOffset()).toBe(300);
+        if (title === 'publication_date') {
+            expect(renderDeadline(title, obj)).toEqual(rtrn);
+        }
+        else {
+            expect(renderDeadline(title, obj)).toEqual(rtrn);
+        }
     });
     describe('formatMissingAccountBalancesData', () => {
         it('should handle no amount, or string amount being passed in results', () => {


### PR DESCRIPTION
**High level description:**

Showing EST calendar date from timestamp on table and UTC calendar date from timestamp in modal.

**Technical details:**

see commit message

**JIRA Ticket:**
[DEV-6805](https://federal-spending-transparency.atlassian.net/browse/DEV-6805)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
