### PR TITLE
[DEV-7132] Obligated Amount Burnup Chart Redline

### DIFF
--- a/src/_scss/pages/agencyV2/visualizations/_totalObligationsOverTime.scss
+++ b/src/_scss/pages/agencyV2/visualizations/_totalObligationsOverTime.scss
@@ -17,7 +17,7 @@
                 stroke-width: 1;
             }
             .total-budget-difference {
-                fill: $color-secondary;
+                fill: $color-green;
                 opacity: 0.1;
             }
             .today-line {

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/AgencyBudgetLine.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/AgencyBudgetLine.jsx
@@ -2,14 +2,12 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 const propTypes = {
-    data: PropTypes.arrayOf(PropTypes.shape({
-        period: PropTypes.number,
-        obligated: PropTypes.number
-    })),
+    data: PropTypes.array,
     xScale: PropTypes.func,
     xDomain: PropTypes.array,
     yScale: PropTypes.func,
     height: PropTypes.number,
+    width: PropTypes.number,
     agencyBudget: PropTypes.number,
     todaysDate: PropTypes.number,
     padding: PropTypes.object
@@ -23,9 +21,21 @@ const AgencyBudgetLine = ({
     height,
     agencyBudget,
     todaysDate,
-    padding
+    padding,
+    width
 }) => {
     const [show, setShow] = useState(false);
+    const [lineData, setLineData] = useState({
+        x1: 0,
+        x2: 0,
+        y1: 0
+    });
+    const [rectangleData, setRectangleData] = useState({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0
+    });
 
     useEffect(() => {
         if ((todaysDate >= xDomain[0]) && (todaysDate <= xDomain[1])) {
@@ -36,16 +46,46 @@ const AgencyBudgetLine = ({
         }
     }, [xScale, xDomain, todaysDate]);
 
+    useEffect(() => {
+        if (xScale && yScale && agencyBudget) {
+            setLineData(
+                {
+                    x1: padding.left,
+                    x2: show ? xScale(todaysDate) + padding.left : width - padding.left,
+                    y1: height - yScale(agencyBudget) - padding.top
+                }
+            );
+        }
+    }, [xScale, yScale, show]);
+
+    useEffect(() => {
+        if (xScale && yScale && data.length) {
+            setRectangleData(
+                {
+                    x: padding.left,
+                    y: height - yScale(agencyBudget) - padding.top,
+                    width: show ? xScale(todaysDate) : width - padding.left - padding.right,
+                    height: height - yScale(data[data.length - 1].obligated) - padding.bottom - padding.top
+                }
+            );
+        }
+    }, [xScale, yScale, show]);
+
     return (
         <g>
-            {show && <line
+            <line
                 tabIndex="0"
                 className="total-budget-line"
-                x1={padding.left}
-                x2={xScale(todaysDate) + padding.left}
-                y1={height - yScale(agencyBudget - padding.top)}
-                y2={height - yScale(agencyBudget - padding.top)} />}
-            {show && <rect className="total-budget-difference" x={padding.left} y={height - yScale(agencyBudget - padding.top)} width={xScale(todaysDate)} height={yScale(agencyBudget) - yScale(data[data.length - 1].obligated) - padding.bottom} />}
+                x1={lineData.x1}
+                x2={lineData.x2}
+                y1={lineData.y1}
+                y2={lineData.y1} />
+            <rect
+                className="total-budget-difference"
+                x={rectangleData.x}
+                y={rectangleData.y}
+                width={rectangleData.width}
+                height={rectangleData.height} />
         </g>
     );
 };

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/AgencyBudgetLine.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/AgencyBudgetLine.jsx
@@ -48,11 +48,12 @@ const AgencyBudgetLine = ({
 
     useEffect(() => {
         if (xScale && yScale && agencyBudget) {
+            const y = height - yScale(agencyBudget) - padding.top;
             setLineData(
                 {
                     x1: padding.left,
                     x2: show ? xScale(todaysDate) + padding.left : width - padding.left,
-                    y1: height - yScale(agencyBudget) - padding.top
+                    y1: isNaN(y) ? 0 : y
                 }
             );
         }

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/AgencyBudgetLine.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/AgencyBudgetLine.jsx
@@ -1,0 +1,58 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+    xScale: PropTypes.func,
+    xDomain: PropTypes.array,
+    yScale: PropTypes.func,
+    height: PropTypes.number,
+    agencyBudget: PropTypes.number,
+    todaysDate: PropTypes.number,
+    padding: PropTypes.object
+};
+
+const AgencyBudgetLine = ({
+    xScale,
+    xDomain,
+    yScale,
+    height,
+    agencyBudget,
+    todaysDate,
+    padding
+}) => {
+    const [lineXValue, setLineXValue] = useState(0);
+    const [show, setShow] = useState(false);
+
+    useEffect(() => {
+        if ((todaysDate >= xDomain[0]) && (todaysDate <= xDomain[1])) {
+            setShow(true);
+        }
+        else {
+            setShow(false);
+        }
+    }, [xScale, xDomain, todaysDate]);
+
+    useEffect(() => {
+        if (xScale && show) {
+            setLineXValue(xScale(todaysDate) + padding.left);
+        }
+    }, [xScale, show]);
+
+    return (
+        <g>
+            {show && <desc>A line representing todays date</desc>}
+            {show && <line
+                tabIndex="0"
+                className="total-budget-line"
+                x1={padding.left}
+                x2={xScale(todaysDate) + padding.left}
+                y1={height - yScale(agencyBudget - padding.top)}
+                y2={height - yScale(agencyBudget - padding.top)} />}
+            {show && <text tabIndex="0" className="today-text" x={lineXValue - 35} y={10}>Today</text>}
+            {show && <rect className="total-budget-difference" x={padding.left} y={height - yScale(agencyBudget - padding.top)} width={xScale(todaysDate)} height={yScale(todaysDate)} />}
+        </g>
+    );
+};
+
+AgencyBudgetLine.propTypes = propTypes;
+export default AgencyBudgetLine;

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/AgencyBudgetLine.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/AgencyBudgetLine.jsx
@@ -2,6 +2,10 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 const propTypes = {
+    data: PropTypes.arrayOf(PropTypes.shape({
+        period: PropTypes.number,
+        obligated: PropTypes.number
+    })),
     xScale: PropTypes.func,
     xDomain: PropTypes.array,
     yScale: PropTypes.func,
@@ -12,6 +16,7 @@ const propTypes = {
 };
 
 const AgencyBudgetLine = ({
+    data,
     xScale,
     xDomain,
     yScale,
@@ -20,7 +25,6 @@ const AgencyBudgetLine = ({
     todaysDate,
     padding
 }) => {
-    const [lineXValue, setLineXValue] = useState(0);
     const [show, setShow] = useState(false);
 
     useEffect(() => {
@@ -32,15 +36,8 @@ const AgencyBudgetLine = ({
         }
     }, [xScale, xDomain, todaysDate]);
 
-    useEffect(() => {
-        if (xScale && show) {
-            setLineXValue(xScale(todaysDate) + padding.left);
-        }
-    }, [xScale, show]);
-
     return (
         <g>
-            {show && <desc>A line representing todays date</desc>}
             {show && <line
                 tabIndex="0"
                 className="total-budget-line"
@@ -48,8 +45,7 @@ const AgencyBudgetLine = ({
                 x2={xScale(todaysDate) + padding.left}
                 y1={height - yScale(agencyBudget - padding.top)}
                 y2={height - yScale(agencyBudget - padding.top)} />}
-            {show && <text tabIndex="0" className="today-text" x={lineXValue - 35} y={10}>Today</text>}
-            {show && <rect className="total-budget-difference" x={padding.left} y={height - yScale(agencyBudget - padding.top)} width={xScale(todaysDate)} height={yScale(todaysDate)} />}
+            {show && <rect className="total-budget-difference" x={padding.left} y={height - yScale(agencyBudget - padding.top)} width={xScale(todaysDate)} height={yScale(agencyBudget) - yScale(data[data.length - 1].obligated) - padding.bottom} />}
         </g>
     );
 };

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/TotalObligationsOverTimeVisualization.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/TotalObligationsOverTimeVisualization.jsx
@@ -157,6 +157,7 @@ const TotalObligationsOverTimeVisualization = ({
                     yScale={yScale}
                     agencyBudget={agencyBudget}
                     height={height}
+                    width={width}
                     todaysDate={todaysDate}
                     padding={padding} />
             </g>

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/TotalObligationsOverTimeVisualization.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/TotalObligationsOverTimeVisualization.jsx
@@ -13,6 +13,7 @@ import { xLabelHeightPlusPadding, yOffsetForPathStrokeWidth, defaultPadding } fr
 import Paths from 'components/agencyV2/visualizations/totalObligationsOverTime/paths/Paths';
 import Axis from './axis/Axis';
 import TodayLineAndtext from './TodayLineAndtext';
+import AgencyBudgetLine from './AgencyBudgetLine';
 
 const propTypes = {
     height: PropTypes.number,
@@ -146,6 +147,15 @@ const TotalObligationsOverTimeVisualization = ({
                 <TodayLineAndtext
                     xScale={xScale}
                     xDomain={xDomain}
+                    height={height}
+                    todaysDate={todaysDate}
+                    padding={padding} />
+                <AgencyBudgetLine
+                    data={dataWithFirstAndLastCoordinate}
+                    xScale={xScale}
+                    xDomain={xDomain}
+                    yScale={yScale}
+                    agencyBudget={agencyBudget}
                     height={height}
                     todaysDate={todaysDate}
                     padding={padding} />


### PR DESCRIPTION
**High level description:**

Add line representing agency budget per fiscal year and shaded area representing difference between agency budget and most recent submission period obligation per fiscal year

**JIRA Ticket:**
[DEV-7132](https://federal-spending-transparency.atlassian.net/browse/DEV-7132)

**Mockup:**
[Mock](https://bahdigital.invisionapp.com/d/main#/console/14222398/296055430/preview)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [n/a] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
