### PR TITLE
Dev-7525 Federal Account Page Award ID Click Bug

### DIFF
--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -85,7 +85,9 @@ export default class ResultsTable extends React.Component {
             cellClass = ResultsTableLinkCell;
             props.id = this.props.results[rowIndex].generated_internal_id;
             props.column = 'award';
-            props.onClick = () => this.props.awardIdClick(props.id);
+            if (this.props.awardIdClick) {
+                props.onClick = () => this.props.awardIdClick(props.id);
+            }
         }
         else if ((column.columnName === 'Sub-Award ID') && this.props.subaward) {
             const row = this.props.results[rowIndex];


### PR DESCRIPTION
**High level description:**

Federal Account Page award id click navigates users to the award page.

**Technical details:**

> • do not use onClick if not passed.

**JIRA Ticket:**
[DEV-7525](https://federal-spending-transparency.atlassian.net/browse/DEV-7525)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [N/A] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [N/A] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [N/A] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
