### PR TITLE
6780 remove form tag to ignore Enter

### DIFF
--- a/src/js/components/search/filters/programSource/TreasuryAccountFilters.jsx
+++ b/src/js/components/search/filters/programSource/TreasuryAccountFilters.jsx
@@ -75,7 +75,7 @@ export default class TreasuryAccountFilters extends React.Component {
 
         return (
             <div className="program-source-tab">
-                <form className="program-source-components">
+                <div className="program-source-components">
                     {activeTab === 2 && (
                         <div className="program-source-components__heading">
                             Treasury Account Components
@@ -102,7 +102,7 @@ export default class TreasuryAccountFilters extends React.Component {
                             <EntityWarning message={message} />
                         </div>
                     </div>
-                </form>
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
**High level description:**

When users hit Enter on the tree filter, the page would refresh. This fixes that behavior (so nothing happens)

**Technical details:**

Unlike the other checkbox trees w/ filter, this one was inside a form that caused the behavior. Just change it to a div.

**JIRA Ticket:**
[DEV-6780](https://federal-spending-transparency.atlassian.net/browse/DEV-6780)

**Mockup:**
na

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- na Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- na Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- na Verified mobile/tablet/desktop/monitor responsiveness
- na Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- na Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- na [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- na [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- na Design review complete `if applicable`
- na [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
