### PR TITLE
[DEV-6929] fix persistent Submission Statistics search string

### DIFF
--- a/src/js/containers/aboutTheData/AgenciesContainer.jsx
+++ b/src/js/containers/aboutTheData/AgenciesContainer.jsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import DrilldownCell from 'components/aboutTheData/DrilldownCell';
 import CellWithModal from 'components/aboutTheData/CellWithModal';
-import { setTableData, setTableSort, setTotals, setSearchResults } from 'redux/actions/aboutTheData';
+import { setTableData, setTableSort, setTotals, setSearchResults, setSearchTerm } from 'redux/actions/aboutTheData';
 import { getTotalBudgetaryResources, getAgenciesReportingData, getSubmissionPublicationDates, usePagination, isPeriodSelectable } from 'helpers/aboutTheDataHelper';
 import BaseAgencyRow from 'models/v2/aboutTheData/BaseAgencyRow';
 import PublicationOverviewRow from 'models/v2/aboutTheData/PublicationOverviewRow';
@@ -185,6 +185,7 @@ const AgenciesContainer = ({
             console.info('canceling request on unmount');
             totalsReq.current.cancel();
         }
+        dispatch(setSearchTerm(''));
     }, []);
 
     useEffect(() => {

--- a/tests/containers/aboutTheData/AgenciesContainer-test.jsx
+++ b/tests/containers/aboutTheData/AgenciesContainer-test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { render, waitFor } from 'test-utils';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
 
 import * as redux from 'react-redux';
 import { List } from 'immutable';
@@ -313,5 +315,44 @@ test('when totals are defined and the search term is defined, one request is mad
         // if you changes this to three the test will fail; once on mount, then only once more.
         expect(submissionsRequest).toHaveBeenCalledTimes(2);
         expect(submissionsRequest).toHaveBeenLastCalledWith('2020', '8', 'current_total_budget_authority_amount', 'desc', 1, 10, 'test');
+    });
+});
+
+test('should clear a search term on unmount', () => {
+    // Create a fake reducer that calls a mock function for the action type we are interested in
+    const setSearchTerm = jest.fn();
+    const mockReducer = (state, action) => {
+        if (action.type === 'SET_ABOUT_THE_DATA_SEARCH_TERM') {
+            setSearchTerm(action?.payload);
+        }
+    };
+
+    // Create a mock Redux store with a search term applied
+    const mockStore = {
+        aboutTheData: {
+            submissionsSearchResults: [],
+            publicationsSearchResults: [],
+            searchTerm: 'test',
+            allPublications: [],
+            federalTotals: [1],
+            submissionsSort: ['current_total_budget_authority_amount', 'desc'],
+            publicationsSort: ['current_total_budget_authority_amount', 'desc']
+        },
+        allSubmissions: [],
+        submissionPeriods: new List([
+            { submission_fiscal_year: 2020, submission_fiscal_month: 8 }
+        ])
+    };
+
+    // Render a wrapped component with the mock reducer and store, then unmount it
+    const { unmount } = render((
+        <Provider store={createStore(mockReducer, mockStore)}>
+            <AgenciesContainer {...defaultProps} />
+        </Provider>
+    ));
+    unmount();
+
+    return waitFor(() => {
+        expect(setSearchTerm).toHaveBeenLastCalledWith('');
     });
 });


### PR DESCRIPTION
**High level description:**

Fixes a bug that was causing the search to persist even after navigating away from the page. 

**JIRA Ticket:**
[DEV-6929](https://federal-spending-transparency.atlassian.net/browse/DEV-6929)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations

Reviewer(s):
- [ ] Code review complete
