### PR TITLE
Dev-7396 COVID-19 Date Note uses Cached Submission Period Data

### DIFF
--- a/src/js/helpers/accountHelper.js
+++ b/src/js/helpers/accountHelper.js
@@ -37,8 +37,8 @@ export const fetchAvailableObjectClasses = (federalAccountId) => apiRequest({
     url: `v2/federal_accounts/${federalAccountId}/available_object_classes`
 });
 
-export const fetchAllSubmissionDates = () => apiRequest({
-    url: 'v2/references/submission_periods/'
+export const fetchAllSubmissionDates = (cached = false) => apiRequest({
+    url: cached ? 'v2/references/submission_periods/?use_cache=true' : 'v2/references/submission_periods/'
 });
 
 export const getSubmissionDeadlines = (fiscalYear, fiscalPeriod, submissionPeriods) => {


### PR DESCRIPTION
**High level description:**

The COVID-19 Date Note will display data based on cached submission periods data from the api.

**Technical details:**

> • submission periods endpoint has an optional param for fetching cached data. Defaults to false.

> • Date Note components always fetch new submission period data from the api. Defaults to using cached data.

**JIRA Ticket:**
[DEV-7396](https://federal-spending-transparency.atlassian.net/browse/DEV-7396)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [N/A] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [N/A] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [N/A] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [x] [API #3139](https://github.com/fedspendingtransparency/usaspending-api/pull/3139) merged concurrently
- [ ] Code review complete
