### PR TITLE
[DEV-6952] moneyFormatter.calculatePercentage refactor to accept absolute minimum

### DIFF
--- a/src/js/helpers/moneyFormatter.js
+++ b/src/js/helpers/moneyFormatter.js
@@ -208,12 +208,27 @@ export const formatTreemapValues = (value) => {
     return `${formattedCurrency}${longLabel}`;
 };
 
-export const calculatePercentage = (value, total, returnValue = '--', decimalPlaces = 1) => {
+const replaceDecimal = new RegExp(/\.|%/g);
+
+const isFormattedZero = (formatted) => {
+    const parsed = formatted.replace(replaceDecimal, '');
+    return parsed.split('').every((str) => str === '0');
+};
+
+const calculatePercentageDefaultConfig = {
+    absoluteMin: null
+};
+
+export const calculatePercentage = (value, total, returnValue = '--', decimalPlaces = 1, config = calculatePercentageDefaultConfig) => {
     // handles if denominator is zero, or falsy
     if (!total || typeof total !== 'number') return returnValue;
     // handles if numerator is not a number
     if (value !== 0 && typeof value !== 'number') return returnValue;
-    return `${((value / total) * 100).toFixed(decimalPlaces)}%`;
+    const formatted = `${((value / total) * 100).toFixed(decimalPlaces)}%`;
+    if (value > 0 && isFormattedZero(formatted) && config?.absoluteMin) {
+        return config.absoluteMin;
+    }
+    return formatted;
 };
 
 export const formatNumber = (number) => {

--- a/src/js/models/v2/aboutTheData/BaseAgencyRow.js
+++ b/src/js/models/v2/aboutTheData/BaseAgencyRow.js
@@ -19,7 +19,7 @@ BaseAgencyRow.populate = function populate(data) {
     this.certified = data.recent_publication_date_certified || false;
     // eslint-disable-next-line camelcase
     this._federalTotal = data?.federalTotal?.total_budgetary_resources;
-    this.percentageOfTotalFederalBudget = calculatePercentage(this._budgetAuthority, this._federalTotal, '--', 2);
+    this.percentageOfTotalFederalBudget = calculatePercentage(this._budgetAuthority, this._federalTotal, '--', 2, { absoluteMin: '< 0.01%' });
 };
 
 export default BaseAgencyRow;

--- a/src/js/models/v2/aboutTheData/PublicationOverviewRow.js
+++ b/src/js/models/v2/aboutTheData/PublicationOverviewRow.js
@@ -62,7 +62,7 @@ const DatesRow = {
     },
     get percentageOfTotalFederalBudget() {
         // eslint-disable-next-line camelcase
-        return calculatePercentage(this._budgetAuthority, this._federalTotal, "--", 2);
+        return calculatePercentage(this._budgetAuthority, this._federalTotal, "--", 2, { absoluteMin: '< 0.01%' });
     }
 };
 

--- a/tests/helpers/moneyFormatter-test.js
+++ b/tests/helpers/moneyFormatter-test.js
@@ -31,14 +31,14 @@ test.each([
     [50, 100, '50.0%'],
     [50, 0, 'Happy Troll Dance', 'Happy Troll Dance'],
     [50, 0, '--'],
-    // TODO: DEV-6952 created to handle this.
-    [.0000000001, 100000, "0.00%", '--', 2],
+    [.0000000001, 100000, "< 0.01%", '--', 2, { absoluteMin: '< 0.01%' }],
+    [.0000000001, 100000, "0.00%", '--', 2, { absoluteMin: null }],
     [50, null, '--'],
     [50, 'null', '--'],
     [50, '', '--'],
     [null, 100, '--'],
     ['null', 100, '--'],
     ['', 100, '--']
-])('calculatePercentage with inputs %s and %s returns %s', (num, denom, rtrn, defaultRtrn = '--', toDecimalPlaces = 1) => {
-    expect(calculatePercentage(num, denom, defaultRtrn, toDecimalPlaces)).toEqual(rtrn);
+])('calculatePercentage with inputs %s and %s returns %s', (num, denom, rtrn, defaultRtrn = '--', toDecimalPlaces = 1, config = { absoluteMin: '' }) => {
+    expect(calculatePercentage(num, denom, defaultRtrn, toDecimalPlaces, config)).toEqual(rtrn);
 });


### PR DESCRIPTION
**High level description:**
When value is greater than zero, but it gets rounded to zero by the accounting library, show an absolute minimum

**Technical details:**
See commit message

**JIRA Ticket:**
[DEV-6952](https://federal-spending-transparency.atlassian.net/browse/DEV-6952)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Unit tests added

Reviewer(s):
- [x] Code review complete
