### PR TITLE
[DEV-7496] Fix typo in spending explorer

### DIFF
--- a/src/js/helpers/explorerHelper.js
+++ b/src/js/helpers/explorerHelper.js
@@ -13,6 +13,20 @@ export const fetchBreakdown = (params) => apiRequest({
     data: params
 });
 
+export const pluralizeSubdivision = (activeSubdivision) => {
+    let pluralText = '';
+    if (activeSubdivision === 'program_activity') {
+        pluralText = 'Program Activities';
+    }
+    else if (activeSubdivision === 'object_class') {
+        pluralText = 'Object Classes';
+    }
+    else {
+        pluralText = `${startCase(activeSubdivision)}s`;
+    }
+    return pluralText;
+};
+
 /**
  * @param {Array} dataForTree an array of objects from api representing spending explorer tree cells
  * @param {Int} total integer representing total spending amount for selected criteria
@@ -23,12 +37,13 @@ export const fetchBreakdown = (params) => apiRequest({
  */
 export const appendCellForDataOutsideTree = (dataForTree, overallTotal, activeSubdivision) => {
     const totalNotShown = overallTotal - dataForTree.reduce((sum, item) => sum + item.amount, 0);
+    const subdivisionText = pluralizeSubdivision(activeSubdivision);
     return [{
         id: null,
         link: false,
         code: "N/A",
         type: '',
-        name: `Sum of all ${startCase(activeSubdivision)}s after Top 500`,
+        name: `Sum of all ${subdivisionText} after Top 500`,
         amount: totalNotShown
     }]
         .concat(dataForTree);

--- a/tests/helpers/explorerHelper-test.js
+++ b/tests/helpers/explorerHelper-test.js
@@ -12,6 +12,13 @@ describe('explorerHelper', () => {
             expect(dataForTreeWithAppendedCell[0].name).toEqual('Sum of all Awards after Top 500');
         });
     });
+    describe('pluralizeSubdivision', () => {
+        it('returns pluralized subdivision string', () => {
+            const dataForTree = [{ amount: 1 }, { amount: 2 }];
+            const dataForTreeWithAppendedCell = appendCellForDataOutsideTree(dataForTree, 10, 'object_class');
+            expect(dataForTreeWithAppendedCell[0].name).toEqual('Sum of all Object Classes after Top 500');
+        });
+    });
     describe('truncateDataForTreemap', () => {
         it('returns an array of maximum 500 items, sorted on the amount property, with no negative values', () => {
             const dataForTree = new Array(1000).fill().map((item, i) => ({ amount: Math.random(i) }));


### PR DESCRIPTION
**High level description:**

In Spending Explorer, verify the word "Class" is spelled correctly to say “Sum of all Object Classes after Top 500”

In Spending Explorer, verify the word "Activities" is spelled correctly to say “Sum of all Program Activities after Top 500”

**Technical details:**
Add logic to determine if the active subdivision is object class or program activity and return the correct pluralization. Currently we only have 2 cases to handle pluralization (object class and program activity), so this solution does not cover all english plural edge cases. 

**JIRA Ticket:**
[DEV-7496](https://federal-spending-transparency.atlassian.net/browse/DEV-7496)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [n/a] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a] Design review complete `if applicable`
- [n/a] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
