### PR TITLE
Dev-6614 Agency V2 Burn-up Chart Edge Case Obligation Exceeds Agency Budget

### DIFF
--- a/src/_scss/pages/agencyV2/visualizations/_totalObligationsOverTime.scss
+++ b/src/_scss/pages/agencyV2/visualizations/_totalObligationsOverTime.scss
@@ -4,12 +4,8 @@
         .total-obligations-over-time-svg-body {
             .paths {
                 .path {
-                    stroke: $color-cool-blue;
                     stroke-width: 1;
                     fill: none;
-                }
-                .area-path {
-                    fill: $color-cool-blue-lightest;
                 }
             }
             .total-budget-line {

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/AgencyBudgetLine.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/AgencyBudgetLine.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 const propTypes = {
     data: PropTypes.array,
+    obligationExceedsBudget: PropTypes.bool,
     xScale: PropTypes.func,
     xDomain: PropTypes.array,
     yScale: PropTypes.func,
@@ -15,6 +16,7 @@ const propTypes = {
 
 const AgencyBudgetLine = ({
     data,
+    obligationExceedsBudget,
     xScale,
     xDomain,
     yScale,
@@ -81,12 +83,12 @@ const AgencyBudgetLine = ({
                 x2={lineData.x2}
                 y1={lineData.y1}
                 y2={lineData.y1} />
-            <rect
+            {!obligationExceedsBudget && <rect
                 className="total-budget-difference"
                 x={rectangleData.x}
                 y={rectangleData.y}
                 width={rectangleData.width}
-                height={rectangleData.height} />
+                height={rectangleData.height} />}
         </g>
     );
 };

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/TotalObligationsOverTimeVisualization.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/TotalObligationsOverTimeVisualization.jsx
@@ -14,6 +14,7 @@ import Paths from 'components/agencyV2/visualizations/totalObligationsOverTime/p
 import Axis from './axis/Axis';
 import TodayLineAndtext from './TodayLineAndtext';
 import AgencyBudgetLine from './AgencyBudgetLine';
+import PathAndAreaPathLinearGradients from './paths/PathAndAreaPathLinearGradients';
 
 const propTypes = {
     height: PropTypes.number,
@@ -51,6 +52,7 @@ const TotalObligationsOverTimeVisualization = ({
     const [xTicks, setXTicks] = useState([]);
     const [dataWithFirstAndLastCoordinate, setDataWithFirstAndLastCoordinate] = useState([]);
     const [description, setDescription] = useState('');
+    const [obligationExceedsBudget, setObligationExceedsBudget] = useState(false);
     // x domain
     useEffect(() => {
         // start of the domain is October 1st of the prior selected fiscal year midnight local time
@@ -116,6 +118,17 @@ const TotalObligationsOverTimeVisualization = ({
     }, [xScale, xDomain]);
 
     useEffect(() => {
+        if (data.length && agencyBudget) {
+            if (Math.max(...data.map((x) => x.obligated)) > agencyBudget) {
+                setObligationExceedsBudget(true);
+            }
+            else if (obligationExceedsBudget) {
+                setObligationExceedsBudget(false);
+            }
+        }
+    }, [data, agencyBudget]);
+
+    useEffect(() => {
         setDescription(dataWithFirstAndLastCoordinate.reduce((acc, val, i, array) => {
             let newDescription = acc;
             newDescription += `Period ${val?.period || 'unknown'} with end date ${format(val.endDate, 'MM/dd/yyyy')} and obligation $${formatNumber(val.obligated)}${i + 1 !== array.length ? ',' : ''}`;
@@ -128,6 +141,14 @@ const TotalObligationsOverTimeVisualization = ({
             className="total-obligations-over-time-svg"
             height={height}
             width={width}>
+            <defs>
+                <PathAndAreaPathLinearGradients
+                    yScale={yScale}
+                    height={height}
+                    agencyBudget={agencyBudget}
+                    data={dataWithFirstAndLastCoordinate}
+                    padding={padding} />
+            </defs>
             <g className="total-obligations-over-time-svg-body">
                 <Paths
                     data={dataWithFirstAndLastCoordinate}
@@ -152,6 +173,7 @@ const TotalObligationsOverTimeVisualization = ({
                     padding={padding} />
                 <AgencyBudgetLine
                     data={dataWithFirstAndLastCoordinate}
+                    obligationExceedsBudget={obligationExceedsBudget}
                     xScale={xScale}
                     xDomain={xDomain}
                     yScale={yScale}

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/AreaPath.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/AreaPath.jsx
@@ -63,7 +63,8 @@ const AreaPath = ({
             <desc>{`The area under the curve representative of the following periods, dates, and obligations: ${description}`}</desc>
             <path
                 className={`area-path ${classname}`}
-                d={d} />
+                d={d}
+                fill="url(#areaPathLinearGradient)" />
         </g>
     );
 };

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/Path.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/Path.jsx
@@ -50,7 +50,7 @@ const Path = ({
     return (
         <g tabIndex="0">
             <desc>{`The linear line representative of the following periods, dates, and obligations: ${description}`}</desc>
-            <path className="path" d={d} />
+            <path className="path" d={d} stroke="url(#pathLinearGradient)" />
         </g>
     );
 };

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/PathAndAreaPathLinearGradients.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/PathAndAreaPathLinearGradients.jsx
@@ -6,8 +6,7 @@ const propTypes = {
     yScale: PropTypes.func,
     height: PropTypes.number.isRequired,
     agencyBudget: PropTypes.number.isRequired,
-    data: PropTypes.array.isRequired,
-    padding: PropTypes.object.isRequired
+    data: PropTypes.array.isRequired
 };
 
 const PathAndAreaPathLinearGradients = ({

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/PathAndAreaPathLinearGradients.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/PathAndAreaPathLinearGradients.jsx
@@ -1,0 +1,59 @@
+
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+    yScale: PropTypes.func,
+    height: PropTypes.number.isRequired,
+    agencyBudget: PropTypes.number.isRequired,
+    data: PropTypes.array.isRequired,
+    padding: PropTypes.object.isRequired
+};
+
+const PathAndAreaPathLinearGradients = ({
+    yScale,
+    height,
+    agencyBudget,
+    data
+}) => {
+    const [agencyBudgetStoppingPoint, setAgencyBudgetStoppingPoint] = useState(0);
+
+    useEffect(() => {
+        if (yScale && height && agencyBudget && data.length) {
+            const maxObligation = Math.max(...data.map((x) => x.obligated));
+            const difference = maxObligation - agencyBudget;
+            // the stopping point between gradient colors equates to the percent difference between max obligation and agency budget
+            const percentDifference = `${((difference / maxObligation) * 100)}%`;
+            if (difference >= 0) {
+                setAgencyBudgetStoppingPoint(percentDifference);
+            }
+            else {
+                setAgencyBudgetStoppingPoint('0%');
+            }
+        }
+    }, [yScale, height, agencyBudget]);
+
+    return (
+        <g>
+            <linearGradient id="pathLinearGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+                {/* $color-secondary */}
+                <stop offset="0%" stopColor="#e31c3d" stopOpacity="1" />
+                <stop offset={agencyBudgetStoppingPoint} stopColor="#e31c3d" stopOpacity="1" />
+                {/* $color-cool-blue; */}
+                <stop offset={agencyBudgetStoppingPoint} stopColor="#205493" stopOpacity="1" />
+                <stop offset="100%" stopColor="#205493" stopOpacity="1" />
+            </linearGradient>
+            <linearGradient id="areaPathLinearGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+                {/* $color-secondary-lightest */}
+                <stop offset="0%" stopColor="#f9dede" stopOpacity="1" />
+                <stop offset={agencyBudgetStoppingPoint} stopColor="#f9dede" stopOpacity="1" />
+                {/* $color-cool-blue-lightest; */}
+                <stop offset={agencyBudgetStoppingPoint} stopColor="#dce4ef" stopOpacity="1" />
+                <stop offset="100%" stopColor="#dce4ef" stopOpacity="1" />
+            </linearGradient>
+        </g>
+    );
+};
+
+PathAndAreaPathLinearGradients.propTypes = propTypes;
+export default PathAndAreaPathLinearGradients;

--- a/tests/components/agency/overview/TotalObligationsOverTimeVisualization-test.jsx
+++ b/tests/components/agency/overview/TotalObligationsOverTimeVisualization-test.jsx
@@ -3,73 +3,30 @@ import React from 'react';
 import { render, screen } from 'test-utils';
 import TotalObligationsOverTimeVisualization from 'components/agencyV2/visualizations/totalObligationsOverTime/TotalObligationsOverTimeVisualization';
 import { defaultPadding } from 'dataMapping/agencyV2/visualizations/totalObligationsOverTime';
+import { mock2020Data, mock2021Data } from './mockData';
 
-const mock2020Data = [
-    {
-        endDate: 1577768400000,
-        obligated: 227170135560.3,
-        period: 3
-    },
-    {
-        endDate: 1585627200000,
-        obligated: 580584099932.03,
-        period: 6
-    },
-    {
-        endDate: 1588219200000,
-        obligated: 1040324359196.91,
-        period: 7
-    }
-];
+describe('Today Line', () => {
+    it('should show today line', () => {
+        render(<TotalObligationsOverTimeVisualization
+            height={17}
+            width={400}
+            padding={defaultPadding}
+            agencyBudget={3471478083842.64}
+            data={mock2021Data}
+            fy="2021"
+            todaysDate={1622126989275} />);
+        expect(screen.getByText('Today')).toBeTruthy();
+    });
 
-const mock2021Data = [
-    {
-        endDate: 1606712400000,
-        obligated: 121466500151.75,
-        period: 2
-    },
-    {
-        endDate: 1609390800000,
-        obligated: 225939783327.81,
-        period: 3
-    },
-    {
-        endDate: 1612069200000,
-        obligated: 441947534122.58,
-        period: 4
-    },
-    {
-        endDate: 1614488400000,
-        obligated: 549265048938.4,
-        period: 5
-    },
-    {
-        endDate: 1617163200000,
-        obligated: 1045875996396.89,
-        period: 6
-    }
-];
-
-test('should show today line', () => {
-    render(<TotalObligationsOverTimeVisualization
-        height={17}
-        width={400}
-        padding={defaultPadding}
-        agencyBudget={3471478083842.64}
-        data={mock2021Data}
-        fy="2021"
-        todaysDate={1622126989275} />);
-    expect(screen.getByText('Today')).toBeTruthy();
-});
-
-test('should not show today line when todays date does not fall in the x domain', () => {
-    render(<TotalObligationsOverTimeVisualization
-        height={17}
-        width={400}
-        padding={defaultPadding}
-        agencyBudget={3471478083842.64}
-        data={mock2020Data}
-        fy="2020"
-        todaysDate={1622126989275} />);
-    expect(screen.queryByText('Today')).toBeFalsy();
+    it('should not show today line when todays date does not fall in the x domain', () => {
+        render(<TotalObligationsOverTimeVisualization
+            height={17}
+            width={400}
+            padding={defaultPadding}
+            agencyBudget={3471478083842.64}
+            data={mock2020Data}
+            fy="2020"
+            todaysDate={1622126989275} />);
+        expect(screen.queryByText('Today')).toBeFalsy();
+    });
 });

--- a/tests/components/agency/overview/mockData.js
+++ b/tests/components/agency/overview/mockData.js
@@ -60,3 +60,49 @@ export const mockTotalBudgetaryResources = [
         total_budgetary_resources: 7157959573120.1
     }
 ];
+
+export const mock2020Data = [
+    {
+        endDate: 1577768400000,
+        obligated: 227170135560.3,
+        period: 3
+    },
+    {
+        endDate: 1585627200000,
+        obligated: 580584099932.03,
+        period: 6
+    },
+    {
+        endDate: 1588219200000,
+        obligated: 1040324359196.91,
+        period: 7
+    }
+];
+
+export const mock2021Data = [
+    {
+        endDate: 1606712400000,
+        obligated: 121466500151.75,
+        period: 2
+    },
+    {
+        endDate: 1609390800000,
+        obligated: 225939783327.81,
+        period: 3
+    },
+    {
+        endDate: 1612069200000,
+        obligated: 441947534122.58,
+        period: 4
+    },
+    {
+        endDate: 1614488400000,
+        obligated: 549265048938.4,
+        period: 5
+    },
+    {
+        endDate: 1617163200000,
+        obligated: 1045875996396.89,
+        period: 6
+    }
+];


### PR DESCRIPTION
**High level description:**

When obligations exceed the agency budget, the line and area shading will be red.

**Technical details:**

> • add gradients for the path and area path.
> • hide difference rectangle when obligations exceed the agency budget.

**JIRA Ticket:**
[DEV-6614](https://federal-spending-transparency.atlassian.net/browse/DEV-6614)

**Mockup:**
https://bahdigital.invisionapp.com/share/M8IAH1EZUH5#/screens/296060805

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (37 vs 37 between local and qat) 
- [N/A] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
