### PR TITLE
Warmfix DEV-7088 Percent of Total Federal Budget

### DIFF
--- a/src/js/containers/aboutTheData/AgenciesContainer.jsx
+++ b/src/js/containers/aboutTheData/AgenciesContainer.jsx
@@ -124,8 +124,8 @@ const AgenciesContainer = ({
         const newPage = goToFirstPage ? 1 : publicationsPage;
         setLoading([false, false, true]);
         // Get the (cumulative) total budgetary resources from the latest (revealed) period
-        const latestPeriod = getLatestPeriod(submissionPeriods.toJS(), selectedFy).period;
-        const federalTotal = getFederalBudget(federalTotals, selectedFy, latestPeriod);
+        const latestPeriod = getLatestPeriod(submissionPeriods.toJS(), selectedFy);
+        const federalTotal = getFederalBudget(federalTotals, latestPeriod);
         publicationsReq.current = getSubmissionPublicationDates(selectedFy, publicationsSort[0], publicationsSort[1], newPage, publicationsLimit, searchTerm);
         return publicationsReq.current.promise
             .then(({ data: { results, page_metadata: { total: totalItems } } }) => {

--- a/src/js/containers/aboutTheData/AgenciesContainer.jsx
+++ b/src/js/containers/aboutTheData/AgenciesContainer.jsx
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import DrilldownCell from 'components/aboutTheData/DrilldownCell';
 import CellWithModal from 'components/aboutTheData/CellWithModal';
 import { setTableData, setTableSort, setTotals, setSearchResults, setSearchTerm } from 'redux/actions/aboutTheData';
-import { getTotalBudgetaryResources, getAgenciesReportingData, getSubmissionPublicationDates, usePagination, isPeriodSelectable } from 'helpers/aboutTheDataHelper';
+import { getTotalBudgetaryResources, getAgenciesReportingData, getSubmissionPublicationDates, usePagination, isPeriodSelectable, getFederalBudget } from 'helpers/aboutTheDataHelper';
 import BaseAgencyRow from 'models/v2/aboutTheData/BaseAgencyRow';
 import PublicationOverviewRow from 'models/v2/aboutTheData/PublicationOverviewRow';
 import AgencyDownloadLinkCell from 'components/aboutTheData/AgencyDownloadLinkCell';
@@ -122,12 +122,14 @@ const AgenciesContainer = ({
         }
         const newPage = goToFirstPage ? 1 : publicationsPage;
         setLoading([false, false, true]);
+        // Get the (cumulative) total budgetary resources from the latest period available
+        const federalTotal = getFederalBudget(federalTotals, selectedFy);
         publicationsReq.current = getSubmissionPublicationDates(selectedFy, publicationsSort[0], publicationsSort[1], newPage, publicationsLimit, searchTerm);
         return publicationsReq.current.promise
             .then(({ data: { results, page_metadata: { total: totalItems } } }) => {
                 const parsedResults = results.map((d) => {
                     const row = Object.create(PublicationOverviewRow);
-                    row.populate(parseInt(selectedFy, 10), d, federalTotals);
+                    row.populate(d, federalTotal);
                     return row;
                 });
                 changePublicationsTotal(totalItems);

--- a/src/js/containers/aboutTheData/AgenciesContainer.jsx
+++ b/src/js/containers/aboutTheData/AgenciesContainer.jsx
@@ -8,6 +8,7 @@ import DrilldownCell from 'components/aboutTheData/DrilldownCell';
 import CellWithModal from 'components/aboutTheData/CellWithModal';
 import { setTableData, setTableSort, setTotals, setSearchResults, setSearchTerm } from 'redux/actions/aboutTheData';
 import { getTotalBudgetaryResources, getAgenciesReportingData, getSubmissionPublicationDates, usePagination, isPeriodSelectable, getFederalBudget } from 'helpers/aboutTheDataHelper';
+import { getLatestPeriod } from 'helpers/accountHelper';
 import BaseAgencyRow from 'models/v2/aboutTheData/BaseAgencyRow';
 import PublicationOverviewRow from 'models/v2/aboutTheData/PublicationOverviewRow';
 import AgencyDownloadLinkCell from 'components/aboutTheData/AgencyDownloadLinkCell';
@@ -122,8 +123,9 @@ const AgenciesContainer = ({
         }
         const newPage = goToFirstPage ? 1 : publicationsPage;
         setLoading([false, false, true]);
-        // Get the (cumulative) total budgetary resources from the latest period available
-        const federalTotal = getFederalBudget(federalTotals, selectedFy);
+        // Get the (cumulative) total budgetary resources from the latest (revealed) period
+        const latestPeriod = getLatestPeriod(submissionPeriods.toJS(), selectedFy).period;
+        const federalTotal = getFederalBudget(federalTotals, selectedFy, latestPeriod);
         publicationsReq.current = getSubmissionPublicationDates(selectedFy, publicationsSort[0], publicationsSort[1], newPage, publicationsLimit, searchTerm);
         return publicationsReq.current.promise
             .then(({ data: { results, page_metadata: { total: totalItems } } }) => {

--- a/src/js/helpers/aboutTheDataHelper.js
+++ b/src/js/helpers/aboutTheDataHelper.js
@@ -240,5 +240,6 @@ export const getFederalBudget = (federalTotals, fy) => {
     const parsedFederalTotals = federalTotals
         .filter(({ fiscal_year: y }) => y === parseInt(fy, 10)) // filter on the selected fiscal year
         .sort((a, b) => b.fiscal_period - a.fiscal_period); // sort by descending fiscal period
-    return parsedFederalTotals[0].total_budgetary_resources;
+    // eslint-disable-next-line camelcase
+    return parsedFederalTotals[0]?.total_budgetary_resources;
 };

--- a/src/js/helpers/aboutTheDataHelper.js
+++ b/src/js/helpers/aboutTheDataHelper.js
@@ -235,10 +235,9 @@ export const getAllAgenciesEmail = (fy, period, tab) => {
     };
 };
 
-export const getFederalBudget = (federalTotals, fy, period) => {
+export const getFederalBudget = (federalTotals, latestPeriod) => {
     const parsedFederalTotals = federalTotals
-        .filter(({ fiscal_year: y }) => y === parseInt(fy, 10)) // filter on the selected fiscal year
-        .filter(({ fiscal_period: p }) => p === period); // filter on the latest (revealed) fiscal period
+        .find(({ fiscal_period: p, fiscal_year: y }) => (p === latestPeriod.period && y === latestPeriod.year));
     // eslint-disable-next-line camelcase
-    return parsedFederalTotals[0]?.total_budgetary_resources;
+    return parsedFederalTotals?.total_budgetary_resources;
 };

--- a/src/js/helpers/aboutTheDataHelper.js
+++ b/src/js/helpers/aboutTheDataHelper.js
@@ -234,3 +234,11 @@ export const getAllAgenciesEmail = (fy, period, tab) => {
         body: `View agency submission details on USAspending: ${url}`
     };
 };
+
+export const getFederalBudget = (federalTotals, fy) => {
+    // Get the (cumulative) total budgetary resources from the latest period available
+    const parsedFederalTotals = federalTotals
+        .filter(({ fiscal_year: y }) => y === parseInt(fy, 10)) // filter on the selected fiscal year
+        .sort((a, b) => b.fiscal_period - a.fiscal_period); // sort by descending fiscal period
+    return parsedFederalTotals[0].total_budgetary_resources;
+};

--- a/src/js/helpers/aboutTheDataHelper.js
+++ b/src/js/helpers/aboutTheDataHelper.js
@@ -235,11 +235,10 @@ export const getAllAgenciesEmail = (fy, period, tab) => {
     };
 };
 
-export const getFederalBudget = (federalTotals, fy) => {
-    // Get the (cumulative) total budgetary resources from the latest period available
+export const getFederalBudget = (federalTotals, fy, period) => {
     const parsedFederalTotals = federalTotals
         .filter(({ fiscal_year: y }) => y === parseInt(fy, 10)) // filter on the selected fiscal year
-        .sort((a, b) => b.fiscal_period - a.fiscal_period); // sort by descending fiscal period
+        .filter(({ fiscal_period: p }) => p === period); // filter on the latest (revealed) fiscal period
     // eslint-disable-next-line camelcase
     return parsedFederalTotals[0]?.total_budgetary_resources;
 };

--- a/src/js/models/v2/aboutTheData/PublicationOverviewRow.js
+++ b/src/js/models/v2/aboutTheData/PublicationOverviewRow.js
@@ -19,14 +19,12 @@ const addFuturePeriods = (periods) => {
 };
 
 const DatesRow = {
-    populate(fy, data, totals) {
+    populate(data, federalTotal) {
         this._name = data.agency_name || '';
         this._abbreviation = data.abbreviation || '';
         this.code = data.toptier_code || '';
         this._budgetAuthority = data.current_total_budget_authority_amount || 0;
-        this._federalTotal = totals
-            .filter(({ fiscal_year: y }) => y === fy)
-            .reduce((acc, { total_budgetary_resources: t }) => acc + t, 0);
+        this._federalTotal = federalTotal;
         this.periods = addFuturePeriods(data.periods)
             .map(({ submission_dates: { publication_date: p, certification_date: c }, quarterly: isQuarterly }) => {
                 if (p === '--') {

--- a/tests/containers/aboutTheData/mockData.js
+++ b/tests/containers/aboutTheData/mockData.js
@@ -11,6 +11,16 @@ export const mockAPI = {
                     total_budgetary_resources: 4000.00,
                     fiscal_year: 2020,
                     fiscal_period: 5
+                },
+                {
+                    total_budgetary_resources: 10000,
+                    fiscal_year: 2020,
+                    fiscal_period: 7
+                },
+                {
+                    total_budgetary_resources: 10002,
+                    fiscal_year: 2000,
+                    fiscal_period: 8
                 }
             ]
         }

--- a/tests/helpers/aboutTheDataHelper-test.js
+++ b/tests/helpers/aboutTheDataHelper-test.js
@@ -303,8 +303,17 @@ test('getAgencyDetailEmail', () => {
     expect(getAgencyDetailEmail('test', '123').subject.includes('test')).toEqual(true);
 });
 
-test('getFederalBudget returns total budgetary resources for the given FY and period', () => {
-    expect(getFederalBudget(mockFederalTotals, '2020', 7)).toEqual(10000);
-    expect(getFederalBudget(mockFederalTotals, '2020', 6)).toEqual(8000.72);
-    expect(getFederalBudget(mockFederalTotals, '2000', 8)).toEqual(10002);
+test('getFederalBudget returns total budgetary resources for the given latest period', () => {
+    expect(getFederalBudget(mockFederalTotals, {
+        year: 2020,
+        period: 7
+    })).toEqual(10000);
+    expect(getFederalBudget(mockFederalTotals, {
+        year: 2020,
+        period: 6
+    })).toEqual(8000.72);
+    expect(getFederalBudget(mockFederalTotals, {
+        year: 2000,
+        period: 8
+    })).toEqual(10002);
 });

--- a/tests/helpers/aboutTheDataHelper-test.js
+++ b/tests/helpers/aboutTheDataHelper-test.js
@@ -300,10 +300,11 @@ test.each([
 
 test('getAgencyDetailEmail', () => {
     expect(getAgencyDetailEmail('test', '123').body.includes('test')).toEqual(true);
-    expect(getAgencyDetailEmail('test', '123').subject.includes('test')).toEqual(true)
+    expect(getAgencyDetailEmail('test', '123').subject.includes('test')).toEqual(true);
 });
 
-test('getFederalBudget', () => {
-    expect(getFederalBudget(mockFederalTotals, '2020')).toEqual(10000);
-    expect(getFederalBudget(mockFederalTotals, '2000')).toEqual(10002);
+test('getFederalBudget returns total budgetary resources for the given FY and period', () => {
+    expect(getFederalBudget(mockFederalTotals, '2020', 7)).toEqual(10000);
+    expect(getFederalBudget(mockFederalTotals, '2020', 6)).toEqual(8000.72);
+    expect(getFederalBudget(mockFederalTotals, '2000', 8)).toEqual(10002);
 });

--- a/tests/helpers/aboutTheDataHelper-test.js
+++ b/tests/helpers/aboutTheDataHelper-test.js
@@ -10,7 +10,8 @@ import {
     getPeriodWithTitleById,
     convertDatesToMilliseconds,
     getAllAgenciesEmail,
-    getAgencyDetailEmail
+    getAgencyDetailEmail,
+    getFederalBudget
 } from 'helpers/aboutTheDataHelper';
 
 import {
@@ -23,6 +24,10 @@ import {
     mockDates,
     badMockDates
 } from '../mockData/helpers/aboutTheDataHelper';
+
+import { mockAPI } from '../containers/aboutTheData/mockData';
+
+const mockFederalTotals = mockAPI.totals.data.results;
 
 const mockPeriods = {
     data: {
@@ -296,4 +301,9 @@ test.each([
 test('getAgencyDetailEmail', () => {
     expect(getAgencyDetailEmail('test', '123').body.includes('test')).toEqual(true);
     expect(getAgencyDetailEmail('test', '123').subject.includes('test')).toEqual(true)
-})
+});
+
+test('getFederalBudget', () => {
+    expect(getFederalBudget(mockFederalTotals, '2020')).toEqual(10000);
+    expect(getFederalBudget(mockFederalTotals, '2000')).toEqual(10002);
+});

--- a/tests/models/aboutTheData/PublicationOverviewRow-test.js
+++ b/tests/models/aboutTheData/PublicationOverviewRow-test.js
@@ -7,10 +7,10 @@ import PublicationOverviewRow from 'models/v2/aboutTheData/PublicationOverviewRo
 import { mockAPI } from '../../containers/aboutTheData/mockData';
 
 const mockRow = mockAPI.publications.data.results[0];
-const mockTotals = mockAPI.totals.data.results;
+const mockTotal = 10000;
 
 const mockDatesRow = Object.create(PublicationOverviewRow);
-mockDatesRow.populate(2020, mockRow, mockTotals);
+mockDatesRow.populate(mockRow, mockTotal);
 
 test('should format the agency name', () => {
     expect(mockDatesRow.name).toEqual('Mock Agency (ABC)');
@@ -22,13 +22,13 @@ test('should handle an agency with no abbreviation', () => {
         abbreviation: ''
     };
     const mockDatesRowMod = Object.create(mockDatesRow);
-    mockDatesRowMod.populate('2020', missingAbbrev, mockTotals);
+    mockDatesRowMod.populate(missingAbbrev, mockTotal);
     expect(mockDatesRowMod.name).toEqual('Mock Agency');
 });
 
 test('should format the percent of total federal budget', () => {
-    // 8000.72 / 1200.72
-    expect(mockDatesRow.percentageOfTotalFederalBudget).toEqual('66.67%');
+    // 8000.72 / 10000
+    expect(mockDatesRow.percentageOfTotalFederalBudget).toEqual('80.01%');
 });
 
 test('should always have 11 periods', () => {


### PR DESCRIPTION
**High level description:**

In the `Updates by Fiscal Year` tab, fixes the calculation for `Percent of Total Federal Budget` column's denominator.

**Technical details:**

- Instead of summing the `total_budgetary_resources` for each period in the selected fiscal year, get the (cumulative) `total_budgetary_resources` from the latest fiscal period available in the selected year.
- Moved the parsing logic to a helper function instead of the `PublicationOverviewRow` data model, since we can calculate the total once and pass it to every row. This also eliminates the need to pass the selected FY to every row.

**JIRA Ticket:**
[DEV-7088](https://federal-spending-transparency.atlassian.net/browse/DEV-7088)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations [React Testing Library](react-testing-library.md)

Reviewer(s):
- [x] [API #3067](https://github.com/fedspendingtransparency/usaspending-api/pull/3067) merged concurrently
- [x] Code review complete
- [x] Updated to use the latest period _that has been revealed_ instead of the latest available from GTAS
