### PR TITLE
Dev 7172 add tracking adv search to award summary

### DIFF
--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -84,7 +84,7 @@ export default class ResultsTable extends React.Component {
             cellClass = ResultsTableLinkCell;
             props.id = this.props.results[rowIndex].generated_internal_id;
             props.column = 'award';
-            props.onClick = this.props.awardIdClick(props.id);
+            props.onClick = () => this.props.awardIdClick(props.id);
         }
         else if ((column.columnName === 'Sub-Award ID') && this.props.subaward) {
             const row = this.props.results[rowIndex];

--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -24,6 +24,7 @@ const propTypes = {
     tableInstance: PropTypes.string,
     sort: PropTypes.object,
     updateSort: PropTypes.func,
+    awardIdClick: PropTypes.func,
     subAwardIdClick: PropTypes.func
 };
 

--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -83,6 +83,7 @@ export default class ResultsTable extends React.Component {
             cellClass = ResultsTableLinkCell;
             props.id = this.props.results[rowIndex].generated_internal_id;
             props.column = 'award';
+            props.onClick = this.props.awardIdClick(props.id);
         }
         else if ((column.columnName === 'Sub-Award ID') && this.props.subaward) {
             const row = this.props.results[rowIndex];

--- a/src/js/components/search/table/ResultsTableSection.jsx
+++ b/src/js/components/search/table/ResultsTableSection.jsx
@@ -27,6 +27,7 @@ const propTypes = {
     updateSort: PropTypes.func,
     reorderColumns: PropTypes.func,
     subaward: PropTypes.bool,
+    awardIdClick: PropTypes.func,
     subAwardIdClick: PropTypes.func
 };
 
@@ -89,23 +90,23 @@ export default class ResultsTableSection extends React.Component {
                                 classNames="table-message-fade"
                                 timeout={{ exit: 225, enter: 195 }}
                                 exit>
-                                    <>
-                                        {this.props.inFlight && (
-                                            <div className="results-table-message-container">
-                                                <ResultsTableLoadingMessage />
-                                            </div>
-                                        )}
-                                        {this.props.error && (
-                                            <div className="results-table-message-container full">
-                                                <ResultsTableErrorMessage />
-                                            </div>
-                                        )}
-                                        {!this.props.error && !this.props.inFlight && this.props.results.length === 0 && (
-                                            <div className="results-table-message-container full">
-                                                <ResultsTableNoResults />
-                                            </div>
-                                        )}
-                                    </>
+                                <>
+                                    {this.props.inFlight && (
+                                        <div className="results-table-message-container">
+                                            <ResultsTableLoadingMessage />
+                                        </div>
+                                    )}
+                                    {this.props.error && (
+                                        <div className="results-table-message-container full">
+                                            <ResultsTableErrorMessage />
+                                        </div>
+                                    )}
+                                    {!this.props.error && !this.props.inFlight && this.props.results.length === 0 && (
+                                        <div className="results-table-message-container full">
+                                            <ResultsTableNoResults />
+                                        </div>
+                                    )}
+                                </>
                             </CSSTransition>
 
                         )}
@@ -121,6 +122,7 @@ export default class ResultsTableSection extends React.Component {
                         <ResultsTable
                             {...this.props}
                             visibleWidth={this.state.tableWidth}
+                            awardIdClick={this.props.awardIdClick}
                             subAwardIdClick={this.props.subAwardIdClick} />
                     )}
                 </div>

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -466,24 +466,15 @@ export class ResultsTableContainer extends React.Component {
     }
 
     awardIdClick = (id) => {
-
-
-        console.log(`awardIdClick ${id}`);
-
-        // Analytics.event({
-        //     category: 'Advanced Search - Spending by Prime Award',
-        //     action: `Clicked ${id}`,
-        //     label: useQueryParams(['hash'])
-        // });
-        // this.props.subAwardIdClicked(true);
+        Analytics.event({
+            category: 'Advanced Search - Spending by Prime Award',
+            action: `Clicked ${id}`,
+            label: useQueryParams(['hash'])
+        });
+        this.props.subAwardIdClicked(true);
     }
 
     subAwardIdClick = (id) => {
-
-
-
-        console.log('subAwardIdClick');
-
         Analytics.event({
             category: 'Advanced Search - Link',
             action: 'Subaward ID Clicked',

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -468,7 +468,7 @@ export class ResultsTableContainer extends React.Component {
     awardIdClick = (id) => {
 
 
-        console.log('clicked');
+        console.log(`awardIdClick ${id}`);
 
         // Analytics.event({
         //     category: 'Advanced Search - Spending by Prime Award',
@@ -479,6 +479,11 @@ export class ResultsTableContainer extends React.Component {
     }
 
     subAwardIdClick = (id) => {
+
+
+
+        console.log('subAwardIdClick');
+
         Analytics.event({
             category: 'Advanced Search - Link',
             action: 'Subaward ID Clicked',

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -15,7 +15,6 @@ import tableTabsTooltips from 'dataMapping/shared/tableTabsTooltips';
 import SearchAwardsOperation from 'models/search/SearchAwardsOperation';
 import { subAwardIdClicked } from 'redux/actions/search/searchSubAwardTableActions';
 import * as SearchHelper from 'helpers/searchHelper';
-import { useQueryParams } from 'helpers/queryParams';
 import Analytics from 'helpers/analytics/Analytics';
 
 import { awardTypeGroups, subawardTypeGroups } from 'dataMapping/search/awardType';
@@ -469,9 +468,8 @@ export class ResultsTableContainer extends React.Component {
         Analytics.event({
             category: 'Advanced Search - Spending by Prime Award',
             action: `Clicked ${id}`,
-            label: useQueryParams(['hash'])
+            label: new URLSearchParams(this.props.location.search).get('hash')
         });
-        this.props.subAwardIdClicked(true);
     }
 
     subAwardIdClick = (id) => {

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -15,6 +15,7 @@ import tableTabsTooltips from 'dataMapping/shared/tableTabsTooltips';
 import SearchAwardsOperation from 'models/search/SearchAwardsOperation';
 import { subAwardIdClicked } from 'redux/actions/search/searchSubAwardTableActions';
 import * as SearchHelper from 'helpers/searchHelper';
+import { useQueryParams } from 'helpers/queryParams';
 import Analytics from 'helpers/analytics/Analytics';
 
 import { awardTypeGroups, subawardTypeGroups } from 'dataMapping/search/awardType';
@@ -464,6 +465,19 @@ export class ResultsTableContainer extends React.Component {
         });
     }
 
+    awardIdClick = (id) => {
+
+
+        console.log('clicked');
+
+        // Analytics.event({
+        //     category: 'Advanced Search - Spending by Prime Award',
+        //     action: `Clicked ${id}`,
+        //     label: useQueryParams(['hash'])
+        // });
+        // this.props.subAwardIdClicked(true);
+    }
+
     subAwardIdClick = (id) => {
         Analytics.event({
             category: 'Advanced Search - Link',
@@ -495,6 +509,7 @@ export class ResultsTableContainer extends React.Component {
                 updateSort={this.updateSort}
                 loadNextPage={this.loadNextPage}
                 subaward={this.props.subaward}
+                awardIdClick={this.awardIdClick}
                 subAwardIdClick={this.subAwardIdClick} />
         );
     }


### PR DESCRIPTION
**High level description:**

add new GA event to track advanced search click-through to awards summary

**Technical details:**

copied & adapted subaward event code; NOTE: we don't know how to test this until it reaches prod

**JIRA Ticket:**
[DEV-7172](https://federal-spending-transparency.atlassian.net/browse/DEV-7172)

**Mockup:**


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- na Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- na Verified mobile/tablet/desktop/monitor responsiveness
- na Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- na Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- na [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- na [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- na Design review complete `if applicable`
- na [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
