### PR TITLE
[DEV-6622] Agency w/ no DEFC was showing a 0

### DIFF
--- a/src/js/components/agencyV2/overview/AgencyOverview.jsx
+++ b/src/js/components/agencyV2/overview/AgencyOverview.jsx
@@ -162,7 +162,7 @@ const AgencyOverview = ({
                 <div className="agency-overview__title">
                     <h3>
                         {name}
-                        {name && covidDefCodes.length &&
+                        {name && covidDefCodes.length > 0 &&
                             <TooltipWrapper className="agency-overview__tooltip covid-19-flag" tooltipComponent={<CovidTooltip fy={fy} codes={covidDefCodes} />}>
                                 <span className="covid-spending-flag">
                                     COVID-19 Spending


### PR DESCRIPTION
**High level description:**

Fixes a bug where a 0 would appear where the tooltip would've appeared if the agency had covid spending

**Technical details:**

Apparently JSX conditionals evaluate 0 as truthy.

**JIRA Ticket:**
[DEV-6622](https://federal-spending-transparency.atlassian.net/browse/DEV-6622)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
`N/A` Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A` [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
