### PR TITLE
[DEV-7446] Add award category tabs to subagency section

### DIFF
--- a/src/js/components/agencyV2/AgencyPage.jsx
+++ b/src/js/components/agencyV2/AgencyPage.jsx
@@ -23,6 +23,7 @@ import Sidebar from 'components/sharedComponents/sidebar/Sidebar';
 import AccountSpending from 'components/agencyV2/accountSpending/AccountSpending';
 import AgencySection from './AgencySection';
 import AgencyOverview from './overview/AgencyOverview';
+import AwardSpendingSubagency from './awardSpending/AwardSpendingSubagency';
 import PageWrapper from '../sharedComponents/PageWrapper';
 
 require('pages/agencyV2/index.scss');
@@ -65,7 +66,8 @@ export const AgencyProfileV2 = ({
         {
             name: 'sub-agency',
             display: 'Sub-Agency',
-            overLine: 'Award Spending'
+            overLine: 'Award Spending',
+            component: <AwardSpendingSubagency />
         }
     ];
 

--- a/src/js/components/agencyV2/awardSpending/AwardSpendingSubagency.jsx
+++ b/src/js/components/agencyV2/awardSpending/AwardSpendingSubagency.jsx
@@ -1,0 +1,58 @@
+/**
+ * AwardSpendingSubagency.jsx
+ * Created by Afna Saifudeen 8/4/21
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Tabs } from 'data-transparency-ui';
+import { useStateWithPrevious } from 'helpers';
+
+const propTypes = {
+    fy: PropTypes.string,
+    agencyId: PropTypes.string
+};
+
+export const tabs = [
+    {
+        internal: 'all',
+        label: 'All Awards'
+    },
+    {
+        internal: 'contracts',
+        label: 'Contracts'
+    },
+    {
+        internal: 'idvs',
+        label: 'Contract IDVs'
+    },
+    {
+        internal: 'grants',
+        label: 'Grants'
+    },
+    {
+        internal: 'direct_payments',
+        label: 'Direct Payments'
+    },
+    {
+        internal: 'loans',
+        label: 'Loans'
+    },
+    {
+        internal: 'other',
+        label: 'Other Financial Assistance'
+    }
+];
+
+const AwardSpendingSubagency = () => {
+    const [activeTab, setActiveTab] = useStateWithPrevious('all_awards');
+    return (
+        <div className="body__content agency-budget-category">
+            <Tabs types={tabs} switchTab={setActiveTab} active={activeTab} />
+        </div>
+    );
+};
+
+AwardSpendingSubagency.propTypes = propTypes;
+export default AwardSpendingSubagency;

--- a/src/js/components/agencyV2/awardSpending/AwardSpendingSubagency.jsx
+++ b/src/js/components/agencyV2/awardSpending/AwardSpendingSubagency.jsx
@@ -32,12 +32,12 @@ export const tabs = [
         label: 'Grants'
     },
     {
-        internal: 'direct_payments',
-        label: 'Direct Payments'
-    },
-    {
         internal: 'loans',
         label: 'Loans'
+    },
+    {
+        internal: 'direct_payments',
+        label: 'Direct Payments'
     },
     {
         internal: 'other',
@@ -46,7 +46,7 @@ export const tabs = [
 ];
 
 const AwardSpendingSubagency = () => {
-    const [activeTab, setActiveTab] = useStateWithPrevious('all_awards');
+    const [activeTab, setActiveTab] = useStateWithPrevious('all');
     return (
         <div className="body__content agency-budget-category">
             <Tabs types={tabs} switchTab={setActiveTab} active={activeTab} />


### PR DESCRIPTION
**High level description:**

Adds award category tabs to subagency section on agency profile page

**JIRA Ticket:**
[DEV-7446](https://federal-spending-transparency.atlassian.net/browse/DEV-7446)

**Mockup:**
https://bahdigital.invisionapp.com/share/CZIAH1ZQGPF#/screens/296056413_agency-Profile-Mvp

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a] Design review complete `if applicable`
- [n/a] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
