### PR TITLE
[DEV-6706] Account Download DEFC User Selection validation logic update

### DIFF
--- a/src/js/components/bulkDownload/accounts/UserSelections.jsx
+++ b/src/js/components/bulkDownload/accounts/UserSelections.jsx
@@ -25,7 +25,8 @@ export default class UserSelections extends React.Component {
     }
 
     generateDefCodesString() {
-        if (this.props.accounts.defCodes && this.props.accounts.defCodes.length > 0) {
+        const { submissionTypes, defCodes } = this.props.accounts;
+        if (defCodes.length && !(submissionTypes.length === 1 && submissionTypes.includes('accountBalances'))) {
             return (
                 <div className="selection__content">{this.props.accounts.defCodes.toString()}</div>
             );

--- a/tests/components/bulkDownload/accounts/UserSelections-test.jsx
+++ b/tests/components/bulkDownload/accounts/UserSelections-test.jsx
@@ -1,0 +1,32 @@
+/**
+ * UserSelections-test.jsx
+ * Created by Maxwell Kendall 04/09/2021
+*/
+
+import React from 'react';
+import { render, screen, waitFor } from 'test-utils';
+
+import { initialState } from 'redux/reducers/bulkDownload/bulkDownloadReducer';
+import UserSelections from 'components/bulkDownload/accounts/UserSelections';
+
+const defaultProps = {
+    accounts: {
+        ...initialState.accounts,
+        defCodes: ['TEST!!!!', 'TEST2!!!!']
+    }
+};
+
+test.each([
+    [['test', 'accountBalances'], true],
+    [['accountBalances'], false],
+    [[], true]
+])('when submission types include %s, def codes are displayed (want: %s) ', (arr, bool) => {
+    render(<UserSelections accounts={{ ...defaultProps.accounts, submissionTypes: arr }} />);
+    const defCodes = screen.queryAllByText(`TEST!!!!,TEST2!!!!`);
+    if (bool) {
+        expect(defCodes.length).toBeTruthy();
+    }
+    else {
+        expect(defCodes.length).toBeFalsy();
+    }
+});


### PR DESCRIPTION
**High level description:**

If a user only has selected accountBalances for file type, DEFC filter
selections are not relevant. In the first delivery of this ticket, we made
it so when this was the only selection the DEFC checkbox tree was
disabled.

This delivery ensures the user selection form (SS Below) removes DEFC from
the selected options when relevant. Specifically, this handles the edge
case where a user selects a file type besides accountBalances, selects DEFC, then removes the file type down to
only accountBalances. In this case, we not only disable the tree but
we also remove the DEFC from the selected options.

![image](https://user-images.githubusercontent.com/12897813/114212491-e5a15400-992f-11eb-94ce-600d84276e0c.png)


**Technical details:**

Adds test!

**JIRA Ticket:**
[DEV-6706](https://federal-spending-transparency.atlassian.net/browse/DEV-6706)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A`  Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A`  Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
