### PR TITLE
[DEV-6622] COVID Tooltip on Agency V2

### DIFF
--- a/src/_scss/pages/agencyV2/overview/_overview.scss
+++ b/src/_scss/pages/agencyV2/overview/_overview.scss
@@ -30,20 +30,20 @@
             @include justify-content(flex-end);
             padding-top: 2.2rem;
             .agency-overview__title {
+                @include display(flex);
+                @include justify-content(flex-start);
+                @include align-items(center);
+                @include flex-wrap(wrap);
                 h3 {
-                    // position: relative;
-                    @include display(flex);
-                    @include justify-content(center);
-                    @include align-items(center);
                     font-size: 3.6rem;
                     line-height: 4.5rem;
                 }
                 .agency-overview__sub-agencies {
                     font-size: 1.8rem;
+                    width: 100%;
                 }
                 .agency-overview__tooltip {
-                    // position: absolute;
-                    padding: rem(3) rem(7);
+                    // padding: rem(3) rem(7);
                     @include display(flex);
                     @include justify-content(center);
                     @include align-items(center);
@@ -55,6 +55,18 @@
                     height: rem(25);
                     border-radius: rem(4);
                     width: rem(132);
+                    margin-left: rem(10);
+                    .tooltip-spacer {
+                        transform: translateX(14px);
+                    }
+                    .tooltip-pointer {
+                        &.left {
+                            left: rem(-16);
+                        }
+                        &.smart-bottom-left {
+                            top: rem(-16);
+                        }
+                    }
                 }
             }
         }

--- a/src/_scss/pages/agencyV2/overview/_overview.scss
+++ b/src/_scss/pages/agencyV2/overview/_overview.scss
@@ -9,12 +9,19 @@
         .agency-overview__title {
             display: block;
             h3 {
+                @include display(flex);
+                @include align-items(center);
                 margin: 0;
                 font-size: 2rem;
                 font-weight: $font-semibold;
                 letter-spacing: 0;
                 line-height: 2.5rem;
                 padding-bottom: 0.3rem;
+                .tooltip-wrapper > div:first-of-type {
+                    height: 100%;
+                    @include display(flex);
+                    @include align-items(center);
+                }
             }
             .agency-overview__sub-agencies {
                 font-size: 1.4rem;
@@ -43,7 +50,6 @@
                     width: 100%;
                 }
                 .agency-overview__tooltip {
-                    // padding: rem(3) rem(7);
                     @include display(flex);
                     @include justify-content(center);
                     @include align-items(center);

--- a/src/_scss/pages/agencyV2/overview/_overview.scss
+++ b/src/_scss/pages/agencyV2/overview/_overview.scss
@@ -31,11 +31,30 @@
             padding-top: 2.2rem;
             .agency-overview__title {
                 h3 {
+                    // position: relative;
+                    @include display(flex);
+                    @include justify-content(center);
+                    @include align-items(center);
                     font-size: 3.6rem;
                     line-height: 4.5rem;
                 }
                 .agency-overview__sub-agencies {
                     font-size: 1.8rem;
+                }
+                .agency-overview__tooltip {
+                    // position: absolute;
+                    padding: rem(3) rem(7);
+                    @include display(flex);
+                    @include justify-content(center);
+                    @include align-items(center);
+                    background: $color-disaster-covid-19;
+                    color: $color-white;
+                    font-size: rem(14);
+                    font-weight: 600;
+                    text-align: center;
+                    height: rem(25);
+                    border-radius: rem(4);
+                    width: rem(132);
                 }
             }
         }

--- a/src/js/components/agencyV2/overview/AgencyOverview.jsx
+++ b/src/js/components/agencyV2/overview/AgencyOverview.jsx
@@ -8,19 +8,59 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { throttle } from 'lodash';
-import { LoadingMessage } from 'data-transparency-ui';
+import { LoadingMessage, TooltipWrapper, TooltipComponent } from 'data-transparency-ui';
+
+import { DEFC_OBJECT } from 'propTypes';
 
 import { mediumScreen } from 'dataMapping/shared/mobileBreakpoints';
 import ExternalLink from 'components/sharedComponents/ExternalLink';
 import ReadMore from 'components/sharedComponents/ReadMore';
 import FySummary from './FySummary';
 
+const CovidTooltip = ({
+    codes,
+    fy
+}) => {
+    const getText = () => codes
+        .map(({ code, public_law: pl, title }) => {
+            const parsedPublicLaw = `${pl}`;
+            return (
+                <li>
+                    <strong>{`DEFC: ${code}`}</strong>
+                    <p>{`${parsedPublicLaw},`}</p>
+                    <p>{`${title}`}</p>
+                </li>
+            );
+        });
+    return (
+        <TooltipComponent title="Disaster and Emergency Funding Codes (DEFC)">
+            <p>{`In FY ${fy}, this agency received supllemental funding in response to the following`}</p>
+            {getText()}
+            <Link to={{
+                pathname: "/disaster/covid-19/",
+                search: "?section=sub-agency"
+            }}>
+                {`View this agency's DEFC spending.`}
+            </Link>
+        </TooltipComponent>
+    );
+};
+
+CovidTooltip.propTypes = {
+    fy: PropTypes.string,
+    codes: PropTypes.arrayOf(DEFC_OBJECT)
+};
+
 const propTypes = {
     isLoading: PropTypes.bool,
+    covidDefCodes: PropTypes.arrayOf(DEFC_OBJECT),
     fy: PropTypes.string
 };
 
-const AgencyOverview = ({ isLoading, fy }) => {
+const AgencyOverview = ({
+    isLoading,
+    fy
+}) => {
     const {
         name,
         logo,
@@ -28,7 +68,8 @@ const AgencyOverview = ({ isLoading, fy }) => {
         mission,
         congressionalJustification,
         showAboutData,
-        subtierCount
+        subtierCount,
+        covidDefCodes
     } = useSelector((state) => state.agencyV2.overview);
 
     const [windowWidth, setWindowWidth] = useState(window.innerWidth);
@@ -116,7 +157,16 @@ const AgencyOverview = ({ isLoading, fy }) => {
         <>
             <div className="agency-overview__top">
                 <div className="agency-overview__title">
-                    <h3>{name}</h3>
+                    <h3>
+                        {name}
+                        {covidDefCodes.length > 0 &&
+                            <TooltipWrapper className="agency-overview__tooltip covid-19-flag" tooltipComponent={<CovidTooltip fy={fy} codes={covidDefCodes} />}>
+                                <span className="covid-spending-flag">
+                                    COVID-19 Spending
+                                </span>
+                            </TooltipWrapper>
+                        }
+                    </h3>
                     <div className="agency-overview__sub-agencies">Includes {subtierCount} awarding sub-agencies</div>
                 </div>
                 {image}

--- a/src/js/components/agencyV2/overview/AgencyOverview.jsx
+++ b/src/js/components/agencyV2/overview/AgencyOverview.jsx
@@ -41,7 +41,7 @@ const CovidTooltip = ({
             </ul>
             <Link to={{
                 pathname: "/disaster/covid-19/",
-                search: "?section=sub-agency"
+                search: "?section=award_spending_by_agency"
             }}>
                 {`View this agency's DEFC spending.`}
             </Link>
@@ -171,7 +171,6 @@ const AgencyOverview = ({
                         }
                     </h3>
                     <div className="agency-overview__sub-agencies">Includes {subtierCount} awarding sub-agencies</div>
-                    {image}
                 </div>
                 {image}
             </div>

--- a/src/js/components/agencyV2/overview/AgencyOverview.jsx
+++ b/src/js/components/agencyV2/overview/AgencyOverview.jsx
@@ -17,25 +17,28 @@ import ExternalLink from 'components/sharedComponents/ExternalLink';
 import ReadMore from 'components/sharedComponents/ReadMore';
 import FySummary from './FySummary';
 
+const replaceEmergencyPl = new RegExp(/(Emergency P.L.|Non-emergency P.L.)/);
+
 const CovidTooltip = ({
     codes,
     fy
 }) => {
     const getText = () => codes
         .map(({ code, public_law: pl, title }) => {
-            const parsedPublicLaw = `${pl}`;
+            const parsedPublicLaw = `${pl.includes('Non-emergency') ? 'Not designated as emergency' : 'Designated as emergency'}`;
             return (
                 <li>
                     <strong>{`DEFC: ${code}`}</strong>
-                    <p>{`${parsedPublicLaw},`}</p>
-                    <p>{`${title}`}</p>
+                    <p>{`${parsedPublicLaw}; ${pl.replace(replaceEmergencyPl, 'Public Law')}, ${title.toUpperCase()}`}</p>
                 </li>
             );
         });
     return (
         <TooltipComponent title="Disaster and Emergency Funding Codes (DEFC)">
-            <p>{`In FY ${fy}, this agency received supllemental funding in response to the following`}</p>
-            {getText()}
+            <p>{`In FY ${fy}, this agency received supplemental funding in response to the following:`}</p>
+            <ul>
+                {getText()}
+            </ul>
             <Link to={{
                 pathname: "/disaster/covid-19/",
                 search: "?section=sub-agency"
@@ -159,7 +162,7 @@ const AgencyOverview = ({
                 <div className="agency-overview__title">
                     <h3>
                         {name}
-                        {covidDefCodes.length > 0 &&
+                        {name && covidDefCodes.length &&
                             <TooltipWrapper className="agency-overview__tooltip covid-19-flag" tooltipComponent={<CovidTooltip fy={fy} codes={covidDefCodes} />}>
                                 <span className="covid-spending-flag">
                                     COVID-19 Spending
@@ -168,6 +171,7 @@ const AgencyOverview = ({
                         }
                     </h3>
                     <div className="agency-overview__sub-agencies">Includes {subtierCount} awarding sub-agencies</div>
+                    {image}
                 </div>
                 {image}
             </div>

--- a/src/js/components/covid19/recipient/map/MapWrapper.jsx
+++ b/src/js/components/covid19/recipient/map/MapWrapper.jsx
@@ -30,7 +30,9 @@ const propTypes = {
     filters: PropTypes.object,
     activeFilters: PropTypes.object,
     awardTypeFilters: PropTypes.array,
-    scope: PropTypes.string
+    scope: PropTypes.string,
+    onMapLoaded: PropTypes.func.isRequired,
+    isMapLoaded: PropTypes.bool.isRequired
 };
 
 const defaultProps = {
@@ -39,7 +41,8 @@ const defaultProps = {
         values: []
     },
     showLayerToggle: false,
-    children: null
+    children: null,
+    onMapLoaded: () => {}
 };
 
 const numCountyQuantiles = 200;
@@ -55,7 +58,6 @@ export default class MapWrapper extends React.Component {
                 segments: [],
                 units: {}
             },
-            mapReady: false,
             isFiltersOpen: true
         };
 
@@ -88,6 +90,9 @@ export default class MapWrapper extends React.Component {
                 this.displayData();
             }
         }
+        if (!prevProps.isMapLoaded && this.props.isMapLoaded) {
+            this.prepareMap();
+        }
     }
 
     componentWillUnmount() {
@@ -112,20 +117,14 @@ export default class MapWrapper extends React.Component {
 
     mapReady = () => {
         // map has mounted, load the state shapes
-        this.setState({
-            mapReady: true
-        }, () => {
-            this.prepareMap();
-        });
+        this.props.onMapLoaded(true);
     }
 
     countUnique = (iterable) => new Set(iterable).size
 
     mapRemoved = () => {
         // map is about to be removed
-        this.setState({
-            mapReady: false
-        });
+        this.props.onMapLoaded(false);
     }
 
     prepareMap = () => {
@@ -261,7 +260,7 @@ export default class MapWrapper extends React.Component {
     }
 
     prepareLayers = () => new Promise((resolve, reject) => {
-        if (!this.state.mapReady) {
+        if (!this.props.isMapLoaded) {
             // something went wrong, the map isn't ready yet
             reject();
         }
@@ -394,7 +393,7 @@ export default class MapWrapper extends React.Component {
 
     displayData = () => {
         // don't do anything if the map has not yet loaded
-        if (!this.state.mapReady) {
+        if (!this.props.isMapLoaded) {
             // add to the map operation queue
             this.queueMapOperation('displayData', this.displayData);
             return;

--- a/src/js/containers/covid19/recipient/map/MapContainer.jsx
+++ b/src/js/containers/covid19/recipient/map/MapContainer.jsx
@@ -11,6 +11,8 @@ import { uniqueId, keyBy, isEqual } from 'lodash';
 import MapboxGL from 'mapbox-gl/dist/mapbox-gl';
 import MapWrapper from 'components/covid19/recipient/map/MapWrapper';
 import { Tabs } from "data-transparency-ui";
+
+import { setIsMapLoaded } from 'redux/actions/covid19/covid19Actions';
 import MapBroadcaster from 'helpers/mapBroadcaster';
 import LoadingSpinner from 'components/sharedComponents/LoadingSpinner';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -32,7 +34,9 @@ import Analytics from 'helpers/analytics/Analytics';
 import SummaryInsightsContainer from '../SummaryInsightsContainer';
 
 const propTypes = {
-    defCodes: PropTypes.array
+    defCodes: PropTypes.array,
+    isMapLoaded: PropTypes.bool.isRequired,
+    onMapLoaded: PropTypes.func.isRequired
 };
 
 export class MapContainer extends React.Component {
@@ -431,6 +435,8 @@ export class MapContainer extends React.Component {
                     tablessStyle />
                 <SummaryInsightsContainer activeFilter={this.state.activeFilters.awardType} />
                 <MapWrapper
+                    isMapLoaded={this.props.isMapLoaded}
+                    onMapLoaded={this.props.onMapLoaded}
                     data={this.state.data}
                     scope={this.state.scope}
                     renderHash={this.state.renderHash}
@@ -464,6 +470,10 @@ MapContainer.propTypes = propTypes;
 
 export default connect(
     (state) => ({
-        defCodes: state.covid19.defCodes
+        defCodes: state.covid19.defCodes,
+        isMapLoaded: state.covid19.isRecipientMapLoaded
+    }),
+    (dispatch) => ({
+        onMapLoaded: (bool) => dispatch(setIsMapLoaded(bool))
     })
 )(MapContainer);

--- a/src/js/helpers/apiRequest.js
+++ b/src/js/helpers/apiRequest.js
@@ -13,7 +13,8 @@ const localUrl = `http://localhost:8000/api/`;
 const getBaseUrl = (params) => {
     if (params.isMocked) return mockUrl;
     if (params.isLocal) return localUrl;
-    return kGlobalConstants.API;
+    // return kGlobalConstants.API;
+    return 'https://qat-api.usaspending.gov/api/';
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/js/helpers/apiRequest.js
+++ b/src/js/helpers/apiRequest.js
@@ -13,8 +13,7 @@ const localUrl = `http://localhost:8000/api/`;
 const getBaseUrl = (params) => {
     if (params.isMocked) return mockUrl;
     if (params.isLocal) return localUrl;
-    // return kGlobalConstants.API;
-    return 'https://qat-api.usaspending.gov/api/';
+    return kGlobalConstants.API;
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/js/models/v2/agencyV2/BaseAgencyOverview.js
+++ b/src/js/models/v2/agencyV2/BaseAgencyOverview.js
@@ -15,7 +15,13 @@ const BaseAgencyOverview = {
         this.congressionalJustification = data.congressional_justification_url || '';
         this.showAboutData = data.about_agency_data || false;
         this.subtierCount = data.subtier_agency_count || 0;
+        this._defCodes = data.def_codes;
     },
+
+    get covidDefCodes() {
+        return this._defCodes.filter(({ disaster: d }) => d === 'covid_19');
+    },
+
     get name() {
         const abbreviation = this._abbreviation ? ` (${this._abbreviation})` : '';
         return `${this._name}${abbreviation}`;

--- a/src/js/propTypes/index.js
+++ b/src/js/propTypes/index.js
@@ -151,3 +151,11 @@ export const SUBMISSION_PERIOD_PROPS = PropTypes.arrayOf(PropTypes.shape({
     submission_fiscal_month: PropTypes.number,
     is_quarter: PropTypes.bool
 }));
+
+export const DEFC_OBJECT = PropTypes.shape({
+    code: PropTypes.string.isRequired,
+    public_law: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    urls: PropTypes.string.isRequired,
+    disaster: PropTypes.string
+});

--- a/src/js/redux/actions/covid19/covid19Actions.js
+++ b/src/js/redux/actions/covid19/covid19Actions.js
@@ -17,3 +17,8 @@ export const setTotals = (awardType, totals) => ({
     type: `SET_COVID_AWARD_AMOUNTS${awardType && '_'}${awardType}`,
     totals
 });
+
+export const setIsMapLoaded = (bool) => ({
+    type: 'SET_IS_RECIPIENT_MAP_LOADED',
+    payload: bool
+});

--- a/src/js/redux/reducers/agencyV2/agencyV2Reducer.js
+++ b/src/js/redux/reducers/agencyV2/agencyV2Reducer.js
@@ -10,7 +10,8 @@ const budgetaryResources = Object.create(BaseAgencyBudgetaryResources);
 
 export const initialState = {
     overview: {
-        name: ''
+        name: '',
+        covidDefCodes: []
     },
     budgetaryResources
 };

--- a/src/js/redux/reducers/covid19/covid19Reducer.js
+++ b/src/js/redux/reducers/covid19/covid19Reducer.js
@@ -9,7 +9,8 @@ const initialState = {
     allAwardTypeTotals: {},
     assistanceTotals: {},
     spendingByAgencyTotals: {},
-    recipientTotals: {}
+    recipientTotals: {},
+    isRecipientMapLoaded: false
 };
 
 const covid19Reducer = (state = initialState, action) => {
@@ -31,6 +32,9 @@ const covid19Reducer = (state = initialState, action) => {
         }
         case 'SET_COVID_AWARD_AMOUNTS_RECIPIENT': {
             return Object.assign({}, state, { recipientTotals: action.totals });
+        }
+        case 'SET_IS_RECIPIENT_MAP_LOADED': {
+            return Object.assign({}, state, { isRecipientMapLoaded: action.payload });
         }
         default: return state;
     }

--- a/tests/models/agency/BaseAgencyOverview-test.js
+++ b/tests/models/agency/BaseAgencyOverview-test.js
@@ -18,6 +18,43 @@ export const mockAgency = {
     congressional_justification_url: 'https://www.treasury.gov/cj',
     about_agency_data: null,
     subtier_agency_count: 10,
+    def_codes: [
+        {
+            code: "Q",
+            public_law: "Excluded from tracking (uses non-emergency/non-disaster designated appropriations)",
+            title: null,
+            urls: null,
+            disaster: null
+        },
+        {
+            code: "E",
+            public_law: "Emergency P.L. 116-20",
+            title: "Additional Supplemental Appropriations for Disaster Relief Act, 2019",
+            urls: "https://www.congress.gov/116/plaws/publ20/PLAW-116publ20.pdf",
+            disaster: null
+        },
+        {
+            code: "C",
+            public_law: "Emergency P.L. 115-123",
+            title: "Bipartisan Budget Act of 2018",
+            urls: "https://www.congress.gov/115/plaws/publ123/PLAW-115publ123.htm",
+            disaster: null
+        },
+        {
+            code: "J",
+            public_law: "Wildfire Suppression P.L. 116-94",
+            title: "Further Consolidated Appropriations Act, 2020",
+            urls: "https://www.congress.gov/bill/116th-congress/house-bill/1865/text",
+            disaster: null
+        },
+        {
+            code: "M",
+            public_law: "Emergency P.L. 116-127",
+            title: "Families First Coronavirus Response Act",
+            urls: "https://www.congress.gov/116/plaws/publ127/PLAW-116publ127.pdf",
+            disaster: "covid_19"
+        }
+    ],
     messages: []
 };
 
@@ -36,5 +73,8 @@ describe('BaseAgencyOverview', () => {
         const agencyOverviewMod = Object.create(BaseAgencyOverview);
         agencyOverviewMod.populate(missingAbbrev);
         expect(agencyOverviewMod.name).toEqual('Mock Agency');
+    });
+    it('should return only covid def codes', () => {
+        expect(agencyOverview.covidDefCodes.length).toEqual(1);
     });
 });

--- a/tests/redux/reducers/covid19/covid19Reducer-test.js
+++ b/tests/redux/reducers/covid19/covid19Reducer-test.js
@@ -4,7 +4,7 @@
  */
 
 import covid19Reducer from 'redux/reducers/covid19/covid19Reducer';
-import { setDEFCodes, setOverview, setTotals } from 'redux/actions/covid19/covid19Actions';
+import { setDEFCodes, setOverview, setTotals, setIsMapLoaded } from 'redux/actions/covid19/covid19Actions';
 import { defCodes, overview } from './mockData';
 
 describe('Covid 19 Reducer', () => {
@@ -64,5 +64,10 @@ describe('Covid 19 Reducer', () => {
         expect(state.recipientTotals).toEqual({
             awardCount: 526742, faceValueOfLoan: undefined, obligation: 213458852480.17, outlay: 8367346004.33
         });
+    });
+    it('should SET_IS_RECIPIENT_MAP_LOADED', () => {
+        let state = covid19Reducer(undefined, {});
+        state = covid19Reducer(state, setIsMapLoaded(true));
+        expect(state.isRecipientMapLoaded).toEqual(true);
     });
 });


### PR DESCRIPTION
**High level description:**

Agency V2 Tooltip when COVID spending is present, tooltip also links to agency page with active section.

**Technical details:**

See commits!

**JIRA Ticket:**
[DEV-6622](https://federal-spending-transparency.atlassian.net/browse/DEV-6622)

**Mockup:**
https://bahdigital.invisionapp.com/share/WUIAG3CQ4JG#/screens/296054001_DEFC

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
- [ ] DTUI Release
