### PR TITLE
[DEV-7542] Remove placeholder tooltips in agency section

### DIFF
--- a/src/_scss/pages/agencyV2/index.scss
+++ b/src/_scss/pages/agencyV2/index.scss
@@ -80,6 +80,9 @@
                 hr {
                     height: rem(2)
                 }
+                .usda-section-title__desc  {
+                    padding-right: rem(8);
+                }
             }
         }
     }

--- a/src/js/components/agencyV2/AgencySection.jsx
+++ b/src/js/components/agencyV2/AgencySection.jsx
@@ -33,9 +33,7 @@ const AgencySection = ({
         overLine={section?.overLine}
         description={section?.overLine
             ? <span className="usda-section-title__desc">This section covers <strong>{section.overLine}</strong></span>
-            : <span className="usda-section-title__desc">This section covers <strong>Total and Award Spending</strong></span>}
-        descTooltip={{ component: <TooltipComponent /> }}
-        titleTooltip={{ component: <TooltipComponent /> }}>
+            : <span className="usda-section-title__desc">This section covers <strong>Total and Award Spending</strong></span>}>
         {children}
     </SectionTitle>
 

--- a/src/js/components/agencyV2/AgencySection.jsx
+++ b/src/js/components/agencyV2/AgencySection.jsx
@@ -13,13 +13,6 @@ const propTypes = {
     isLoading: PropTypes.bool
 };
 
-const TooltipComponent = () => (
-    <>
-        <h4 className="tooltip__title">Coming Soon</h4>
-        <p className="tooltip__text">The tooltip content for this section is currently under review.</p>
-    </>
-);
-
 const AgencySection = ({
     section,
     icon = "chart-area",


### PR DESCRIPTION
**High level description:**

- Remove the "coming soon" tooltip next to "Overview"

- Remove the "coming soon" tooltip next to "This section covers Total and Award Spending"

**JIRA Ticket:**
[DEV-7542](https://federal-spending-transparency.atlassian.net/browse/DEV-7542)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a] Design review complete `if applicable`
- [n/a] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
