### PR TITLE
Fix/dev 6896 object class tip missing percent

### DIFF
--- a/src/js/components/agency/visualizations/objectClass/MajorObjectClasses.jsx
+++ b/src/js/components/agency/visualizations/objectClass/MajorObjectClasses.jsx
@@ -247,7 +247,7 @@ export default class MajorObjectClasses extends React.Component {
         return (
             <div className="treemap-inner-wrap">
                 {greatThanOneHundredDescription}
-                { this.createTooltip()}
+                { this.createTooltip() }
                 <div
                     className="tree-wrapper"
                     ref={(sr) => {

--- a/src/js/components/agency/visualizations/objectClass/MajorObjectClasses.jsx
+++ b/src/js/components/agency/visualizations/objectClass/MajorObjectClasses.jsx
@@ -213,13 +213,13 @@ export default class MajorObjectClasses extends React.Component {
             const node = find(this.state.finalNodes,
                 { key: `${this.state.hoveredObjectClass}` });
 
-            const obligated_amount = parseFloat(objectClass.obligated_amount);
+            const obligatedAmount = parseFloat(objectClass.obligated_amount);
 
             tooltip = (<ObjectClassTooltip
                 name={objectClass.major_object_class_name}
-                value={MoneyFormatter.formatTreemapValues(obligated_amount)}
+                value={MoneyFormatter.formatTreemapValues(obligatedAmount)}
                 percentage={MoneyFormatter.calculatePercentage(
-                    obligated_amount, this.props.totalObligation)
+                    obligatedAmount, this.props.totalObligation)
                 }
                 description={objectClassDefinition.description}
                 x={node.props.x0}

--- a/src/js/components/agency/visualizations/objectClass/MajorObjectClasses.jsx
+++ b/src/js/components/agency/visualizations/objectClass/MajorObjectClasses.jsx
@@ -213,11 +213,13 @@ export default class MajorObjectClasses extends React.Component {
             const node = find(this.state.finalNodes,
                 { key: `${this.state.hoveredObjectClass}` });
 
+            const obligated_amount = parseFloat(objectClass.obligated_amount);
+
             tooltip = (<ObjectClassTooltip
                 name={objectClass.major_object_class_name}
-                value={MoneyFormatter.formatTreemapValues(objectClass.obligated_amount)}
+                value={MoneyFormatter.formatTreemapValues(obligated_amount)}
                 percentage={MoneyFormatter.calculatePercentage(
-                    objectClass.obligated_amount, this.props.totalObligation)
+                    obligated_amount, this.props.totalObligation)
                 }
                 description={objectClassDefinition.description}
                 x={node.props.x0}
@@ -245,7 +247,7 @@ export default class MajorObjectClasses extends React.Component {
         return (
             <div className="treemap-inner-wrap">
                 {greatThanOneHundredDescription}
-                { this.createTooltip() }
+                { this.createTooltip()}
                 <div
                     className="tree-wrapper"
                     ref={(sr) => {
@@ -255,7 +257,7 @@ export default class MajorObjectClasses extends React.Component {
                         width={this.state.visualizationWidth}
                         height={this.state.visualizationHeight}
                         className="treemap-svg overlay">
-                        { this.state.finalNodes }
+                        {this.state.finalNodes}
                     </svg>
                 </div>
             </div>

--- a/src/js/components/agency/visualizations/objectClass/MinorObjectClasses.jsx
+++ b/src/js/components/agency/visualizations/objectClass/MinorObjectClasses.jsx
@@ -266,7 +266,7 @@ export default class MinorObjectClasses extends React.Component {
                     <h6>{totalSpend} | {percentage}</h6>
                     <p>{objectClassDefinition.description}</p>
                 </div>
-                { this.createTooltip()}
+                { this.createTooltip() }
                 <div
                     className="tree-wrapper"
                     ref={(sr) => {

--- a/src/js/components/agency/visualizations/objectClass/MinorObjectClasses.jsx
+++ b/src/js/components/agency/visualizations/objectClass/MinorObjectClasses.jsx
@@ -219,11 +219,13 @@ export default class MinorObjectClasses extends React.Component {
             const node = find(this.state.finalNodes,
                 { key: `${this.state.hoveredObjectClass}` });
 
+            const obligated_amount = parseFloat(objectClass.obligated_amount);
+
             tooltip = (<ObjectClassTooltip
                 name={objectClass.object_class_name}
-                value={MoneyFormatter.formatTreemapValues(objectClass.obligated_amount)}
+                value={MoneyFormatter.formatTreemapValues(obligated_amount)}
                 percentage={MoneyFormatter.calculatePercentage(
-                    objectClass.obligated_amount, this.props.totalMinorObligation)
+                    obligated_amount, this.props.totalMinorObligation)
                 }
                 description={objectClassDefinition.description}
                 x={node.props.x0}
@@ -238,7 +240,7 @@ export default class MinorObjectClasses extends React.Component {
     }
 
     render() {
-        const value = this.props.majorObjectClass.obligated_amount;
+        const value = parseFloat(this.props.majorObjectClass.obligated_amount);
         const totalSpend = MoneyFormatter.formatTreemapValues(value);
         const percentage = MoneyFormatter.calculatePercentage(
             value, this.props.totalObligation);
@@ -264,7 +266,7 @@ export default class MinorObjectClasses extends React.Component {
                     <h6>{totalSpend} | {percentage}</h6>
                     <p>{objectClassDefinition.description}</p>
                 </div>
-                { this.createTooltip() }
+                { this.createTooltip()}
                 <div
                     className="tree-wrapper"
                     ref={(sr) => {
@@ -274,7 +276,7 @@ export default class MinorObjectClasses extends React.Component {
                         width={this.state.visualizationWidth}
                         height={this.state.visualizationHeight}
                         className="treemap-svg overlay">
-                        { this.state.finalNodes }
+                        {this.state.finalNodes}
                     </svg>
                 </div>
             </div>

--- a/src/js/components/agency/visualizations/objectClass/MinorObjectClasses.jsx
+++ b/src/js/components/agency/visualizations/objectClass/MinorObjectClasses.jsx
@@ -219,13 +219,13 @@ export default class MinorObjectClasses extends React.Component {
             const node = find(this.state.finalNodes,
                 { key: `${this.state.hoveredObjectClass}` });
 
-            const obligated_amount = parseFloat(objectClass.obligated_amount);
+            const obligatedAmount = parseFloat(objectClass.obligated_amount);
 
             tooltip = (<ObjectClassTooltip
                 name={objectClass.object_class_name}
-                value={MoneyFormatter.formatTreemapValues(obligated_amount)}
+                value={MoneyFormatter.formatTreemapValues(obligatedAmount)}
                 percentage={MoneyFormatter.calculatePercentage(
-                    obligated_amount, this.props.totalMinorObligation)
+                    obligatedAmount, this.props.totalMinorObligation)
                 }
                 description={objectClassDefinition.description}
                 x={node.props.x0}


### PR DESCRIPTION
**High level description:**

Hovertip on object class chart was showing "--" for all percentages.

**Technical details:**

Obligation amount from API is a string, which was not being parsed before math.

**JIRA Ticket:**
[DEV-6896](https://federal-spending-transparency.atlassian.net/browse/DEV-6896)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge (not Safari; all others in Windows)
- [x] Verified mobile/tablet/desktop/monitor responsiveness - N/A
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension) - N/A
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [x] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable` - N/A
- [x] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable` - N/A

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
