### PR TITLE
Warmfix DEV-7038 Agency Submission Statistics tooltips

### DIFF
--- a/src/_scss/pages/aboutTheData/_tableControls.scss
+++ b/src/_scss/pages/aboutTheData/_tableControls.scss
@@ -1,5 +1,6 @@
 .table-controls {
     max-width: 100%;
+    z-index: 15; // prevents tab tooltips from displaying behind the sticky table headers
     .usa-dt-tab:focus {
         outline: none;
     }


### PR DESCRIPTION
**High level description:**

Fixes a bug causing the Agency Submission Statistics tab tooltips to display behind sticky table headers.

**Technical details:**

Added a z-index (of higher value than the table headers) to the tabs' parent element.

**JIRA Ticket:**
[DEV-7038](https://federal-spending-transparency.atlassian.net/browse/DEV-7038)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge

Reviewer(s):
- [x] Code review complete
- [x] Confirm that only warmfix changes have been merged to `dev` OR change the base to `qat`
