### PR TITLE
[BUG] COVID Profile Page Mobile responsiveness

### DIFF
--- a/src/_scss/pages/covid19/index.scss
+++ b/src/_scss/pages/covid19/index.scss
@@ -12,10 +12,9 @@
     width: 100%;
 
     .site-header,
-    .usda-page-header,
     .sticky-header,
     .page__loading,
-    .usda-page__container,
+    .main-content,
     .footer-container {
         width: 100%;
     }


### PR DESCRIPTION
**High level description:**

COVID profile Page body content is not shrinking in mobile. This is because the SCSS assumes a class name that is not there. It is not there b/c the new page header component is not.

**Technical details:**

Adding back class name from [this change](https://github.com/fedspendingtransparency/usaspending-website/pull/2494/files?file-filters%5B%5D=.scss#diff-abf430f3d7ccb81422037aa2956d7179efaad96001e82c03dc49ea6259a6853dR18)

**JIRA Ticket:**
`N/A`

The following are ALL required for the PR to be merged:

Author:
`N/A`  Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
- [x] Test in IE
