### PR TITLE
reverting #2437 from DEV-6973 due to bad timing

### DIFF
--- a/src/js/components/covid19/DataSourcesAndMethodologiesPage.jsx
+++ b/src/js/components/covid19/DataSourcesAndMethodologiesPage.jsx
@@ -691,10 +691,7 @@ export default () => {
                                             For <strong>Award Spending (including Loan Spending)</strong>, sum together:
                                             <ul>
                                                 <li>
-                                                    Outlayed Amount Funded by COVID-19 Supplementals for every award ID (award unique key) tagged with a COVID-19 DEFC [for Linked Awards only].
-                                                </li>
-                                                <li>
-                                                    Gross Outlay Amount, Downward Adjustments of Prior Year Prepaid Advanced Undelivered Orders and Obligation Refunds Collected, and Downward Adjustments of Prior Year Paid Delivered Orders and Obligations Refunds Collected for every award ID (award unique key) tagged with a COVID-19 DEFC [for Linked and Unlinked Awards].
+                                                    Either Gross Outlay Amount (for linked and unlinked data) or Outlayed Amount Funded by COVID-19 Supplementals (for linked data only) for every award ID (award unique key) tagged with a COVID-19 DEFC.
                                                 </li>
                                                 <li>
                                                     Filter by any award type as desired.


### PR DESCRIPTION
**High level description:**
Reverting #2437 

Restores https://github.com/fedspendingtransparency/usaspending-website/pull/2437/files#diff-b3e290a801b417a71a707cadc0671efc1e51c75529c2d7228e911555c765bbfcL694

- [x] Code review complete
