### PR TITLE
[DEV-7348] adding new links on COVID Profile DS&M Section

### DIFF
--- a/src/_scss/pages/covid19/_dataSourcesAndMethodology.scss
+++ b/src/_scss/pages/covid19/_dataSourcesAndMethodology.scss
@@ -41,6 +41,11 @@
         list-style: disc;
         padding-bottom: rem(10);
         .other-resources__link__container {
+            @include display(flex);
+            @include flex-wrap(wrap);
+            @media(min-width: $large-screen) {
+                display: block;
+            }
           .other-resources__link__text {
             padding-right: 0.3rem;
           }

--- a/src/js/components/covid19/OtherResources.jsx
+++ b/src/js/components/covid19/OtherResources.jsx
@@ -154,6 +154,22 @@ const OtherResources = ({
                                     onClick={handleClick}>
                                     https://home.treasury.gov/policy-issues/cares&nbsp;
                                     <span className="other-resources__link__icon">
+                                        <FontAwesomeIcon size="sm" icon="external-link-alt" />,&nbsp;
+                                    </span>
+                                </a>
+                                <a
+                                    href="https://www.irs.gov/statistics/soi-tax-stats-coronavirus-aid-relief-and-economic-security-act-cares-act-statistics"
+                                    onClick={handleClick}>
+                                    https://www.irs.gov/statistics/soi-tax-stats-coronavirus-aid-relief-and-economic-security-act-cares-act-statistics&nbsp;
+                                    <span className="other-resources__link__icon">
+                                        <FontAwesomeIcon size="sm" icon="external-link-alt" />,&nbsp;
+                                    </span>
+                                </a>
+                                <a
+                                    href="https://home.treasury.gov/policy-issues/coronavirus"
+                                    onClick={handleClick}>
+                                    https://home.treasury.gov/policy-issues/coronavirus&nbsp;
+                                    <span className="other-resources__link__icon">
                                         <FontAwesomeIcon size="sm" icon="external-link-alt" />
                                     </span>
                                 </a>


### PR DESCRIPTION
**High level description:**

Adds two new comma delimitted links to treasury section of DS&M section of covid 19 pg.

**JIRA Ticket:**
[DEV-7348](https://federal-spending-transparency.atlassian.net/browse/DEV-7348)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
`N/A` Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
`N/A` Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
`N/A` Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
`N/A` Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
`N/A`  [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
`N/A` [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
`N/A` Design review complete `if applicable`
`N/A` [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
