### PR TITLE
Dev-6876 Covid Banner Floating Off Course

### DIFF
--- a/src/js/helpers/stickyHeaderHelper.js
+++ b/src/js/helpers/stickyHeaderHelper.js
@@ -35,10 +35,10 @@ export const useDynamicStickyClass = (stickyRef, fixedStickyBreakpoint = null) =
                 // we don't know which y position to apply the sticky class
                 setIsSticky(true);
             }
-            else if (scrollY < fixedStickyBreakpoint && isSticky) {
+            else if (scrollY < fixedStickyBreakpoint) {
                 setIsSticky(false);
             }
-            else if (scrollY < dynamicStickyBreakpoint && isSticky) {
+            else if (scrollY < dynamicStickyBreakpoint) {
                 setIsSticky(false);
             }
         }, 100),


### PR DESCRIPTION
**High level description:**

Fixes a bug when the covid banner will cover the main nav when scrolling down the page then back up.

**Technical details:**

> • removes the `isSticky` condition from the false `isSticky` conditional.

**JIRA Ticket:**
[DEV-6876](https://federal-spending-transparency.atlassian.net/browse/DEV-6876)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [N/A] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
