### PR TITLE
Fix Agency v2 Spending by Budget Cateogry tables

### DIFF
--- a/src/js/components/agencyV2/AgencyPage.jsx
+++ b/src/js/components/agencyV2/AgencyPage.jsx
@@ -114,7 +114,7 @@ export const AgencyProfileV2 = ({
             toolBarComponents={[
                 <FiscalYearPicker selectedFy={selectedFy} latestFy={latestFy} handleFyChange={(fy) => setSelectedFy({ fy })} />,
                 <ShareIcon url={getBaseUrl(slug)} onShareOptionClick={handleShare} />,
-                <DownloadIconButton downloadInFlight={false} handleClick={() => {}} />
+                <DownloadIconButton downloadInFlight={false} onClick={() => {}} />
             ]}>
             <main id="main-content" className="main-content usda__flex-row">
                 <div className="sidebar usda__flex-col">

--- a/src/js/components/agencyV2/AgencyPage.jsx
+++ b/src/js/components/agencyV2/AgencyPage.jsx
@@ -44,7 +44,6 @@ export const AgencyProfileV2 = ({
     agencyId,
     setSelectedFy,
     isError,
-    // errorMessage,
     isLoading,
     latestFy
 }) => {

--- a/src/js/components/agencyV2/overview/BarChart.jsx
+++ b/src/js/components/agencyV2/overview/BarChart.jsx
@@ -72,7 +72,7 @@ const BarChart = ({
                                     height: `${(budget / greatestAgencyBudget) * 100}%`,
                                     minHeight: '0.5%'
                                 }}
-                                longDesc={`FY ${fyStr[2]}${fyStr[3]} total budgetary resources are ${formatMoney(budget)};
+                                alt={`FY ${fyStr[2]}${fyStr[3]} total budgetary resources are ${formatMoney(budget)};
                                     a ${(budget / greatestAgencyBudget).toFixed(2)} to 1 ratio compared to the largest total budgetary resources
                                     in 5 consecutive years (${formatMoney(greatestAgencyBudget)}).`} />
                         </TooltipWrapper>

--- a/src/js/containers/agencyV2/accountSpending/TableContainer.jsx
+++ b/src/js/containers/agencyV2/accountSpending/TableContainer.jsx
@@ -106,8 +106,7 @@ const TableContainer = ({
         const request = fetchSpendingByCategory(agencyId, type, params);
         request.promise
             .then((res) => {
-                const parsedData = parseAccount(res.data.results, agencyObligated);
-                setResults(parsedData);
+                parseAccount(res.data.results, agencyObligated);
                 setTotalItems(res.data.page_metadata.total);
                 setLoading(false);
             }).catch((err) => {

--- a/src/js/containers/agencyV2/accountSpending/TableContainer.jsx
+++ b/src/js/containers/agencyV2/accountSpending/TableContainer.jsx
@@ -9,7 +9,7 @@ import { useSelector } from 'react-redux';
 import { Table, Pagination } from 'data-transparency-ui';
 import { accountColumns, accountFields } from 'dataMapping/agency/tableColumns';
 import { fetchSpendingByCategory } from 'apis/agencyV2';
-import BaseAccountSpendingRow from 'models/v2/agencyV2/BaseAccountSpendingRow';
+import { parseRows } from 'helpers/agencyV2/BudgetCategoryHelper';
 import { useStateWithPrevious } from 'helpers';
 
 const propTypes = {
@@ -39,58 +39,8 @@ const TableContainer = ({
     const [results, setResults] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(false);
-    const { budgetaryResources: { dataByYear: resourcesByYear } } = useSelector((state) => state.agencyV2);
-    const { agencyObligated } = resourcesByYear[fy] || 0;
-
-    const parseAccount = (data) => {
-        // add total obligation to each object and it's children objects
-        const dataAndTotalObligation = data.map((d) => {
-            let dataChildrenAndTotalObligation = [];
-            if (d.children && d.children.length > 0) {
-                dataChildrenAndTotalObligation = d.children.map((child) => ({
-                    ...child,
-                    total_obligated_amount: agencyObligated
-                }));
-            }
-
-            if (dataChildrenAndTotalObligation.length > 0) {
-                return {
-                    ...d,
-                    children: dataChildrenAndTotalObligation,
-                    total_obligated_amount: agencyObligated
-                };
-            }
-
-            return {
-                ...d,
-                total_obligated_amount: agencyObligated
-            };
-        });
-
-        // parse row and row's children
-        const parsedData = dataAndTotalObligation.map((item) => {
-            const accountSpendingRow = Object.create(BaseAccountSpendingRow);
-            accountSpendingRow.populate(item);
-
-            let rowChildren = [];
-            if (item.children && item.children.length > 0) {
-                rowChildren = item.children.map((childItem) => {
-                    const accountChildSpendingRow = Object.create(BaseAccountSpendingRow);
-                    accountChildSpendingRow.populate(childItem);
-                    return accountChildSpendingRow;
-                });
-            }
-
-            if (rowChildren && rowChildren.length > 0) {
-                Object.defineProperty(accountSpendingRow, "children", {
-                    value: rowChildren
-                });
-            }
-
-            return accountSpendingRow;
-        });
-        setResults(parsedData);
-    };
+    const { dataByYear } = useSelector((state) => state.agencyV2.budgetaryResources);
+    const { agencyObligated } = dataByYear[fy] || 0;
 
     const fetchSpendingByCategoryCallback = useCallback(() => {
         setLoading(true);
@@ -106,7 +56,8 @@ const TableContainer = ({
         const request = fetchSpendingByCategory(agencyId, type, params);
         request.promise
             .then((res) => {
-                parseAccount(res.data.results, agencyObligated);
+                const parsedData = parseRows(res.data.results, agencyObligated);
+                setResults(parsedData);
                 setTotalItems(res.data.page_metadata.total);
                 setLoading(false);
             }).catch((err) => {

--- a/src/js/helpers/agencyV2/BudgetCategoryHelper.js
+++ b/src/js/helpers/agencyV2/BudgetCategoryHelper.js
@@ -1,0 +1,52 @@
+import BaseAccountSpendingRow from 'models/v2/agencyV2/BaseAccountSpendingRow';
+
+// eslint-disable-next-line import/prefer-default-export
+export const parseRows = (data, agencyObligated) => {
+    // add total obligation to each object and it's children objects
+    const dataAndTotalObligation = data.map((d) => {
+        let dataChildrenAndTotalObligation = [];
+        if (d.children && d.children.length > 0) {
+            dataChildrenAndTotalObligation = d.children.map((child) => ({
+                ...child,
+                total_obligated_amount: agencyObligated
+            }));
+        }
+
+        if (dataChildrenAndTotalObligation.length > 0) {
+            return {
+                ...d,
+                children: dataChildrenAndTotalObligation,
+                total_obligated_amount: agencyObligated
+            };
+        }
+
+        return {
+            ...d,
+            total_obligated_amount: agencyObligated
+        };
+    });
+
+    // parse row and row's children
+    const parsedData = dataAndTotalObligation.map((item) => {
+        const accountSpendingRow = Object.create(BaseAccountSpendingRow);
+        accountSpendingRow.populate(item);
+
+        let rowChildren = [];
+        if (item.children && item.children.length > 0) {
+            rowChildren = item.children.map((childItem) => {
+                const accountChildSpendingRow = Object.create(BaseAccountSpendingRow);
+                accountChildSpendingRow.populate(childItem);
+                return accountChildSpendingRow;
+            });
+        }
+
+        if (rowChildren && rowChildren.length > 0) {
+            Object.defineProperty(accountSpendingRow, "children", {
+                value: rowChildren
+            });
+        }
+
+        return accountSpendingRow;
+    });
+    return parsedData;
+};

--- a/tests/containers/agencyV2/accountSpending/TableContainer-test.jsx
+++ b/tests/containers/agencyV2/accountSpending/TableContainer-test.jsx
@@ -7,9 +7,11 @@ import React from 'react';
 import { render, waitFor } from 'test-utils';
 
 import * as apis from 'apis/agencyV2';
+import * as helpers from 'helpers/agencyV2/BudgetCategoryHelper';
 import TableContainer from 'containers/agencyV2/accountSpending/TableContainer';
 
-const mockResponse = {
+// eslint-disable-next-line import/prefer-default-export
+export const mockResponse = {
     toptier_code: "012",
     fiscal_year: 2020,
     page_metadata: {
@@ -54,7 +56,11 @@ const defaultProps = {
     subHeading: 'test'
 };
 
-test('no duplicate API Requests 👌👌👌👌 on fy change', () => {
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+test('no duplicate API Requests on fy change', () => {
     const spy = jest.spyOn(apis, 'fetchSpendingByCategory').mockReturnValue({
         promise: Promise.resolve({ data: mockResponse }),
         cancel: jest.fn()
@@ -67,7 +73,7 @@ test('no duplicate API Requests 👌👌👌👌 on fy change', () => {
     });
 });
 
-test('no duplicate API Requests 👌👌👌👌 on type change', () => {
+test('no duplicate API Requests on type change', () => {
     const spy = jest.spyOn(apis, 'fetchSpendingByCategory').mockReturnValue({
         promise: Promise.resolve({ data: mockResponse }),
         cancel: jest.fn()
@@ -75,7 +81,16 @@ test('no duplicate API Requests 👌👌👌👌 on type change', () => {
     const { rerender } = render(<TableContainer {...defaultProps} />);
     rerender(<TableContainer {...defaultProps} type="object_class" />);
     return waitFor(() => {
-        expect(spy).toHaveBeenCalledTimes(2);
-        expect(spy).not.toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).not.toHaveBeenCalledTimes(2);
+    });
+});
+
+test('parses data from the API using agency obligated amount from redux state', () => {
+    const spy = jest.spyOn(helpers, 'parseRows');
+    render(<TableContainer {...defaultProps} />);
+    return waitFor(() => {
+        expect(spy).toHaveBeenCalled();
+        expect(spy).toHaveBeenCalledWith(mockResponse.results, undefined);
     });
 });

--- a/tests/helpers/agencyV2/BudgetCategoryHelper-test.js
+++ b/tests/helpers/agencyV2/BudgetCategoryHelper-test.js
@@ -1,0 +1,27 @@
+import { parseRows } from 'helpers/agencyV2/BudgetCategoryHelper';
+import BaseAccountSpendingRow from 'models/v2/agencyV2/BaseAccountSpendingRow';
+import { mockResponse } from '../../containers/agencyV2/accountSpending/TableContainer-test';
+
+const mockData = mockResponse.results;
+
+describe('parseRows', () => {
+    test('the returned objects have BaseAccountSpendingRow in their prototype chain', () => {
+        const result = parseRows(mockData, 4000);
+        expect(Object.getPrototypeOf(result[0])).toEqual(BaseAccountSpendingRow);
+    });
+
+    test('the returned nested / child objects have BaseAccountSpendingRow in their prototype chain', () => {
+        const result = parseRows(mockData, 4000);
+        expect(Object.getPrototypeOf(result[0].children[0])).toEqual(BaseAccountSpendingRow);
+    });
+
+    test('adds agency obligated amount to each result', () => {
+        const result = parseRows(mockData, 4000);
+        expect(result[0]._totalObligatedAmount).toEqual(4000);
+    });
+
+    test('adds agency obligated amount to each nested / child result', () => {
+        const result = parseRows(mockData, 4000);
+        expect(result[0].children[0]._totalObligatedAmount).toEqual(4000);
+    });
+});


### PR DESCRIPTION
**High level description:**

Fixes the Agency v2 Spending by Budget Category tables.

**Technical details:**

- We were calling `setResults` in two different places, causing the "No results" message to be perpetually displayed
- Resolves a couple of console errors
- Moves the helper function that parses table rows out of the component and adds unit tests for it
- More comprehensive unit tests for `TableContainer`

**JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [N/A] Linked to this PR in JIRA ticket
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)

Reviewer(s):
- [x] Code review complete
