### PR TITLE
DEV-7432 Hotfix homepage images in Safari

### DIFF
--- a/src/_scss/pages/homepage/features/_carousel.scss
+++ b/src/_scss/pages/homepage/features/_carousel.scss
@@ -54,7 +54,7 @@
                 width: 100%;
 
                 // within the box, we need to center the image
-                picture.feature-carousel-image__image {
+                .feature-carousel-image__image {
                     img {
                         display: block;
                         background-color: $color-white;

--- a/src/_scss/pages/homepage/features/_carousel.scss
+++ b/src/_scss/pages/homepage/features/_carousel.scss
@@ -54,13 +54,15 @@
                 width: 100%;
 
                 // within the box, we need to center the image
-                img.feature-carousel-image__image {
-                    display: block;
-                    background-color: $color-white;
-                    padding: rem(10);
-                    border: 1px solid $color-gray-lighter;
-                    margin-left: auto;
-                    margin-right: auto;
+                picture.feature-carousel-image__image {
+                    img {
+                        display: block;
+                        background-color: $color-white;
+                        padding: rem(10);
+                        border: 1px solid $color-gray-lighter;
+                        margin-left: auto;
+                        margin-right: auto;
+                    }
                 }
             }
         }

--- a/src/_scss/pages/homepage/features/_covidFeature.scss
+++ b/src/_scss/pages/homepage/features/_covidFeature.scss
@@ -119,6 +119,8 @@
             }
             .feature-covid-item__image {
                 display: none; /* 0 - 991px */
+                object-fit: cover;
+                object-position: top;
 
                 @include media($medium-screen) { /* 992 - 1023px */
                     display: block;
@@ -218,6 +220,8 @@
 
             .feature-covid-award-summary__image {
                 display: none; /* 0 - 991px */
+                object-fit: cover;
+                object-position: top;
 
                 @include media($medium-screen) { /* 992 - 1023px */
                     display: block;

--- a/src/js/components/homepage/features/ImageCarousel.jsx
+++ b/src/js/components/homepage/features/ImageCarousel.jsx
@@ -217,11 +217,11 @@ export default class ImageCarousel extends React.Component {
                     key={image.key || image.src}
                     aria-hidden={this.state.page !== index + 1}
                     tabIndex={-1}>
-                    <img
-                        className="feature-carousel-image__image"
-                        srcSet={image.srcSet}
-                        src={image.src}
-                        alt={image.alt} />
+                    <picture className="feature-carousel-image__image">
+                        <source srcSet={image.srcSet} type="image/webp" />
+                        <source srcSet={image.src} type="image/png" />
+                        <img src={image.src} alt={image.alt} />
+                    </picture>
                 </li>
             );
         });

--- a/src/js/components/homepage/features/SpendingExplorerFeature.jsx
+++ b/src/js/components/homepage/features/SpendingExplorerFeature.jsx
@@ -18,11 +18,11 @@ const SpendingExplorerFeature = () => (
     <div className="feature-spending-explorer">
         <div className="feature-spending-explorer__wrapper">
             <div className="feature-spending-explorer__image-wrapper feature-spending-explorer__image-wrapper_desktop">
-                <img
-                    className="feature-spending-explorer__image"
-                    srcSet="img/homepage-spending-explorer.webp 1x, img/homepage-spending-explorer@2x.webp 2x"
-                    src="img/homepage-spending-explorer.png"
-                    alt="Screenshot of the Spending Explorer" />
+                <picture>
+                    <source srcSet="img/homepage-spending-explorer.webp 1x, img/homepage-spending-explorer@2x.webp 2x" type="image/webp" />
+                    <source srcSet="img/homepage-spending-explorer.png" type="image/png" />
+                    <img src="img/homepage-spending-explorer.png" alt="Screenshot of the Spending Explorer" />
+                </picture>
             </div>
             <div className="feature-spending-explorer__content">
                 <h2
@@ -31,11 +31,11 @@ const SpendingExplorerFeature = () => (
                     A big-picture view of the federal spending landscape
                 </h2>
                 <div className="feature-spending-explorer__image-wrapper feature-spending-explorer__image-wrapper_mobile">
-                    <img
-                        className="feature-spending-explorer__image"
-                        srcSet="img/homepage-spending-explorer.webp 1x, img/homepage-spending-explorer@2x.webp 2x"
-                        src="img/homepage-spending-explorer.png"
-                        alt="Screenshot of the Spending Explorer" />
+                    <picture className="feature-spending-explorer__image">
+                        <source srcSet="img/homepage-spending-explorer.webp 1x, img/homepage-spending-explorer@2x.webp 2x" type="image/webp" />
+                        <source srcSet="img/homepage-spending-explorer.png" type="image/png" />
+                        <img src="img/homepage-spending-explorer.png" alt="Screenshot of the Spending Explorer" />
+                    </picture>
                 </div>
                 <div className="homepage-feature-description">
                     <p>

--- a/src/js/containers/homepage/CovidFeatureContainer.jsx
+++ b/src/js/containers/homepage/CovidFeatureContainer.jsx
@@ -85,29 +85,29 @@ const CovidFeatureContainer = ({
                     </div>
                 </div>
                 <div className="feature-covid-official-spending-data__image-wrapper">
-                    <img
-                        className="feature-covid-official-spending-data__image"
-                        srcSet="img/homepage-covid-official-spending-data.webp 790w"
-                        src="img/homepage-covid-official-spending-data.png"
-                        alt="Illustration of people interacting with data" />
+                    <picture className="feature-covid-official-spending-data__image">
+                        <source srcSet="img/homepage-covid-official-spending-data.webp 790w" type="image/webp" />
+                        <source srcSet="img/homepage-covid-official-spending-data.png" type="image/png" />
+                        <img src="img/homepage-covid-official-spending-data.png" alt="Illustration of people interacting with data" />
+                    </picture>
                 </div>
             </div>
             <div className="advanced-search-and-spending-profile__wrapper">
                 <div className="advanced-search__content-wrapper">
                     <div className="feature-covid-item__image-wrapper">
-                        <img
-                            className="feature-covid-item__image"
-                            srcSet="img/homepage-covid-ss-adv-search.webp 790w"
-                            src="img/homepage-covid-ss-adv-search.png"
-                            alt="Screenshot of Advanced Search page with COVID-19 Spending updates" />
+                        <picture className="feature-covid-item__image">
+                            <source srcSet="img/homepage-covid-ss-adv-search.webp 790w" type="image/webp" />
+                            <source srcSet="img/homepage-covid-ss-adv-search.png" type="image/png" />
+                            <img src="img/homepage-covid-ss-adv-search.png" alt="Screenshot of Advanced Search page with COVID-19 Spending updates" />
+                        </picture>
                     </div>
                     <h2 className="homepage-feature-title">COVID-19 Advanced Search Filter</h2>
                     <div className="feature-covid-item__image-wrapper">
-                        <img
-                            className="feature-covid-item__image-mobile"
-                            srcSet="img/homepage-covid-ss-adv-search.webp 790w"
-                            src="img/homepage-covid-ss-adv-search.png"
-                            alt="Screenshot of Advanced Search page with COVID-19 Spending updates" />
+                        <picture className="feature-covid-item__image-mobile">
+                            <source srcSet="img/homepage-covid-ss-adv-search.webp 790w" type="image/webp" />
+                            <source srcSet="img/homepage-covid-ss-adv-search.png" type="image/png" />
+                            <img src="img/homepage-covid-ss-adv-search.png" alt="Screenshot of Advanced Search page with COVID-19 Spending updates" />
+                        </picture>
                     </div>
                     <div className="homepage-feature-description adv-search-spending-profile__text">
                         <p>Use the new <strong className="homepage-feature-description_weight_bold">Disaster Emergency Fund Code (DEFC)</strong> filter to show awards related to COVID-19 spending. The new filter works alongside our existing filters, so you can narrow your search to exactly what you want.</p>
@@ -126,19 +126,19 @@ const CovidFeatureContainer = ({
 
                 <div className="advanced-search__content-wrapper-right">
                     <div className="feature-covid-item__image-wrapper">
-                        <img
-                            className="feature-covid-item__image"
-                            srcSet="img/homepage-covid-ss-profile.webp 790w"
-                            src="img/homepage-covid-ss-profile.png"
-                            alt="Screenshot of COVID-19 Spending profile page" />
+                        <picture className="feature-covid-item__image">
+                            <source srcSet="img/homepage-covid-ss-profile.webp 790w" type="image/webp" />
+                            <source srcSet="img/homepage-covid-ss-profile.png" type="image/png" />
+                            <img src="img/homepage-covid-ss-profile.png" alt="Screenshot of COVID-19 Spending profile page" />
+                        </picture>
                     </div>
                     <h2 className="homepage-feature-title">COVID-19 Spending Profile</h2>
                     <div className="feature-covid-item__image-wrapper">
-                        <img
-                            className="feature-covid-item__image-mobile"
-                            srcSet="img/homepage-covid-ss-profile.webp 790w"
-                            src="img/homepage-covid-ss-profile.png"
-                            alt="Screenshot of COVID-19 Spending profile page" />
+                        <picture className="feature-covid-item__image-mobile">
+                            <source srcSet="img/homepage-covid-ss-profile.webp 790w" type="image/webp" />
+                            <source srcSet="img/homepage-covid-ss-profile.png" type="image/png" />
+                            <img src="img/homepage-covid-ss-profile.png" alt="Screenshot of COVID-19 Spending profile page" />
+                        </picture>
                     </div>
                     <div className="homepage-feature-description adv-search-spending-profile__text">
                         <p>Our newest profile page shows you COVID-19 spending information as submitted by federal agencies. Learn more about <strong className="homepage-feature-description_weight_bold">who received funding, which agencies outlayed funds,</strong> and <strong className="homepage-feature-description_weight_bold">which programs were funded</strong>.</p>
@@ -159,21 +159,21 @@ const CovidFeatureContainer = ({
                 <div className="feature-award-search__wrapper">
                     <div className="feature-covid__background-flair" />
                     <div className="feature-covid-award-summary__image-wrapper">
-                        <img
-                            className="feature-covid-award-summary__image"
-                            srcSet="img/homepage-covid-ss-award-summary.webp 790w"
-                            src="img/homepage-covid-ss-award-summary.png"
-                            alt="Screenshot of Award Summary page with COVID-19 Spending updates" />
+                        <picture className="feature-covid-award-summary__image">
+                            <source srcSet="img/homepage-covid-ss-award-summary.webp 790w" type="image/webp" />
+                            <source srcSet="img/homepage-covid-ss-award-summary.png" type="image/png" />
+                            <img src="img/homepage-covid-ss-award-summary.png" alt="Screenshot of Award Summary page with COVID-19 Spending updates" />
+                        </picture>
                     </div>
                     <div className="award-summary__text-wrapper">
                         <div>
                             <h2 className="homepage-feature-title">Award Summary pages now feature COVID-19 spending</h2>
                             <div className="feature-covid-award-summary__image-wrapper">
-                                <img
-                                    className="feature-covid-award-summary__image-mobile"
-                                    srcSet="img/homepage-covid-ss-award-summary.webp 790w"
-                                    src="img/homepage-covid-ss-award-summary.png"
-                                    alt="Screenshot of Award Summary page with COVID-19 Spending updates" />
+                                <picture className="feature-covid-award-summary__image-mobile">
+                                    <source srcSet="img/homepage-covid-ss-award-summary.webp 790w" type="image/webp" />
+                                    <source srcSet="img/homepage-covid-ss-award-summary.png" type="image/png" />
+                                    <img src="img/homepage-covid-ss-award-summary.png" alt="Screenshot of Award Summary page with COVID-19 Spending updates"  />
+                                </picture>
                             </div>
                             <div className="homepage-feature-description">
                                 <p><strong className="homepage-feature-description_weight_bold">Purple COVID-19 badges</strong> found on our Award Summary pages have made it easy to identify which awards have been funded through COVID-19 appropriations. You can hover over the badge to see relevant <strong className="homepage-feature-description_weight_bold">DEFCs</strong> associated with that award. The charts found on Award Summary pages now feature <strong className="homepage-feature-description_weight_bold">COVID-19 obligation and outlay amounts.</strong></p>

--- a/src/js/containers/homepage/CovidFeatureContainer.jsx
+++ b/src/js/containers/homepage/CovidFeatureContainer.jsx
@@ -65,11 +65,11 @@ const CovidFeatureContainer = ({
                 <div className="official-spending-data__text">
                     <h2 className="homepage-feature-title">COVID-19 Spending Data</h2>
                     <div className="feature-covid-official-spending-data__image-wrapper">
-                        <img
-                            className="feature-covid-official-spending-data__image-mobile"
-                            srcSet="img/homepage-covid-official-spending-data.webp 790w"
-                            src="img/homepage-covid-official-spending-data.png"
-                            alt="Illustration of people interacting with data" />
+                        <picture className="feature-covid-official-spending-data__image-mobile">
+                            <source srcSet="img/homepage-covid-official-spending-data.webp 790w" type="image/webp" />
+                            <source srcSet="img/homepage-covid-official-spending-data.png" type="image/png" />
+                            <img src="img/homepage-covid-official-spending-data.png" alt="Illustration of people interacting with data" />
+                        </picture>
                     </div>
                     <div className="homepage-feature-description">
                         <p>Spending data from the federal government’s response to COVID-19 is now available to view and download on USAspending. Additional data and features will be released in the coming months. <button className="homepage-feature-description__button" onClick={triggerModal}>Learn more</button>about the updates made across the site related to COVID-19 spending.</p>

--- a/src/js/containers/homepage/CovidFeatureContainer.jsx
+++ b/src/js/containers/homepage/CovidFeatureContainer.jsx
@@ -94,21 +94,17 @@ const CovidFeatureContainer = ({
             </div>
             <div className="advanced-search-and-spending-profile__wrapper">
                 <div className="advanced-search__content-wrapper">
-                    <div className="feature-covid-item__image-wrapper">
-                        <picture className="feature-covid-item__image">
-                            <source srcSet="img/homepage-covid-ss-adv-search.webp 790w" type="image/webp" />
-                            <source srcSet="img/homepage-covid-ss-adv-search.png" type="image/png" />
-                            <img src="img/homepage-covid-ss-adv-search.png" alt="Screenshot of Advanced Search page with COVID-19 Spending updates" />
-                        </picture>
-                    </div>
+                    <picture className="feature-covid-item__image-wrapper" >
+                        <source srcSet="img/homepage-covid-ss-adv-search.webp 790w" type="image/webp" />
+                        <source srcSet="img/homepage-covid-ss-adv-search.png" type="image/png" />
+                        <img className="feature-covid-item__image" src="img/homepage-covid-ss-adv-search.png" alt="Screenshot of Advanced Search page with COVID-19 Spending updates" />
+                    </picture>
                     <h2 className="homepage-feature-title">COVID-19 Advanced Search Filter</h2>
-                    <div className="feature-covid-item__image-wrapper">
-                        <picture className="feature-covid-item__image-mobile">
-                            <source srcSet="img/homepage-covid-ss-adv-search.webp 790w" type="image/webp" />
-                            <source srcSet="img/homepage-covid-ss-adv-search.png" type="image/png" />
-                            <img src="img/homepage-covid-ss-adv-search.png" alt="Screenshot of Advanced Search page with COVID-19 Spending updates" />
-                        </picture>
-                    </div>
+                    <picture className="feature-covid-item__image-wrapper">
+                        <source srcSet="img/homepage-covid-ss-adv-search.webp 790w" type="image/webp" />
+                        <source srcSet="img/homepage-covid-ss-adv-search.png" type="image/png" />
+                        <img className="feature-covid-item__image-mobile" src="img/homepage-covid-ss-adv-search.png" alt="Screenshot of Advanced Search page with COVID-19 Spending updates" />
+                    </picture>
                     <div className="homepage-feature-description adv-search-spending-profile__text">
                         <p>Use the new <strong className="homepage-feature-description_weight_bold">Disaster Emergency Fund Code (DEFC)</strong> filter to show awards related to COVID-19 spending. The new filter works alongside our existing filters, so you can narrow your search to exactly what you want.</p>
                         <p>Additional columns were also added to the search results table to show <strong className="homepage-feature-description_weight_bold">COVID-19 obligations</strong> and <strong className="homepage-feature-description_weight_bold">outlays</strong>.</p>
@@ -125,21 +121,17 @@ const CovidFeatureContainer = ({
                 </div>
 
                 <div className="advanced-search__content-wrapper-right">
-                    <div className="feature-covid-item__image-wrapper">
-                        <picture className="feature-covid-item__image">
-                            <source srcSet="img/homepage-covid-ss-profile.webp 790w" type="image/webp" />
-                            <source srcSet="img/homepage-covid-ss-profile.png" type="image/png" />
-                            <img src="img/homepage-covid-ss-profile.png" alt="Screenshot of COVID-19 Spending profile page" />
-                        </picture>
-                    </div>
+                    <picture className="feature-covid-item__image-wrapper" >
+                        <source srcSet="img/homepage-covid-ss-profile.webp 790w" type="image/webp" />
+                        <source srcSet="img/homepage-covid-ss-profile.png" type="image/png" />
+                        <img className="feature-covid-item__image" src="img/homepage-covid-ss-profile.png" alt="Screenshot of COVID-19 Spending profile page" />
+                    </picture>
                     <h2 className="homepage-feature-title">COVID-19 Spending Profile</h2>
-                    <div className="feature-covid-item__image-wrapper">
-                        <picture className="feature-covid-item__image-mobile">
-                            <source srcSet="img/homepage-covid-ss-profile.webp 790w" type="image/webp" />
-                            <source srcSet="img/homepage-covid-ss-profile.png" type="image/png" />
-                            <img src="img/homepage-covid-ss-profile.png" alt="Screenshot of COVID-19 Spending profile page" />
-                        </picture>
-                    </div>
+                    <picture className="feature-covid-item__image-wrapper" >
+                        <source srcSet="img/homepage-covid-ss-profile.webp 790w" type="image/webp" />
+                        <source srcSet="img/homepage-covid-ss-profile.png" type="image/png" />
+                        <img className="feature-covid-item__image-mobile" src="img/homepage-covid-ss-profile.png" alt="Screenshot of COVID-19 Spending profile page" />
+                    </picture>
                     <div className="homepage-feature-description adv-search-spending-profile__text">
                         <p>Our newest profile page shows you COVID-19 spending information as submitted by federal agencies. Learn more about <strong className="homepage-feature-description_weight_bold">who received funding, which agencies outlayed funds,</strong> and <strong className="homepage-feature-description_weight_bold">which programs were funded</strong>.</p>
                         <p>All COVID-19 spending data is <strong className="homepage-feature-description_weight_bold">available for download</strong> on the profile page with one click. You can also read about our datasets and calculations on the <Link to="/disaster/covid-19/data-sources">Data Sources &amp; Methodology</Link> page </p>
@@ -158,13 +150,11 @@ const CovidFeatureContainer = ({
             <div className="award-summary__wrapper feature-award-search">
                 <div className="feature-award-search__wrapper">
                     <div className="feature-covid__background-flair" />
-                    <div className="feature-covid-award-summary__image-wrapper">
-                        <picture className="feature-covid-award-summary__image">
-                            <source srcSet="img/homepage-covid-ss-award-summary.webp 790w" type="image/webp" />
-                            <source srcSet="img/homepage-covid-ss-award-summary.png" type="image/png" />
-                            <img src="img/homepage-covid-ss-award-summary.png" alt="Screenshot of Award Summary page with COVID-19 Spending updates" />
-                        </picture>
-                    </div>
+                    <picture className="feature-covid-award-summary__image-wrapper">
+                        <source srcSet="img/homepage-covid-ss-award-summary.webp 790w" type="image/webp" />
+                        <source srcSet="img/homepage-covid-ss-award-summary.png" type="image/png" />
+                        <img className="feature-covid-award-summary__image" src="img/homepage-covid-ss-award-summary.png" alt="Screenshot of Award Summary page with COVID-19 Spending updates" />
+                    </picture>
                     <div className="award-summary__text-wrapper">
                         <div>
                             <h2 className="homepage-feature-title">Award Summary pages now feature COVID-19 spending</h2>

--- a/src/js/containers/homepage/CovidFeatureContainer.jsx
+++ b/src/js/containers/homepage/CovidFeatureContainer.jsx
@@ -172,7 +172,7 @@ const CovidFeatureContainer = ({
                                 <picture className="feature-covid-award-summary__image-mobile">
                                     <source srcSet="img/homepage-covid-ss-award-summary.webp 790w" type="image/webp" />
                                     <source srcSet="img/homepage-covid-ss-award-summary.png" type="image/png" />
-                                    <img src="img/homepage-covid-ss-award-summary.png" alt="Screenshot of Award Summary page with COVID-19 Spending updates"  />
+                                    <img src="img/homepage-covid-ss-award-summary.png" alt="Screenshot of Award Summary page with COVID-19 Spending updates" />
                                 </picture>
                             </div>
                             <div className="homepage-feature-description">


### PR DESCRIPTION
**High level description:**

Fixes a bug that prevented some images on the homepage from displaying in Safari.

**Technical details:**

We are now using `<picture>` elements with an `<img>` fallback.

**JIRA Ticket:**
[DEV-7432](https://federal-spending-transparency.atlassian.net/browse/DEV-7432)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Code review complete
