### PR TITLE
Fix AgencyV2 table w/ no total obligations

### DIFF
--- a/src/js/models/v2/agencyV2/BaseAccountSpendingRow.js
+++ b/src/js/models/v2/agencyV2/BaseAccountSpendingRow.js
@@ -19,7 +19,7 @@ const BaseAccountSpendingRow = {
         return formatMoney(this._obligatedAmount);
     },
     get percentOfTotalObligations() {
-        return calculatePercentage(this._obligatedAmount, this._totalObligatedAmount);
+        return calculatePercentage(this._obligatedAmount, this._totalObligatedAmount, '--', 2);
     }
 };
 

--- a/src/js/models/v2/agencyV2/BaseAccountSpendingRow.js
+++ b/src/js/models/v2/agencyV2/BaseAccountSpendingRow.js
@@ -3,8 +3,7 @@
  * Created by James Lee 5/27/20
  */
 
-import { formatMoney } from 'helpers/moneyFormatter';
-import { generatePercentage } from 'helpers/awardAmountHelper';
+import { formatMoney, calculatePercentage } from 'helpers/moneyFormatter';
 
 const BaseAccountSpendingRow = {
     populate(data) {
@@ -20,13 +19,7 @@ const BaseAccountSpendingRow = {
         return formatMoney(this._obligatedAmount);
     },
     get percentOfTotalObligations() {
-        if (this._totalObligatedAmount > 0) {
-            const percentage = generatePercentage(this._obligatedAmount / this._totalObligatedAmount);
-            if (percentage === '0.00%') return 'Less than 0.01%';
-            if (percentage === '-0.00%') return 'Less than -0.01%';
-            return percentage;
-        }
-        return '0.00%';
+        return calculatePercentage(this._obligatedAmount, this._totalObligatedAmount);
     }
 };
 


### PR DESCRIPTION
**High level description:**

Fixes a bug that prevented the Agency v2 table from displaying any results when total obligation is 0 (as it was in dev). This change will display table results with the percentage column showing `--`.

**Technical details:**

- Also updates the loading/error state to use built-in `Table` props
- Uses the more robust `calculatePercentage` helper in the data model
- We will continue to refactor this section in the Spending by Budget Category epic

**JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:

Reviewer(s):
- [x] Code review complete
- [x] #2477 
