### PR TITLE
[DEV-7319] Change URL for the release notes in the footer to go to the wiki

### DIFF
--- a/src/js/containers/Footer.jsx
+++ b/src/js/containers/Footer.jsx
@@ -130,7 +130,7 @@ const Footer = ({
                                 </li>
                                 <li>
                                     <FooterExternalLink
-                                        link="https://github.com/fedspendingtransparency/usaspending-website/wiki#may-4-2021"
+                                        link="https://github.com/fedspendingtransparency/usaspending-website/wiki"
                                         title="Release Notes" />
                                 </li>
                             </ul>

--- a/src/js/containers/Footer.jsx
+++ b/src/js/containers/Footer.jsx
@@ -130,7 +130,7 @@ const Footer = ({
                                 </li>
                                 <li>
                                     <FooterExternalLink
-                                        link="https://github.com/fedspendingtransparency/usaspending-website/releases"
+                                        link="https://github.com/fedspendingtransparency/usaspending-website/wiki#may-4-2021"
                                         title="Release Notes" />
                                 </li>
                             </ul>


### PR DESCRIPTION
**High level description:**

Update release notes URL to go to wiki which is more user friendly for non-devs

**Technical details:**

update Footer.jsx

**JIRA Ticket:**
[DEV-7319](https://federal-spending-transparency.atlassian.net/browse/DEV-7319)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [n/a] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a] Design review complete `if applicable`
- [n/a] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
