### PR TITLE
[DEV-6951] Handling falsy values from API for data that represents dollar amounts:

### DIFF
--- a/src/js/helpers/moneyFormatter.js
+++ b/src/js/helpers/moneyFormatter.js
@@ -40,7 +40,19 @@ export const unitWords = {
 
 export const formatMoney = (value) => Accounting.formatMoney(value, accountingOptions);
 
-export const formatMoneyWithPrecision = (value, precision) => {
+/**
+ * formatMoneyWithPrecision
+ * @param {number} value to be formatted into a precise dollar amount
+ * @param {number} precision decimal places to apply to formatting
+ * @param {string} falsyReturnValue in case where value is invalid, use this format
+ * @returns {string} a formatted string representing a dollar value
+ * NOTE: falsyReturnValue is opt in to play nicely with existing consumers. This is a newer param following a new precedent.
+ * set by calculatePercentage.
+**/
+export const formatMoneyWithPrecision = (value, precision, falsyReturnValue = null) => {
+    if (falsyReturnValue && !value && value !== 0) {
+        return falsyReturnValue;
+    }
     const modifiedOptions = Object.assign({}, accountingOptions, {
         precision
     });

--- a/src/js/models/v2/aboutTheData/CoreReportingRow.js
+++ b/src/js/models/v2/aboutTheData/CoreReportingRow.js
@@ -8,25 +8,25 @@ import { format } from 'date-fns';
 
 const CoreReportingRow = {
     populateCore(data) {
-        this._budgetAuthority = data.current_total_budget_authority_amount || 0;
+        this._budgetAuthority = data.current_total_budget_authority_amount;
         this._mostRecentPublicationDate = data.recent_publication_date || null;
         /* eslint-disable camelcase */
-        this._gtasObligationTotal = data.tas_account_discrepancies_totals?.gtas_obligation_total || 0;
+        this._gtasObligationTotal = data.tas_account_discrepancies_totals?.gtas_obligation_total;
         this._discrepancyCount = data.tas_account_discrepancies_totals?.missing_tas_accounts_count || 0;
         /* eslint-enable camelcase */
-        this._obligationDifference = data.obligation_difference || 0;
+        this._obligationDifference = data.obligation_difference;
         this._unlinkedContracts = data.unlinked_contract_award_count || 0;
         this._unlinkedAssistance = data.unlinked_assistance_award_count || 0;
         this.assuranceStatement = data.assurance_statement_url || '';
     },
     get budgetAuthority() {
-        return formatMoneyWithPrecision(this._budgetAuthority, 2);
+        return formatMoneyWithPrecision(this._budgetAuthority, 2, '--');
     },
     get mostRecentPublicationDate() {
         return this._mostRecentPublicationDate ? format(new Date(this._mostRecentPublicationDate), 'MM/dd/yyyy') : '--';
     },
     get obligationDifference() {
-        return formatMoneyWithPrecision(this._obligationDifference, 2);
+        return formatMoneyWithPrecision(this._obligationDifference, 2, '--');
     },
     get discrepancyCount() {
         return formatNumber(this._discrepancyCount);

--- a/tests/helpers/moneyFormatter-test.js
+++ b/tests/helpers/moneyFormatter-test.js
@@ -3,55 +3,42 @@
  * Created by Kevin Li 1/25/17
  */
 
-import { formatMoney, calculatePercentage } from 'helpers/moneyFormatter';
+import { formatMoney, formatMoneyWithPrecision, calculatePercentage } from 'helpers/moneyFormatter';
 
-describe('Money Formatter helper functions', () => {
-    describe('formatMoney', () => {
-        it('should round monetary values to the nearest dollar', () => {
-            const formattedDown = formatMoney(123.45);
-            expect(formattedDown).toEqual('$123');
+test.each([
+    [123.45, '$123'],
+    [123.75, '$124'],
+    [123.50, '$124'],
+    [12345678.23, '$12,345,678'],
+    [-12345678.23, '-$12,345,678'],
+    [0, '$0']
+])('formatMoney: when input is %s --> %s', (input, output) => {
+    expect(formatMoney(input)).toEqual(output);
+});
 
-            const formattedUp = formatMoney(123.75);
-            expect(formattedUp).toEqual('$124');
+test.each([
+    [123.45, '$123.45'],
+    [0, '$0.00', '--'],
+    ['', '--', '--'],
+    [null, '--', '--'],
+    [null, 'you can specify the default return value in this case', 'you can specify the default return value in this case'],
+    ['', '$0.00']
+])('formatMoneyWithPrecision: when input is %s --> %s', (input, output, defaultReturn = null) => {
+    expect(formatMoneyWithPrecision(input, 2, defaultReturn)).toEqual(output);
+});
 
-            const formattedHalf = formatMoney(123.50);
-            expect(formattedHalf).toEqual('$124');
-        });
-
-        it('should format positive values to $XXX,XXX format', () => {
-            const formatted = formatMoney(12345678.23);
-            expect(formatted).toEqual('$12,345,678');
-        });
-
-        it('should format negative values to -$XXX,XXX format', () => {
-            const formatted = formatMoney(-12345678.23);
-            expect(formatted).toEqual('-$12,345,678');
-        });
-
-        it('should handle zero values as $0', () => {
-            const formatted = formatMoney(0);
-            expect(formatted).toEqual('$0');
-        });
-    });
-    describe('calculatePercentage', () => {
-        it('should return a percentage', () => {
-            expect(calculatePercentage(50, 100)).toEqual('50.0%');
-        });
-        it('should return a custom return message when bad data is passed', () => {
-            expect(calculatePercentage(50, 0, 'Happy Troll Dance')).toEqual('Happy Troll Dance');
-        });
-        it('should return a -- when denominator is zero', () => {
-            expect(calculatePercentage(50, 0)).toEqual('--');
-        });
-        it('should return a -- when denominator is not a number', () => {
-            expect(calculatePercentage(50, null)).toEqual('--');
-            expect(calculatePercentage(50, 'null')).toEqual('--');
-            expect(calculatePercentage(50, '')).toEqual('--');
-        });
-        it('should return a -- when numerator is not a number', () => {
-            expect(calculatePercentage(null, 100)).toEqual('--');
-            expect(calculatePercentage('null', 100)).toEqual('--');
-            expect(calculatePercentage('', 100)).toEqual('--');
-        });
-    });
+test.each([
+    [50, 100, '50.0%'],
+    [50, 0, 'Happy Troll Dance', 'Happy Troll Dance'],
+    [50, 0, '--'],
+    // TODO: DEV-6952 created to handle this.
+    [.0000000001, 100000, "0.00%", '--', 2],
+    [50, null, '--'],
+    [50, 'null', '--'],
+    [50, '', '--'],
+    [null, 100, '--'],
+    ['null', 100, '--'],
+    ['', 100, '--']
+])('calculatePercentage with inputs %s and %s returns %s', (num, denom, rtrn, defaultRtrn = '--', toDecimalPlaces = 1) => {
+    expect(calculatePercentage(num, denom, defaultRtrn, toDecimalPlaces)).toEqual(rtrn);
 });

--- a/tests/models/aboutTheData/CoreReportingRow-test.js
+++ b/tests/models/aboutTheData/CoreReportingRow-test.js
@@ -8,29 +8,24 @@ import { mockAPI } from '../../containers/aboutTheData/mockData';
 
 const mockReportingPeriodRow = mockAPI.submissions.data.results[0];
 
-const row = Object.create(CoreReportingRow);
-row.populateCore(mockReportingPeriodRow);
-
-describe('Core Reporting Row model', () => {
-    it('should format the budget authority', () => {
-        expect(row.budgetAuthority).toEqual('$8,000.72');
-    });
-    it('should format the obligation difference', () => {
-        expect(row.obligationDifference).toEqual('$4,000.00');
-    });
-    it('should format the discrepancy count', () => {
-        expect(row.discrepancyCount).toEqual('2,000');
-    });
-    it('should format the publication date', () => {
-        expect(row.mostRecentPublicationDate).toEqual('01/10/2020');
-    });
-    it('should store the raw GTAS Obligation Total', () => {
-        expect(row._gtasObligationTotal).toEqual(50000);
-    });
-    it('should format the unlinked contracts count', () => {
-        expect(row.unlinkedContracts).toEqual('20,002');
-    });
-    it('should format the unlinked assistance awards count', () => {
-        expect(row.unlinkedAssistance).toEqual('10,001');
-    });
+test.each([
+    ['_budgetAuthority', null, { ...mockReportingPeriodRow, current_total_budget_authority_amount: null }],
+    ['_budgetAuthority', 0, { ...mockReportingPeriodRow, current_total_budget_authority_amount: 0 }],
+    ['budgetAuthority', '--', { ...mockReportingPeriodRow, current_total_budget_authority_amount: null }],
+    ['budgetAuthority', '$0.00', { ...mockReportingPeriodRow, current_total_budget_authority_amount: 0 }],
+    ['budgetAuthority', '$8,000.72'],
+    ['_obligationDifference', 0, { ...mockReportingPeriodRow, obligation_difference: 0 }],
+    ['_obligationDifference', null, { ...mockReportingPeriodRow, obligation_difference: null }],
+    ['obligationDifference', '--', { ...mockReportingPeriodRow, obligation_difference: null }],
+    ['obligationDifference', '$0.00', { ...mockReportingPeriodRow, obligation_difference: 0 }],
+    ['obligationDifference', '$4,000.00'],
+    ['discrepancyCount', '2,000'],
+    ['mostRecentPublicationDate', '01/10/2020'],
+    ['_gtasObligationTotal', 50000],
+    ['unlinkedContracts', '20,002'],
+    ['unlinkedAssistance', '10,001']
+])('should format the property %s as %s', (property, output, sourceData = mockReportingPeriodRow) => {
+    const row = Object.create(CoreReportingRow);
+    row.populateCore(sourceData);
+    expect(row[property]).toEqual(output);
 });


### PR DESCRIPTION
**High level description:**
Refactoring Submission Statistics Table model and heleprs to distinguish between falsy values. Tests included

**Technical details:**

See commit messages:

    CoreReportingRow.js -- preserving raw values in our underscore
    prefixed model properties. These values are later passed to
    helper functions that parse the falsy values for us.
    
    + tests added to confirm the return value for various falsy values
    
    moneyFormatter.js -- formatMoneyWithPrecision refactored to
    allow the caller to specify a return value when invalid value is
    passed. This follows the precedent set by calculatePercentage.
    
    + tests added to confirm the return value for various falsy values


**JIRA Ticket:**
[DEV-6951](https://federal-spending-transparency.atlassian.net/browse/DEV-6951)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
