### PR TITLE
DEV-7395 fix Federal Account profile stale data

### DIFF
--- a/src/js/containers/account/visualizations/AccountRankVisualizationContainer.jsx
+++ b/src/js/containers/account/visualizations/AccountRankVisualizationContainer.jsx
@@ -54,7 +54,7 @@ export class AccountRankVisualizationContainer extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (!isEqual(prevProps.reduxFilters, this.props.reduxFilters)) {
+        if (!isEqual(prevProps.reduxFilters, this.props.reduxFilters) || !isEqual(prevProps.account.id, this.props.account.id)) {
             this.newSearch();
         }
     }

--- a/src/js/containers/account/visualizations/AccountTimeVisualizationContainer.jsx
+++ b/src/js/containers/account/visualizations/AccountTimeVisualizationContainer.jsx
@@ -57,7 +57,7 @@ export class AccountTimeVisualizationSectionContainer extends React.PureComponen
     }
 
     componentDidUpdate(prevProps) {
-        if (!isEqual(prevProps.reduxFilters, this.props.reduxFilters)) {
+        if (!isEqual(prevProps.reduxFilters, this.props.reduxFilters) || !isEqual(prevProps.account.id, this.props.account.id)) {
             this.setUpdateStateAndFetch(this.props);
         }
     }

--- a/tests/containers/account/visualizations/AccountRankVisualizationContainer-test.jsx
+++ b/tests/containers/account/visualizations/AccountRankVisualizationContainer-test.jsx
@@ -94,6 +94,29 @@ describe('AccountRankVisualizationContainer', () => {
         fetchDataSpy.reset();
     });
 
+    it('should reload data when the account changes', () => {
+        mockAccountHelper('fetchTasCategoryTotals', 'resolve', mockCategories);
+
+        const container = mount(<AccountRankVisualizationContainer
+            reduxFilters={defaultFilters}
+            account={mockReduxAccount} />);
+
+        jest.runAllTicks();
+
+        expect(fetchDataSpy.callCount).toEqual(1);
+
+        container.setProps({
+            account: Object.assign({}, mockReduxAccount, {
+                id: 1234
+            })
+        });
+
+        jest.runAllTicks();
+
+        expect(fetchDataSpy.callCount).toEqual(2);
+        fetchDataSpy.reset();
+    });
+
     describe('parseData', () => {
         it('should parse the API response and update the container state with series data', () => {
             const container = shallow(<AccountRankVisualizationContainer

--- a/tests/containers/account/visualizations/AccountTimeVisualizationContainer-test.jsx
+++ b/tests/containers/account/visualizations/AccountTimeVisualizationContainer-test.jsx
@@ -8,12 +8,12 @@ import { mount, shallow } from 'enzyme';
 import sinon from 'sinon';
 
 import { AccountTimeVisualizationSectionContainer } from
-        'containers/account/visualizations/AccountTimeVisualizationContainer';
+    'containers/account/visualizations/AccountTimeVisualizationContainer';
 
 import {
     mockBalances, mockReduxAccount, mockQuarters, mockFilteredObligated, mockFilteredObligatedQuarters,
     parsedYearYSeries, parsedQuarterYSeries, parsedYearYSeriesFiltered, parsedQuarterYSeriesFiltered,
-    mockIncomplete, parsedIncomplete
+    mockIncomplete
 }
     from '../mockAccount';
 import { defaultFilters } from '../defaultFilters';
@@ -53,6 +53,29 @@ describe('AccountTimeVisualizationSectionContainer', () => {
         container.setProps({
             reduxFilters: Object.assign({}, defaultFilters, {
                 dateType: 'dr'
+            })
+        });
+
+        const morePromises = container.instance().balanceRequests.map((request) => request.promise);
+        await Promise.all(morePromises);
+
+        expect(fetchDataSpy.callCount).toEqual(2);
+        fetchDataSpy.reset();
+    });
+
+    it('should reload data when the account changes', async () => {
+        const container = mount(<AccountTimeVisualizationSectionContainer
+            reduxFilters={defaultFilters}
+            account={mockReduxAccount} />);
+
+        const promises = container.instance().balanceRequests.map((request) => request.promise);
+        await Promise.all(promises);
+
+        expect(fetchDataSpy.callCount).toEqual(1);
+
+        container.setProps({
+            account: Object.assign({}, mockReduxAccount, {
+                id: 1234
             })
         });
 


### PR DESCRIPTION
**High level description:**

Fixes a bug that prevented visualization data from being fetched when switching between federal account profile pages.

**Technical details:**

Added checks to `componentDidUpdate` to watch for changes to the agency id. 

**JIRA Ticket:**
[DEV-7395](https://federal-spending-transparency.atlassian.net/browse/DEV-7395)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [N/A] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)

Reviewer(s):
- [ ] Code review complete
