### PR TITLE
Bug - Advanced Search Covid Columns

### DIFF
--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -79,6 +79,9 @@ export default class ResultsTable extends React.Component {
             value: this.props.results[rowIndex][columnId],
             dataType: awardTableColumnTypes[columnId]
         };
+        if (column.columnName === 'COVID-19 Obligations' || column.columnName === 'COVID-19 Outlays') {
+            console.log(' Jon : ', this.props.results[rowIndex][column.columnName]);
+        }
         if (column.columnName === 'Award ID') {
             cellClass = ResultsTableLinkCell;
             props.id = this.props.results[rowIndex].generated_internal_id;
@@ -124,7 +127,8 @@ export default class ResultsTable extends React.Component {
         }
         else if (
             (column.columnName === 'COVID-19 Obligations' || column.columnName === 'COVID-19 Outlays')
-            && !this.props.results[rowIndex][column.columnName]) {
+            && !this.props.results[rowIndex][column.columnName] && this.props.results[rowIndex][column.columnName] !== 0) {
+            console.log(' Hitting : ', this.props.results[rowIndex][column.columnName]);
             props.value = '--';
         }
         else if (column.columnName === 'def_codes') {

--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -79,8 +79,7 @@ export default class ResultsTable extends React.Component {
             value: this.props.results[rowIndex][columnId],
             dataType: awardTableColumnTypes[columnId]
         };
-        if (column.columnName === 'COVID-19 Obligations' || column.columnName === 'COVID-19 Outlays') {
-        }
+
         if (column.columnName === 'Award ID') {
             cellClass = ResultsTableLinkCell;
             props.id = this.props.results[rowIndex].generated_internal_id;

--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -80,7 +80,6 @@ export default class ResultsTable extends React.Component {
             dataType: awardTableColumnTypes[columnId]
         };
         if (column.columnName === 'COVID-19 Obligations' || column.columnName === 'COVID-19 Outlays') {
-            console.log(' Jon : ', this.props.results[rowIndex][column.columnName]);
         }
         if (column.columnName === 'Award ID') {
             cellClass = ResultsTableLinkCell;
@@ -128,7 +127,6 @@ export default class ResultsTable extends React.Component {
         else if (
             (column.columnName === 'COVID-19 Obligations' || column.columnName === 'COVID-19 Outlays')
             && !this.props.results[rowIndex][column.columnName] && this.props.results[rowIndex][column.columnName] !== 0) {
-            console.log(' Hitting : ', this.props.results[rowIndex][column.columnName]);
             props.value = '--';
         }
         else if (column.columnName === 'def_codes') {

--- a/src/js/components/search/table/cells/ResultsTableFormattedCell.jsx
+++ b/src/js/components/search/table/cells/ResultsTableFormattedCell.jsx
@@ -22,13 +22,14 @@ export default class ResultsTableFormattedCell extends React.Component {
             // format the content as a date
             return moment(original, 'YYYY-MM-DD').format('M/D/YYYY');
         }
-        else if (type === 'currency') {
+        else if (type === 'currency' && original !== '--') {
             return formatMoney(original);
         }
         return original;
     }
 
     render() {
+        console.log(' This Value : ', this.props.value);
         // cell needs to have some content or it will collapse
         // replace with a &nbsp; if there's no data
         let content = this.props.value;

--- a/src/js/components/search/table/cells/ResultsTableFormattedCell.jsx
+++ b/src/js/components/search/table/cells/ResultsTableFormattedCell.jsx
@@ -29,7 +29,6 @@ export default class ResultsTableFormattedCell extends React.Component {
     }
 
     render() {
-        console.log(' This Value : ', this.props.value);
         // cell needs to have some content or it will collapse
         // replace with a &nbsp; if there's no data
         let content = this.props.value;


### PR DESCRIPTION
**High level description:**

Advanced Search Page Table COVID-19 Obligations and Outlays columns will display `--` for values that do not exist and `$0` for zero values.

**Technical details:**

> • updates the logic in the results table to only use `--` if the api response is falsey and is not equal to zero.
> • update the logic in the formatted table cell to only format currency data when the value is not `--`.

**JIRA Ticket:**
[DEV-7431](https://federal-spending-transparency.atlassian.net/browse/DEV-7431)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [N/A] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [N/A] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [N/A] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
