### PR TITLE
Dev-7106 Checkbox Tree Hash Bug

### DIFF
--- a/src/js/containers/search/filters/naics/NAICSCheckboxTree.jsx
+++ b/src/js/containers/search/filters/naics/NAICSCheckboxTree.jsx
@@ -99,7 +99,24 @@ export class NAICSCheckboxTree extends React.Component {
 
     componentDidMount() {
         const { checkedFromHash, uncheckedFromHash, countsFromHash } = this.props;
-        if (this.props.nodes.length !== 0 && !checkedFromHash.length) {
+        if (this.props.nodes.length !== 0 && checkedFromHash.length) {
+            const newChecked = checkedFromHash
+                .reduce((acc, checked) => {
+                    if (checked.length === 6 && !uncheckedFromHash.includes(checked)) {
+                        return [...acc, checked];
+                    }
+                    const node = getNaicsNodeFromTree(this.props.nodes, checked);
+                    return [
+                        ...acc,
+                        ...getAllDescendants(node, uncheckedFromHash)
+                    ];
+                }, []);
+            this.props.setCheckedNaics(newChecked);
+            this.props.setNaicsCounts(countsFromHash);
+            this.props.stageNaics(newChecked, [], countsFromHash);
+            return Promise.resolve();
+        }
+        else if (this.props.nodes.length !== 0) {
             this.props.showNaicsTree();
             return Promise.resolve();
         }

--- a/src/js/containers/search/filters/naics/NAICSCheckboxTree.jsx
+++ b/src/js/containers/search/filters/naics/NAICSCheckboxTree.jsx
@@ -99,7 +99,7 @@ export class NAICSCheckboxTree extends React.Component {
 
     componentDidMount() {
         const { checkedFromHash, uncheckedFromHash, countsFromHash } = this.props;
-        if (this.props.nodes.length !== 0) {
+        if (this.props.nodes.length !== 0 && !checkedFromHash.length) {
             this.props.showNaicsTree();
             return Promise.resolve();
         }

--- a/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
@@ -96,7 +96,7 @@ export class TASCheckboxTree extends React.Component {
             uncheckedFromHash,
             countsFromHash
         } = this.props;
-        if (this.props.nodes.length !== 0) {
+        if (this.props.nodes.length !== 0 && !checkedFromHash.length) {
             this.props.showTasTree();
             return Promise.resolve();
         }

--- a/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
@@ -96,7 +96,17 @@ export class TASCheckboxTree extends React.Component {
             uncheckedFromHash,
             countsFromHash
         } = this.props;
-        if (this.props.nodes.length !== 0 && !checkedFromHash.length) {
+        if (this.props.nodes.length !== 0 && checkedFromHash.length) {
+            this.setCheckedStateFromUrlHash(checkedFromHash.map((ancestryPath) => ancestryPath.pop()));
+            this.props.setTasCounts(countsFromHash);
+            this.props.stageTas(
+                trimCheckedToCommonAncestors(getTasAncestryPathForChecked(this.props.checked, this.props.nodes)),
+                getTasAncestryPathForChecked(this.props.unchecked, this.props.nodes),
+                countsFromHash
+            );
+            return Promise.resolve();
+        }
+        else if (this.props.nodes.length !== 0) {
             this.props.showTasTree();
             return Promise.resolve();
         }
@@ -394,7 +404,7 @@ export class TASCheckboxTree extends React.Component {
                     isError={isError}
                     errorMessage={errorMessage}
                     isLoading={isLoading}
-                    data={nodes}
+                    data={nodes.sort((a, b) => a.label.localeCompare(b.label))}
                     checked={checked}
                     searchText={searchString}
                     countLabel="TAS"

--- a/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
@@ -93,7 +93,7 @@ export class PSCCheckboxTreeContainer extends React.Component {
             checkedFromHash,
             countsFromHash
         } = this.props;
-        if (nodes.length !== 0) {
+        if (nodes.length !== 0 && !checkedFromHash.length) {
             showPscTree();
             return Promise.resolve();
         }

--- a/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
@@ -93,7 +93,19 @@ export class PSCCheckboxTreeContainer extends React.Component {
             checkedFromHash,
             countsFromHash
         } = this.props;
-        if (nodes.length !== 0 && !checkedFromHash.length) {
+        if (nodes.length !== 0 && checkedFromHash.length) {
+            this.setCheckedStateFromUrlHash(
+                checkedFromHash.map((ancestryPath) => ancestryPath[ancestryPath.length - 1])
+            );
+            this.props.setPscCounts(countsFromHash);
+            this.props.stagePsc(
+                trimCheckedToCommonAncestors(getPscAncestryPathForChecked(this.props.checked, this.props.nodes)),
+                getPscAncestryPathForChecked(this.props.unchecked, this.props.nodes),
+                this.props.counts
+            );
+            return Promise.resolve();
+        }
+        else if (nodes.length !== 0) {
             showPscTree();
             return Promise.resolve();
         }


### PR DESCRIPTION
**High level description:**

When navigating to the advanced search page with a hash we will preserve checked and staging filters from hash.

**Technical details:**

> • mounting PSC, TAS, and NAICS trees not on application load we maintain checked and staged filters from hash without fetching data.

**JIRA Ticket:**
[DEV-7106](https://federal-spending-transparency.atlassian.net/browse/DEV-7106)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [N/A] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [N/A] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
