### PR TITLE
[DEV-7245] update margin between COVID-19 Spending profile text segments and profile sections

### DIFF
--- a/src/_scss/pages/covid19/index.scss
+++ b/src/_scss/pages/covid19/index.scss
@@ -65,7 +65,7 @@
 
                 @include display(flex);
                 @include flex-wrap(wrap);
-                margin-bottom: 10rem;
+                margin-bottom: 5rem;
                 padding: 0 2.5%;
 
                 .body__header {


### PR DESCRIPTION
**High level description:**
Reduce margins between text blocks and sections

**Technical details:**
Update margin from 10rem to 5rem

**JIRA Ticket:**
[DEV-7245](https://federal-spending-transparency.atlassian.net/browse/DEV-7245)

**Mockup:**
-screenshots linked to ticket

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
