### PR TITLE
Dev-7180 Columns Removed for 2017, 2018, 2019, and 2020

### DIFF
--- a/src/js/containers/aboutTheData/AgenciesContainer.jsx
+++ b/src/js/containers/aboutTheData/AgenciesContainer.jsx
@@ -12,7 +12,7 @@ import { getLatestPeriod } from 'helpers/accountHelper';
 import BaseAgencyRow from 'models/v2/aboutTheData/BaseAgencyRow';
 import PublicationOverviewRow from 'models/v2/aboutTheData/PublicationOverviewRow';
 import AgencyDownloadLinkCell from 'components/aboutTheData/AgencyDownloadLinkCell';
-import { agenciesTableColumns } from './AgencyTableMapping';
+import { agenciesTableColumns, parsePeriods } from './AgencyTableMapping';
 
 const propTypes = {
     openModal: PropTypes.func.isRequired,
@@ -20,15 +20,6 @@ const propTypes = {
     selectedFy: PropTypes.string,
     selectedPeriod: PropTypes.string
 };
-
-const parsePeriods = (periods) => periods
-    .map(({ publicationDate, showNotCertified }) => (
-        <div className="generic-cell-content">
-            {(publicationDate) && publicationDate}
-            {!publicationDate && "--"}
-            {showNotCertified && publicationDate && <span className="not-certified">NOT CERTIFIED</span>}
-        </div>
-    ));
 
 const AgenciesContainer = ({
     activeTab,
@@ -131,7 +122,7 @@ const AgenciesContainer = ({
             .then(({ data: { results, page_metadata: { total: totalItems } } }) => {
                 const parsedResults = results.map((d) => {
                     const row = Object.create(PublicationOverviewRow);
-                    row.populate(d, federalTotal);
+                    row.populate(d, federalTotal, selectedFy);
                     return row;
                 });
                 changePublicationsTotal(totalItems);
@@ -363,7 +354,7 @@ const AgenciesContainer = ({
                 )}
                 {activeTab === 'publications' && (
                     <Table
-                        rows={searchTerm ? renderDates(publicationsSearchResults) : renderDates(allPublications)}
+                        rows={searchTerm ? renderDates(publicationsSearchResults, selectedFy) : renderDates(allPublications, selectedFy)}
                         classNames={`${verticalStickyClass} ${horizontalStickyClass} ${arePublicationsLoading ? 'table-loading' : ''}`}
                         columns={agenciesTableColumns[activeTab](selectedFy)}
                         updateSort={handleUpdateSort}

--- a/src/js/containers/aboutTheData/AgencyTableMapping.jsx
+++ b/src/js/containers/aboutTheData/AgencyTableMapping.jsx
@@ -29,7 +29,7 @@ Tooltip.propTypes = {
     position: PropTypes.oneOf(['left', 'right']),
     className: PropTypes.string
 };
-
+// these are the sub-columns that get removed for each FY
 export const publicationsSubColumnPeriodFilters = {
     2020: {
         raw: [2, 4, 5],

--- a/src/js/containers/aboutTheData/AgencyTableMapping.jsx
+++ b/src/js/containers/aboutTheData/AgencyTableMapping.jsx
@@ -30,55 +30,101 @@ Tooltip.propTypes = {
     className: PropTypes.string
 };
 
+export const publicationsSubColumnPeriodFilters = {
+    2020: {
+        raw: [2, 4, 5],
+        labels: ['P01 - P02', 'P04', 'P05']
+    },
+    2019: {
+        raw: [2, 4, 5, 7, 8, 10, 11],
+        labels: ['P01 - P02', 'P04', 'P05', 'P07', 'P08', 'P10', 'P11']
+    },
+    2018: {
+        raw: [2, 4, 5, 7, 8, 10, 11],
+        labels: ['P01 - P02', 'P04', 'P05', 'P07', 'P08', 'P10', 'P11']
+    },
+    2017: {
+        raw: [2, 3, 4, 5, 7, 8, 10, 11],
+        labels: ['P01 - P02', 'P03', 'P04', 'P05', 'P07', 'P08', 'P10', 'P11']
+    }
+};
+
+const publicationsSubColumnFilterFunction = (fy) => (column) => {
+    if (column?.subColumnNames) {
+        const filteredPeriodColumns = column
+            .subColumnNames
+            .filter((subColumn) => !publicationsSubColumnPeriodFilters[fy].labels.find((period) => (period === subColumn.displayName)));
+        return {
+            ...column,
+            columnSpan: `${filteredPeriodColumns.length}`,
+            subColumnNames: filteredPeriodColumns
+        };
+    }
+    return column;
+};
+
+export const parsePeriods = (periods) => periods.map(({ publicationDate }) => (
+    <div className="generic-cell-content">
+        {(publicationDate) && publicationDate}
+        {!publicationDate && "--"}
+    </div>
+));
+
 export const agenciesTableColumns = {
-    publications: (fy) => [
-        { title: 'agency_name', displayName: 'Agency Name' },
-        {
-            title: 'current_total_budget_authority_amount',
-            right: true,
-            displayName: 'Percent of Total Federal Budget',
-            icon: <Tooltip title="Percent of Total Federal Budget" id="percentOfBudgetPublications" />
-        },
-        {
-            title: 'Q1',
-            displayName: `FY ${fy} Q1`,
-            columnSpan: '2',
-            subColumnNames: [
-                { displayName: 'P01 - P02', title: 'publication_date,2' },
-                { displayName: 'P03', title: 'publication_date,3' }
-            ]
-        },
-        {
-            title: 'Q2',
-            displayName: `FY ${fy} Q2`,
-            columnSpan: '3',
-            subColumnNames: [
-                { displayName: 'P04', title: 'publication_date,4' },
-                { displayName: 'P05', title: 'publication_date,5' },
-                { displayName: 'P06', title: 'publication_date,6' }
-            ]
-        },
-        {
-            title: 'Q3',
-            displayName: `FY ${fy} Q3`,
-            columnSpan: '3',
-            subColumnNames: [
-                { displayName: 'P07', title: 'publication_date,7' },
-                { displayName: 'P08', title: 'publication_date,8' },
-                { displayName: 'P09', title: 'publication_date,9' }
-            ]
-        },
-        {
-            title: 'Q4',
-            displayName: `FY ${fy} Q4`,
-            columnSpan: '3',
-            subColumnNames: [
-                { displayName: 'P10', title: 'publication_date,10' },
-                { displayName: 'P11', title: 'publication_date,11' },
-                { displayName: 'P12', title: 'publication_date,12' }
-            ]
-        }
-    ],
+    publications: (fy) => {
+        const columns = [
+            { title: 'agency_name', displayName: 'Agency Name' },
+            {
+                title: 'current_total_budget_authority_amount',
+                right: true,
+                displayName: 'Percent of Total Federal Budget',
+                icon: <Tooltip title="Percent of Total Federal Budget" id="percentOfBudgetPublications" />
+            },
+            {
+                title: 'Q1',
+                displayName: `FY ${fy} Q1`,
+                columnSpan: '2',
+                subColumnNames: [
+                    { displayName: 'P01 - P02', title: 'publication_date,2' },
+                    { displayName: 'P03', title: 'publication_date,3' }
+                ]
+            },
+            {
+                title: 'Q2',
+                displayName: `FY ${fy} Q2`,
+                columnSpan: '3',
+                subColumnNames: [
+                    { displayName: 'P04', title: 'publication_date,4' },
+                    { displayName: 'P05', title: 'publication_date,5' },
+                    { displayName: 'P06', title: 'publication_date,6' }
+                ]
+            },
+            {
+                title: 'Q3',
+                displayName: `FY ${fy} Q3`,
+                columnSpan: '3',
+                subColumnNames: [
+                    { displayName: 'P07', title: 'publication_date,7' },
+                    { displayName: 'P08', title: 'publication_date,8' },
+                    { displayName: 'P09', title: 'publication_date,9' }
+                ]
+            },
+            {
+                title: 'Q4',
+                displayName: `FY ${fy} Q4`,
+                columnSpan: '3',
+                subColumnNames: [
+                    { displayName: 'P10', title: 'publication_date,10' },
+                    { displayName: 'P11', title: 'publication_date,11' },
+                    { displayName: 'P12', title: 'publication_date,12' }
+                ]
+            }
+        ];
+        if (!fy || parseInt(fy, 10) >= 2021) return columns;
+        // 2017 removes all Q1 periods, so we remove the quarter
+        if (fy === '2017') columns.splice(2, 1);
+        return columns.map(publicationsSubColumnFilterFunction(fy));
+    },
     submissions: [
         {
             title: 'agency_name',

--- a/src/js/models/v2/aboutTheData/PublicationOverviewRow.js
+++ b/src/js/models/v2/aboutTheData/PublicationOverviewRow.js
@@ -3,6 +3,7 @@
  */
 
 import { formatMoney, formatNumber, calculatePercentage } from 'helpers/moneyFormatter';
+import { publicationsSubColumnPeriodFilters } from 'containers/aboutTheData/AgencyTableMapping';
 import moment from 'moment';
 
 const addFuturePeriods = (periods) => {
@@ -18,25 +19,28 @@ const addFuturePeriods = (periods) => {
         );
 };
 
-const DatesRow = {
-    populate(data, federalTotal) {
+const PublicationOverviewRow = {
+    populate(data, federalTotal, fy) {
         this._name = data.agency_name || '';
         this._abbreviation = data.abbreviation || '';
         this.code = data.toptier_code || '';
         this._budgetAuthority = data.current_total_budget_authority_amount || 0;
         this._federalTotal = federalTotal;
-        this.periods = addFuturePeriods(data.periods)
-            .map(({ submission_dates: { publication_date: p, certification_date: c }, quarterly: isQuarterly }) => {
+        this.periods = addFuturePeriods(data.periods).filter((result) => {
+            if (parseInt(fy, 10) >= 2021) return true;
+            return !publicationsSubColumnPeriodFilters[fy].raw.find((period) => (period === result.period));
+        })
+            .map(({ submission_dates: { publication_date: p, certification_date: c }, quarterly: isQuarterly, period }) => {
                 if (p === '--') {
                     return {
-                        isQuarterly, publicationDate: p, certificationDate: c, showNotCertified: false
+                        isQuarterly, publicationDate: p, certificationDate: c, period
                     };
                 };
                 return {
                     publicationDate: p ? moment(p).format('MM/DD/YYYY') : null,
                     certificationDate: c ? moment(c).format('MM/DD/YYYY') : null,
-                    showNotCertified: c ? moment(c).isAfter(moment()) : false,
-                    isQuarterly
+                    isQuarterly,
+                    period
                 };
             });
     },
@@ -64,4 +68,4 @@ const DatesRow = {
     }
 };
 
-export default DatesRow;
+export default PublicationOverviewRow;

--- a/tests/models/aboutTheData/PublicationOverviewRow-test.js
+++ b/tests/models/aboutTheData/PublicationOverviewRow-test.js
@@ -61,7 +61,7 @@ test('should remove periods 2, 4, 5, 7, 8, 10, 11 for 2018 & 2019', () => {
     expect(mockDatesRow.periods.find((data) => data.period === 11)).toEqual(undefined);
 });
 
-test('should remove periods 2, 3, 5, 7, 8, 10, 11 for 2017', () => {
+test('should remove periods 2, 3, 4, 5, 7, 8, 10, 11 for 2017', () => {
     mockDatesRow.populate(mockRow, mockTotal, 2017);
     expect(mockDatesRow.periods.find((data) => data.period === 2)).toEqual(undefined);
     expect(mockDatesRow.periods.find((data) => data.period === 3)).toEqual(undefined);

--- a/tests/models/aboutTheData/PublicationOverviewRow-test.js
+++ b/tests/models/aboutTheData/PublicationOverviewRow-test.js
@@ -61,7 +61,7 @@ test('should remove periods 2, 4, 5, 7, 8, 10, 11 for 2018 & 2019', () => {
     expect(mockDatesRow.periods.find((data) => data.period === 11)).toEqual(undefined);
 });
 
-test('should remove periods 2, 4, 5, 7, 8, 10, 11 for 2017', () => {
+test('should remove periods 2, 3, 5, 7, 8, 10, 11 for 2017', () => {
     mockDatesRow.populate(mockRow, mockTotal, 2017);
     expect(mockDatesRow.periods.find((data) => data.period === 2)).toEqual(undefined);
     expect(mockDatesRow.periods.find((data) => data.period === 3)).toEqual(undefined);

--- a/tests/models/aboutTheData/PublicationOverviewRow-test.js
+++ b/tests/models/aboutTheData/PublicationOverviewRow-test.js
@@ -10,7 +10,7 @@ const mockRow = mockAPI.publications.data.results[0];
 const mockTotal = 10000;
 
 const mockDatesRow = Object.create(PublicationOverviewRow);
-mockDatesRow.populate(mockRow, mockTotal);
+mockDatesRow.populate(mockRow, mockTotal, 2021);
 
 test('should format the agency name', () => {
     expect(mockDatesRow.name).toEqual('Mock Agency (ABC)');
@@ -22,7 +22,7 @@ test('should handle an agency with no abbreviation', () => {
         abbreviation: ''
     };
     const mockDatesRowMod = Object.create(mockDatesRow);
-    mockDatesRowMod.populate(missingAbbrev, mockTotal);
+    mockDatesRowMod.populate(missingAbbrev, mockTotal, 2021);
     expect(mockDatesRowMod.name).toEqual('Mock Agency');
 });
 
@@ -31,7 +31,44 @@ test('should format the percent of total federal budget', () => {
     expect(mockDatesRow.percentageOfTotalFederalBudget).toEqual('80.01%');
 });
 
-test('should always have 11 periods', () => {
+test('should always have 11 periods if after FY 2021', () => {
     expect(mockDatesRow.periods.length).toEqual(11);
 });
 
+test('should remove periods 2, 4, 5 for 2020', () => {
+    mockDatesRow.populate(mockRow, mockTotal, 2020);
+    expect(mockDatesRow.periods.find((data) => data.period === 2)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 4)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 5)).toEqual(undefined);
+});
+
+test('should remove periods 2, 4, 5, 7, 8, 10, 11 for 2018 & 2019', () => {
+    mockDatesRow.populate(mockRow, mockTotal, 2018);
+    expect(mockDatesRow.periods.find((data) => data.period === 2)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 4)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 5)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 7)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 8)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 10)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 11)).toEqual(undefined);
+    mockDatesRow.populate(mockRow, mockTotal, 2019);
+    expect(mockDatesRow.periods.find((data) => data.period === 2)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 4)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 5)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 7)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 8)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 10)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 11)).toEqual(undefined);
+});
+
+test('should remove periods 2, 4, 5, 7, 8, 10, 11 for 2017', () => {
+    mockDatesRow.populate(mockRow, mockTotal, 2017);
+    expect(mockDatesRow.periods.find((data) => data.period === 2)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 3)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 4)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 5)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 7)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 8)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 10)).toEqual(undefined);
+    expect(mockDatesRow.periods.find((data) => data.period === 11)).toEqual(undefined);
+});


### PR DESCRIPTION
**High level description:**

On the Fiscal Years Tab on the Agencies Submissions page columns removed for 2017, 2018, 2019, and 2020.

**Technical details:**

> • adds data mapping for specific FY Periods for both the columns and data.

> • filter both the data and columns based on the data mapping for FY.

**JIRA Ticket:**
[DEV-7180](https://federal-spending-transparency.atlassian.net/browse/DEV-7180)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [N/A] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (Decrease from 13 in QAT to 11 locally for FY 2018)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
