### PR TITLE
[DEV-7602] Top Bar Header Alignment

### DIFF
--- a/src/_scss/layouts/default/header/_officialSite.scss
+++ b/src/_scss/layouts/default/header/_officialSite.scss
@@ -61,7 +61,7 @@
     .official-banner__text {
         @include flex(0 0 auto);
         margin: 0;
-        font-size: rem(10);
+        font-size: rem(12);
         line-height: rem(13);
         color: $color-white;
     }

--- a/src/_scss/layouts/default/header/_officialSite.scss
+++ b/src/_scss/layouts/default/header/_officialSite.scss
@@ -1,20 +1,24 @@
+@import "../../../mixins/fullSectionWrap";
+
 .official-banner {
-    padding: rem(5) rem(15);
+    padding: rem(5) 0;
     background-color: #002A43;
 
-    @include media($tablet-screen) {
-        @include display(flex);
-        @include justify-content(space-between);
-        @include align-items(center);
+    .official-banner__wrapper {
+        @include fullSectionWrap(0, 0);
+
+        @include media($tablet-screen) {
+            @include display(flex);
+            @include justify-content(space-between);
+            @include align-items(center);
+        }
     }
 
     .official-banner__site-list {
         @include media($tablet-screen) {
             @include flex(1 1 auto);
         }
-        @include media($large-screen) {
-            margin-left: rem(20);
-        }
+
         @include unstyled-list;
         @include display(flex);
         @include justify-content(flex-start);
@@ -44,21 +48,19 @@
         }
     }
 
-    .official-banner__wrapper {
+    .official-banner__message {
         @include display(flex);
-        @include justify-content(flex-start);
         @include align-items(center);
+        margin-top: rem(4);
 
         @include media($tablet-screen) {
-            @include justify-content(flex-end);
-            @include align-items(center);
+            margin-top: 0;
         }
     }
 
     .official-banner__text {
         @include flex(0 0 auto);
-        margin-right: rem(10);
-
+        margin: 0;
         font-size: rem(10);
         line-height: rem(13);
         color: $color-white;
@@ -68,5 +70,6 @@
         @include flex(0 0 auto);
         width: rem(16);
         height: rem(11);
+        margin-left: rem(10);
     }
 }

--- a/src/_scss/layouts/default/header/_officialSite.scss
+++ b/src/_scss/layouts/default/header/_officialSite.scss
@@ -12,12 +12,13 @@
         @include media($tablet-screen) {
             @include flex(1 1 auto);
         }
+        @include media($large-screen) {
+            margin-left: rem(20);
+        }
         @include unstyled-list;
-
         @include display(flex);
         @include justify-content(flex-start);
         @include align-items(center);
-        margin-left: rem(20);
     }
 
     .official-banner__site-item {
@@ -47,12 +48,10 @@
         @include display(flex);
         @include justify-content(flex-start);
         @include align-items(center);
-        margin-left: rem(20);
 
         @include media($tablet-screen) {
             @include justify-content(flex-end);
             @include align-items(center);
-            margin-left: 0;
         }
     }
 

--- a/src/_scss/layouts/default/header/_officialSite.scss
+++ b/src/_scss/layouts/default/header/_officialSite.scss
@@ -4,7 +4,7 @@
 
     @include media($tablet-screen) {
         @include display(flex);
-        @include justify-content(space-between)
+        @include justify-content(space-between);
         @include align-items(center);
     }
 
@@ -65,7 +65,7 @@
     }
 
     .official-banner__flag {
-        @include flex(0 0 auto)
+        @include flex(0 0 auto);
         width: rem(16);
         height: rem(11);
     }

--- a/src/js/components/sharedComponents/header/Header.jsx
+++ b/src/js/components/sharedComponents/header/Header.jsx
@@ -89,51 +89,53 @@ export default class Header extends React.Component {
                     <div
                         className="official-banner"
                         role="note">
-                        <ul
-                            className="official-banner__site-list">
-                            <li>
-                                <Link
-                                    className="official-banner__site-link"
-                                    to="/"
-                                    onClick={clickedHeaderLink.bind(null, 'https:/www.usaspending.gov')}>
-                                    USAspending.gov
-                                </Link>
-                            </li>
-                            <li
-                                className="official-banner__site-item official-banner__site-item_spacer"
-                                aria-hidden="true">
-                                |
-                            </li>
-                            <li>
-                                <a
-                                    className="official-banner__site-link"
-                                    href="https://datalab.usaspending.gov"
-                                    onClick={clickedHeaderLink.bind(null, 'https://datalab.usaspending.gov')}>
-                                    Data Lab
-                                </a>
-                            </li>
-                            <li
-                                className="official-banner__site-item official-banner__site-item_spacer"
-                                aria-hidden="true">
-                                |
-                            </li>
-                            <li>
-                                <a
-                                    className="official-banner__site-link"
-                                    href="http://fiscaldata.treasury.gov/"
-                                    onClick={clickedHeaderLink.bind(null, 'http://fiscaldata.treasury.gov')}>
-                                    Fiscal Data
-                                </a>
-                            </li>
-                        </ul>
                         <div className="official-banner__wrapper">
-                            <div className="official-banner__text">
-                                An official website of the U.S. government
+                            <ul
+                                className="official-banner__site-list">
+                                <li>
+                                    <Link
+                                        className="official-banner__site-link"
+                                        to="/"
+                                        onClick={clickedHeaderLink.bind(null, 'https:/www.usaspending.gov')}>
+                                        USAspending.gov
+                                    </Link>
+                                </li>
+                                <li
+                                    className="official-banner__site-item official-banner__site-item_spacer"
+                                    aria-hidden="true">
+                                    |
+                                </li>
+                                <li>
+                                    <a
+                                        className="official-banner__site-link"
+                                        href="https://datalab.usaspending.gov"
+                                        onClick={clickedHeaderLink.bind(null, 'https://datalab.usaspending.gov')}>
+                                        Data Lab
+                                    </a>
+                                </li>
+                                <li
+                                    className="official-banner__site-item official-banner__site-item_spacer"
+                                    aria-hidden="true">
+                                    |
+                                </li>
+                                <li>
+                                    <a
+                                        className="official-banner__site-link"
+                                        href="http://fiscaldata.treasury.gov/"
+                                        onClick={clickedHeaderLink.bind(null, 'http://fiscaldata.treasury.gov')}>
+                                        Fiscal Data
+                                    </a>
+                                </li>
+                            </ul>
+                            <div className="official-banner__message">
+                                <p className="official-banner__text">
+                                    An official website of the U.S. government
+                                </p>
+                                <img
+                                    className="official-banner__flag"
+                                    src="img/us_flag_small.png"
+                                    alt="U.S. flag" />
                             </div>
-                            <img
-                                className="official-banner__flag"
-                                src="img/us_flag_small.png"
-                                alt="U.S. flag" />
                         </div>
                     </div>
                     {infoBanner}


### PR DESCRIPTION
**High level description:**

Updated the alignment of the content in the top blue bar in the header to left align with the rest of the content on the page to help with alignment consistency and easy legibility when reading. Also bumped up the text size of the "Official Govt Website" from 10px to 12px  to be more legible and help Lighthouse audits (see https://web.dev/font-size/), confirmed with design team.

**Technical details:**

Utilized the `fullSectionWrap` mixin for the content wrapper, which matches max-width style of the header and content sections wrappers.

**JIRA Ticket:**
[DEV-7602](https://federal-spending-transparency.atlassian.net/browse/DEV-7602)

**Mockup:**
These are older mockups, but you can see how the top bar links align left to the header logo, etc.
https://bahdigital.invisionapp.com/share/NDIAADAZPUS

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
