### PR TITLE
Hotfix DEV-7409 advanced search download filters

### DIFF
--- a/src/js/components/search/SearchPage.jsx
+++ b/src/js/components/search/SearchPage.jsx
@@ -141,7 +141,8 @@ export default class SearchPage extends React.Component {
                         isEnabled={this.props.downloadAvailable}
                         downloadInFlight={this.props.downloadInFlight}
                         onClick={this.showModal} />
-                ]}>
+                ]}
+                filters={this.props.filters}>
                 <div id="main-content">
                     <div className="search-contents">
                         <div className="full-search-sidebar">

--- a/src/js/components/search/SearchPage.jsx
+++ b/src/js/components/search/SearchPage.jsx
@@ -21,6 +21,7 @@ const propTypes = {
     download: PropTypes.object,
     clearAllFilters: PropTypes.func,
     filters: PropTypes.object,
+    appliedFilters: PropTypes.object,
     downloadAvailable: PropTypes.bool,
     downloadInFlight: PropTypes.bool,
     requestsComplete: PropTypes.bool,
@@ -142,7 +143,7 @@ export default class SearchPage extends React.Component {
                         downloadInFlight={this.props.downloadInFlight}
                         onClick={this.showModal} />
                 ]}
-                filters={this.props.filters}>
+                filters={this.props.appliedFilters}>
                 <div id="main-content">
                     <div className="search-contents">
                         <div className="full-search-sidebar">

--- a/src/js/components/sharedComponents/PageWrapper.jsx
+++ b/src/js/components/sharedComponents/PageWrapper.jsx
@@ -19,7 +19,8 @@ const PageWrapper = ({
     ref,
     title,
     overLine,
-    toolBarComponents = []
+    toolBarComponents = [],
+    filters = {}
 }) => (
     <div className={classNames} ref={ref}>
         <MetaTags {...metaTagProps} />
@@ -32,7 +33,7 @@ const PageWrapper = ({
         {React.cloneElement(children, {
             className: `usda-page__container${children.props.className ? ` ${children.props.className}` : ''}`
         })}
-        <Footer />
+        <Footer filters={filters} />
     </div>
 );
 
@@ -43,7 +44,8 @@ PageWrapper.propTypes = {
     title: PropTypes.string.isRequired,
     overLine: PropTypes.string,
     children: PropTypes.element,
-    ref: PropTypes.object
+    ref: PropTypes.object,
+    filters: PropTypes.object
 };
 
 export default PageWrapper;

--- a/src/js/containers/search/SearchContainer.jsx
+++ b/src/js/containers/search/SearchContainer.jsx
@@ -248,6 +248,7 @@ const SearchContainer = ({ history }) => {
         <SearchPage
             hash={urlHash}
             filters={stagedFilters}
+            appliedFilters={appliedFilters}
             noFiltersApplied={areAppliedFiltersEmpty}
             downloadAvailable={downloadAvailable}
             downloadInFlight={downloadInFlight}


### PR DESCRIPTION
**High level description:**

Fixes a bug that prevented advanced search filters from being applied to download requests.

**Technical details:**

In refactoring the global header, we also implemented the `PageWrapper` component, which includes the site `Footer`. On the advanced search page, `DownloadBottomBarContainer` (imported by `Footer`) needed filters passed as a prop. They were left out in the refactor and therefore `undefined`. 

**JIRA Ticket:**
[DEV-7409](https://federal-spending-transparency.atlassian.net/browse/DEV-7409)

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)

Reviewer(s):
- [ ] Code review complete
