### PR TITLE
[DEV-6815] Adding Share Icon to Agency Detail pg

### DIFF
--- a/src/js/components/aboutTheData/AboutTheDataPage.jsx
+++ b/src/js/components/aboutTheData/AboutTheDataPage.jsx
@@ -12,7 +12,7 @@ import { Link, useLocation } from "react-router-dom";
 import Header from "containers/shared/HeaderContainer";
 import ShareIcon from "components/sharedComponents/stickyHeader/ShareIcon";
 import Footer from "containers/Footer";
-import { getPeriodWithTitleById } from "helpers/aboutTheDataHelper";
+import { getPeriodWithTitleById, getAllAgenciesEmail } from "helpers/aboutTheDataHelper";
 import StickyHeader from "components/sharedComponents/stickyHeader/StickyHeader";
 import AboutTheDataModal from "components/aboutTheData/AboutTheDataModal";
 import { LoadingWrapper } from "components/sharedComponents/Loading";
@@ -38,11 +38,6 @@ const TableTabLabel = ({ label }) => {
 
 TableTabLabel.propTypes = {
     label: PropTypes.string.isRequired
-};
-
-const emailDetails = {
-    subject: 'Agency Submission Statistics | USAspending.gov',
-    body: ''
 };
 
 const AboutTheDataPage = ({
@@ -116,9 +111,11 @@ const AboutTheDataPage = ({
                 <div className="sticky-header__title">
                     <h1 tabIndex={-1}>Agency Submission Statistics</h1>
                 </div>
-                <div className="sticky-header__toolbar">
-                    <ShareIcon slug={`submission-statistics/${search}`} email={emailDetails} />
-                </div>
+                {urlFy && urlPeriod && activeTab && (
+                    <div className="sticky-header__toolbar">
+                        <ShareIcon slug={`submission-statistics/${search}`} email={getAllAgenciesEmail(urlFy, urlPeriod, activeTab)} />
+                    </div>
+                )}
             </StickyHeader>
             <main id="main-content" className="main-content">
                 <div className="heading-container">

--- a/src/js/components/aboutTheData/AgencyDetailsPage.jsx
+++ b/src/js/components/aboutTheData/AgencyDetailsPage.jsx
@@ -9,10 +9,12 @@ import { LoadingMessage, ErrorMessage } from 'data-transparency-ui';
 
 import { agencyPageMetaTags } from 'helpers/metaTagHelper';
 import { fetchAgencyOverview } from 'helpers/agencyV2Helper';
+import { getAgencyDetailEmail } from 'helpers/aboutTheDataHelper';
 
 import MetaTags from 'components/sharedComponents/metaTags/MetaTags';
 import Header from 'containers/shared/HeaderContainer';
 import Footer from 'containers/Footer';
+import ShareIcon from 'components/sharedComponents/stickyHeader/ShareIcon';
 import StickyHeader from 'components/sharedComponents/stickyHeader/StickyHeader';
 import Note from 'components/sharedComponents/Note';
 import AgencyDetailsContainer from 'containers/aboutTheData/AgencyDetailsContainer';
@@ -87,6 +89,11 @@ const AgencyDetailsPage = () => {
                         Agency Submission Data
                     </h1>
                 </div>
+                {agencyOverview?.name && (
+                    <div className="sticky-header__toolbar">
+                        <ShareIcon slug={`submission-statistics/agency/${agencyCode}`} email={getAgencyDetailEmail(agencyOverview.name, agencyCode)} />
+                    </div>
+                )}
             </StickyHeader>
             <main id="main-content" className="main-content">
                 {loading && <LoadingMessage />}

--- a/src/js/helpers/aboutTheDataHelper.js
+++ b/src/js/helpers/aboutTheDataHelper.js
@@ -220,3 +220,17 @@ export const renderDeadline = (title, deadlines) => {
     }
     return '--';
 };
+
+export const getAgencyDetailEmail = (agencyName, agencyCode) => ({
+    subject: `Agency Submission Statistics | ${agencyName}`,
+    body: `View agency submission details for ${agencyName} on USAspending: https://www.usaspending.gov/submission-statistics/agency/${agencyCode}`
+});
+
+export const getAllAgenciesEmail = (fy, period, tab) => {
+    const params = new URLSearchParams({ fy, period, tab }).toString();
+    const url = `https://www.usaspending.gov/submission-statistics/?${encodeURIComponent(params)}`;
+    return {
+        subject: 'Agency Submission Statistics | USAspending.gov',
+        body: `View agency submission details on USAspending: ${url}`
+    };
+};

--- a/tests/helpers/aboutTheDataHelper-test.js
+++ b/tests/helpers/aboutTheDataHelper-test.js
@@ -8,7 +8,9 @@ import {
     isPeriodVisible,
     isPeriodSelectable,
     getPeriodWithTitleById,
-    convertDatesToMilliseconds
+    convertDatesToMilliseconds,
+    getAllAgenciesEmail,
+    getAgencyDetailEmail
 } from 'helpers/aboutTheDataHelper';
 
 import {
@@ -268,3 +270,28 @@ test('getPeriodWithTitleById returns correct title for period', () => {
     expect(getPeriodWithTitleById('11').title).toEqual('P11');
     expect(getPeriodWithTitleById('12').title).toEqual('Q4 / P12');
 });
+
+
+test.each([
+    ['2021', '3', 'submissions', 'https://www.usaspending.gov/submission-statistics/?fy=2021&period=3&tab=submissions'],
+    ['2020', '4', 'submissions', 'https://www.usaspending.gov/submission-statistics/?fy=2020&period=4&tab=submissions'],
+    ['2020', '3', 'publications', 'https://www.usaspending.gov/submission-statistics/?fy=2020&period=3&tab=publications'],
+    ['2017', '12', 'submissions', 'https://www.usaspending.gov/submission-statistics/?fy=2017&period=12&tab=submissions'],
+    ['2020', '3', 'submissions', 'https://www.usaspending.gov/submission-statistics/?fy=2020&period=3&tab=submissions']
+])('when fy is %s, period is %s and active tab is %s the body returns the correct url: %s', (fy, period, tab, url) => {
+    const v = getAllAgenciesEmail(fy, period, tab);
+    expect(v.body.includes('fy')).toEqual(true);
+    expect(v.body.includes('period')).toEqual(true);
+    expect(v.body.includes('tab')).toEqual(true);
+    expect(v.body.includes(fy)).toEqual(true);
+    expect(v.body.includes(period)).toEqual(true);
+    expect(v.body.includes(tab)).toEqual(true);
+    const baseURL = 'https://www.usaspending.gov/submission-statistics/?';
+    const queryParams = encodeURIComponent(url.split('?')[1]);
+    expect(v.body.includes(`${baseURL}${queryParams}`)).toEqual(true);
+});
+
+test('getAgencyDetailEmail', () => {
+    expect(getAgencyDetailEmail('test', '123').body.includes('test')).toEqual(true);
+    expect(getAgencyDetailEmail('test', '123').subject.includes('test')).toEqual(true)
+})


### PR DESCRIPTION
**High level description:**

Forgot to add the share icon to the agency specific page.

**Technical details:**

Using conditional rendering to wait for the API to resolve so we have the agency name to include in the email.

Screenshot:
![image](https://user-images.githubusercontent.com/12897813/108866869-9ba02100-75c2-11eb-8162-e18e27b599dd.png)


**JIRA Ticket:**
[DEV-6815](https://federal-spending-transparency.atlassian.net/browse/DEV-6815)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
- [x] Code review complete
- [x] PO approved new content copy