### PR TITLE
DEV-7217 public law query param

### DIFF
--- a/src/js/components/covid19/Covid19Page.jsx
+++ b/src/js/components/covid19/Covid19Page.jsx
@@ -1,0 +1,194 @@
+/**
+ * Covid19Page.jsx
+ * Created by Lizzie Salita 4/27/21
+ */
+
+// TODO: DEV-7122 Move to new Page Header Component
+
+import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+
+import { snakeCase } from 'lodash';
+import Cookies from 'js-cookie';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import MetaTags from 'components/sharedComponents/metaTags/MetaTags';
+import Header from 'containers/shared/HeaderContainer';
+import Sidebar from 'components/sharedComponents/sidebar/Sidebar';
+import StickyHeader from 'components/sharedComponents/stickyHeader/StickyHeader';
+import { stickyHeaderHeight } from 'dataMapping/stickyHeader/stickyHeader';
+import { getStickyBreakPointForSidebar, useDynamicStickyClass } from 'helpers/stickyHeaderHelper';
+import Covid19Section from 'components/covid19/Covid19Section';
+import Footer from 'containers/Footer';
+import Heading from 'components/covid19/Heading';
+import { LoadingWrapper } from 'components/sharedComponents/Loading';
+import ShareIcon from 'components/sharedComponents/stickyHeader/ShareIcon';
+import GlobalModalContainer from 'containers/globalModal/GlobalModalContainer';
+import LinkToAdvancedSearchContainer from 'containers/covid19/LinkToAdvancedSearchContainer';
+import { covidPageMetaTags } from 'helpers/metaTagHelper';
+import {
+    jumpToSection,
+    getStickyBreakPointForCovidBanner,
+    getVerticalOffsetForSidebarFooter
+} from 'helpers/covid19Helper';
+import {
+    slug,
+    getEmailSocialShareData,
+    dataDisclaimerHeight
+} from 'dataMapping/covid19/covid19';
+
+import { showModal } from 'redux/actions/modal/modalActions';
+import DataSourcesAndMethodology from 'components/covid19/DataSourcesAndMethodology';
+import OtherResources from 'components/covid19/OtherResources';
+import Analytics from 'helpers/analytics/Analytics';
+
+import { componentByCovid19Section } from 'containers/covid19/helpers/covid19';
+import DownloadButtonContainer from 'containers/covid19/DownloadButtonContainer';
+import SidebarFooter from './SidebarFooter';
+
+require('pages/covid19/index.scss');
+
+const propTypes = {
+    areDefCodesLoading: PropTypes.bool
+};
+
+const Covid19Page = ({ areDefCodesLoading }) => {
+    const [dataDisclaimerBanner, setDataDisclaimerBanner] = useState(Cookies.get('usaspending_data_disclaimer'));
+    const lastSectionRef = useRef(null);
+    const dataDisclaimerBannerRef = useRef(null);
+    const dispatch = useDispatch();
+    const [isBannerSticky, , , setBannerStickyOnScroll] = useDynamicStickyClass(dataDisclaimerBannerRef, getStickyBreakPointForCovidBanner(Cookies.get('usaspending_covid_homepage')));
+
+    const handleScroll = () => {
+        setBannerStickyOnScroll();
+    };
+
+    useEffect(() => {
+        window.addEventListener('scroll', handleScroll);
+        return () => {
+            window.removeEventListener('scroll', handleScroll);
+        };
+    }, []);
+
+    const handleExternalLinkClick = (url) => {
+        dispatch(showModal(url));
+    };
+
+    const handleCloseBanner = () => {
+        Cookies.set('usaspending_data_disclaimer', 'hide', { expires: 7 });
+        setDataDisclaimerBanner('hide');
+    };
+
+    const handleJumpToSection = (section) => {
+        jumpToSection(section);
+        Analytics.event({ category: 'COVID-19 - Profile', action: `${section} - click` });
+    };
+    return (
+        <div className="usa-da-covid19-page" ref={dataDisclaimerBannerRef}>
+            <MetaTags {...covidPageMetaTags} />
+            <Header />
+            <StickyHeader>
+                <>
+                    <div className="sticky-header__title">
+                        <h1 tabIndex={-1} id="main-focus">
+                            COVID-19 Spending
+                        </h1>
+                    </div>
+                    <div className="sticky-header__toolbar">
+                        <ShareIcon
+                            slug={slug}
+                            email={getEmailSocialShareData} />
+                        <div className="sticky-header__toolbar-item">
+                            <DownloadButtonContainer />
+                        </div>
+                    </div>
+                </>
+            </StickyHeader>
+            <LoadingWrapper isLoading={areDefCodesLoading}>
+                <>
+                    {dataDisclaimerBanner !== 'hide' && (
+                        <div className={`info-banner data-disclaimer${isBannerSticky ? ' sticky-banner' : ''}`}>
+                            <div className="info-top" />
+                            <div className="info-banner__content">
+                                <div className="info-banner__content--title">
+                                    <FontAwesomeIcon size="lg" icon="exclamation-triangle" color="#FDB81E" />
+                                    <h2>Known Data Limitations</h2>
+                                    <FontAwesomeIcon onClick={handleCloseBanner} size="lg" icon="times" color="black" />
+                                </div>
+                                <p>
+                                    USAspending is working with federal agencies to address known limitations in COVID-19 spending data. See <a target="_blank" href="data/data-limitations.pdf" rel="noopener noreferrer">a full description</a> of this issue.
+                                </p>
+                            </div>
+                        </div>
+                    )}
+                    <main id="main-content" className="main-content usda__flex-row">
+                        <div className="sidebar">
+                            <div className={`sidebar__content${!dataDisclaimerBanner ? ' covid-banner' : ''}`}>
+                                <Sidebar
+                                    pageName="covid19"
+                                    isGoingToBeSticky
+                                    fixedStickyBreakpoint={getStickyBreakPointForSidebar()}
+                                    jumpToSection={handleJumpToSection}
+                                    detectActiveSection
+                                    verticalSectionOffset={dataDisclaimerBanner === 'hide'
+                                        ? stickyHeaderHeight
+                                        : stickyHeaderHeight + dataDisclaimerHeight}
+                                    sections={Object.keys(componentByCovid19Section())
+                                        .filter((section) => componentByCovid19Section()[section].showInMenu)
+                                        .map((section) => ({
+                                            section: snakeCase(section),
+                                            label: componentByCovid19Section()[section].title
+                                        }))} >
+                                    <div className="sidebar-footer">
+                                        <SidebarFooter
+                                            pageName="covid19"
+                                            isGoingToBeSticky
+                                            verticalOffset={getVerticalOffsetForSidebarFooter()}
+                                            fixedStickyBreakpoint={getStickyBreakPointForSidebar()} />
+                                    </div>
+                                </Sidebar>
+                            </div>
+                        </div>
+                        <div className="body usda__flex-col">
+                            <section className="body__section">
+                                <Heading />
+                            </section>
+                            {Object.keys(componentByCovid19Section())
+                                .filter((section) => componentByCovid19Section()[section].showInMainSection)
+                                .map((section) => (
+                                    <Covid19Section
+                                        key={section}
+                                        section={section}
+                                        icon={componentByCovid19Section()[section].icon}
+                                        headerText={componentByCovid19Section()[section].headerText}
+                                        title={componentByCovid19Section()[section].title}
+                                        tooltipProps={componentByCovid19Section()[section].tooltipProps}
+                                        tooltip={componentByCovid19Section()[section].tooltip}>
+                                        {componentByCovid19Section()[section].component}
+                                    </Covid19Section>
+                                ))}
+                            <section className="body__section" id="covid19-data_sources_and_methodology">
+                                <DataSourcesAndMethodology
+                                    handleExternalLinkClick={handleExternalLinkClick} />
+                            </section>
+                            <section className="body__section" id="covid19-other_resources">
+                                <OtherResources
+                                    handleExternalLinkClick={handleExternalLinkClick} />
+                                <LinkToAdvancedSearchContainer />
+                            </section>
+                        </div>
+                        <GlobalModalContainer />
+                    </main>
+                </>
+            </LoadingWrapper>
+            <div className="footer-reference" ref={lastSectionRef}>
+                <Footer />
+            </div>
+        </div>
+    );
+};
+
+Covid19Page.propTypes = propTypes;
+
+export default Covid19Page;

--- a/src/js/containers/covid19/Covid19Container.jsx
+++ b/src/js/containers/covid19/Covid19Container.jsx
@@ -3,78 +3,37 @@
  * Created by Jonathan Hill 06/02/20
  */
 
-// TODO: DEV-7122 Move to new Page Header Component
-
-import React, { useState, useEffect, useRef } from 'react';
-import PropTypes from 'prop-types';
+import React, { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
-import { snakeCase } from 'lodash';
-import Cookies from 'js-cookie';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-
-import MetaTags from 'components/sharedComponents/metaTags/MetaTags';
-import Header from 'containers/shared/HeaderContainer';
-import Sidebar from 'components/sharedComponents/sidebar/Sidebar';
-import StickyHeader from 'components/sharedComponents/stickyHeader/StickyHeader';
-import { stickyHeaderHeight } from 'dataMapping/stickyHeader/stickyHeader';
-import { getStickyBreakPointForSidebar, useDynamicStickyClass } from 'helpers/stickyHeaderHelper';
-import Covid19Section from 'components/covid19/Covid19Section';
-import Footer from 'containers/Footer';
-import Heading from 'components/covid19/Heading';
-import { LoadingWrapper } from 'components/sharedComponents/Loading';
-import ShareIcon from 'components/sharedComponents/stickyHeader/ShareIcon';
-import GlobalModalContainer from 'containers/globalModal/GlobalModalContainer';
-import LinkToAdvancedSearchContainer from 'containers/covid19/LinkToAdvancedSearchContainer';
-import { covidPageMetaTags } from 'helpers/metaTagHelper';
-import BaseOverview from 'models/v2/covid19/BaseOverview';
+import { useHistory } from 'react-router-dom';
 import GlobalConstants from 'GlobalConstants';
-import {
-    jumpToSection,
-    getStickyBreakPointForCovidBanner,
-    getVerticalOffsetForSidebarFooter
-} from 'helpers/covid19Helper';
-import {
-    slug,
-    getEmailSocialShareData,
-    dataDisclaimerHeight
-} from 'dataMapping/covid19/covid19';
+import { useQueryParams } from 'helpers/queryParams';
+import BaseOverview from 'models/v2/covid19/BaseOverview';
 import { fetchOverview, fetchAwardAmounts } from 'apis/disaster';
 import { useDefCodes } from 'containers/covid19/WithDefCodes';
 import { setOverview, setTotals } from 'redux/actions/covid19/covid19Actions';
-import { showModal } from 'redux/actions/modal/modalActions';
-import DataSourcesAndMethodology from 'components/covid19/DataSourcesAndMethodology';
-import OtherResources from 'components/covid19/OtherResources';
-import Analytics from 'helpers/analytics/Analytics';
-import { useQueryParams } from 'helpers/queryParams';
-import { componentByCovid19Section } from './helpers/covid19';
-import DownloadButtonContainer from './DownloadButtonContainer';
-import SidebarFooter from '../../components/covid19/SidebarFooter';
+import { defcByPublicLaw } from 'dataMapping/covid19/covid19';
+import Covid19Page from 'components/covid19/Covid19Page';
 
 require('pages/covid19/index.scss');
 
-const Covid19Container = ({ history }) => {
+const Covid19Container = () => {
     const [, areDefCodesLoading, defCodes] = useDefCodes();
-    const [dataDisclaimerBanner, setDataDisclaimerBanner] = useState(Cookies.get('usaspending_data_disclaimer'));
     const overviewRequest = useRef(null);
-    const lastSectionRef = useRef(null);
     const awardAmountRequest = useRef(null);
-    const dataDisclaimerBannerRef = useRef(null);
     const dispatch = useDispatch();
-    const [isBannerSticky, , , setBannerStickyOnScroll] = useDynamicStickyClass(dataDisclaimerBannerRef, getStickyBreakPointForCovidBanner(Cookies.get('usaspending_covid_homepage')));
+    const history = useHistory();
     const { publicLaw } = useQueryParams();
 
-    const handleScroll = () => {
-        setBannerStickyOnScroll();
-    };
-
     useEffect(() => {
-        /** Default to all DEFC if
+        /** Default to all DEFC if:
          * 1) no public law param is defined
          * 2) the public law param is invalid
          * 3) the public law param is for ARP, but the ARP filter is not yet released
          */
+
         if (!publicLaw ||
-            (publicLaw !== 'all' && publicLaw !== 'american-rescue-plan') ||
+            !(publicLaw === 'all' || (publicLaw in defcByPublicLaw)) ||
             (publicLaw === 'american-rescue-plan' && !GlobalConstants.ARP_RELEASED)) {
             history.replace({
                 pathname: '',
@@ -84,15 +43,9 @@ const Covid19Container = ({ history }) => {
     }, [publicLaw]);
 
     useEffect(() => {
-        window.addEventListener('scroll', handleScroll);
-        return () => {
-            window.removeEventListener('scroll', handleScroll);
-        };
-    }, []);
-
-    useEffect(() => {
+        let filteredDefc = [];
         const getOverviewData = async () => {
-            overviewRequest.current = fetchOverview(defCodes.filter((c) => c.disaster === 'covid_19').map((code) => code.code));
+            overviewRequest.current = fetchOverview(filteredDefc);
             try {
                 const { data } = await overviewRequest.current.promise;
                 const newOverview = Object.create(BaseOverview);
@@ -106,7 +59,7 @@ const Covid19Container = ({ history }) => {
         const getAllAwardTypesAmount = async () => {
             const params = {
                 filter: {
-                    def_codes: defCodes.filter((c) => c.disaster === 'covid_19').map((code) => code.code)
+                    def_codes: filteredDefc
                 }
             };
             awardAmountRequest.current = fetchAwardAmounts(params);
@@ -126,6 +79,8 @@ const Covid19Container = ({ history }) => {
             }
         };
         if (defCodes.length) {
+            const allDefc = defCodes.filter((c) => c.disaster === 'covid_19').map((code) => code.code);
+            filteredDefc = publicLaw === "all" ? allDefc : defcByPublicLaw[publicLaw];
             getOverviewData();
             getAllAwardTypesAmount();
             overviewRequest.current = null;
@@ -141,126 +96,9 @@ const Covid19Container = ({ history }) => {
         };
     }, [defCodes, dispatch]);
 
-    const handleExternalLinkClick = (url) => {
-        dispatch(showModal(url));
-    };
-
-    const handleCloseBanner = () => {
-        Cookies.set('usaspending_data_disclaimer', 'hide', { expires: 7 });
-        setDataDisclaimerBanner('hide');
-    };
-
-    const handleJumpToSection = (section) => {
-        jumpToSection(section);
-        Analytics.event({ category: 'COVID-19 - Profile', action: `${section} - click` });
-    };
     return (
-        <div className="usa-da-covid19-page" ref={dataDisclaimerBannerRef}>
-            <MetaTags {...covidPageMetaTags} />
-            <Header />
-            <StickyHeader>
-                <>
-                    <div className="sticky-header__title">
-                        <h1 tabIndex={-1} id="main-focus">
-                            COVID-19 Spending
-                        </h1>
-                    </div>
-                    <div className="sticky-header__toolbar">
-                        <ShareIcon
-                            slug={slug}
-                            email={getEmailSocialShareData} />
-                        <div className="sticky-header__toolbar-item">
-                            <DownloadButtonContainer />
-                        </div>
-                    </div>
-                </>
-            </StickyHeader>
-            <LoadingWrapper isLoading={areDefCodesLoading}>
-                <>
-                    {dataDisclaimerBanner !== 'hide' && (
-                        <div className={`info-banner data-disclaimer${isBannerSticky ? ' sticky-banner' : ''}`}>
-                            <div className="info-top" />
-                            <div className="info-banner__content">
-                                <div className="info-banner__content--title">
-                                    <FontAwesomeIcon size="lg" icon="exclamation-triangle" color="#FDB81E" />
-                                    <h2>Known Data Limitations</h2>
-                                    <FontAwesomeIcon onClick={handleCloseBanner} size="lg" icon="times" color="black" />
-                                </div>
-                                <p>
-                                    USAspending is working with federal agencies to address known limitations in COVID-19 spending data. See <a target="_blank" href="data/data-limitations.pdf" rel="noopener noreferrer">a full description</a> of this issue.
-                                </p>
-                            </div>
-                        </div>
-                    )}
-                    <main id="main-content" className="main-content usda__flex-row">
-                        <div className="sidebar">
-                            <div className={`sidebar__content${!dataDisclaimerBanner ? ' covid-banner' : ''}`}>
-                                <Sidebar
-                                    pageName="covid19"
-                                    isGoingToBeSticky
-                                    fixedStickyBreakpoint={getStickyBreakPointForSidebar()}
-                                    jumpToSection={handleJumpToSection}
-                                    detectActiveSection
-                                    verticalSectionOffset={dataDisclaimerBanner === 'hide'
-                                        ? stickyHeaderHeight
-                                        : stickyHeaderHeight + dataDisclaimerHeight}
-                                    sections={Object.keys(componentByCovid19Section())
-                                        .filter((section) => componentByCovid19Section()[section].showInMenu)
-                                        .map((section) => ({
-                                            section: snakeCase(section),
-                                            label: componentByCovid19Section()[section].title
-                                        }))} >
-                                    <div className="sidebar-footer">
-                                        <SidebarFooter
-                                            pageName="covid19"
-                                            isGoingToBeSticky
-                                            verticalOffset={getVerticalOffsetForSidebarFooter()}
-                                            fixedStickyBreakpoint={getStickyBreakPointForSidebar()} />
-                                    </div>
-                                </Sidebar>
-                            </div>
-                        </div>
-                        <div className="body usda__flex-col">
-                            <section className="body__section">
-                                <Heading />
-                            </section>
-                            {Object.keys(componentByCovid19Section())
-                                .filter((section) => componentByCovid19Section()[section].showInMainSection)
-                                .map((section) => (
-                                    <Covid19Section
-                                        key={section}
-                                        section={section}
-                                        icon={componentByCovid19Section()[section].icon}
-                                        headerText={componentByCovid19Section()[section].headerText}
-                                        title={componentByCovid19Section()[section].title}
-                                        tooltipProps={componentByCovid19Section()[section].tooltipProps}
-                                        tooltip={componentByCovid19Section()[section].tooltip}>
-                                        {componentByCovid19Section()[section].component}
-                                    </Covid19Section>
-                                ))}
-                            <section className="body__section" id="covid19-data_sources_and_methodology">
-                                <DataSourcesAndMethodology
-                                    handleExternalLinkClick={handleExternalLinkClick} />
-                            </section>
-                            <section className="body__section" id="covid19-other_resources">
-                                <OtherResources
-                                    handleExternalLinkClick={handleExternalLinkClick} />
-                                <LinkToAdvancedSearchContainer />
-                            </section>
-                        </div>
-                        <GlobalModalContainer />
-                    </main>
-                </>
-            </LoadingWrapper>
-            <div className="footer-reference" ref={lastSectionRef}>
-                <Footer />
-            </div>
-        </div>
+        <Covid19Page areDefCodesLoading={areDefCodesLoading} />
     );
-};
-
-Covid19Container.propTypes = {
-    history: PropTypes.object
 };
 
 export default Covid19Container;

--- a/src/js/containers/covid19/Covid19Container.jsx
+++ b/src/js/containers/covid19/Covid19Container.jsx
@@ -43,9 +43,8 @@ const Covid19Container = () => {
     }, [publicLaw]);
 
     useEffect(() => {
-        let filteredDefc = [];
         const getOverviewData = async () => {
-            overviewRequest.current = fetchOverview(filteredDefc);
+            overviewRequest.current = fetchOverview(defCodes.filter((c) => c.disaster === 'covid_19').map((code) => code.code));
             try {
                 const { data } = await overviewRequest.current.promise;
                 const newOverview = Object.create(BaseOverview);
@@ -59,7 +58,7 @@ const Covid19Container = () => {
         const getAllAwardTypesAmount = async () => {
             const params = {
                 filter: {
-                    def_codes: filteredDefc
+                    def_codes: defCodes.filter((c) => c.disaster === 'covid_19').map((code) => code.code)
                 }
             };
             awardAmountRequest.current = fetchAwardAmounts(params);
@@ -79,8 +78,6 @@ const Covid19Container = () => {
             }
         };
         if (defCodes.length) {
-            const allDefc = defCodes.filter((c) => c.disaster === 'covid_19').map((code) => code.code);
-            filteredDefc = publicLaw === "all" ? allDefc : defcByPublicLaw[publicLaw];
             getOverviewData();
             getAllAwardTypesAmount();
             overviewRequest.current = null;

--- a/src/js/dataMapping/covid19/covid19.js
+++ b/src/js/dataMapping/covid19/covid19.js
@@ -369,3 +369,7 @@ export const tooltipMapping = {
         paragraph: 'This amount represents how much is left to be obligated, or promised to be paid, by agencies. '
     }
 };
+
+export const defcByPublicLaw = {
+    'american-rescue-plan': ['V']
+};

--- a/tests/containers/account/WithLatestFy-test.js
+++ b/tests/containers/account/WithLatestFy-test.js
@@ -1,5 +1,5 @@
 /**
- * WithDefCodes-test.js
+ * WitLatestFy-test.js
  * Created by Max Kendall 02/5/2021
 * */
 

--- a/tests/containers/covid19/Covid19Container-test.jsx
+++ b/tests/containers/covid19/Covid19Container-test.jsx
@@ -1,0 +1,86 @@
+/**
+ * Covid19Container-test.jsx
+ * Created by Lizzie Salita 4/27/21
+ */
+
+import React from 'react';
+import { render } from 'test-utils';
+import '@testing-library/jest-dom/extend-expect';
+import { useQueryParams } from 'helpers/queryParams';
+import Covid19Container from 'containers/covid19/Covid19Container';
+import { mockDefCodes } from '../../mockData/helpers/disasterHelper';
+
+// Mock the child component so we can isolate functionality of the container
+jest.mock('components/covid19/Covid19Page', () =>
+    jest.fn(() => null));
+
+// Set American Rescue Plan release var to true
+jest.mock('GlobalConstants', () => ({
+    ARP_RELEASED: true
+}));
+
+// Mock the custom hook useDEFCodes to prevent making an actual API request
+jest.mock('containers/covid19/WithDefCodes', () => ({
+    useDefCodes: () => [null, false, mockDefCodes]
+}));
+
+// Mock the custom hook useQueryParams
+jest.mock('helpers/queryParams', () => ({
+    useQueryParams: jest.fn()
+}));
+
+// Mock history.replace()
+const mockHistoryReplace = jest.fn();
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useHistory: () => ({
+        replace: mockHistoryReplace
+    })
+}));
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('COVID-19 Container', () => {
+    it('redirects to all DEFC when the public law query param is invalid', () => {
+        useQueryParams.mockImplementation(() => ({ publicLaw: 'blah' }));
+        render((
+            <Covid19Container />
+        ));
+        expect(mockHistoryReplace).toHaveBeenCalledTimes(1);
+        expect(mockHistoryReplace).toHaveBeenCalledWith({
+            pathname: '',
+            search: '?publicLaw=all'
+        });
+    });
+
+    it('redirects if no public law query param is provided', () => {
+        useQueryParams.mockImplementation(() => ({ publicLaw: '' }));
+        render((
+            <Covid19Container />
+        ));
+        expect(mockHistoryReplace).toHaveBeenCalledTimes(1);
+        expect(mockHistoryReplace).toHaveBeenCalledWith({
+            pathname: '',
+            search: '?publicLaw=all'
+        });
+    });
+
+    describe('when a valid public law query param is provided', () => {
+        it('does not redirect all DEFC', () => {
+            useQueryParams.mockImplementation(() => ({ publicLaw: 'all' }));
+            render((
+                <Covid19Container />
+            ));
+            expect(mockHistoryReplace).not.toHaveBeenCalled();
+        });
+        it('does not redirect American Rescue Plan', () => {
+            useQueryParams.mockImplementation(() => ({ publicLaw: 'american-rescue-plan' }));
+            render((
+                <Covid19Container />
+            ));
+            expect(mockHistoryReplace).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
**High level description:**

Implements a public law query param on the Covid Profile (`/disaster/covid-19?publicLaw=all` or `/disaster/covid-19?publicLaw=american-rescue-plan`)

**Technical details:**

Refactoring for separation of duties:
- Moves the page layout and UI logic to a new file, `Covid19Page`
- Keeps just the top-level API requests for overview data and award amounts in `Covid19Container`

**JIRA Ticket:**
[DEV-7217](https://federal-spending-transparency.atlassian.net/browse/DEV-7217)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)

Reviewer(s):
- [x] Code review complete
