### PR TITLE
DEV-6356 fix sidebar overlap

### DIFF
--- a/src/js/components/about/AboutContent.jsx
+++ b/src/js/components/about/AboutContent.jsx
@@ -3,7 +3,7 @@
  * Created by Mike Bray 11/20/2017
  **/
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { find } from 'lodash';
@@ -100,6 +100,12 @@ const AboutContent = ({ location }) => {
             dispatch(showModal(e.target.parentNode.getAttribute('data-href') || e.target.getAttribute('data-href') || e.target.value));
         }
     };
+
+    useEffect(() => {
+        if (location.state?.fromCareersLink) {
+            jumpToSection('careers');
+        }
+    }, []);
 
     return (
         <div className="about-content-wrapper">

--- a/src/js/components/about/AboutContent.jsx
+++ b/src/js/components/about/AboutContent.jsx
@@ -3,10 +3,10 @@
  * Created by Mike Bray 11/20/2017
  **/
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
-import { find, throttle } from 'lodash';
+import { find } from 'lodash';
 import { useDispatch } from 'react-redux';
 import { showModal } from 'redux/actions/modal/modalActions';
 import { scrollToY } from 'helpers/scrollToHelper';
@@ -70,32 +70,6 @@ const propTypes = {
 
 const AboutContent = ({ location }) => {
     const [activeSection, setActiveSection] = useState(location.state?.fromCareersLink ? 'careers' : 'mission');
-    const [sectionPositions, setSectionPositions] = useState([]);
-    const [windowHeight, setWindowHeight] = useState(0);
-
-    const cacheSectionPositions = throttle(async () => {
-        // it is expensive to measure the DOM elements on every scroll, so measure them upfront
-        // (and when the window resizes) and cache the values
-        const newSectionPositions = aboutSections.map((section) => {
-            const sectionCode = section.section;
-            const domElement = document.getElementById(`about-${sectionCode}`);
-            if (!domElement) {
-                // couldn't find the element
-                return { section: sectionCode, top: 0, bottom: 0 };
-            }
-
-            const topPos = domElement.offsetTop;
-            const bottomPos = domElement.offsetHeight + topPos;
-
-            return {
-                section: sectionCode,
-                top: topPos,
-                bottom: bottomPos
-            };
-        });
-        setSectionPositions(newSectionPositions);
-        setWindowHeight(window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight);
-    }, 100);
 
     const jumpToSection = (section = '') => {
         // we've been provided a section to jump to
@@ -119,93 +93,6 @@ const AboutContent = ({ location }) => {
         scrollToY(sectionTop, 700);
     };
 
-    const highlightCurrentSection = throttle(() => {
-        const windowTop = window.pageYOffset || document.documentElement.scrollTop;
-        const windowBottom = windowTop + windowHeight;
-
-        // determine the section to highlight
-        let currentActiveSection = aboutSections[0].section;
-        let bottomSectionVisible = false;
-        const visibleSections = [];
-
-        // ignore sections if only 30px of the top or bottom are visible
-        const edgeMargin = 50;
-        const visibleTop = windowTop + edgeMargin;
-        const visibleBottom = windowBottom - edgeMargin;
-
-        sectionPositions.forEach((section, index) => {
-            // check if the section is in view at all
-            if (section.top <= visibleBottom && section.bottom >= visibleTop) {
-                // at least some of the section is in view, determine how much
-                const height = section.bottom - section.top;
-                const visibleHeight = Math.min(section.bottom, visibleBottom) -
-                    Math.max(visibleTop, section.top);
-                const percentageVisible = visibleHeight / height;
-                visibleSections.push({
-                    section: section.section,
-                    amount: percentageVisible
-                });
-
-                if (index === sectionPositions.length - 1) {
-                    // this is the last section and it is visible
-                    bottomSectionVisible = true;
-                }
-            }
-            else if (index === sectionPositions.length - 1) {
-                // this is the last section, so highlight it if we're at the bottom or lower
-                // on the page
-                if (section.top <= visibleTop) {
-                    // we are lower than the top of the last section
-                    bottomSectionVisible = true;
-                    visibleSections.push({
-                        section: section.section,
-                        amount: 1
-                    });
-                }
-            }
-        });
-
-        // select the first section we saw
-        if (visibleSections.length > 0) {
-            currentActiveSection = visibleSections[0].section;
-            if (visibleSections[0].amount < 0.15 && visibleSections.length > 1) {
-                // less than 15% of the first section is visible and we have more than 1 section,
-                // select the next section
-                currentActiveSection = visibleSections[1].section;
-            }
-        }
-
-        // handle a case where we're at the bottom but there's the bottom section is not tall enough
-        // to be the first visible section (which will cause the bottom section to never be
-        // active)
-        if (bottomSectionVisible && visibleSections.length > 1) {
-            const bottomSection = visibleSections[visibleSections.length - 1];
-            const previousSection = visibleSections[visibleSections.length - 2];
-            if (previousSection.amount < 0.5 && bottomSection.amount === 1) {
-                // less than half of the previous section is visible and all of the bottom section
-                // is visible, select the bottom section
-                currentActiveSection = bottomSection.section;
-            }
-        }
-
-        if (currentActiveSection === activeSection) {
-            // no change
-            return;
-        }
-        setActiveSection(currentActiveSection);
-    }, 100);
-
-    useEffect(() => {
-        cacheSectionPositions();
-        window.addEventListener('scroll', highlightCurrentSection);
-        window.addEventListener('resize', cacheSectionPositions);
-        if (location.state?.fromCareersLink) jumpToSection('careers');
-        return () => {
-            window.removeEventListener('scroll', highlightCurrentSection);
-            window.removeEventListener('resize', cacheSectionPositions);
-        };
-    }, []);
-
     const dispatch = useDispatch();
     const onExternalLinkClick = (e) => {
         e.persist();
@@ -222,6 +109,7 @@ const AboutContent = ({ location }) => {
                     active={activeSection}
                     pageName="about"
                     sections={aboutSections}
+                    detectActiveSection={setActiveSection}
                     jumpToSection={jumpToSection}
                     fixedStickyBreakpoint={getStickyBreakPointForSidebar()} />
             </div>

--- a/src/js/components/about/AboutContent.jsx
+++ b/src/js/components/about/AboutContent.jsx
@@ -105,7 +105,7 @@ const AboutContent = ({ location }) => {
         if (location.state?.fromCareersLink) {
             jumpToSection('careers');
         }
-    }, []);
+    }, [location.state]);
 
     return (
         <div className="about-content-wrapper">

--- a/src/js/components/sharedComponents/sidebar/Sidebar.jsx
+++ b/src/js/components/sharedComponents/sidebar/Sidebar.jsx
@@ -247,7 +247,9 @@ const Sidebar = ({
 
     return (
         <div ref={outerReferenceDiv}>
-            <div className={`${pageName}-sidebar-reference ${floatSidebar}`} ref={referenceDiv} />
+            <div className={`${pageName}-sidebar-reference ${floatSidebar}`} ref={referenceDiv}>
+              &nsbp;
+            </div>
             <div ref={div} className={`${pageName}-sidebar-content ${floatSidebar}`} style={{ width: sidebarWidth }}>
                 <div className={`${pageName}-sidebar-content-background`}>
                     {fyPicker && (

--- a/tests/components/about/AboutContent-test.jsx
+++ b/tests/components/about/AboutContent-test.jsx
@@ -1,0 +1,24 @@
+/**
+ * AboutContent-test.jsx
+ * Created by Lizzie Salita 3/9/21
+ */
+
+import React from 'react';
+import { Route } from 'react-router-dom';
+import AboutContent from 'components/about/AboutContent';
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@test-utils';
+
+describe('About Page content', () => {
+    it('should set Careers as the active section based on the router location', () => {
+        render((
+            <Route location={{
+                state: { fromCareersLink: true }
+            }}>
+                <AboutContent />
+            </Route >
+        ));
+        const sidebarLink = screen.queryAllByText('Careers')[0];
+        expect(sidebarLink).toHaveClass('active');
+    });
+});


### PR DESCRIPTION
**High level description:**

Fixes two bugs with the sidebar:
- Overlap with main content after scrolling (in `dev`) caused by a DEV-6356 change
- Active section not highlighting as you scroll (in `qat`)

**JIRA Ticket:**
[DEV-6356](https://federal-spending-transparency.atlassian.net/browse/DEV-6356)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations

Reviewer(s):
- [x] Code review complete
