### PR TITLE
Dev-7482 Spending Explorer Award Tooltip Disclaimer

### DIFF
--- a/src/js/components/explorer/detail/visualization/ExplorerAwardTooltip.jsx
+++ b/src/js/components/explorer/detail/visualization/ExplorerAwardTooltip.jsx
@@ -87,7 +87,7 @@ export default class ExplorerTooltip extends React.Component {
         const percentString = `${(Math.round(this.props.percent * 1000) / 10)}%`;
 
         let hideDisclaimer = 'hide';
-        if (this.props.amount !== this.props.total) {
+        if ((this.props.amount !== this.props.total) && this.props.name !== 'Non-Award Spending') {
             hideDisclaimer = '';
         }
 


### PR DESCRIPTION
**High level description:**

Removes the disclaimer from the spending explorer award tooltip when the tooltip is for Non-Award Spending.

**Technical details:**

> • add condition to exclude disclaimer for Non-Award Spending award tooltips in the spending explorer.

**JIRA Ticket:**
[DEV-7482](https://federal-spending-transparency.atlassian.net/browse/DEV-7482)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [N/A] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [N/A] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [N/A] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
