### PR TITLE
[DEV-4521] remove hard coded FY in agency v2 table

### DIFF
--- a/src/js/components/agencyV2/accountSpending/AccountSpending.jsx
+++ b/src/js/components/agencyV2/accountSpending/AccountSpending.jsx
@@ -57,7 +57,7 @@ const AccountSpending = ({ agencyId, fy }) => {
 
     useEffect(() => {
         // request budgetary resources data for this agency
-        const budgetaryResourcesRequest = fetchBudgetaryResources(agencyId);
+        const budgetaryResourcesRequest = fetchBudgetaryResources(agencyId, fy);
         budgetaryResourcesRequest.promise
             .then((res) => {
                 // parse the response using our data model
@@ -68,7 +68,7 @@ const AccountSpending = ({ agencyId, fy }) => {
             }).catch((err) => {
                 console.error(err);
             });
-    }, [agencyId]);
+    }, [agencyId, fy]);
 
     return (
         <div className="body__content">

--- a/src/js/containers/agencyV2/accountSpending/CountTabContainer.jsx
+++ b/src/js/containers/agencyV2/accountSpending/CountTabContainer.jsx
@@ -28,7 +28,7 @@ const CountTabContainer = (props) => {
         // Reset any existing results
         setCount(null);
         setSubCount(null);
-        const countRequest = fetchSpendingCount(props.agencyId, 2020, props.type);
+        const countRequest = fetchSpendingCount(props.agencyId, props.fy, props.type);
         countRequest.promise
             .then((res) => {
                 setCount(res.data[props.countField]);

--- a/src/js/containers/agencyV2/accountSpending/TableContainer.jsx
+++ b/src/js/containers/agencyV2/accountSpending/TableContainer.jsx
@@ -95,7 +95,7 @@ const TableContainer = (props) => {
         setLoading(true);
         // Make a request with the new page number
         const params = {
-            fiscal_year: 2020,
+            fiscal_year: props.fy,
             limit: pageSize,
             page: currentPage,
             sort: accountFields[sort],
@@ -123,7 +123,7 @@ const TableContainer = (props) => {
         else {
             fetchSpendingByCategoryCallback();
         }
-    }, [props.type, props.agencyId, pageSize, sort, order, totalObligation]);
+    }, [props.type, props.fy, props.agencyId, pageSize, sort, order, totalObligation]);
 
     useEffect(() => {
         fetchSpendingByCategoryCallback();

--- a/tests/components/agency/AccountSpending-test.jsx
+++ b/tests/components/agency/AccountSpending-test.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, waitFor } from 'test-utils';
+import * as helpers from 'helpers/agencyV2Helper';
+import AccountSpending from 'components/agencyV2/accountSpending/AccountSpending';
+
+const defaultProps = {
+    agencyId: '012',
+    fy: '2020'
+};
+
+const mockData = {
+    data: []
+};
+
+let fetchBudgetaryResourcesSpy;
+let fetchSpendingCountSpy;
+let fetchSpendingByCategorySpy;
+
+beforeEach(() => {
+    fetchBudgetaryResourcesSpy = jest.spyOn(helpers, 'fetchBudgetaryResources').mockReturnValue({
+        promise: new Promise((resolve) => {
+            return process.nextTick(() => (resolve(mockData)));
+        }),
+        cancel: jest.fn()
+    }).mockClear();
+    fetchSpendingCountSpy = jest.spyOn(helpers, 'fetchSpendingCount').mockReturnValue({
+        promise: new Promise((resolve) => {
+            return process.nextTick(() => (resolve(mockData)));
+        }),
+        cancel: jest.fn()
+    }).mockClear();
+    fetchSpendingByCategorySpy = jest.spyOn(helpers, 'fetchSpendingByCategory').mockReturnValue({
+        promise: new Promise((resolve) => {
+            return process.nextTick(() => (resolve({
+                data: {
+                    page_metadata: {
+                        total: 1
+                    },
+                    results: []
+                }
+            })));
+        }),
+        cancel: jest.fn()
+    }).mockClear();
+});
+
+test('should fetch the data on first render ', () => {
+    render(<AccountSpending {...defaultProps} />);
+    return waitFor(() => {
+        expect(fetchBudgetaryResourcesSpy).toHaveBeenCalledTimes(1);
+        expect(fetchBudgetaryResourcesSpy).toHaveBeenCalledWith(defaultProps.agencyId, defaultProps.fy);
+        // expect(fetchSpendingCountSpy).toHaveBeenCalledTimes(1);
+        // expect(fetchSpendingCountSpy).toHaveBeenCalledWith(defaultProps.agencyId, defaultProps.fy, 'budget_function');
+        // expect(fetchSpendingByCategorySpy).toHaveBeenCalledTimes(1);
+        // expect(fetchSpendingByCategorySpy).toHaveBeenCalledWith(defaultProps.agencyId, 'budget_function', {
+        //     fiscal_year: defaultProps.fy,
+        //     limit: 10,
+        //     page: 1,
+        //     sort: 'obligatedAmount',
+        //     order: 'desc'
+        // });
+    });
+});
+
+test('should fetch the data again when fy changes ', () => {
+    const { rerender } = render(<AccountSpending {...defaultProps} />);
+    rerender(<AccountSpending {...defaultProps} fy="2021" />);
+    return waitFor(() => {
+        expect(fetchBudgetaryResourcesSpy).toHaveBeenCalledTimes(2);
+        expect(fetchBudgetaryResourcesSpy).toHaveBeenCalledWith(defaultProps.agencyId, "2021");
+    });
+});


### PR DESCRIPTION
**High level description:**
Table in Agency V2 had hard-coded FY values. This updates them to use props.

**Technical details:**
Adds a test file. There are a lot of duplicate API requests. Treating that as outside this delivery.

**JIRA Ticket:**
[DEV-4521](https://federal-spending-transparency.atlassian.net/browse/DEV-4521)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)

Reviewer(s):
- [x] Code review complete
