### PR TITLE
Fix/dev 7474 fix mobile menu links

### DIFF
--- a/src/js/components/sharedComponents/header/mobile/MobileDropdownItem.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileDropdownItem.jsx
@@ -16,7 +16,7 @@ import DropdownComingSoon from '../DropdownComingSoon';
 const propTypes = {
     active: PropTypes.bool,
     comingSoon: PropTypes.bool,
-    url: PropTypes.string,
+    url: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({ pathname: PropTypes.string, search: PropTypes.string })]),
     search: PropTypes.string,
     title: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
     hideMobileNav: PropTypes.func,

--- a/src/js/dataMapping/navigation/menuOptions.jsx
+++ b/src/js/dataMapping/navigation/menuOptions.jsx
@@ -71,7 +71,8 @@ export const resourceOptions = [
         label: 'Data Model',
         enabled: true,
         url: 'https://fiscal.treasury.gov/data-transparency/DAIMS-current.html',
-        shouldOpenNewTab: true
+        shouldOpenNewTab: true,
+        externalLink: true
     },
     {
         label: "Agency Submission Statistics",
@@ -86,7 +87,8 @@ export const resourceOptions = [
         label: 'API Tutorial',
         url: 'https://api.usaspending.gov/docs/intro-tutorial',
         enabled: true,
-        shouldOpenNewTab: true
+        shouldOpenNewTab: true,
+        externalLink: true
     }
 ];
 

--- a/src/js/dataMapping/navigation/menuOptions.jsx
+++ b/src/js/dataMapping/navigation/menuOptions.jsx
@@ -135,7 +135,8 @@ export const downloadOptions = [
         callToAction: 'Download Raw Files',
         shouldOpenNewTab: true,
         enabled: true,
-        internalDomain: true
+        internalDomain: true,
+        externalLink: true
     },
     {
         label: 'Database Download',
@@ -146,7 +147,8 @@ export const downloadOptions = [
         callToAction: 'Explore Database Download',
         shouldOpenNewTab: true,
         enabled: true,
-        internalDomain: true
+        internalDomain: true,
+        externalLink: true
     },
     {
         label: 'Dataset Metadata',


### PR DESCRIPTION
NOTE: PR 2628 is the same, but merging to staging, if that's what warm fixes are doing now

**High level description:**

fixes external mobile menu links

**Technical details:**

DEV-6662 updated some of the menu logic, but didn't update the mobile menus. This should fix Download > Agency Submission Files and Database Download, and Resources > Data Model and API Tutorial

**JIRA Ticket:**
[DEV-7474](https://federal-spending-transparency.atlassian.net/browse/DEV-7474)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- n/a Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- n/a Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- n/a Verified mobile/tablet/desktop/monitor responsiveness
- n/a Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- n/a Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- n/a [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- n/a [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- n/a Design review complete `if applicable`
- n/a [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
