### PR TITLE
7230 map hhs disclaimer ut => mn, add space

### DIFF
--- a/src/js/containers/covid19/recipient/map/MapContainer.jsx
+++ b/src/js/containers/covid19/recipient/map/MapContainer.jsx
@@ -447,8 +447,8 @@ export class MapContainer extends React.Component {
                 </MapWrapper>
                 <Note message={(
                     <>
-                        Amounts reported for Utah reflect an award by HHS from the Provider Relief Fund (PRF)
-                        to a single entity in Utah which will make payments to recipients across the country.
+                        Amounts reported for Minnesota reflect an award by HHS from the Provider Relief Fund (PRF)
+                        to a single entity in Minnesota which will make payments to recipients across the country.{' '}
                         <a href="data/data-limitations.pdf" target="_blank" rel="noopener noreferrer">
                             See more information about HHS&apos;s data submission.
                         </a>


### PR DESCRIPTION
**High level description:**

HHS disclaimer on COVID map referenced UT, should be MN. Also added a space after sentence (JSX quirk).

**Technical details:**
na

**JIRA Ticket:**
[DEV-7230](https://federal-spending-transparency.atlassian.net/browse/DEV-7230)

**Mockup:**
na

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
- [x] Code review complete
