### PR TITLE
[dev-7401] Fix award spending sub-agency and CFDA copy

### DIFF
--- a/src/js/components/covid19/Covid19Tooltips.jsx
+++ b/src/js/components/covid19/Covid19Tooltips.jsx
@@ -72,7 +72,7 @@ export const AwardSpendingTT = () => (
                 Award Spending refers to money given through contracts or financial assistance to individuals, organizations, businesses, or state, local, or tribal governments.
             </p><br />
             <p>
-                Award Spending stands in contrast to Total Spending, also known as Account Spending, which refers to the totality of agency obligations and outlays, including agency expenses.
+                Award Spending is a portion of Total Spending, also known as Account Spending, which refers to the totality of agency obligations and outlays, including agency expenses.
             </p>
         </div>
     </div>

--- a/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
+++ b/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
@@ -15,7 +15,6 @@ import SpendingByCFDAContainer from 'containers/covid19/assistanceListing/Spendi
 import GlossaryLink from 'components/sharedComponents/GlossaryLink';
 import { scrollIntoView } from 'containers/covid19/helpers/scrollHelper';
 import Analytics from 'helpers/analytics/Analytics';
-import ReadMore from 'components/sharedComponents/ReadMore';
 import Note, { dodNote } from 'components/sharedComponents/Note';
 import DateNote from '../DateNote';
 
@@ -129,11 +128,9 @@ const SpendingByCFDA = () => {
                 <p>
                     <span className="glossary-term">Catalog of Federal Domestic Assistance (CFDA) Programs</span> <GlossaryLink term="cfda-program" />, also known as Assistance Listings, are programs, like Supplemental Nutrition Assistance Program (SNAP) that provide financial assistance to individuals, organizations, businesses, or state, local, or tribal governments. All financial assistance awards must be associated with a CFDA Program, all of which must be explicitly authorized by law.
                 </p>
-                <ReadMore>
-                    <p>
-                        In this section, you will see awards that CFDA Programs have funded in response to COVID-19. Financial assistance awards represent the vast majority of COVID-19 appropriated spending.
-                    </p>
-                </ReadMore>
+                <p>
+                    In this section, you will see awards that CFDA Programs have funded in response to COVID-19. Financial assistance awards represent the vast majority of COVID-19 appropriated spending.
+                </p>
             </div>
             <div ref={moreOptionsTabsRef}>
                 <Tabs active={activeTab} types={tabs} switchTab={changeActiveTab} />

--- a/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
+++ b/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
@@ -16,7 +16,6 @@ import AwardSpendingAgencyTableContainer from 'containers/covid19/awardSpendingA
 import SummaryInsightsContainer from 'containers/covid19/SummaryInsightsContainer';
 import { Tabs } from "data-transparency-ui";
 import Analytics from 'helpers/analytics/Analytics';
-import ReadMore from 'components/sharedComponents/ReadMore';
 
 import { scrollIntoView } from '../../../containers/covid19/helpers/scrollHelper';
 
@@ -140,11 +139,9 @@ const AwardSpendingAgency = () => {
                 <p>
                     Federal agencies receive funding from Congress and they issue awards to recipients using those funds. In this section we show which agencies and sub-agencies have awarded funds in response to the COVID-19 pandemic, as well as a breakdown of their obligated and outlayed funds.
                 </p>
-                <ReadMore>
-                    <p>
-                        <em>Please note that agencies without COVID-19 appropriated funds are not represented here.</em>
-                    </p>
-                </ReadMore>
+                <p>
+                    <em>Please note that agencies without COVID-19 appropriated funds are not represented here.</em>
+                </p>
             </div>
             <div ref={moreOptionsTabsRef}>
                 <Tabs active={activeTab.internal} types={tabs} switchTab={changeActiveTab} />


### PR DESCRIPTION
**High level description:**

Address testing finds for DEV-7401:
- Update Award spending tooltip copy
- Remove 'Read More' in both sections

**JIRA Ticket:**
[DEV-7401](https://federal-spending-transparency.atlassian.net/browse/DEV-7401)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a] Design review complete `if applicable`
- [n/a] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
