### PR TITLE
[DEV-6909] fix padding on generic cells

### DIFF
--- a/src/_scss/components/_stickyTable.scss
+++ b/src/_scss/components/_stickyTable.scss
@@ -49,7 +49,7 @@
                     padding: 1.2rem;
                     @import '../pages/aboutTheData/actionCell';
                     .generic-cell-content {
-                        padding-right: 2.4rem;
+                        padding-right: 3.6rem; // to match 0.8 padding + 2.8 width of the action button
                         .not-certified {
                             margin-left: rem(5);
                             background: #dce4ee;


### PR DESCRIPTION
**High level description:**

Vertically aligns values when non-zero cells (with a modal button) are in the same column as "generic" cells (without a modal button) in the Submission Statistics tables.

**Technical details:**

* Calculated based on the width of the button and the padding to add space between the cell value and the button.

**JIRA Ticket:**
[DEV-6909](https://federal-spending-transparency.atlassian.net/browse/DEV-6909)

**Mockup:**
https://bahdigital.invisionapp.com/share/5BIAFVV7KUX#/296054033_Hover__Unlinked-Assistance

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
- [x] Code review complete
