### PR TITLE
[DEV-6622] COVID Page Query Param "section" Restored

### DIFF
--- a/src/js/components/covid19/Covid19Page.jsx
+++ b/src/js/components/covid19/Covid19Page.jsx
@@ -9,7 +9,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { snakeCase } from 'lodash';
+import { omit, snakeCase } from 'lodash';
 import Cookies from 'js-cookie';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -37,7 +37,7 @@ import {
     getEmailSocialShareData,
     dataDisclaimerHeight
 } from 'dataMapping/covid19/covid19';
-import { useQueryParams } from 'helpers/queryParams';
+import { getQueryParamString, useQueryParams } from 'helpers/queryParams';
 import { showModal } from 'redux/actions/modal/modalActions';
 import DataSourcesAndMethodology from 'components/covid19/DataSourcesAndMethodology';
 import OtherResources from 'components/covid19/OtherResources';
@@ -76,8 +76,10 @@ const Covid19Page = ({ areDefCodesLoading }) => {
     useEffect(() => {
         if (isRecipientMapLoaded && query.section) {
             handleJumpToSection(query.section);
+            const newParams = getQueryParamString(omit(query, ['section']));
             history.push({
-                pathname: '/disaster/covid-19'
+                pathname: '/disaster/covid-19',
+                search: newParams
             });
         }
     }, [isRecipientMapLoaded]);

--- a/src/js/components/sharedComponents/GlossaryLink.jsx
+++ b/src/js/components/sharedComponents/GlossaryLink.jsx
@@ -11,8 +11,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { getNewUrlForGlossary } from 'helpers/glossaryHelper';
 
 const propTypes = {
-    term: PropTypes.string.isRequired,
-    currentUrl: PropTypes.string.isRequired
+    term: PropTypes.string.isRequired
 };
 
 const GlossaryLink = ({ term }) => {

--- a/src/js/containers/covid19/Covid19Container.jsx
+++ b/src/js/containers/covid19/Covid19Container.jsx
@@ -7,7 +7,7 @@ import React, { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import GlobalConstants from 'GlobalConstants';
-import { useQueryParams } from 'helpers/queryParams';
+import { combineQueryParams, getQueryParamString, useQueryParams } from 'helpers/queryParams';
 import BaseOverview from 'models/v2/covid19/BaseOverview';
 import { fetchOverview, fetchAwardAmounts } from 'apis/disaster';
 import { useDefCodes } from 'containers/covid19/WithDefCodes';
@@ -23,7 +23,8 @@ const Covid19Container = () => {
     const awardAmountRequest = useRef(null);
     const dispatch = useDispatch();
     const history = useHistory();
-    const { publicLaw } = useQueryParams();
+    const query = useQueryParams();
+    const { publicLaw } = query;
 
     useEffect(() => {
         /** Default to all DEFC if:
@@ -35,9 +36,10 @@ const Covid19Container = () => {
         if (!publicLaw ||
             !(publicLaw === 'all' || (publicLaw in defcByPublicLaw)) ||
             (publicLaw === 'american-rescue-plan' && !GlobalConstants.ARP_RELEASED)) {
+            const newParams = getQueryParamString({ ...query, publicLaw: 'all' });
             history.replace({
                 pathname: '',
-                search: '?publicLaw=all'
+                search: newParams
             });
         }
     }, [publicLaw]);

--- a/src/js/containers/covid19/Covid19Container.jsx
+++ b/src/js/containers/covid19/Covid19Container.jsx
@@ -7,7 +7,7 @@ import React, { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import GlobalConstants from 'GlobalConstants';
-import { combineQueryParams, getQueryParamString, useQueryParams } from 'helpers/queryParams';
+import { getQueryParamString, useQueryParams } from 'helpers/queryParams';
 import BaseOverview from 'models/v2/covid19/BaseOverview';
 import { fetchOverview, fetchAwardAmounts } from 'apis/disaster';
 import { useDefCodes } from 'containers/covid19/WithDefCodes';

--- a/tests/containers/covid19/Covid19Container-test.jsx
+++ b/tests/containers/covid19/Covid19Container-test.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { render } from 'test-utils';
 import '@testing-library/jest-dom/extend-expect';
-import { useQueryParams } from 'helpers/queryParams';
+import { useQueryParams, getQueryParamString } from 'helpers/queryParams';
 import Covid19Container from 'containers/covid19/Covid19Container';
 import { mockDefCodes } from '../../mockData/helpers/disasterHelper';
 
@@ -26,7 +26,15 @@ jest.mock('containers/covid19/WithDefCodes', () => ({
 
 // Mock the custom hook useQueryParams
 jest.mock('helpers/queryParams', () => ({
-    useQueryParams: jest.fn()
+    useQueryParams: jest.fn(),
+    getQueryParamString: jest.fn().mockImplementation((obj) => {
+        return Object.entries(obj).reduce((str, [key, value], i, src) => {
+            if (i === src.length - 1) {
+                return `${str}${key}=${value}`;
+            }
+            return `${str}${key}=${value}&`;
+        }, '?');
+    })
 }));
 
 // Mock history.replace()
@@ -44,26 +52,26 @@ afterEach(() => {
 
 describe('COVID-19 Container', () => {
     it('redirects to all DEFC when the public law query param is invalid', () => {
-        useQueryParams.mockImplementation(() => ({ publicLaw: 'blah' }));
+        useQueryParams.mockImplementation(() => ({ publicLaw: 'blah', section: 'blah-blah' }));
         render((
             <Covid19Container />
         ));
         expect(mockHistoryReplace).toHaveBeenCalledTimes(1);
         expect(mockHistoryReplace).toHaveBeenCalledWith({
             pathname: '',
-            search: '?publicLaw=all'
+            search: '?publicLaw=all&section=blah-blah'
         });
     });
 
     it('redirects if no public law query param is provided', () => {
-        useQueryParams.mockImplementation(() => ({ publicLaw: '' }));
+        useQueryParams.mockImplementation(() => ({ section: 'blah' }));
         render((
             <Covid19Container />
         ));
         expect(mockHistoryReplace).toHaveBeenCalledTimes(1);
         expect(mockHistoryReplace).toHaveBeenCalledWith({
             pathname: '',
-            search: '?publicLaw=all'
+            search: '?section=blah&publicLaw=all'
         });
     });
 


### PR DESCRIPTION
**High level description:**

Restores the query param "section" overwritten by the "publicLaw" param

**Technical details:**

See tests and commits

**JIRA Ticket:**
[DEV-6622](https://federal-spending-transparency.atlassian.net/browse/DEV-6622)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
