### PR TITLE
[DEV-7341] Recipient Box and whisker plot labels

### DIFF
--- a/src/_scss/pages/agencyV2/visualizations/_recipientDistribution.scss
+++ b/src/_scss/pages/agencyV2/visualizations/_recipientDistribution.scss
@@ -1,6 +1,7 @@
 .recipient-distribution-visualization-container {
     width: 100%;
     .recipient-distribution-svg {
+        overflow: visible;
         .recipient-distribution-svg-body {
             .i-beam-line {
                 stroke: $color-gray-light;
@@ -8,6 +9,17 @@
             }
             .shaded-box {
                 fill: #88B4C0;
+            }
+            .top-count-text {
+                font-size: rem(12);
+                line-height: rem(12);
+                fill: $color-gray;
+                font-weight: $font-semibold;
+            }
+            .top-count-text-desc {
+                font-size: rem(10);
+                line-height: rem(10);
+                fill: $color-gray;
             }
             
         }

--- a/src/js/components/agencyV2/visualizations/RecipientDistribution.jsx
+++ b/src/js/components/agencyV2/visualizations/RecipientDistribution.jsx
@@ -6,6 +6,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { scaleLinear } from 'd3-scale';
+import { formatNumber, formatMoneyWithUnitsShortLabel, formatMoneyWithUnits } from 'helpers/moneyFormatter';
 
 const propTypes = {
     height: PropTypes.number,
@@ -27,6 +28,17 @@ const RecipientDistribution = ({
         width: 0,
         height: 0
     });
+    const [recipientCounts, setRecipientCounts] = useState({
+        topCount: 0,
+        midCount: 0,
+        bottomCount: 0
+    });
+    const [formattedValues, setFormattedValues] = useState({
+        valMax: 0,
+        val75pct: 0,
+        val25pct: 0,
+        valMin: 0
+    });
 
     useEffect(() => {
         if (data) {
@@ -41,14 +53,29 @@ const RecipientDistribution = ({
             const boxScale = yScale(data.pct75) - yScale(data.pct25);
             setRectangleData(
                 {
-                    x: 0,
+                    x: 20,
                     y: height - yScale(data.pct25) - (boxScale < 1 ? 1 : boxScale),
-                    width: 72,
+                    width: 32,
                     height: boxScale < 1 ? 1 : boxScale
                 }
             );
+            setRecipientCounts(
+                {
+                    topCount: formatNumber(data._numberOfRecipients * 0.25),
+                    midCount: formatNumber(data._numberOfRecipients * 0.50),
+                    bottomCount: formatNumber(data._numberOfRecipients * 0.25)
+                }
+            );
+            setFormattedValues(
+                {
+                    valMax: formatMoneyWithUnitsShortLabel(data.maxRecipients),
+                    val75pct: formatMoneyWithUnitsShortLabel(data.pct75),
+                    val25pct: formatMoneyWithUnitsShortLabel(data.pct25),
+                    valMin: formatMoneyWithUnits(data.minRecipients)
+                }
+            );
         }
-    }, [data]);
+    }, []);
 
     return (
         <svg
@@ -66,15 +93,15 @@ const RecipientDistribution = ({
                 <line // bottom tick representing $0
                     tabIndex="0"
                     className="i-beam-line"
-                    x1={0}
-                    x2={width}
+                    x1={26}
+                    x2={46}
                     y1={lineData.y2}
                     y2={lineData.y2} />
                 <line // upper tick representing max
                     tabIndex="0"
                     className="i-beam-line"
-                    x1={0}
-                    x2={width}
+                    x1={26}
+                    x2={46}
                     y1={0}
                     y2={0} />
                 <rect // shaded box representing 25th percentile -> 75th percentile
@@ -83,6 +110,48 @@ const RecipientDistribution = ({
                     y={rectangleData.y}
                     width={rectangleData.width}
                     height={rectangleData.height} />
+                <line // top count label
+                    tabIndex="0"
+                    className="i-beam-line"
+                    x1={54}
+                    x2={59}
+                    y1={0}
+                    y2={0} />
+                <text tabIndex="0" x={63} y={6.5}>
+                    <tspan className="top-count-text" x="63">Top {recipientCounts.topCount}</tspan>
+                    <tspan className="top-count-text" x="63" dy="1.1em">Recipients</tspan>
+                    <tspan className="top-count-text-desc" x="63" dy="1.2em">Awarded between</tspan>
+                    <tspan className="top-count-text-desc" x="63" dy="1.2em">{formattedValues.valMax} and</tspan>
+                    <tspan className="top-count-text-desc" x="63" dy="1.2em">{formattedValues.val75pct}</tspan>
+                </text>
+                <line // bottom count label
+                    tabIndex="0"
+                    className="i-beam-line"
+                    x1={54}
+                    x2={59}
+                    y1={lineData.y2}
+                    y2={lineData.y2} />
+                <text tabIndex="0" x={63} y={130}>
+                    <tspan className="top-count-text" x="63">Bottom {recipientCounts.bottomCount}</tspan>
+                    <tspan className="top-count-text" x="63" dy="1.1em">Recipients</tspan>
+                    <tspan className="top-count-text-desc" x="63" dy="1.2em">Awarded between</tspan>
+                    <tspan className="top-count-text-desc" x="63" dy="1.2em">{formattedValues.val25pct} and</tspan>
+                    <tspan className="top-count-text-desc" x="63" dy="1.2em">{formattedValues.valMin}</tspan>
+                </text>
+                <line // middle count label
+                    tabIndex="0"
+                    className="i-beam-line"
+                    x1={12}
+                    x2={17}
+                    y1={lineData.y2}
+                    y2={lineData.y2} />
+                <text tabIndex="0" x={-60} y={130}>
+                    <tspan className="top-count-text" x="-60">Middle {recipientCounts.midCount}</tspan>
+                    <tspan className="top-count-text" x="-60" dy="1.1em">Recipients</tspan>
+                    <tspan className="top-count-text-desc" x="-60" dy="1.2em">Awarded between</tspan>
+                    <tspan className="top-count-text-desc" x="-60" dy="1.2em">{formattedValues.val75pct} and</tspan>
+                    <tspan className="top-count-text-desc" x="-60" dy="1.2em">{formattedValues.val25pct}</tspan>
+                </text>
             </g>
         </svg>
     );

--- a/src/js/components/agencyV2/visualizations/RecipientDistribution.jsx
+++ b/src/js/components/agencyV2/visualizations/RecipientDistribution.jsx
@@ -145,12 +145,12 @@ const RecipientDistribution = ({
                     x2={17}
                     y1={lineData.y2}
                     y2={lineData.y2} />
-                <text tabIndex="0" x={-60} y={130}>
-                    <tspan className="top-count-text" x="-60">Middle {recipientCounts.midCount}</tspan>
-                    <tspan className="top-count-text" x="-60" dy="1.1em">Recipients</tspan>
-                    <tspan className="top-count-text-desc" x="-60" dy="1.2em">Awarded between</tspan>
-                    <tspan className="top-count-text-desc" x="-60" dy="1.2em">{formattedValues.val75pct} and</tspan>
-                    <tspan className="top-count-text-desc" x="-60" dy="1.2em">{formattedValues.val25pct}</tspan>
+                <text tabIndex="0" textAnchor="end" x={10} y={130}>
+                    <tspan className="top-count-text" x="10">Middle {recipientCounts.midCount}</tspan>
+                    <tspan className="top-count-text" x="10" dy="1.1em">Recipients</tspan>
+                    <tspan className="top-count-text-desc" x="10" dy="1.2em">Awarded between</tspan>
+                    <tspan className="top-count-text-desc" x="10" dy="1.2em">{formattedValues.val75pct} and</tspan>
+                    <tspan className="top-count-text-desc" x="10" dy="1.2em">{formattedValues.val25pct}</tspan>
                 </text>
             </g>
         </svg>

--- a/src/js/components/agencyV2/visualizations/RecipientDistribution.jsx
+++ b/src/js/components/agencyV2/visualizations/RecipientDistribution.jsx
@@ -145,8 +145,9 @@ const RecipientDistribution = ({
                     x2={18}
                     y1={lineData.y2}
                     y2={lineData.y2} />
-                <text tabIndex="0" textAnchor="end" x={12} y={lineData.y2 - 60}>
-                    <tspan className="top-count-text" x="12">Middle {recipientCounts.midCount}</tspan>
+                <text tabIndex="0" textAnchor="end" x={12} y={lineData.y2 - 73}>
+                    <tspan className="top-count-text" x="12">Middle</tspan>
+                    <tspan className="top-count-text" x="12" dy="1.1em">{recipientCounts.midCount}</tspan>
                     <tspan className="top-count-text" x="12" dy="1.1em">Recipients</tspan>
                     <tspan className="top-count-text-desc" x="12" dy="1.2em">Awarded</tspan>
                     <tspan className="top-count-text-desc" x="12" dy="1.2em">between</tspan>

--- a/src/js/components/agencyV2/visualizations/RecipientDistribution.jsx
+++ b/src/js/components/agencyV2/visualizations/RecipientDistribution.jsx
@@ -53,9 +53,9 @@ const RecipientDistribution = ({
             const boxScale = yScale(data.pct75) - yScale(data.pct25);
             setRectangleData(
                 {
-                    x: 20,
+                    x: 22,
                     y: height - yScale(data.pct25) - (boxScale < 1 ? 1 : boxScale),
-                    width: 32,
+                    width: 28,
                     height: boxScale < 1 ? 1 : boxScale
                 }
             );
@@ -93,15 +93,15 @@ const RecipientDistribution = ({
                 <line // bottom tick representing $0
                     tabIndex="0"
                     className="i-beam-line"
-                    x1={26}
-                    x2={46}
+                    x1={28}
+                    x2={44}
                     y1={lineData.y2}
                     y2={lineData.y2} />
                 <line // upper tick representing max
                     tabIndex="0"
                     className="i-beam-line"
-                    x1={26}
-                    x2={46}
+                    x1={28}
+                    x2={44}
                     y1={0}
                     y2={0} />
                 <rect // shaded box representing 25th percentile -> 75th percentile
@@ -114,43 +114,44 @@ const RecipientDistribution = ({
                     tabIndex="0"
                     className="i-beam-line"
                     x1={54}
-                    x2={59}
+                    x2={58}
                     y1={0}
                     y2={0} />
-                <text tabIndex="0" x={63} y={6.5}>
-                    <tspan className="top-count-text" x="63">Top {recipientCounts.topCount}</tspan>
-                    <tspan className="top-count-text" x="63" dy="1.1em">Recipients</tspan>
-                    <tspan className="top-count-text-desc" x="63" dy="1.2em">Awarded between</tspan>
-                    <tspan className="top-count-text-desc" x="63" dy="1.2em">{formattedValues.valMax} and</tspan>
-                    <tspan className="top-count-text-desc" x="63" dy="1.2em">{formattedValues.val75pct}</tspan>
+                <text tabIndex="0" x={60} y={7}>
+                    <tspan className="top-count-text" x="60">Top {recipientCounts.topCount}</tspan>
+                    <tspan className="top-count-text" x="60" dy="1.1em">Recipients</tspan>
+                    <tspan className="top-count-text-desc" x="60" dy="1.2em">Awarded between</tspan>
+                    <tspan className="top-count-text-desc" x="60" dy="1.2em">{formattedValues.valMax} and</tspan>
+                    <tspan className="top-count-text-desc" x="60" dy="1.2em">{formattedValues.val75pct}</tspan>
                 </text>
                 <line // bottom count label
                     tabIndex="0"
                     className="i-beam-line"
                     x1={54}
-                    x2={59}
+                    x2={58}
                     y1={lineData.y2}
                     y2={lineData.y2} />
-                <text tabIndex="0" x={63} y={130}>
-                    <tspan className="top-count-text" x="63">Bottom {recipientCounts.bottomCount}</tspan>
-                    <tspan className="top-count-text" x="63" dy="1.1em">Recipients</tspan>
-                    <tspan className="top-count-text-desc" x="63" dy="1.2em">Awarded between</tspan>
-                    <tspan className="top-count-text-desc" x="63" dy="1.2em">{formattedValues.val25pct} and</tspan>
-                    <tspan className="top-count-text-desc" x="63" dy="1.2em">{formattedValues.valMin}</tspan>
+                <text tabIndex="0" x={60} y={lineData.y2 - 48}>
+                    <tspan className="top-count-text" x="60">Bottom {recipientCounts.bottomCount}</tspan>
+                    <tspan className="top-count-text" x="60" dy="1.1em">Recipients</tspan>
+                    <tspan className="top-count-text-desc" x="60" dy="1.2em">Awarded between</tspan>
+                    <tspan className="top-count-text-desc" x="60" dy="1.2em">{formattedValues.val25pct} and</tspan>
+                    <tspan className="top-count-text-desc" x="60" dy="1.2em">{formattedValues.valMin}</tspan>
                 </text>
                 <line // middle count label
                     tabIndex="0"
                     className="i-beam-line"
-                    x1={12}
-                    x2={17}
+                    x1={14}
+                    x2={18}
                     y1={lineData.y2}
                     y2={lineData.y2} />
-                <text tabIndex="0" textAnchor="end" x={10} y={130}>
-                    <tspan className="top-count-text" x="10">Middle {recipientCounts.midCount}</tspan>
-                    <tspan className="top-count-text" x="10" dy="1.1em">Recipients</tspan>
-                    <tspan className="top-count-text-desc" x="10" dy="1.2em">Awarded between</tspan>
-                    <tspan className="top-count-text-desc" x="10" dy="1.2em">{formattedValues.val75pct} and</tspan>
-                    <tspan className="top-count-text-desc" x="10" dy="1.2em">{formattedValues.val25pct}</tspan>
+                <text tabIndex="0" textAnchor="end" x={12} y={lineData.y2 - 60}>
+                    <tspan className="top-count-text" x="12">Middle {recipientCounts.midCount}</tspan>
+                    <tspan className="top-count-text" x="12" dy="1.1em">Recipients</tspan>
+                    <tspan className="top-count-text-desc" x="12" dy="1.2em">Awarded</tspan>
+                    <tspan className="top-count-text-desc" x="12" dy="1.2em">between</tspan>
+                    <tspan className="top-count-text-desc" x="12" dy="1.2em">{formattedValues.val75pct} and</tspan>
+                    <tspan className="top-count-text-desc" x="12" dy="1.2em">{formattedValues.val25pct}</tspan>
                 </text>
             </g>
         </svg>

--- a/src/js/helpers/moneyFormatter.js
+++ b/src/js/helpers/moneyFormatter.js
@@ -228,6 +228,28 @@ export const formatMoneyWithUnits = (value) => {
     return `${formattedCurrency}${longLabel}`;
 };
 
+export const formatMoneyWithUnitsShortLabel = (value) => {
+    if (typeof value !== 'number') return '--';
+    // Format the ceiling and current values to be friendly strings
+    const units = calculateUnitForSingleValue(value);
+    let precision = 1;
+    // Only reformat at a million or higher
+    if (units.unit < unitValues.MILLION) {
+        units.unit = 1;
+        units.unitLabel = '';
+        units.longLabel = '';
+        precision = 0;
+    }
+    const formattedValue = value / units.unit;
+
+    const formattedCurrency = formatMoneyWithPrecision(formattedValue, precision);
+
+    // Don't add an extra space when there's no units string to display
+    const unitLabel = units.unit > 1 ? ` ${startCase(units.unitLabel)}` : '';
+
+    return `${formattedCurrency}${unitLabel}`;
+};
+
 const replaceDecimal = new RegExp(/\.|%/g);
 
 const isFormattedZero = (formatted) => {

--- a/tests/helpers/moneyFormatter-test.js
+++ b/tests/helpers/moneyFormatter-test.js
@@ -3,7 +3,7 @@
  * Created by Kevin Li 1/25/17
  */
 
-import { formatMoney, formatMoneyWithPrecision, calculatePercentage, formatTreemapValues, formatMoneyWithUnits } from 'helpers/moneyFormatter';
+import { formatMoney, formatMoneyWithPrecision, calculatePercentage, formatTreemapValues, formatMoneyWithUnits, formatMoneyWithUnitsShortLabel } from 'helpers/moneyFormatter';
 
 test.each([
     [123.45, '$123'],
@@ -64,4 +64,17 @@ test.each([
     [null, '--']
 ])('formatMoneyWithUnits: when input is %s --> %s', (input, output) => {
     expect(formatMoneyWithUnits(input, true)).toEqual(output);
+});
+
+test.each([
+    [123.45, '$123'],
+    [1230.50, '$1,231'],
+    [12345678.23, '$12.3 M'],
+    [-12345678.23, '-$12.3 M'],
+    [1234567800.23, '$1.2 B'],
+    [-1234567800.23, '-$1.2 B'],
+    [0, '$0'],
+    [null, '--']
+])('formatMoneyWithUnitsShortLabel: when input is %s --> %s', (input, output) => {
+    expect(formatMoneyWithUnitsShortLabel(input, true)).toEqual(output);
 });


### PR DESCRIPTION
**High level description:**

Add labels and formatted monetary values according to mock for top count, middle count, and bottom count

**Technical details:**
Implement labels using svg <text> and <tspan>
Implement money formatter to match values in mock

**JIRA Ticket:**
[DEV-7341](https://federal-spending-transparency.atlassian.net/browse/DEV-7341)

**Mockup:**
https://bahdigital.invisionapp.com/d/main#/console/14222398/296061875/preview
screenshot in [DEV-4344](https://federal-spending-transparency.atlassian.net/browse/DEV-4344)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [n/a] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
