### PR TITLE
[DEV-7167] fix broken link

### DIFF
--- a/src/js/components/aboutTheData/AboutTheDataPage.jsx
+++ b/src/js/components/aboutTheData/AboutTheDataPage.jsx
@@ -85,7 +85,7 @@ const AboutTheDataPage = ({ history }) => {
                             on a quarterly and/or monthly basis to USAspending.gov. The table below
                             shows information about the status and content of these submissions. It will
                             be updated as agencies publish/certify new submissions or
-                            republish/recertify existing submissions. For more information about the data in this table, visit <Link to="data-sources">the Data Sources and Methodology page.</Link>
+                            republish/recertify existing submissions. For more information about the data in this table, visit <Link to="/submission-statistics/data-sources">the Data Sources and Methodology page.</Link>
                         </p>
                     </div>
                     <LoadingWrapper isLoading={!activeTab}>

--- a/src/js/components/aboutTheData/AgencyDetailsPage.jsx
+++ b/src/js/components/aboutTheData/AgencyDetailsPage.jsx
@@ -104,7 +104,7 @@ const AgencyDetailsPage = () => {
                             <div className="heading-container">
                                 <div className="back-link">
                                     <Link to={{
-                                        pathname: "/submission-statistics/",
+                                        pathname: "/submission-statistics",
                                         search: `?${new URLSearchParams({ tab: 'submissions' }).toString()}`
                                     }}>
                                         <FontAwesomeIcon icon="angle-left" />&nbsp;Back to All Agencies


### PR DESCRIPTION
**High level description:**

- On the main Agency Submission Statistics page, fixes the `Data Sources and Methodology Page` link
- On the single Agency Submission Statistics page, removes a trailing slash from the `Back to All Agencies` link

**Technical details:**

According to [react-router documentation](https://knowbody.github.io/react-router-docs/api/Link.html), `<Link>` does not support relative paths.

**JIRA Ticket:**
[DEV-7167](https://federal-spending-transparency.atlassian.net/browse/DEV-7167)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
- [x] Code review complete
