### PR TITLE
Dev-7188 Agency Reporting Page Null Percentage

### DIFF
--- a/src/js/models/v2/aboutTheData/BaseReportingPeriodRow.js
+++ b/src/js/models/v2/aboutTheData/BaseReportingPeriodRow.js
@@ -2,7 +2,7 @@
  * BaseReportingPeriodRow.js
  * Created by Lizzie Salita 12/8/20
  */
-
+import { isNull } from 'lodash';
 import { formatNumberWithPrecision } from 'helpers/moneyFormatter';
 import { getPeriodWithTitleById } from 'helpers/aboutTheDataHelper';
 import CoreReportingRow from './CoreReportingRow';
@@ -15,12 +15,7 @@ BaseReportingPeriodRow.populate = function populate(data) {
     this.fiscalPeriod = parseInt(data.fiscal_period, 10) || 0;
     this.reportingPeriod = `FY ${this.fiscalYear}: ${getPeriodWithTitleById(`${this.fiscalPeriod}`).title}`;
     this._percentOfBudget = data.percent_of_total_budgetary_resources;
-    if (!this._percentOfBudget && typeof this._percentOfBudget !== 'number') {
-        this.percentOfBudget = '--';
-    }
-    else {
-        this.percentOfBudget = `${formatNumberWithPrecision(this._percentOfBudget, 2)}%`;
-    }
+    this.percentOfBudget = isNull(this._percentOfBudget) ? '--' : `${formatNumberWithPrecision(this._percentOfBudget, 2)}%`;
 };
 
 export default BaseReportingPeriodRow;

--- a/src/js/models/v2/aboutTheData/BaseReportingPeriodRow.js
+++ b/src/js/models/v2/aboutTheData/BaseReportingPeriodRow.js
@@ -14,8 +14,13 @@ BaseReportingPeriodRow.populate = function populate(data) {
     this.fiscalYear = parseInt(data.fiscal_year, 10) || 0;
     this.fiscalPeriod = parseInt(data.fiscal_period, 10) || 0;
     this.reportingPeriod = `FY ${this.fiscalYear}: ${getPeriodWithTitleById(`${this.fiscalPeriod}`).title}`;
-    this._percentOfBudget = data.percent_of_total_budgetary_resources || 0;
-    this.percentOfBudget = `${formatNumberWithPrecision(this._percentOfBudget, 2)}%`;
+    this._percentOfBudget = data.percent_of_total_budgetary_resources;
+    if (!this._percentOfBudget && typeof this._percentOfBudget !== 'number') {
+        this.percentOfBudget = '--';
+    }
+    else {
+        this.percentOfBudget = `${formatNumberWithPrecision(this._percentOfBudget, 2)}%`;
+    }
 };
 
 export default BaseReportingPeriodRow;

--- a/tests/containers/aboutTheData/mockData.js
+++ b/tests/containers/aboutTheData/mockData.js
@@ -165,11 +165,12 @@ export const mockReportingPeriodRow = {
                     tas_obligation_not_in_gtas_total: 343345,
                     missing_tas_accounts_count: 20
                 },
-                percent_of_total_budgetary_resources: 2.189,
+                percent_of_total_budgetary_resources: 2.1,
                 obligation_difference: 4000.00,
                 unlinked_contract_award_count: 20002,
                 unlinked_assistance_award_count: 10001,
-                assurance_statement_url: 'https://files.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2020/Q1/MockAgency(ABC)-Assurance_Statement.txt'}
+                assurance_statement_url: 'https://files.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2020/Q1/MockAgency(ABC)-Assurance_Statement.txt'
+            }
         ]
     }
 };

--- a/tests/models/aboutTheData/BaseReportingPeriodRow-test.js
+++ b/tests/models/aboutTheData/BaseReportingPeriodRow-test.js
@@ -34,10 +34,22 @@ describe('BaseReportingPeriodRow', () => {
         reportingPeriodRowMod.populate(period2);
         expect(reportingPeriodRowMod.reportingPeriod).toEqual('FY 2020: P01 - P02');
     });
-    it('should format the percent of budgetary resources', () => {
-        expect(reportingPeriodRow.percentOfBudget).toEqual('2.19%');
-    });
     it('should have CoreReportingRow in its prototype chain', () => {
         expect(Object.getPrototypeOf(reportingPeriodRow)).toMatchObject(CoreReportingRow);
+    });
+    it('should format the percent of budgetary resources', () => {
+        expect(reportingPeriodRow.percentOfBudget).toEqual('2.10%');
+    });
+    it('should handle null percent of budgetary resources', () => {
+        const noPercentage = mockReportingPeriodRow.data.results[0];
+        noPercentage.percent_of_total_budgetary_resources = null;
+        reportingPeriodRow.populate(noPercentage);
+        expect(reportingPeriodRow.percentOfBudget).toEqual('--');
+    });
+    it('should handle 0 percent of budgetary resources', () => {
+        const noPercentage = mockReportingPeriodRow.data.results[0];
+        noPercentage.percent_of_total_budgetary_resources = 0;
+        reportingPeriodRow.populate(noPercentage);
+        expect(reportingPeriodRow.percentOfBudget).toEqual('0.00%');
     });
 });


### PR DESCRIPTION
**High level description:**

Updates Agency Reporting Page to display `--` for `null` percentages.

**Technical details:**

> • updates to `BaseReportingPeriodRow` model.

**JIRA Ticket:**
[DEV-7188](https://federal-spending-transparency.atlassian.net/browse/DEV-7188)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [N/A] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [N/A] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
