### PR TITLE
Hotfix menu mapping in prod

### DIFF
--- a/src/js/components/sharedComponents/header/NavBar.jsx
+++ b/src/js/components/sharedComponents/header/NavBar.jsx
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEnvelope } from "@fortawesome/free-regular-svg-icons";
 
 import Analytics from 'helpers/analytics/Analytics';
-import { searchOptions, profileOptions, downloadGlobalNavigationOptions, resourceOptions } from 'dataMapping/navigation/menuOptions';
+import { searchOptions, profileOptions, downloadOptions, resourceOptions } from 'dataMapping/navigation/menuOptions';
 import EmailSignUp from 'components/homepage/EmailSignUp';
 
 import { DEV } from '../../../GlobalConstants';
@@ -184,7 +184,7 @@ export default class NavBar extends React.Component {
                                 <Dropdown
                                     title="Download"
                                     label="Download"
-                                    items={downloadGlobalNavigationOptions} />
+                                    items={downloadOptions} />
                             </li>
                             <li
                                 className="full-menu__item"

--- a/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
@@ -9,7 +9,7 @@ import { withRouter, Link } from 'react-router-dom';
 
 import Analytics from 'helpers/analytics/Analytics';
 
-import { searchOptions, profileOptions, downloadGlobalNavigationOptions, resourceOptions } from 'dataMapping/navigation/menuOptions';
+import { searchOptions, profileOptions, downloadOptions, resourceOptions } from 'dataMapping/navigation/menuOptions';
 
 import MobileTop from './MobileTop';
 import MobileDropdown from './MobileDropdown';
@@ -97,7 +97,7 @@ export class MobileNav extends React.Component {
                             <MobileDropdown
                                 {...this.props}
                                 label="Download Center"
-                                items={downloadGlobalNavigationOptions}
+                                items={downloadOptions}
                                 active={this.state.url} />
                             <hr className="mobile-nav-content__divider" />
                         </li>

--- a/src/js/dataMapping/navigation/menuOptions.jsx
+++ b/src/js/dataMapping/navigation/menuOptions.jsx
@@ -5,14 +5,7 @@
 
 import GlobalConstants from 'GlobalConstants';
 
-const {
-    QAT,
-    DEV,
-    FILES_SERVER_BASE_URL,
-    API
-} = GlobalConstants;
-
-const isLowerEnv = (QAT || DEV);
+const { FILES_SERVER_BASE_URL } = GlobalConstants;
 
 export const searchOptions = [
     {
@@ -97,8 +90,6 @@ export const resourceOptions = [
     }
 ];
 
-const underResourcesInLowerEnv = ["api", "data dictionary"];
-
 export const downloadOptions = [
     {
         label: 'Award Data Archive',
@@ -156,28 +147,6 @@ export const downloadOptions = [
         internalDomain: true
     },
     {
-        label: 'API',
-        type: '',
-        url: API.replace("api/", ""),
-        code: 'api',
-        description: 'An automated way for advanced users to access all the data behind USAspending.gov. Accessible documentation includes tutorials, best practices, and more.',
-        callToAction: 'Explore Our API',
-        shouldOpenNewTab: true,
-        enabled: true,
-        internalDomain: true
-    },
-    {
-        label: 'Data Dictionary',
-        type: 'data-dictionary',
-        url: '/data-dictionary',
-        code: 'dictionary',
-        description: '',
-        callToAction: 'Explore the Data Dictionary',
-        shouldOpenNewTab: false,
-        enabled: true,
-        externalLink: false
-    },
-    {
         label: 'Dataset Metadata',
         type: 'dataset_metadata',
         url: '/download_center/dataset_metadata',
@@ -189,6 +158,3 @@ export const downloadOptions = [
         externalLink: false
     }
 ];
-
-export const downloadGlobalNavigationOptions = downloadOptions
-    .filter(({ label }) => !(isLowerEnv && underResourcesInLowerEnv.includes(label.toLowerCase())));


### PR DESCRIPTION
**High level description:**

Fixes a bug that caused Data Dictionary and API menu options to show up under both "Resources" and "Download" in production and staging.

**Technical details:**

Removes `isLowerEnv` logic and removes Data Dictionary and API from the download options mapping.

The following are ALL required for the PR to be merged:

Author:
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR @plooksm via screenshot + video

Reviewer(s):
- [x] Code review complete
