### PR TITLE
[DEV-7481] Non-Award Spending on Spending Explorer broken link fix

### DIFF
--- a/src/js/components/sharedComponents/TreemapCell.jsx
+++ b/src/js/components/sharedComponents/TreemapCell.jsx
@@ -60,7 +60,7 @@ export default class TreemapCell extends React.Component {
     }
 
     clickedCell() {
-        if (this.props.data.id) {
+        if (this.props.data.id !== 'undefined') {
             this.exitedCell();
             this.props.selectedCell(this.props.data.id, this.props.data);
         }

--- a/src/js/components/sharedComponents/TreemapCell.jsx
+++ b/src/js/components/sharedComponents/TreemapCell.jsx
@@ -60,7 +60,7 @@ export default class TreemapCell extends React.Component {
     }
 
     clickedCell() {
-        if (this.props.data.id !== 'undefined') {
+        if (this.props.data.id !== 'undefined' && this.props.data.id) {
             this.exitedCell();
             this.props.selectedCell(this.props.data.id, this.props.data);
         }


### PR DESCRIPTION
**High level description:**

In tree view, "Non-award Spending" cell becomes a clickable link that sends you to a broken page.

**Technical details:**
Non-award spending has an undefined ID causing the broken link. Adding a check for undefined prevents the cell from becoming a clickable link. 

**JIRA Ticket:**
[DEV-7481](https://federal-spending-transparency.atlassian.net/browse/DEV-7481)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a] Design review complete `if applicable`
- [n/a] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
