### PR TITLE
Dev-7178 Handle Null Value for TAS, Difference, Unlinked Contract & FA

### DIFF
--- a/src/js/containers/aboutTheData/AgenciesContainer.jsx
+++ b/src/js/containers/aboutTheData/AgenciesContainer.jsx
@@ -7,7 +7,14 @@ import { useDispatch, useSelector } from 'react-redux';
 import DrilldownCell from 'components/aboutTheData/DrilldownCell';
 import CellWithModal from 'components/aboutTheData/CellWithModal';
 import { setTableData, setTableSort, setTotals, setSearchResults, setSearchTerm } from 'redux/actions/aboutTheData';
-import { getTotalBudgetaryResources, getAgenciesReportingData, getSubmissionPublicationDates, usePagination, isPeriodSelectable, getFederalBudget } from 'helpers/aboutTheDataHelper';
+import {
+    getTotalBudgetaryResources,
+    getAgenciesReportingData,
+    getSubmissionPublicationDates,
+    usePagination,
+    isPeriodSelectable,
+    getFederalBudget
+} from 'helpers/aboutTheDataHelper';
 import { getLatestPeriod } from 'helpers/accountHelper';
 import BaseAgencyRow from 'models/v2/aboutTheData/BaseAgencyRow';
 import PublicationOverviewRow from 'models/v2/aboutTheData/PublicationOverviewRow';
@@ -249,10 +256,13 @@ const AgenciesContainer = ({
             mostRecentPublicationDate,
             _discrepancyCount,
             discrepancyCount: GtasNotInFileA,
+            _obligationDifference,
             obligationDifference,
             _gtasObligationTotal,
             percentageOfTotalFederalBudget,
+            _unlinkedContracts,
             unlinkedContracts,
+            _unlinkedAssistance,
             unlinkedAssistance,
             assuranceStatement
         }) => [
@@ -270,7 +280,7 @@ const AgenciesContainer = ({
                         fiscalYear: selectedFy,
                         fiscalPeriod: selectedPeriod?.id
                     }} />),
-            (_discrepancyCount === 0 ?
+            (isNaN(_discrepancyCount) ?
                 <div className="generic-cell-content">{GtasNotInFileA}</div> :
                 <CellWithModal
                     data={GtasNotInFileA}
@@ -283,38 +293,44 @@ const AgenciesContainer = ({
                         fiscalYear: selectedFy,
                         fiscalPeriod: selectedPeriod?.id
                     }} />),
-            (<CellWithModal
-                data={obligationDifference}
-                openModal={openModal}
-                modalType="reportingDifferences"
-                agencyData={{
-                    agencyName,
-                    agencyCode: code,
-                    fiscalYear: selectedFy,
-                    fiscalPeriod: selectedPeriod?.id
-                }} />),
-            unlinkedContracts !== '0' ? (<CellWithModal
-                data={unlinkedContracts}
-                openModal={openModal}
-                modalType="unlinkedData"
-                agencyData={{
-                    agencyName,
-                    agencyCode: code,
-                    fiscalYear: selectedFy,
-                    fiscalPeriod: selectedPeriod?.id,
-                    type: 'Contract'
-                }} />) : (<div className="generic-cell-content">{unlinkedContracts}</div>),
-            unlinkedAssistance !== '0' ? (<CellWithModal
-                data={unlinkedAssistance}
-                openModal={openModal}
-                modalType="unlinkedData"
-                agencyData={{
-                    agencyName,
-                    agencyCode: code,
-                    fiscalYear: selectedFy,
-                    fiscalPeriod: selectedPeriod?.id,
-                    type: 'Assistance'
-                }} />) : (<div className="generic-cell-content">{unlinkedAssistance}</div>),
+            (isNaN(_obligationDifference) ?
+                <div className="generic-cell-content">{obligationDifference}</div> :
+                <CellWithModal
+                    data={obligationDifference}
+                    openModal={openModal}
+                    modalType="reportingDifferences"
+                    agencyData={{
+                        agencyName,
+                        agencyCode: code,
+                        fiscalYear: selectedFy,
+                        fiscalPeriod: selectedPeriod?.id
+                    }} />),
+            (isNaN(_unlinkedContracts) ?
+                <div className="generic-cell-content">{unlinkedContracts}</div> :
+                <CellWithModal
+                    data={unlinkedContracts}
+                    openModal={openModal}
+                    modalType="unlinkedData"
+                    agencyData={{
+                        agencyName,
+                        agencyCode: code,
+                        fiscalYear: selectedFy,
+                        fiscalPeriod: selectedPeriod?.id,
+                        type: 'Contract'
+                    }} />),
+            (isNaN(_unlinkedAssistance) ?
+                <div className="generic-cell-content">{unlinkedAssistance}</div> :
+                <CellWithModal
+                    data={unlinkedAssistance}
+                    openModal={openModal}
+                    modalType="unlinkedData"
+                    agencyData={{
+                        agencyName,
+                        agencyCode: code,
+                        fiscalYear: selectedFy,
+                        fiscalPeriod: selectedPeriod?.id,
+                        type: 'Assistance'
+                    }} />),
             (<div className="generic-cell-content"><AgencyDownloadLinkCell file={assuranceStatement} /></div>)
         ]);
 

--- a/src/js/containers/aboutTheData/AgencyDetailsContainer.jsx
+++ b/src/js/containers/aboutTheData/AgencyDetailsContainer.jsx
@@ -72,7 +72,7 @@ const AgencyDetailsContainer = ({ modalClick, agencyName, agencyCode }) => {
                             agencyName,
                             agencyCode
                         }} />,
-                rowData._discrepancyCount === 0 ?
+                isNaN(rowData._discrepancyCount) ?
                     <div className="generic-cell-content">{rowData.discrepancyCount}</div> :
                     <CellWithModal
                         data={rowData.discrepancyCount}
@@ -85,17 +85,20 @@ const AgencyDetailsContainer = ({ modalClick, agencyName, agencyCode }) => {
                             agencyCode,
                             gtasObligationTotal: rowData._gtasObligationTotal
                         }} />,
-                <CellWithModal
-                    data={rowData.obligationDifference}
-                    openModal={modalClick}
-                    modalType="reportingDifferences"
-                    agencyData={{
-                        fiscalYear: rowData.fiscalYear,
-                        fiscalPeriod: rowData.fiscalPeriod,
-                        agencyName,
-                        agencyCode
-                    }} />,
-                rowData._unlinkedContracts !== 0 ? (
+                isNaN(rowData._obligationDifference) ?
+                    <div className="generic-cell-content">{rowData.obligationDifference}</div> :
+                    <CellWithModal
+                        data={rowData.obligationDifference}
+                        openModal={modalClick}
+                        modalType="reportingDifferences"
+                        agencyData={{
+                            fiscalYear: rowData.fiscalYear,
+                            fiscalPeriod: rowData.fiscalPeriod,
+                            agencyName,
+                            agencyCode
+                        }} />,
+                isNaN(rowData._unlinkedContracts) ?
+                    <div className="generic-cell-content">{rowData.unlinkedContracts}</div> :
                     <CellWithModal
                         data={rowData.unlinkedContracts}
                         openModal={modalClick}
@@ -106,11 +109,9 @@ const AgencyDetailsContainer = ({ modalClick, agencyName, agencyCode }) => {
                             fiscalYear: rowData.fiscalYear,
                             fiscalPeriod: rowData.fiscalPeriod,
                             type: 'Contract'
-                        }} />
-                ) : (
-                    <div className="generic-cell-content">{rowData.unlinkedContracts}</div>
-                ),
-                rowData._unlinkedAssistance !== 0 ? (
+                        }} />,
+                isNaN(rowData._unlinkedAssistance) ?
+                    <div className="generic-cell-content">{rowData.unlinkedAssistance}</div> :
                     <CellWithModal
                         data={rowData.unlinkedAssistance}
                         openModal={modalClick}
@@ -121,10 +122,7 @@ const AgencyDetailsContainer = ({ modalClick, agencyName, agencyCode }) => {
                             fiscalYear: rowData.fiscalYear,
                             fiscalPeriod: rowData.fiscalPeriod,
                             type: 'Assistance'
-                        }} />
-                ) : (
-                    <div className="generic-cell-content">{rowData.unlinkedAssistance}</div>
-                ),
+                        }} />,
                 <div className="generic-cell-content">
                     <AgencyDownloadLinkCell file={rowData.assuranceStatement} />
                 </div>

--- a/src/js/models/v2/aboutTheData/CoreReportingRow.js
+++ b/src/js/models/v2/aboutTheData/CoreReportingRow.js
@@ -12,11 +12,11 @@ const CoreReportingRow = {
         this._mostRecentPublicationDate = data.recent_publication_date || null;
         /* eslint-disable camelcase */
         this._gtasObligationTotal = data.tas_account_discrepancies_totals?.gtas_obligation_total;
-        this._discrepancyCount = data.tas_account_discrepancies_totals?.missing_tas_accounts_count || 0;
+        this._discrepancyCount = data.tas_account_discrepancies_totals?.missing_tas_accounts_count;
         /* eslint-enable camelcase */
         this._obligationDifference = data.obligation_difference;
-        this._unlinkedContracts = data.unlinked_contract_award_count || 0;
-        this._unlinkedAssistance = data.unlinked_assistance_award_count || 0;
+        this._unlinkedContracts = data.unlinked_contract_award_count;
+        this._unlinkedAssistance = data.unlinked_assistance_award_count;
         this.assuranceStatement = data.assurance_statement_url || '';
     },
     get budgetAuthority() {
@@ -29,13 +29,13 @@ const CoreReportingRow = {
         return formatMoneyWithPrecision(this._obligationDifference, 2, '--');
     },
     get discrepancyCount() {
-        return formatNumber(this._discrepancyCount);
+        return isNaN(this._discrepancyCount) ? '--' : formatNumber(this._discrepancyCount);
     },
     get unlinkedContracts() {
-        return formatNumber(this._unlinkedContracts);
+        return isNaN(this._unlinkedContracts) ? '--' : formatNumber(this._unlinkedContracts);
     },
     get unlinkedAssistance() {
-        return formatNumber(this._unlinkedAssistance);
+        return isNaN(this._unlinkedAssistance) ? '--' : formatNumber(this._unlinkedAssistance);
     }
 };
 


### PR DESCRIPTION
**High level description:**

The Agency and Agencies Reporting Pages will show `--` when no data exists and will not show the modal.

**Technical details:**

> • isNaN everything :)

> • The Agency and Agencies page table rows check raw data value from the `CoreReportingRow` private variables, `_obligationDifference`, `_discrepancyCount`, `_unlinkedContracts`, `_unlinkedAssistance` and decide when to show modal.

> • Agency and Agencies `CoreReportingRow` properties `_obligationDifference`, `_discrepancyCount`, `_unlinkedContracts`, `_unlinkedAssistance` keep raw data value and return formatted value or `--` for their respective public variables.

**JIRA Ticket:**
[DEV-7178](https://federal-spending-transparency.atlassian.net/browse/DEV-7178)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [N/A] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [N/A] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [N/A] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
