### PR TITLE
[DEV-6881] Show a note on DOD-owned Federal Account profiles

### DIFF
--- a/src/js/components/account/Account.jsx
+++ b/src/js/components/account/Account.jsx
@@ -35,7 +35,7 @@ export default class Account extends React.Component {
                     <AccountOverview account={this.props.account} currentFiscalYear={this.props.currentFiscalYear} />
                     <div className="filter-results">
                         <SearchSidebar />
-                        <SearchResults />
+                        <SearchResults showNote={this.props.account.parent_agency_toptier_code === '097'} />
                     </div>
                 </main>
                 <Footer />

--- a/src/js/components/account/SearchResults.jsx
+++ b/src/js/components/account/SearchResults.jsx
@@ -4,6 +4,7 @@
  **/
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import AccountTopFilterBarContainer from
     'containers/account/topFilterBar/AccountTopFilterBarContainer';
@@ -13,7 +14,11 @@ import AccountTimeVisualizationContainer from
 import AccountRankVisualizationContainer from
     'containers/account/visualizations/AccountRankVisualizationContainer';
 import AccountAwardsContainer from 'containers/account/awards/AccountAwardsContainer';
+import Note, { dodNote } from 'components/sharedComponents/Note';
 
+const propTypes = {
+    showNote: PropTypes.bool
+};
 
 export default class SearchResults extends React.Component {
     render() {
@@ -24,8 +29,11 @@ export default class SearchResults extends React.Component {
                     <AccountTimeVisualizationContainer />
                     <AccountRankVisualizationContainer />
                     <AccountAwardsContainer />
+                    {this.props.showNote && <Note message={dodNote} />}
                 </div>
             </div>
         );
     }
 }
+
+SearchResults.propTypes = propTypes;

--- a/src/js/models/account/FederalAccount.js
+++ b/src/js/models/account/FederalAccount.js
@@ -12,7 +12,8 @@ const fields = [
     'title',
     'agency_identifier',
     'main_account_code',
-    'totals'
+    'totals',
+    'parent_agency_toptier_code'
 ];
 
 const defaultValues = [
@@ -29,7 +30,8 @@ const defaultValues = [
         balanceBroughtForward: 0,
         otherBudgetaryResources: 0,
         appropriations: 0
-    }
+    },
+    ''
 ];
 
 const formatData = (data) => {


### PR DESCRIPTION
**Technical details:**

- Adds a new API field, `parent_agency_toptier_code` to our data model
- Checks for the value to match `097` (Dept of Defense toptier code)

**JIRA Ticket:**
[DEV-6881](https://federal-spending-transparency.atlassian.net/browse/DEV-6881)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [x] [API contract](https://github.com/fedspendingtransparency/usaspending-api/blob/dev/usaspending_api/api_contracts/contracts/v2/federal_accounts/account_number.md) updated 

Reviewer(s):
- [x] [API #3049](https://github.com/fedspendingtransparency/usaspending-api/pull/3049) merged concurrently
- [x] Code review complete
