### PR TITLE
Dev-7396 use references submission periods endpoint cache

### DIFF
--- a/src/js/helpers/accountHelper.js
+++ b/src/js/helpers/accountHelper.js
@@ -38,7 +38,7 @@ export const fetchAvailableObjectClasses = (federalAccountId) => apiRequest({
 });
 
 export const fetchAllSubmissionDates = () => apiRequest({
-    url: 'v2/references/submission_periods/'
+    url: 'v2/references/submission_periods/?use_cache=true'
 });
 
 export const getSubmissionDeadlines = (fiscalYear, fiscalPeriod, submissionPeriods) => {


### PR DESCRIPTION
**High level description:**

use cached endpoint due to discrepancies that arise during ending submission periods and the pipeline for a consistent ux.

**Technical details:**

> • use cached endpoint due to discrepancies that arise during ending submission periods and the pipeline for a consistent ux.

**JIRA Ticket:**
[DEV-7396](https://federal-spending-transparency.atlassian.net/browse/DEV-7396)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [N/A] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [N/A] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [N/A] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [x] [API #3139](https://github.com/fedspendingtransparency/usaspending-api/pull/3139) merged concurrently
- [ ] Code review complete
