### PR TITLE
DEV-6954 about the data modal buttons

### DIFF
--- a/src/js/containers/aboutTheData/AgenciesContainer.jsx
+++ b/src/js/containers/aboutTheData/AgenciesContainer.jsx
@@ -250,7 +250,9 @@ const AgenciesContainer = ({
         .map(({
             name: agencyName,
             code,
+            _mostRecentPublicationDate,
             mostRecentPublicationDate,
+            _discrepancyCount,
             discrepancyCount: GtasNotInFileA,
             obligationDifference,
             _gtasObligationTotal,
@@ -261,7 +263,7 @@ const AgenciesContainer = ({
         }) => [
             (<DrilldownCell data={agencyName} id={code} searchTerm={searchTerm} />),
             (<div className="generic-cell-content">{percentageOfTotalFederalBudget}</div>),
-            (mostRecentPublicationDate === '--' ?
+            (!_mostRecentPublicationDate ?
                 <div className="generic-cell-content">{mostRecentPublicationDate}</div> :
                 <CellWithModal
                     data={mostRecentPublicationDate}
@@ -273,7 +275,7 @@ const AgenciesContainer = ({
                         fiscalYear: selectedFy,
                         fiscalPeriod: selectedPeriod?.id
                     }} />),
-            (GtasNotInFileA === '0' ?
+            (_discrepancyCount === 0 ?
                 <div className="generic-cell-content">{GtasNotInFileA}</div> :
                 <CellWithModal
                     data={GtasNotInFileA}

--- a/src/js/containers/aboutTheData/AgenciesContainer.jsx
+++ b/src/js/containers/aboutTheData/AgenciesContainer.jsx
@@ -261,27 +261,31 @@ const AgenciesContainer = ({
         }) => [
             (<DrilldownCell data={agencyName} id={code} searchTerm={searchTerm} />),
             (<div className="generic-cell-content">{percentageOfTotalFederalBudget}</div>),
-            (<CellWithModal
-                data={mostRecentPublicationDate}
-                openModal={openModal}
-                modalType="publicationDates"
-                agencyData={{
-                    agencyName,
-                    agencyCode: code,
-                    fiscalYear: selectedFy,
-                    fiscalPeriod: selectedPeriod?.id
-                }} />),
-            (<CellWithModal
-                data={GtasNotInFileA}
-                openModal={openModal}
-                modalType="missingAccountBalance"
-                agencyData={{
-                    agencyName,
-                    gtasObligationTotal: _gtasObligationTotal,
-                    agencyCode: code,
-                    fiscalYear: selectedFy,
-                    fiscalPeriod: selectedPeriod?.id
-                }} />),
+            (mostRecentPublicationDate === '--' ?
+                <div className="generic-cell-content">{mostRecentPublicationDate}</div> :
+                <CellWithModal
+                    data={mostRecentPublicationDate}
+                    openModal={openModal}
+                    modalType="publicationDates"
+                    agencyData={{
+                        agencyName,
+                        agencyCode: code,
+                        fiscalYear: selectedFy,
+                        fiscalPeriod: selectedPeriod?.id
+                    }} />),
+            (GtasNotInFileA === '0' ?
+                <div className="generic-cell-content">{GtasNotInFileA}</div> :
+                <CellWithModal
+                    data={GtasNotInFileA}
+                    openModal={openModal}
+                    modalType="missingAccountBalance"
+                    agencyData={{
+                        agencyName,
+                        gtasObligationTotal: _gtasObligationTotal,
+                        agencyCode: code,
+                        fiscalYear: selectedFy,
+                        fiscalPeriod: selectedPeriod?.id
+                    }} />),
             (<CellWithModal
                 data={obligationDifference}
                 openModal={openModal}

--- a/src/js/containers/aboutTheData/AgencyDetailsContainer.jsx
+++ b/src/js/containers/aboutTheData/AgencyDetailsContainer.jsx
@@ -60,7 +60,7 @@ const AgencyDetailsContainer = ({ modalClick, agencyName, agencyCode }) => {
             return [
                 <div className="generic-cell-content">{rowData.reportingPeriod}</div>,
                 <div className="generic-cell-content">{rowData.percentOfBudget}</div>,
-                rowData.mostRecentPublicationDate === '--' ?
+                !rowData._mostRecentPublicationDate ?
                     <div className="generic-cell-content">{rowData.mostRecentPublicationDate}</div> :
                     <CellWithModal
                         data={rowData.mostRecentPublicationDate}

--- a/src/js/containers/aboutTheData/AgencyDetailsContainer.jsx
+++ b/src/js/containers/aboutTheData/AgencyDetailsContainer.jsx
@@ -60,27 +60,31 @@ const AgencyDetailsContainer = ({ modalClick, agencyName, agencyCode }) => {
             return [
                 <div className="generic-cell-content">{rowData.reportingPeriod}</div>,
                 <div className="generic-cell-content">{rowData.percentOfBudget}</div>,
-                <CellWithModal
-                    data={rowData.mostRecentPublicationDate}
-                    openModal={modalClick}
-                    modalType="publicationDates"
-                    agencyData={{
-                        fiscalYear: rowData.fiscalYear,
-                        fiscalPeriod: rowData.fiscalPeriod,
-                        agencyName,
-                        agencyCode
-                    }} />,
-                <CellWithModal
-                    data={rowData.discrepancyCount}
-                    openModal={modalClick}
-                    modalType="missingAccountBalance"
-                    agencyData={{
-                        fiscalYear: rowData.fiscalYear,
-                        fiscalPeriod: rowData.fiscalPeriod,
-                        agencyName,
-                        agencyCode,
-                        gtasObligationTotal: rowData._gtasObligationTotal
-                    }} />,
+                rowData.mostRecentPublicationDate === '--' ?
+                    <div className="generic-cell-content">{rowData.mostRecentPublicationDate}</div> :
+                    <CellWithModal
+                        data={rowData.mostRecentPublicationDate}
+                        openModal={modalClick}
+                        modalType="publicationDates"
+                        agencyData={{
+                            fiscalYear: rowData.fiscalYear,
+                            fiscalPeriod: rowData.fiscalPeriod,
+                            agencyName,
+                            agencyCode
+                        }} />,
+                rowData._discrepancyCount === 0 ?
+                    <div className="generic-cell-content">{rowData.discrepancyCount}</div> :
+                    <CellWithModal
+                        data={rowData.discrepancyCount}
+                        openModal={modalClick}
+                        modalType="missingAccountBalance"
+                        agencyData={{
+                            fiscalYear: rowData.fiscalYear,
+                            fiscalPeriod: rowData.fiscalPeriod,
+                            agencyName,
+                            agencyCode,
+                            gtasObligationTotal: rowData._gtasObligationTotal
+                        }} />,
                 <CellWithModal
                     data={rowData.obligationDifference}
                     openModal={modalClick}

--- a/src/js/containers/aboutTheData/AgencyTableMapping.jsx
+++ b/src/js/containers/aboutTheData/AgencyTableMapping.jsx
@@ -89,7 +89,7 @@ export const agenciesTableColumns = {
         },
         {
             title: 'missing_tas_accounts_count',
-            displayName: 'Number of TAS Missing from Account Balance Data',
+            displayName: 'Number of TASs Missing from Account Balance Data',
             icon: <Tooltip title="Number of TASs Missing from Account Balance Data" />,
             right: true
         },

--- a/tests/components/aboutTheData/AboutTheDataPage-test.jsx
+++ b/tests/components/aboutTheData/AboutTheDataPage-test.jsx
@@ -109,7 +109,7 @@ test('renders the details table first', async () => {
     });
     render(<AboutTheDataPage {...defaultProps} />);
     // shows the correct table
-    const [table] = screen.getAllByText('Number of TAS Missing from Account Balance Data');
+    const [table] = screen.getAllByText('Number of TASs Missing from Account Balance Data');
     expect(table).toBeDefined();
 });
 


### PR DESCRIPTION
**High level description:**

Prevents modal buttons from displaying on cells with no data for the `Most Recent Update` and `Number of TASs Missing from Account Balance Data` columns.

**Technical details:**

Also fixes a discrepancy between "Number of **TAS** Missing from Account Balance Data" and "Number of **TASs** Missing from Account Balance Data" to match the mockup.

**JIRA Ticket:**
[DEV-6954](https://federal-spending-transparency.atlassian.net/browse/DEV-6954)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md) - it's been difficult to isolate the button logic in a unit test without refactoring the containers. LMK what you think!

Reviewer(s):
- [x] Code review complete
