### PR TITLE
Mod-Dev 7540 BurnUp Chart Min & Max Exceeds Extremes

### DIFF
--- a/src/_scss/pages/agencyV2/visualizations/_totalObligationsOverTime.scss
+++ b/src/_scss/pages/agencyV2/visualizations/_totalObligationsOverTime.scss
@@ -8,6 +8,16 @@
                     fill: none;
                 }
             }
+            .zero-line {
+                stroke: $color-gray;
+                stroke-width: 1;
+                stroke-dasharray: 4;
+            }
+            .zero-tick {
+              color: $color-gray;
+              font-size: rem(12);
+              line-height: rem(12);
+            }
             .total-budget-line {
                 stroke: $color-secondary;
                 stroke-width: 1;

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/AgencyBudgetLine.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/AgencyBudgetLine.jsx
@@ -3,30 +3,29 @@ import PropTypes from 'prop-types';
 
 const propTypes = {
     data: PropTypes.array,
-    obligationExceedsBudget: PropTypes.bool,
     xScale: PropTypes.func,
-    xDomain: PropTypes.array,
     yScale: PropTypes.func,
     height: PropTypes.number,
     width: PropTypes.number,
     agencyBudget: PropTypes.number,
     todaysDate: PropTypes.number,
-    padding: PropTypes.object
+    padding: PropTypes.object,
+    scenario: PropTypes.string,
+    showTodayLineAndText: PropTypes.bool
 };
 
 const AgencyBudgetLine = ({
     data,
-    obligationExceedsBudget,
     xScale,
-    xDomain,
     yScale,
     height,
     agencyBudget,
     todaysDate,
     padding,
-    width
+    width,
+    scenario,
+    showTodayLineAndText
 }) => {
-    const [show, setShow] = useState(false);
     const [lineData, setLineData] = useState({
         x1: 0,
         x2: 0,
@@ -40,39 +39,30 @@ const AgencyBudgetLine = ({
     });
 
     useEffect(() => {
-        if ((todaysDate >= xDomain[0]) && (todaysDate <= xDomain[1])) {
-            setShow(true);
-        }
-        else {
-            setShow(false);
-        }
-    }, [xScale, xDomain, todaysDate]);
-
-    useEffect(() => {
         if (xScale && yScale && agencyBudget) {
-            const y = height - yScale(agencyBudget) - padding.top;
+            const y = height - yScale(agencyBudget) - padding.bottom;
             setLineData(
                 {
                     x1: padding.left,
-                    x2: show ? xScale(todaysDate) + padding.left : width - padding.left,
+                    x2: showTodayLineAndText ? xScale(todaysDate) + padding.left : width - padding.left,
                     y1: isNaN(y) ? 0 : y
                 }
             );
         }
-    }, [xScale, yScale, show]);
+    }, [xScale, yScale, showTodayLineAndText]);
 
     useEffect(() => {
         if (xScale && yScale && data.length) {
             setRectangleData(
                 {
                     x: padding.left,
-                    y: height - yScale(agencyBudget) - padding.top,
-                    width: show ? xScale(todaysDate) : width - padding.left - padding.right,
-                    height: height - yScale(data[data.length - 1].obligated) - padding.bottom - padding.top
+                    y: height - yScale(agencyBudget) - padding.bottom,
+                    width: showTodayLineAndText ? xScale(todaysDate) : width - padding.left - padding.right,
+                    height: height - yScale(Math.max(...data.map((x) => x.obligated))) - padding.bottom - padding.top
                 }
             );
         }
-    }, [xScale, yScale, show]);
+    }, [xScale, yScale, showTodayLineAndText]);
 
     return (
         <g>
@@ -83,7 +73,7 @@ const AgencyBudgetLine = ({
                 x2={lineData.x2}
                 y1={lineData.y1}
                 y2={lineData.y1} />
-            {!obligationExceedsBudget && <rect
+            {!(scenario === 'exceedsMax' || scenario === 'exceedsMaxAndMin') && <rect
                 className="total-budget-difference"
                 x={rectangleData.x}
                 y={rectangleData.y}

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/TodayLineAndtext.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/TodayLineAndtext.jsx
@@ -8,48 +8,38 @@ import PropTypes from 'prop-types';
 
 const propTypes = {
     xScale: PropTypes.func,
-    xDomain: PropTypes.array,
     height: PropTypes.number,
     todaysDate: PropTypes.number,
-    padding: PropTypes.object
+    padding: PropTypes.object,
+    showTodayLineAndText: PropTypes.bool
 };
 
 const TodayLineAndtext = ({
     xScale,
-    xDomain,
     height,
     todaysDate,
-    padding
+    padding,
+    showTodayLineAndText
 }) => {
     const [lineXValue, setLineXValue] = useState(0);
-    const [show, setShow] = useState(false);
 
     useEffect(() => {
-        if ((todaysDate >= xDomain[0]) && (todaysDate <= xDomain[1])) {
-            setShow(true);
-        }
-        else {
-            setShow(false);
-        }
-    }, [xScale, xDomain, todaysDate]);
-
-    useEffect(() => {
-        if (xScale && show) {
+        if (xScale && showTodayLineAndText) {
             setLineXValue(xScale(todaysDate) + padding.left);
         }
-    }, [xScale, show]);
+    }, [xScale, showTodayLineAndText]);
 
     return (
         <g>
-            {show && <desc>A line representing todays date</desc>}
-            {show && <line
+            <desc>A line representing todays date</desc>
+            <line
                 tabIndex="0"
                 className="today-line"
                 x1={lineXValue}
                 x2={lineXValue}
                 y1={0}
-                y2={height - padding.bottom} />}
-            {show && <text tabIndex="0" className="today-text" x={lineXValue - 35} y={10}>Today</text>}
+                y2={height - padding.bottom} />
+            <text tabIndex="0" className="today-text" x={lineXValue - 35} y={10}>Today</text>
         </g>
     );
 };

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/ZeroLineAndTick.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/ZeroLineAndTick.jsx
@@ -1,0 +1,61 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+    yScale: PropTypes.func,
+    xScale: PropTypes.func,
+    height: PropTypes.number,
+    padding: PropTypes.object,
+    width: PropTypes.number,
+    showTodayLineAndText: PropTypes.bool,
+    todaysDate: PropTypes.number
+};
+
+const ZeroLineAndTick = ({
+    yScale,
+    xScale,
+    height,
+    padding,
+    width,
+    showTodayLineAndText,
+    todaysDate
+}) => {
+    const [lineData, setLineData] = useState({ x1: 0, x2: 0, y: 0 });
+    const [textData, setTextData] = useState({ x: 0, y: 0 });
+
+    useEffect(() => {
+        if (xScale && yScale) {
+            const y = height - yScale(0) - padding.bottom;
+            const x2 = showTodayLineAndText ? padding.left + xScale(todaysDate) : width - padding.right;
+            setLineData({ x1: padding.left, x2, y });
+            /**
+             * text position
+            /* x removes 12 due to the width of the text and removes 3 for spacing
+            /* y adds 4 for height of the text
+            */
+            setTextData({ x: padding.left - 12 - 3, y: y + 4 });
+        }
+    }, [xScale, yScale, height, padding, width, showTodayLineAndText]);
+
+    return (
+        <g>
+            <text
+                tabIndex="0"
+                className="zero-tick"
+                x={textData.x}
+                y={textData.y}>
+                $0
+            </text>
+            <line
+                tabIndex="0"
+                className="zero-line"
+                x1={lineData.x1}
+                x2={lineData.x2}
+                y1={lineData.y}
+                y2={lineData.y} />
+        </g>
+    );
+};
+
+ZeroLineAndTick.propTypes = propTypes;
+export default ZeroLineAndTick;

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/AreaPath.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/AreaPath.jsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { determineScenario, pathDefinition } from 'helpers/agencyV2/visualizations/TotalObligationsOverTimeVisualizationHelper';
+import { pathDefinition } from 'helpers/agencyV2/visualizations/TotalObligationsOverTimeVisualizationHelper';
 import PropTypes from 'prop-types';
 
 const propTypes = {

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/AreaPath.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/AreaPath.jsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import { determineScenario, pathDefinition } from 'helpers/agencyV2/visualizations/TotalObligationsOverTimeVisualizationHelper';
 import PropTypes from 'prop-types';
 
 const propTypes = {
@@ -21,7 +22,8 @@ const propTypes = {
         right: PropTypes.number,
         bottom: PropTypes.number,
         top: PropTypes.number
-    })
+    }),
+    scenario: PropTypes.string
 };
 
 const AreaPath = ({
@@ -38,26 +40,25 @@ const AreaPath = ({
         bottom: 0,
         right: 0,
         left: 0
-    }
+    },
+    scenario
 }) => {
     const [d, setD] = useState('');
     useEffect(() => {
         if (xScale && yScale) {
-            setD(data.reduce((path, currentItem, i, originalArray) => {
-                if (i === 0) {
-                    const updatedPath = `${path}${xScale(currentItem[xProperty]) + padding.left},${height - yScale(currentItem[yProperty]) - padding.bottom}`;
-                    return updatedPath;
-                }
-                if (originalArray.length === i + 1) {
-                    const updatedPath = `${path}L${xScale(currentItem[xProperty]) + padding.left},${height - yScale(currentItem[yProperty]) - padding.bottom}L${xScale(currentItem[xProperty]) + padding.left},${height - padding.bottom}Z`;
-                    return updatedPath;
-                }
-                const updatedPath = `${path}L${xScale(currentItem[xProperty]) + padding.left},${height - yScale(currentItem[yProperty]) - padding.bottom}`;
-                return updatedPath;
-            }, 'M'));
+            setD(pathDefinition(
+                data,
+                xScale,
+                xProperty,
+                padding,
+                yScale,
+                yProperty,
+                height,
+                (scenario === 'exceedsMin' || scenario === 'exceedsMaxAndMin') ? 0 : null,
+                true
+            ));
         }
-    }, [data, xScale, yScale]);
-
+    }, [data, xScale, yScale, scenario]);
     return (
         <g tabIndex="0">
             <desc>{`The area under the curve representative of the following periods, dates, and obligations: ${description}`}</desc>

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/Path.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/Path.jsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import { pathDefinition } from 'helpers/agencyV2/visualizations/TotalObligationsOverTimeVisualizationHelper';
 import PropTypes from 'prop-types';
 
 const propTypes = {
@@ -36,17 +37,9 @@ const Path = ({
 
     useEffect(() => {
         if (xScale && yScale) {
-            setD(data.reduce((path, currentItem, i) => {
-                if (i === 0) {
-                    const updatedPath = `${path}${xScale(currentItem[xProperty]) + padding.left},${height - yScale(currentItem[yProperty]) - padding.bottom}`;
-                    return updatedPath;
-                }
-                const updatedPath = `${path}L${xScale(currentItem[xProperty]) + padding.left},${height - yScale(currentItem[yProperty]) - padding.bottom}`;
-                return updatedPath;
-            }, 'M'));
+            setD(pathDefinition(data, xScale, xProperty, padding, yScale, yProperty, height, null, false));
         }
     }, [data, xScale, yScale]);
-
     return (
         <g tabIndex="0">
             <desc>{`The linear line representative of the following periods, dates, and obligations: ${description}`}</desc>

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/PathAndAreaPathLinearGradients.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/PathAndAreaPathLinearGradients.jsx
@@ -1,9 +1,7 @@
 
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import {
-    stoppingPoints
-} from 'helpers/agencyV2/visualizations/TotalObligationsOverTimeVisualizationHelper';
+import { stoppingPoints } from 'helpers/agencyV2/visualizations/TotalObligationsOverTimeVisualizationHelper';
 import {
     pathStopColorRed,
     pathStopColorBlue,

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/PathAndAreaPathLinearGradients.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/PathAndAreaPathLinearGradients.jsx
@@ -1,54 +1,57 @@
 
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import {
+    stoppingPoints
+} from 'helpers/agencyV2/visualizations/TotalObligationsOverTimeVisualizationHelper';
+import {
+    pathStopColorRed,
+    pathStopColorBlue,
+    areaPathStopColorRed,
+    areaPathStopColorBlue,
+    normalStoppingPoints
+} from 'dataMapping/agencyV2/visualizations/totalObligationsOverTime';
 
 const propTypes = {
-    yScale: PropTypes.func,
-    height: PropTypes.number.isRequired,
     agencyBudget: PropTypes.number.isRequired,
-    data: PropTypes.array.isRequired
+    data: PropTypes.array.isRequired,
+    width: PropTypes.number
 };
 
 const PathAndAreaPathLinearGradients = ({
-    yScale,
-    height,
     agencyBudget,
-    data
+    data,
+    width
 }) => {
-    const [agencyBudgetStoppingPoint, setAgencyBudgetStoppingPoint] = useState(0);
+    const [gradientStops, setGradientStops] = useState(normalStoppingPoints);
 
-    useEffect(() => {
-        if (yScale && height && agencyBudget && data.length) {
-            const maxObligation = Math.max(...data.map((x) => x.obligated));
-            const difference = maxObligation - agencyBudget;
-            // the stopping point between gradient colors equates to the percent difference between max obligation and agency budget
-            const percentDifference = `${((difference / maxObligation) * 100)}%`;
-            if (difference >= 0) {
-                setAgencyBudgetStoppingPoint(percentDifference);
-            }
-            else {
-                setAgencyBudgetStoppingPoint('0%');
-            }
-        }
-    }, [yScale, height, agencyBudget]);
+    useEffect(() => setGradientStops(stoppingPoints(agencyBudget, data)), [agencyBudget, data, width]);
 
     return (
         <g>
+            {/* path linear gradient */}
             <linearGradient id="pathLinearGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                {/* $color-secondary */}
-                <stop offset="0%" stopColor="#e31c3d" stopOpacity="1" />
-                <stop offset={agencyBudgetStoppingPoint} stopColor="#e31c3d" stopOpacity="1" />
-                {/* $color-cool-blue; */}
-                <stop offset={agencyBudgetStoppingPoint} stopColor="#205493" stopOpacity="1" />
-                <stop offset="100%" stopColor="#205493" stopOpacity="1" />
+                {
+                    gradientStops.map((stop, i) => (
+                        <stop
+                            key={`${stop.offset}-${i}`}
+                            offset={stop.offset}
+                            stopColor={stop.stopColor === 'blue' ? pathStopColorBlue : pathStopColorRed}
+                            stopOpacity="1" />
+                    ))
+                }
             </linearGradient>
+            {/* area path linear gradient */}
             <linearGradient id="areaPathLinearGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                {/* $color-secondary-lightest */}
-                <stop offset="0%" stopColor="#f9dede" stopOpacity="1" />
-                <stop offset={agencyBudgetStoppingPoint} stopColor="#f9dede" stopOpacity="1" />
-                {/* $color-cool-blue-lightest; */}
-                <stop offset={agencyBudgetStoppingPoint} stopColor="#dce4ef" stopOpacity="1" />
-                <stop offset="100%" stopColor="#dce4ef" stopOpacity="1" />
+                {
+                    gradientStops.map((stop, i) => (
+                        <stop
+                            key={`${stop.offset}-${i}`}
+                            offset={stop.offset}
+                            stopColor={stop.stopColor === 'blue' ? areaPathStopColorBlue : areaPathStopColorRed}
+                            stopOpacity="1" />
+                    ))
+                }
             </linearGradient>
         </g>
     );

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/Paths.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/paths/Paths.jsx
@@ -24,7 +24,8 @@ const propTypes = {
         right: PropTypes.number,
         bottom: PropTypes.number,
         top: PropTypes.number
-    })
+    }),
+    scenario: PropTypes.string
 };
 
 const Paths = ({
@@ -36,7 +37,8 @@ const Paths = ({
     yScaleForPath = () => {},
     height,
     width,
-    padding
+    padding,
+    scenario
 }) => (
     <g className="paths">
         <AreaPath
@@ -46,7 +48,8 @@ const Paths = ({
             yScale={yScale}
             height={height}
             width={width}
-            padding={padding} />
+            padding={padding}
+            scenario={scenario} />
         <Path
             data={data.sort((a, b) => a.endDate - b.endDate)}
             description={description}

--- a/src/js/containers/agencyV2/visualizations/TotalObligationsOverTimeContainer.jsx
+++ b/src/js/containers/agencyV2/visualizations/TotalObligationsOverTimeContainer.jsx
@@ -24,6 +24,20 @@ const propTypes = {
     isError: PropTypes.bool
 };
 
+const mockExceedingAmounts = (data, agencyBudget) => data.map((d, i) => {
+    const newData = d;
+    if (i === 1) {
+        newData.obligated -= agencyBudget;
+    }
+    if (i === 3) {
+        newData.obligated += agencyBudget;
+    }
+    // if (i + 1 === data.length) {
+    //     newData.obligated += agencyBudget;
+    // }
+    return newData;
+});
+
 const TotalObligationsOverTimeContainer = ({
     agencyBudget,
     obligationsByPeriod,
@@ -42,7 +56,8 @@ const TotalObligationsOverTimeContainer = ({
         setLoading(true);
         const javaScriptSubmissionPeriods = submissionPeriods.toJS();
         if (javaScriptSubmissionPeriods.length && obligationsByPeriod.length && !isLoading && !isError) {
-            setData(addSubmissionEndDatesToBudgetaryResources(obligationsByPeriod, javaScriptSubmissionPeriods, fy).sort((a, b) => a.period - b.period));
+            // setData(addSubmissionEndDatesToBudgetaryResources(obligationsByPeriod, javaScriptSubmissionPeriods, fy).sort((a, b) => a.period - b.period));
+            setData(mockExceedingAmounts(addSubmissionEndDatesToBudgetaryResources(obligationsByPeriod, javaScriptSubmissionPeriods, fy).sort((a, b) => a.period - b.period), agencyBudget));
             setLoading(false);
         }
     }, [submissionPeriods, obligationsByPeriod, isLoading, isError, fy]);

--- a/src/js/containers/agencyV2/visualizations/TotalObligationsOverTimeContainer.jsx
+++ b/src/js/containers/agencyV2/visualizations/TotalObligationsOverTimeContainer.jsx
@@ -24,20 +24,6 @@ const propTypes = {
     isError: PropTypes.bool
 };
 
-const mockExceedingAmounts = (data, agencyBudget) => data.map((d, i) => {
-    const newData = d;
-    if (i === 1) {
-        newData.obligated -= agencyBudget;
-    }
-    if (i === 3) {
-        newData.obligated += agencyBudget;
-    }
-    // if (i + 1 === data.length) {
-    //     newData.obligated += agencyBudget;
-    // }
-    return newData;
-});
-
 const TotalObligationsOverTimeContainer = ({
     agencyBudget,
     obligationsByPeriod,
@@ -56,8 +42,7 @@ const TotalObligationsOverTimeContainer = ({
         setLoading(true);
         const javaScriptSubmissionPeriods = submissionPeriods.toJS();
         if (javaScriptSubmissionPeriods.length && obligationsByPeriod.length && !isLoading && !isError) {
-            // setData(addSubmissionEndDatesToBudgetaryResources(obligationsByPeriod, javaScriptSubmissionPeriods, fy).sort((a, b) => a.period - b.period));
-            setData(mockExceedingAmounts(addSubmissionEndDatesToBudgetaryResources(obligationsByPeriod, javaScriptSubmissionPeriods, fy).sort((a, b) => a.period - b.period), agencyBudget));
+            setData(addSubmissionEndDatesToBudgetaryResources(obligationsByPeriod, javaScriptSubmissionPeriods, fy).sort((a, b) => a.period - b.period));
             setLoading(false);
         }
     }, [submissionPeriods, obligationsByPeriod, isLoading, isError, fy]);

--- a/src/js/dataMapping/agencyV2/visualizations/totalObligationsOverTime.js
+++ b/src/js/dataMapping/agencyV2/visualizations/totalObligationsOverTime.js
@@ -13,9 +13,25 @@ export const xLabelHeightPlusPadding = xLabelHeight + xLabelSpacing;
 
 export const yOffsetForPathStrokeWidth = (pathStrokeWidth + 1) / 2;
 
+export const defaultHeight = 179;
+
 export const defaultPadding = {
     top: 24,
     bottom: 24,
     right: 30,
     left: 30
 };
+
+// $color-secondary
+export const pathStopColorRed = '#e31c3d';
+// $color-cool-blue
+export const pathStopColorBlue = '#205493';
+// $color-secondary-lightest
+export const areaPathStopColorRed = '#f9dede';
+// $color-cool-blue-lightest
+export const areaPathStopColorBlue = '#dce4ef';
+
+export const normalStoppingPoints = [
+    { offset: '0%', stopColor: 'blue' },
+    { offset: '100%', stopColor: 'blue' }
+];

--- a/src/js/helpers/agencyV2/visualizations/TotalObligationsOverTimeVisualizationHelper.js
+++ b/src/js/helpers/agencyV2/visualizations/TotalObligationsOverTimeVisualizationHelper.js
@@ -132,6 +132,11 @@ export const pathDefinition = (data, xScale, xProperty, padding, yScale, yProper
         const updatedPath = `M${xScale(currentItem[xProperty]) + padding.left},${height - yScale(currentItem[yProperty]) - padding.bottom}`;
         return updatedPath;
     }
+    /**
+     * When adding an area path we must close at a certain height.
+     * With a normal area path that is usually the height of the graph.
+     * When using a negative scenario we want to close the graph at 0.
+     */
     if ((originalArray.length === i + 1) && areaPath) {
         const updatedPath = `${path}L${xScale(currentItem[xProperty]) + padding.left},${height - yScale(currentItem[yProperty]) - padding.bottom}L${xScale(currentItem[xProperty]) + padding.left},${(close === null) ? (height - padding.bottom) : (height - yScale(close) - padding.bottom)}Z`;
         return updatedPath;

--- a/src/js/helpers/agencyV2/visualizations/TotalObligationsOverTimeVisualizationHelper.js
+++ b/src/js/helpers/agencyV2/visualizations/TotalObligationsOverTimeVisualizationHelper.js
@@ -3,10 +3,12 @@
  * Created by Jonathan Hill 04/09/2021
  */
 
+import { normalStoppingPoints } from 'dataMapping/agencyV2/visualizations/totalObligationsOverTime';
+
 export const getYDomain = (data, agencyBudget) => {
     const obligatedAmounts = data.map((x) => x.obligated);
     if (agencyBudget) obligatedAmounts.push(agencyBudget);
-    return [0, Math.max(...obligatedAmounts)];
+    return [Math.min(...obligatedAmounts), Math.max(...obligatedAmounts)];
 };
 
 export const getMilliseconds = (date) => date.getTime();
@@ -34,3 +36,107 @@ export const addSubmissionEndDatesToBudgetaryResources = (budgetaryResources, su
         })
         .filter((budgetaryResource) => budgetaryResource);
 };
+
+export const exceedsMaxPercentDifference = (agencyBudget, data, maxAndMin) => {
+    const maxObligation = Math.max(...data.map((x) => x.obligated));
+    if (maxAndMin) {
+        const minObligation = Math.min(...data.map((x) => x.obligated));
+        const diff = maxObligation - agencyBudget;
+        const total = maxObligation + Math.abs(minObligation);
+        /**
+         * Exceeds max and min only
+         * the percent difference between the agency budget and the max obligation
+         * with the total being the sum of the max and min obligations.
+         */
+        return `${((diff / total) * 100)}%`;
+    }
+    const difference = maxObligation - agencyBudget;
+    /**
+     * Exceeds max only
+     * the percent difference between the agency budget and max obligation.
+     */
+    return `${((difference / maxObligation) * 100)}%`;
+};
+
+export const exceedsMinPercentDifference = (agencyBudget, data) => {
+    const minObligation = Math.abs(Math.min(...data.map((x) => x.obligated)));
+    const totalAmountOfMoney = minObligation + Math.max(...data.map((x) => x.obligated));
+    const difference = totalAmountOfMoney - minObligation;
+    /**
+     * the stopping point between gradient colors equates to the percent difference between
+     * the absolute total (from min - max) and agency budget
+     */
+    return `${((difference / totalAmountOfMoney) * 100)}%`;
+};
+
+export const exceedsMaxAndMinStoppingPoints = (agencyBudget, data) => {
+    const maxPercentDifference = exceedsMaxPercentDifference(agencyBudget, data, true);
+    const minPercentDifference = exceedsMinPercentDifference(agencyBudget, data);
+    return [
+        // start red for exceeding max
+        { offset: '0%', stopColor: 'red' },
+        { offset: maxPercentDifference, stopColor: 'red' },
+        // go to blue for normal
+        { offset: maxPercentDifference, stopColor: 'blue' },
+        { offset: minPercentDifference, stopColor: 'blue' },
+        // go back to red for exceeding min
+        { offset: minPercentDifference, stopColor: 'red' },
+        { offset: '100%', stopColor: 'red' }
+    ];
+};
+
+export const exceedsMaxStoppingPoints = (agencyBudget, data) => {
+    const percentDifference = exceedsMaxPercentDifference(agencyBudget, data);
+    return [
+        { offset: '0%', stopColor: 'red' },
+        { offset: percentDifference, stopColor: 'red' },
+        { offset: percentDifference, stopColor: 'blue' },
+        { offset: '100%', stopColor: 'blue' }
+    ];
+};
+
+export const exceedsMinStoppingPoints = (agencyBudget, data) => {
+    const percentDifference = exceedsMinPercentDifference(agencyBudget, data);
+    return [
+        { offset: '0%', stopColor: 'blue' },
+        { offset: percentDifference, stopColor: 'blue' },
+        { offset: percentDifference, stopColor: 'red' },
+        { offset: '100%', stopColor: 'red' }
+    ];
+};
+
+export const stoppingPointsByScenario = (scenario, agencyBudget, data) => {
+    if (scenario === 'exceedsMaxAndMin') return exceedsMaxAndMinStoppingPoints(agencyBudget, data);
+    if (scenario === 'exceedsMax') return exceedsMaxStoppingPoints(agencyBudget, data);
+    if (scenario === 'exceedsMin') return exceedsMinStoppingPoints(agencyBudget, data);
+    return normalStoppingPoints;
+};
+
+export const determineScenario = (agencyBudget, data) => {
+    if (agencyBudget && data.length) {
+        const obligations = data.map((x) => x.obligated);
+        const exceedsMax = Math.max(...obligations) > agencyBudget;
+        const exceedsMin = Math.min(...obligations) < 0;
+        if (exceedsMax && exceedsMin) return 'exceedsMaxAndMin';
+        if (exceedsMax) return 'exceedsMax';
+        if (exceedsMin) return 'exceedsMin';
+        return 'normal';
+    }
+    return 'normal';
+};
+
+export const stoppingPoints = (agencyBudget, data) => stoppingPointsByScenario(determineScenario(agencyBudget, data), agencyBudget, data);
+
+export const pathDefinition = (data, xScale, xProperty, padding, yScale, yProperty, height, close, areaPath) => data.reduce((path, currentItem, i, originalArray) => {
+    if (i === 0) {
+        const updatedPath = `M${xScale(currentItem[xProperty]) + padding.left},${height - yScale(currentItem[yProperty]) - padding.bottom}`;
+        return updatedPath;
+    }
+    if ((originalArray.length === i + 1) && areaPath) {
+        const updatedPath = `${path}L${xScale(currentItem[xProperty]) + padding.left},${height - yScale(currentItem[yProperty]) - padding.bottom}L${xScale(currentItem[xProperty]) + padding.left},${(close === null) ? (height - padding.bottom) : (height - yScale(close) - padding.bottom)}Z`;
+        return updatedPath;
+    }
+
+    const updatedPath = `${path}L${xScale(currentItem[xProperty]) + padding.left},${height - yScale(currentItem[yProperty]) - padding.bottom}`;
+    return updatedPath;
+}, '');

--- a/tests/helpers/agencyV2/visualizations/TotalObligationsOverTimeVisualizationHelper-test.js
+++ b/tests/helpers/agencyV2/visualizations/TotalObligationsOverTimeVisualizationHelper-test.js
@@ -1,4 +1,13 @@
-import { addSubmissionEndDatesToBudgetaryResources } from 'helpers/agencyV2/visualizations/TotalObligationsOverTimeVisualizationHelper';
+import {
+    addSubmissionEndDatesToBudgetaryResources,
+    determineScenario,
+    exceedsMinStoppingPoints,
+    exceedsMaxStoppingPoints,
+    exceedsMaxAndMinStoppingPoints,
+    exceedsMaxPercentDifference,
+    exceedsMinPercentDifference,
+    pathDefinition
+} from 'helpers/agencyV2/visualizations/TotalObligationsOverTimeVisualizationHelper';
 import { mockSubmissions } from '../../../mockData/helpers/aboutTheDataHelper';
 
 const mockBudgetaryResources = [
@@ -20,6 +29,12 @@ const mockBudgetaryResources = [
     }
 ];
 
+const agencyBudget = 10;
+const maxAndMinStoppingPoints = [{ obligated: 50 }, { obligated: -10 }, { obligated: 1 }];
+const maxStoppingPoints = [{ obligated: 50 }, { obligated: 20 }, { obligated: 1 }];
+const minStoppingPoints = [{ obligated: 9 }, { obligated: -10 }, { obligated: 1 }];
+const normalStoppingPoints = [{ obligated: 5 }, { obligated: 6 }];
+
 describe('Total Obligations Over Time Visualization Helper', () => {
     it('should return an object with endDate, period, and obligated properties', () => {
         const data = addSubmissionEndDatesToBudgetaryResources(mockBudgetaryResources, mockSubmissions, '2020');
@@ -29,5 +44,81 @@ describe('Total Obligations Over Time Visualization Helper', () => {
         expect(data[1]).toHaveProperty('period', 6);
         expect(typeof data[1].obligated === 'number').toBeTruthy();
         expect(typeof data[1].endDate === 'number').toBeTruthy();
+    });
+});
+
+describe('DetermineScenario', () => {
+    it.each([
+        ['exceedsMaxAndMin', agencyBudget, maxAndMinStoppingPoints],
+        ['exceedsMax', agencyBudget, maxStoppingPoints],
+        ['exceedsMin', agencyBudget, minStoppingPoints],
+        ['normal', agencyBudget, normalStoppingPoints]
+    ])('should return the scenario when data %s', (scenario, agencyBudget, data) => {
+        expect(determineScenario(agencyBudget, data)).toEqual(scenario);
+    });
+});
+
+describe('Stopping Points', () => {
+    it('should return correct properties and order of colors for exceedsMinStoppingPoints', () => {
+        const stoppingPoints = exceedsMinStoppingPoints(agencyBudget, minStoppingPoints);
+        expect(stoppingPoints[0].offset).toEqual('0%');
+        expect(stoppingPoints[0].stopColor).toEqual('blue');
+        expect(stoppingPoints[1].stopColor).toEqual('blue');
+        expect(stoppingPoints[2].stopColor).toEqual('red');
+        expect(stoppingPoints[3].offset).toEqual('100%');
+        expect(stoppingPoints[3].stopColor).toEqual('red');
+    });
+    it('should return correct properties and order of colors for exceedsMaxStoppingPoints', () => {
+        const stoppingPoints = exceedsMaxStoppingPoints(agencyBudget, maxStoppingPoints);
+        expect(stoppingPoints[0].offset).toEqual('0%');
+        expect(stoppingPoints[0].stopColor).toEqual('red');
+        expect(stoppingPoints[1].stopColor).toEqual('red');
+        expect(stoppingPoints[2].stopColor).toEqual('blue');
+        expect(stoppingPoints[3].offset).toEqual('100%');
+        expect(stoppingPoints[3].stopColor).toEqual('blue');
+    });
+    it('should return correct properties and order of colors for exceedsMaxAndMinStoppingPoints', () => {
+        const stoppingPoints = exceedsMaxAndMinStoppingPoints(agencyBudget, maxAndMinStoppingPoints);
+        expect(stoppingPoints[0].offset).toEqual('0%');
+        expect(stoppingPoints[0].stopColor).toEqual('red');
+        expect(stoppingPoints[1].stopColor).toEqual('red');
+        expect(stoppingPoints[2].stopColor).toEqual('blue');
+        expect(stoppingPoints[3].stopColor).toEqual('blue');
+        expect(stoppingPoints[4].stopColor).toEqual('red');
+        expect(stoppingPoints[5].offset).toEqual('100%');
+        expect(stoppingPoints[5].stopColor).toEqual('red');
+    });
+});
+
+describe('Percent Differences', () => {
+    it('should return the percent difference for exceedsMin', () => {
+        expect(exceedsMinPercentDifference(agencyBudget, minStoppingPoints).substring(0, 4)).toEqual('47.3');
+    });
+    it('should return the percent difference for exceedsMax', () => {
+        expect(exceedsMaxPercentDifference(agencyBudget, maxStoppingPoints).substring(0, 4)).toEqual('80%');
+    });
+    it('should return the percent difference for exceedsMaxAndMin', () => {
+        expect(exceedsMaxPercentDifference(agencyBudget, maxAndMinStoppingPoints, true).substring(0, 4)).toEqual('66.6');
+    });
+});
+
+describe('Path Definition', () => {
+    it('should draw a normal path', () => {
+        const path = pathDefinition(normalStoppingPoints, () => {}, 'obligated', {
+            left: 0, right: 0, top: 0, bottom: 0
+        }, () => {}, 'obligated', 100);
+        expect(path[path.length - 1] === 'Z').toBeFalsy();
+    });
+    it('should draw an area path', () => {
+        const path = pathDefinition(normalStoppingPoints, () => {}, 'obligated', {
+            left: 0, right: 0, top: 0, bottom: 0
+        }, () => {}, 'obligated', 100, null, true);
+        expect(path.substring(path.length - 4, path.length)).toEqual('100Z');
+    });
+    it('should draw an area path and close at 10', () => {
+        const path = pathDefinition(normalStoppingPoints, () => {}, 'obligated', {
+            left: 0, right: 0, top: 0, bottom: 0
+        }, (x) => x, 'obligated', 100, 10, true);
+        expect(path.substring(path.length - 3, path.length)).toEqual('90Z');
     });
 });


### PR DESCRIPTION
**High level description:**

High level description of the PR.

**Technical details:**

Technical details for the knowledge of other developers.

> • to test scenarios of exceeding min/max/both in the `TotalObligationsOverTimeContainer.jsx` replace `setData(addSubmissionEndDatesToBudgetaryResources(obligationsByPeriod, javaScriptSubmissionPeriods, fy).sort((a, b) => a.period - b.period));` with `setData(mockExceedingAmounts(addSubmissionEndDatesToBudgetaryResources(obligationsByPeriod, javaScriptSubmissionPeriods, fy).sort((a, b) => a.period - b.period), agencyBudget));`
and add 
```
const mockExceedingAmounts = (data, agencyBudget) => data.map((d, i) => {
    const newData = d;
    if (i === 1) {
        newData.obligated -= agencyBudget;
    }
    if (i === 3) {
        newData.obligated += agencyBudget;
    }
    // if (i + 1 === data.length) {
    //     newData.obligated += agencyBudget;
    // }
    return newData;
});
```
outside of the component and you and change the `+=/-=` to update the scenarios.

> • refactor viz to use scenario based display model.
> • add min scenario, max, normal and max and min scenario.
> • update total budget line and rectangle to show when needed.
> • add zero tick and line.


**JIRA Ticket:**
[DEV-7540](https://federal-spending-transparency.atlassian.net/browse/DEV-7540)

**Mockup:**
https://bahdigital.invisionapp.com/d/main/#/console/14222398/296060806/inspect

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
