### PR TITLE
Mod/dev 7671 add home event tracking

### DIFF
--- a/src/js/components/about/About.jsx
+++ b/src/js/components/about/About.jsx
@@ -16,6 +16,7 @@ export default class About extends React.Component {
     render() {
         return (
             <PageWrapper
+                pageName="About"
                 classNames="usa-da-about-page"
                 metaTagProps={aboutPageMetaTags}
                 title="About">

--- a/src/js/components/about/DBInfo.jsx
+++ b/src/js/components/about/DBInfo.jsx
@@ -45,7 +45,7 @@ export default class DBInfo extends React.Component {
                         </p>
                     </div>
                 </main>
-                <Footer />
+                <Footer pageName="DBInfo" />
             </div>
         );
     }

--- a/src/js/components/about/legal/common/LegalPage.jsx
+++ b/src/js/components/about/legal/common/LegalPage.jsx
@@ -34,7 +34,7 @@ export default class LegalPage extends React.Component {
         }
         return (
             <PageWrapper
-            pageName="Legal"
+                pageName="Legal"
                 classNames="usa-da-legal-page"
                 title="Legal"
                 metaTagProps={metaTags}>

--- a/src/js/components/about/legal/common/LegalPage.jsx
+++ b/src/js/components/about/legal/common/LegalPage.jsx
@@ -34,6 +34,7 @@ export default class LegalPage extends React.Component {
         }
         return (
             <PageWrapper
+            pageName="Legal"
                 classNames="usa-da-legal-page"
                 title="Legal"
                 metaTagProps={metaTags}>

--- a/src/js/components/aboutTheData/AboutTheDataPage.jsx
+++ b/src/js/components/aboutTheData/AboutTheDataPage.jsx
@@ -70,6 +70,7 @@ const AboutTheDataPage = ({ history }) => {
 
     return (
         <PageWrapper
+            pageName="Agency Submission Statistics"
             classNames="about-the-data about-the-data_agencies-page"
             title="Agency Submission Statistics"
             toolBarComponents={[

--- a/src/js/components/aboutTheData/AgencyDetailsPage.jsx
+++ b/src/js/components/aboutTheData/AgencyDetailsPage.jsx
@@ -83,6 +83,7 @@ const AgencyDetailsPage = () => {
 
     return (
         <PageWrapper
+            pageName="Agency Profile"
             classNames="about-the-data about-the-data_agency-details-page"
             metaTagProps={agencyOverview ? agencyPageMetaTags(agencyOverview) : {}}
             overLine="Agency Profile"

--- a/src/js/components/aboutTheData/DataSourcesAndMethodologiesPage.jsx
+++ b/src/js/components/aboutTheData/DataSourcesAndMethodologiesPage.jsx
@@ -85,6 +85,7 @@ const DataSourcesAndMethodologiesPage = () => {
 
     return (
         <PageWrapper
+            pageName="Submissions Statistics DS&M"
             overLine="Data Sources and Methodology"
             title="Agency Submissions Statistics"
             classNames="usa-da-dsm-page"

--- a/src/js/components/account/Account.jsx
+++ b/src/js/components/account/Account.jsx
@@ -33,6 +33,7 @@ export default class Account extends React.Component {
             const slug = `federal_account/${accountSymbol}`;
             return (
                 <PageWrapper
+                    pageName="Federal Account Profile"
                     classNames="usa-da-account-page"
                     overLine="Federal Account Profile"
                     title={`Federal Account Symbol: ${accountSymbol}`}

--- a/src/js/components/account/InvalidAccount.jsx
+++ b/src/js/components/account/InvalidAccount.jsx
@@ -30,7 +30,7 @@ export default class InvalidAccount extends React.Component {
                             Please check the ID and try again." />
                     </div>
                 </main>
-                <Footer />
+                <Footer pageName="Invalid Account" />
             </div>
         );
     }

--- a/src/js/components/account/LoadingAccount.jsx
+++ b/src/js/components/account/LoadingAccount.jsx
@@ -29,7 +29,7 @@ export default class LoadingAccount extends React.Component {
                             message="" />
                     </div>
                 </main>
-                <Footer />
+                <Footer pageName="Loading Account" />
             </div>
         );
     }

--- a/src/js/components/accountLanding/AccountLandingPage.jsx
+++ b/src/js/components/accountLanding/AccountLandingPage.jsx
@@ -25,6 +25,7 @@ export default class AccountLandingPage extends React.Component {
     render() {
         return (
             <PageWrapper
+                pageName="Federal Account Profiles"
                 classNames="usa-da-account-landing"
                 title="Federal Account Profiles"
                 metaTagProps={accountLandingPageMetaTags}

--- a/src/js/components/agency/AgencyPage.jsx
+++ b/src/js/components/agency/AgencyPage.jsx
@@ -46,6 +46,7 @@ export default class AgencyPage extends React.Component {
 
         return (
             <PageWrapper
+                pageName="Agency Profile"
                 classNames="usa-da-agency-page"
                 overLine="Agency Profile"
                 title={overview?.name}

--- a/src/js/components/agencyLanding/AgencyLandingPage.jsx
+++ b/src/js/components/agencyLanding/AgencyLandingPage.jsx
@@ -28,6 +28,7 @@ export default class AgencyLandingPage extends React.Component {
     render() {
         return (
             <PageWrapper
+                pageName="Agency Profiles"
                 classNames="usa-da-agency-landing"
                 title="Agency Profiles"
                 metaTagProps={agencyLandingPageMetaTags}

--- a/src/js/components/agencyV2/AgencyPage.jsx
+++ b/src/js/components/agencyV2/AgencyPage.jsx
@@ -106,6 +106,7 @@ export const AgencyProfileV2 = ({
 
     return (
         <PageWrapper
+            pageName="Agency Profile"
             classNames="usa-da-agency-page-v2"
             overLine="Agency Profile"
             title={name}

--- a/src/js/components/award/Award.jsx
+++ b/src/js/components/award/Award.jsx
@@ -163,6 +163,7 @@ export default class Award extends React.Component {
             : `${startCase(overview?.category)} Summary`;
         return (
             <PageWrapper
+                pageName="Award Profile"
                 classNames="usa-da-award-v2-page"
                 overLine="Award Profile"
                 metaTagProps={overview ? MetaTagHelper.awardPageMetaTags(overview) : {}}

--- a/src/js/components/bulkDownload/BulkDownloadPage.jsx
+++ b/src/js/components/bulkDownload/BulkDownloadPage.jsx
@@ -103,6 +103,7 @@ export default class BulkDownloadPage extends React.Component {
         }
         return (
             <PageWrapper
+                pageName="Download Center"
                 classNames="usa-da-bulk-download-page"
                 title="Download Center"
                 metaTagProps={this.props.dataType in metaTagsByDataType ? metaTagsByDataType[this.props.dataType] : {}}>

--- a/src/js/components/covid19/Covid19Page.jsx
+++ b/src/js/components/covid19/Covid19Page.jsx
@@ -79,6 +79,7 @@ const Covid19Page = ({ areDefCodesLoading }) => {
 
     return (
         <PageWrapper
+            pageName="COVID-19 Spending"
             classNames="usa-da-covid19-page"
             metaTagProps={covidPageMetaTags}
             title="COVID-19 Spending"

--- a/src/js/components/covid19/DataSourcesAndMethodologiesPage.jsx
+++ b/src/js/components/covid19/DataSourcesAndMethodologiesPage.jsx
@@ -152,6 +152,7 @@ export default () => {
 
     return (
         <PageWrapper
+            pageName="COVID DS&M"
             classNames="usa-da-dsm-page"
             ref={dataDisclaimerBannerRef}
             overLine="Data Sources &amp; Methodology"

--- a/src/js/components/dataDictionary/DataDictionaryPage.jsx
+++ b/src/js/components/dataDictionary/DataDictionaryPage.jsx
@@ -15,6 +15,7 @@ require('pages/dataDictionary/dataDictionaryPage.scss');
 export default class DataDictionaryPage extends React.Component {
     render = () => (
         <PageWrapper
+            pageName="Data Dictionary"
             classNames="usa-da-data-dictionary-page"
             metaTagProps={dataDictionaryPageMetaTags}
             overLine="resources"

--- a/src/js/components/errorPage/ErrorPage.jsx
+++ b/src/js/components/errorPage/ErrorPage.jsx
@@ -40,7 +40,7 @@ const ErrorPage = () => (
                 </div>
             </div>
         </main>
-        <Footer />
+        <Footer pageName="Error Page" />
     </div>
 );
 

--- a/src/js/components/explorer/ExplorerWrapperPage.jsx
+++ b/src/js/components/explorer/ExplorerWrapperPage.jsx
@@ -35,6 +35,7 @@ const ExplorerWrapperPage = (props) => {
 
     return (
         <PageWrapper
+            pageName="Spending Explorer"
             classNames="usa-da-explorer-page"
             title="Spending Explorer"
             metaTagProps={explorerPageMetaTags}

--- a/src/js/components/homepage/Homepage.jsx
+++ b/src/js/components/homepage/Homepage.jsx
@@ -32,7 +32,7 @@ const Homepage = () => (
             <Community />
         </main>
         <GlobalModalContainer />
-        <Footer />
+        <Footer pageName="Homepage" />
     </div>
 );
 

--- a/src/js/components/homepage/features/PaneFeature.jsx
+++ b/src/js/components/homepage/features/PaneFeature.jsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import RedirectModal from 'components/sharedComponents/RedirectModal';
+import Analytics from 'helpers/analytics/Analytics';
 
 const PaneFeature = () => {
     const [isRedirectModalMounted, setIsRedirectModalMounted] = useState(false);
@@ -21,6 +22,12 @@ const PaneFeature = () => {
         setRedirectModalURL('');
         setIsRedirectModalMounted(false);
     };
+
+    const trackLink = (label) => Analytics.event({
+        category: 'Homepage',
+        action: 'Link',
+        label
+    });
 
     return (
         <div className="feature-pane">
@@ -38,7 +45,8 @@ const PaneFeature = () => {
                                 target="_blank"
                                 role="button"
                                 rel="noopener noreferrer"
-                                className="feature-pane__button white">
+                                className="feature-pane__button white"
+                                onClick={() => trackLink('feature 1')}>
                                 Explore Fiscal Data <span className="feature-pane__button-icon"><FontAwesomeIcon icon="external-link-alt" /></span>
                             </a>
                         </div>
@@ -54,7 +62,8 @@ const PaneFeature = () => {
                                 role="button"
                                 rel="noopener noreferrer"
                                 value="https://datalab.usaspending.gov/federal-covid-funding/"
-                                className="feature-pane__button white">
+                                className="feature-pane__button white"
+                                onClick={() => trackLink('feature 2')}>
                                 Explore Data Lab <span className="feature-pane__button-icon"><FontAwesomeIcon icon="external-link-alt" /></span>
                             </a>
                         </div>
@@ -77,7 +86,8 @@ const PaneFeature = () => {
                                 target="_blank"
                                 role="button"
                                 rel="noopener noreferrer"
-                                className="feature-pane__button white">
+                                className="feature-pane__button white"
+                                onClick={() => trackLink('feature 3')}>
                                 Explore the Guide <span className="feature-pane__button-icon"><FontAwesomeIcon icon="external-link-alt" /></span>
                             </a>
                         </div>

--- a/src/js/components/homepage/features/PaneFeature.jsx
+++ b/src/js/components/homepage/features/PaneFeature.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import Analytics from 'helpers/analytics/Analytics';
 
 const PaneFeature = () => {
     const trackLink = (label) => Analytics.event({
@@ -14,74 +15,75 @@ const PaneFeature = () => {
     });
 
     return (
-      <div className="feature-pane">
-        <div className="feature-pane__wrapper">
-            <h2 className="feature-pane__title">OTHER DATA ACT CONTENT</h2>
-            <div className="feature-pane__content-wrapper">
-                <div className="feature-pane__content feature-pane__content-fiscal-data">
-                    <h3 className="feature-pane__content-title">FiscalData.Treasury.gov</h3>
-                    <p className="feature-pane_content-text">
+        <div className="feature-pane">
+            <div className="feature-pane__wrapper">
+                <h2 className="feature-pane__title">OTHER DATA ACT CONTENT</h2>
+                <div className="feature-pane__content-wrapper">
+                    <div className="feature-pane__content feature-pane__content-fiscal-data">
+                        <h3 className="feature-pane__content-title">FiscalData.Treasury.gov</h3>
+                        <p className="feature-pane_content-text">
                         Fiscal Data is a new site featuring federal financial data in machine-readable formats with comprehensive metadata. Explore and download the data today!
-                    </p>
-                    <div className="feature-pane__button-wrapper">
-                        <a
-                            href="https://FiscalData.Treasury.gov"
-                            target="_blank"
-                            role="button"
-                            rel="noopener noreferrer"
-                            className="feature-pane__button white"
-                            onClick={() => trackLink('feature 1')}>
+                        </p>
+                        <div className="feature-pane__button-wrapper">
+                            <a
+                                href="https://FiscalData.Treasury.gov"
+                                target="_blank"
+                                role="button"
+                                rel="noopener noreferrer"
+                                className="feature-pane__button white"
+                                onClick={() => trackLink('feature 1')}>
                             Explore Fiscal Data <span className="feature-pane__button-icon"><FontAwesomeIcon icon="external-link-alt" /></span>
-                        </a>
+                            </a>
+                        </div>
                     </div>
-                </div>
-                <div className="feature-pane__content-divider" />
-                <div className="feature-pane__content feature-pane__content-covid">
-                    <h3 className="feature-pane__content-title feature-pane__content-title-transparent-bg">
+                    <div className="feature-pane__content-divider" />
+                    <div className="feature-pane__content feature-pane__content-covid">
+                        <h3 className="feature-pane__content-title feature-pane__content-title-transparent-bg">
                         The Federal Response to COVID-19
-                    </h3>
-                    <div className="feature-pane__button-wrapper">
-                        <a
-                            href="https://datalab.usaspending.gov/federal-covid-funding/"
-                            target="_blank"
-                            role="button"
-                            rel="noopener noreferrer"
-                            value="https://datalab.usaspending.gov/federal-covid-funding/"
-                            className="feature-pane__button white"
-                            onClick={() => trackLink('feature 2')}>
+                        </h3>
+                        <div className="feature-pane__button-wrapper">
+                            <a
+                                href="https://datalab.usaspending.gov/federal-covid-funding/"
+                                target="_blank"
+                                role="button"
+                                rel="noopener noreferrer"
+                                value="https://datalab.usaspending.gov/federal-covid-funding/"
+                                className="feature-pane__button white"
+                                onClick={() => trackLink('feature 2')}>
                             Explore Data Lab <span className="feature-pane__button-icon"><FontAwesomeIcon icon="external-link-alt" /></span>
-                        </a>
+                            </a>
+                        </div>
                     </div>
-                </div>
-                <div className="feature-pane__content-divider" />
-                <div className="feature-pane__content feature-pane__content-finances-guide">
-                    <p className="feature-pane__content-overline">
+                    <div className="feature-pane__content-divider" />
+                    <div className="feature-pane__content feature-pane__content-finances-guide">
+                        <p className="feature-pane__content-overline">
                         Updated for FY 2019
-                    </p>
-                    <h3 className="feature-pane__content-title">
+                        </p>
+                        <h3 className="feature-pane__content-title">
                         Your Guide to America’s Finances
-                    </h3>
-                    <p className="feature-pane_content-text">
+                        </h3>
+                        <p className="feature-pane_content-text">
                         Your Guide provides a snapshot of Fiscal Year 2019 revenue, spending,
                         deficit, and debt, along with data for download.
                         Click below to visit our partner site.
-                    </p>
-                    <div className="feature-pane__button-wrapper">
-                        <a
-                            href="https://datalab.usaspending.gov/americas-finance-guide/"
-                            target="_blank"
-                            role="button"
-                            rel="noopener noreferrer"
-                            className="feature-pane__button white"
-                            onClick={() => trackLink('feature 3')}>
+                        </p>
+                        <div className="feature-pane__button-wrapper">
+                            <a
+                                href="https://datalab.usaspending.gov/americas-finance-guide/"
+                                target="_blank"
+                                role="button"
+                                rel="noopener noreferrer"
+                                className="feature-pane__button white"
+                                onClick={() => trackLink('feature 3')}>
                             Explore the Guide <span className="feature-pane__button-icon"><FontAwesomeIcon icon="external-link-alt" /></span>
-                        </a>
+                            </a>
+                        </div>
                     </div>
                 </div>
+                <hr className="feature-pane__bottom-divider" />
             </div>
-            <hr className="feature-pane__bottom-divider" />
         </div>
-    </div>
-)};
+    );
+};
 
 export default PaneFeature;

--- a/src/js/components/keyword/KeywordPage.jsx
+++ b/src/js/components/keyword/KeywordPage.jsx
@@ -78,6 +78,7 @@ export default class KeywordPage extends React.Component {
     render() {
         return (
             <PageWrapper
+                pageName="Keyword Search"
                 classNames="usa-da-keyword-page"
                 title="Keyword Search"
                 metaTagProps={MetaTagHelper.keywordPageMetaTags}

--- a/src/js/components/recipient/RecipientPage.jsx
+++ b/src/js/components/recipient/RecipientPage.jsx
@@ -71,6 +71,7 @@ export const RecipientPage = ({
 
     return (
         <PageWrapper
+            pageName="Recipient Profile"
             classNames="usa-da-recipient-page"
             overLine="Recipient Profile"
             title={recipient.overview.name}

--- a/src/js/components/recipientLanding/RecipientLandingPage.jsx
+++ b/src/js/components/recipientLanding/RecipientLandingPage.jsx
@@ -28,6 +28,7 @@ export default class RecipientLandingPage extends React.Component {
     render() {
         return (
             <PageWrapper
+                pageName="Recipient Profiles"
                 classNames="usa-da-recipient-landing"
                 title="Recipient Profiles"
                 metaTagProps={recipientLandingPageMetaTags}

--- a/src/js/components/search/SearchPage.jsx
+++ b/src/js/components/search/SearchPage.jsx
@@ -130,6 +130,7 @@ export default class SearchPage extends React.Component {
 
         return (
             <PageWrapper
+                pageName="Advanced Search"
                 classNames="usa-da-search-page"
                 title="Advanced Search"
                 metaTagProps={MetaTagHelper.searchPageMetaTags}

--- a/src/js/components/sharedComponents/Loading.jsx
+++ b/src/js/components/sharedComponents/Loading.jsx
@@ -56,7 +56,7 @@ export const LoadingWrapper = ({
                                 <FontAwesomeIcon icon="spinner" spin size="lg" />
                                 <h4>{`${msg}${dots}`}</h4>
                             </div>
-                            {includeFooter && (<Footer />)}
+                            {includeFooter && (<Footer pageName="Loading" />)}
                         </PageHeader>
                     </>
                 )}
@@ -64,7 +64,7 @@ export const LoadingWrapper = ({
                     <FontAwesomeIcon icon="spinner" spin size="lg" />
                     <h4>{`${msg}${dots}`}</h4>
                 </div>
-                {includeFooter && (<Footer />)}
+                {includeFooter && (<Footer pageName="Loading" />)}
             </>
         );
     }

--- a/src/js/components/sharedComponents/PageWrapper.jsx
+++ b/src/js/components/sharedComponents/PageWrapper.jsx
@@ -13,6 +13,7 @@ import Header from 'containers/shared/HeaderContainer';
 import Footer from 'containers/Footer';
 
 const PageWrapper = ({
+    pageName,
     classNames,
     metaTagProps = {},
     children,
@@ -33,11 +34,12 @@ const PageWrapper = ({
         {React.cloneElement(children, {
             className: `usda-page__container${children.props.className ? ` ${children.props.className}` : ''}`
         })}
-        <Footer filters={filters} />
+        <Footer pageName={pageName} filters={filters} />
     </div>
 );
 
 PageWrapper.propTypes = {
+    pageName: PropTypes.string.isRequired,
     classNames: PropTypes.string,
     metaTagProps: PropTypes.object,
     toolBarComponents: PropTypes.arrayOf(PropTypes.element),

--- a/src/js/components/sharedComponents/Subscribe.jsx
+++ b/src/js/components/sharedComponents/Subscribe.jsx
@@ -4,9 +4,21 @@
  **/
 
 import React from 'react';
+import PropTypes from 'prop-types';
+import Analytics from 'helpers/analytics/Analytics';
 import { Envelope, CaretRight } from 'components/sharedComponents/icons/Icons';
 
 export default class Subscribe extends React.Component {
+    static propTypes = {
+        pageName: PropTypes.string.isRequired
+    }
+
+    trackLink = () => Analytics.event({
+        category: this.props.pageName,
+        action: 'Link',
+        label: 'sign-up'
+    });
+
     render() {
         return (
             <div className="subscribe">
@@ -21,7 +33,8 @@ export default class Subscribe extends React.Component {
                 </div>
                 <a
                     className="subscribe__link"
-                    href="mailto:join-usaspending@lists.fiscal.treasury.gov?subject=Yes!%20I'd%20like%20to%20receive%20updates.">
+                    href="mailto:join-usaspending@lists.fiscal.treasury.gov?subject=Yes!%20I'd%20like%20to%20receive%20updates."
+                    onClick={this.trackLink}>
                     Sign Up
                     <CaretRight />
                 </a>

--- a/src/js/components/state/StatePage.jsx
+++ b/src/js/components/state/StatePage.jsx
@@ -53,6 +53,7 @@ const StatePage = ({
 
     return (
         <PageWrapper
+            pageName="State Profile"
             classNames="usa-da-state-page"
             overLine="state profile"
             title={stateProfile.overview.name}

--- a/src/js/components/stateLanding/StateLandingPage.jsx
+++ b/src/js/components/stateLanding/StateLandingPage.jsx
@@ -28,6 +28,7 @@ export default class StateLandingPage extends React.Component {
     render() {
         return (
             <PageWrapper
+                pageName="State Profiles"
                 classNames="usa-da-state-landing"
                 title="State Profiles"
                 metaTagProps={stateLandingPageMetaTags}

--- a/src/js/components/testStyles/TestStylePage.jsx
+++ b/src/js/components/testStyles/TestStylePage.jsx
@@ -46,7 +46,7 @@ export default class TestStylePage extends React.Component {
                         </div>
                     </div>
                 </main>
-                <Footer />
+                <Footer pageName="Test Style Page" />
             </div>
         );
     }

--- a/src/js/containers/Footer.jsx
+++ b/src/js/containers/Footer.jsx
@@ -23,6 +23,7 @@ import FooterExternalLink from 'components/sharedComponents/FooterExternalLink';
 import Subscribe from 'components/sharedComponents/Subscribe';
 
 const propTypes = {
+    pageName: PropTypes.string.isRequired,
     filters: PropTypes.object,
     redirectUser: PropTypes.func
 };
@@ -35,6 +36,7 @@ const clickedFooterLink = (route) => {
 };
 
 const Footer = ({
+    pageName,
     filters,
     redirectUser
 }) => {
@@ -49,7 +51,7 @@ const Footer = ({
             <DownloadBottomBarContainer
                 filters={filters} />
             <BulkDownloadBottomBarContainer />
-            <Subscribe />
+            <Subscribe pageName={pageName} />
             <footer
                 className="footer-outer-wrap"
                 role="contentinfo"

--- a/src/js/containers/homepage/CovidHighlights.jsx
+++ b/src/js/containers/homepage/CovidHighlights.jsx
@@ -22,6 +22,7 @@ import withLatestFy from 'containers/account/WithLatestFy';
 import { formatMoneyWithPrecision } from 'helpers/moneyFormatter';
 import { fetchOverview, fetchDisasterSpending } from 'apis/disaster';
 import { scrollToY } from 'helpers/scrollToHelper';
+import Analytics from 'helpers/analytics/Analytics';
 
 // datamapping
 import { allDefCAwardTypeCodes } from 'dataMapping/covid19/covid19';
@@ -30,7 +31,6 @@ import { allDefCAwardTypeCodes } from 'dataMapping/covid19/covid19';
 import HeroButton from 'components/homepage/hero/HeroButton';
 import HomePageTooltip from 'components/homepage/hero/CovidTooltip';
 import TotalAmount from 'components/homepage/hero/TotalAmount';
-
 
 const defaultParams = {
     pagination: {
@@ -266,6 +266,12 @@ export class CovidHighlights extends React.Component {
         this.setState({ isIncrementComplete: true });
     }
 
+    trackLink = () => Analytics.event({
+        category: 'Homepage',
+        action: 'Link',
+        label: 'covid hero'
+    });
+
     render() {
         const {
             isAmountLoading,
@@ -308,7 +314,8 @@ export class CovidHighlights extends React.Component {
                         <div className="covid-profile-link__button-wrap">
                             <Link
                                 className="covid-profile-link__button"
-                                to="/disaster/covid-19">
+                                to="/disaster/covid-19"
+                                onClick={this.trackLink}>
                                 View all COVID-19 spending
                             </Link>
                             <hr />


### PR DESCRIPTION
**High level description:**

add GA tracking to links on home page and list signup

**Technical details:**

had to pass page name to each instance of Footer and PageWrapper

**JIRA Ticket:**
[DEV-7671](https://federal-spending-transparency.atlassian.net/browse/DEV-7671)

**Mockup:**
none

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
-na [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
-na [ ] Verified mobile/tablet/desktop/monitor responsiveness
-na [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
-na [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
-na [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
-na [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
-na [ ] Design review complete `if applicable`
-na [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
