### PR TITLE
[DEV-7483] Fix Spending Explorer "Top 500" bug

### DIFF
--- a/src/js/containers/explorer/detail/DetailContentContainer.jsx
+++ b/src/js/containers/explorer/detail/DetailContentContainer.jsx
@@ -236,9 +236,10 @@ export class DetailContentContainer extends React.Component {
             isTruncated = Math.abs(total - resultTotal) > 10;
         }
 
-        parsedResults = ExplorerHelper.appendCellForDataOutsideTree(parsedResults, total, request.subdivision)
-            .sort((a, b) => b.amount - a.amount);
-
+        if (isTruncated) {
+            parsedResults = ExplorerHelper.appendCellForDataOutsideTree(parsedResults, total, request.subdivision)
+                .sort((a, b) => b.amount - a.amount);
+        }
         // build the trail item of the last applied filter using the request object
         const trailItem = Object.assign({}, request, {
             total


### PR DESCRIPTION
**High level description:**
Fixes bug where the `Results after top 500` row was being added to results with less than 500 results

**Technical description:**
Moves the addition of the `Results after Top 500` row to the spending explorer into an `if` statement so it will only add that row if there are more than 500 results.

**JIRA Ticket:**
[DEV-7483](https://federal-spending-transparency.atlassian.net/browse/DEV-7483)

The following are ALL required for the PR to be merged:

Author:
- [X] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [X] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [X] Verified mobile/tablet/desktop/monitor responsiveness
- [X] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
Reviewer(s):
- [ ] Design review complete `if applicable`
- [x] Code review complete
