### PR TITLE
[DEV-7059] Prevent empty arrays for downloads

### DIFF
--- a/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
+++ b/src/js/containers/bulkDownload/BulkDownloadPageContainer.jsx
@@ -110,7 +110,6 @@ export class BulkDownloadPageContainer extends React.Component {
                 },
                 def_codes: formState.defCodes
             },
-            columns: [],
             file_format: formState.fileFormat
         };
 
@@ -190,8 +189,16 @@ export class BulkDownloadPageContainer extends React.Component {
             this.request.cancel();
         }
 
+        const bulkParams = params;
+
+        // Prevent empty arrays in the download request; empty array defaults are defined by the reducer
+        for (const filterType in bulkParams.filters) {
+            if (Array.isArray(bulkParams.filters[filterType]) && !bulkParams.filters[filterType].length) {
+                delete bulkParams.filters[filterType];
+            }
+        }
+
         if (type === 'awards') {
-            const bulkParams = params;
             // Need to check if sub_agency is set or not
             if (bulkParams.filters.sub_agency && bulkParams.filters.sub_agency.toLowerCase() === 'select a sub-agency') {
                 delete bulkParams.filters.sub_agency;
@@ -201,7 +208,7 @@ export class BulkDownloadPageContainer extends React.Component {
         }
 
         else if (type === 'accounts') {
-            this.request = BulkDownloadHelper.requestAccountsDownload(params);
+            this.request = BulkDownloadHelper.requestAccountsDownload(bulkParams);
         }
 
         this.request.promise

--- a/src/js/containers/search/modals/fullDownload/DownloadBottomBarContainer.jsx
+++ b/src/js/containers/search/modals/fullDownload/DownloadBottomBarContainer.jsx
@@ -104,9 +104,13 @@ export class DownloadBottomBarContainer extends React.Component {
         }
 
         const params = {
-            filters: filterSet,
-            columns
+            filters: filterSet
         };
+
+        if (columns.length > 0) {
+            params.columns = columns;
+        }
+
         this.request = DownloadHelper.requestFullDownload(params, type);
 
         this.request.promise


### PR DESCRIPTION
**High level description:**

Majority of API endpoints currently use TinyShield to validate requests. Part of that validation is that empty arrays are not permitted. Last sprint and into this sprint TinyShield was put in place for all downloads and the restriction on empty arrays was lifted temporarily to avoid breaking downloads from the frontend. This PR removes those few places where empty arrays occur so that the restriction for the TinyShield can be put back in place. 

**Technical details:**

Remove filters that have a value of an empty array since we aren't actually filtering on them and remove the `columns` filter / conditionally add it. Currently the columns filter is not implemented anywhere on the frontend.

**JIRA Ticket:**
[DEV-7059](https://federal-spending-transparency.atlassian.net/browse/DEV-7059)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [x] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable` (API contract will have all empty arrays removed when that change is put back in place for backend)

Reviewer(s):
- [x] Code review complete
