### PR TITLE
Dev-6562 Advanced Search Submit Bug

### DIFF
--- a/src/js/components/search/SearchSidebarSubmit.jsx
+++ b/src/js/components/search/SearchSidebarSubmit.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const propTypes = {
+    stagedFiltersAreEmpty: PropTypes.bool,
     requestsComplete: PropTypes.bool,
     filtersChanged: PropTypes.bool,
     applyStagedFilters: PropTypes.func,
@@ -16,7 +17,11 @@ const propTypes = {
 const SearchSidebarSubmit = (props) => {
     let disabled = false;
     let title = 'Click to submit your search.';
-    if (!props.requestsComplete || !props.filtersChanged) {
+    if (props.stagedFiltersAreEmpty) {
+        title = 'Add or update a filter to submit.';
+        disabled = true;
+    }
+    else if (!props.requestsComplete || !props.filtersChanged) {
         title = 'Add or update a filter to submit.';
         disabled = true;
     }

--- a/src/js/containers/search/SearchSidebarSubmitContainer.jsx
+++ b/src/js/containers/search/SearchSidebarSubmitContainer.jsx
@@ -7,14 +7,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-
+import { isEqual } from 'lodash';
 import * as appliedFilterActions from 'redux/actions/search/appliedFilterActions';
 import { clearAllFilters as clearStagedFilters } from 'redux/actions/search/searchFilterActions';
 import { resetMapLegendToggle } from 'redux/actions/search/mapLegendToggleActions';
 
 import { areFiltersEqual } from 'helpers/searchHelper';
 import SearchSidebarSubmit from 'components/search/SearchSidebarSubmit';
-
+import { initialState } from 'redux/reducers/search/searchFiltersReducer';
 import {
     convertFiltersToAnalyticEvents,
     sendAnalyticEvents,
@@ -112,6 +112,7 @@ export class SearchSidebarSubmitContainer extends React.Component {
     render() {
         return (
             <SearchSidebarSubmit
+                stagedFiltersAreEmpty={isEqual(initialState, this.props.stagedFilters)}
                 filtersChanged={this.state.filtersChanged}
                 requestsComplete={this.props.requestsComplete}
                 applyStagedFilters={this.applyStagedFilters}

--- a/src/js/containers/search/SearchSidebarSubmitContainer.jsx
+++ b/src/js/containers/search/SearchSidebarSubmitContainer.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { isEqual } from 'lodash';
 import * as appliedFilterActions from 'redux/actions/search/appliedFilterActions';
 import { clearAllFilters as clearStagedFilters } from 'redux/actions/search/searchFilterActions';
 import { resetMapLegendToggle } from 'redux/actions/search/mapLegendToggleActions';
@@ -45,7 +44,8 @@ export class SearchSidebarSubmitContainer extends React.Component {
         super(props);
 
         this.state = {
-            filtersChanged: false
+            filtersChanged: false,
+            stagedFiltersAreEmpty: false
         };
 
         this.resetFilters = this.resetFilters.bind(this);
@@ -61,6 +61,8 @@ export class SearchSidebarSubmitContainer extends React.Component {
             this.stagingChanged();
         }
     }
+
+    areStagedFiltersEmpty = () => areFiltersEqual(this.props.stagedFilters, initialState);
 
     compareStores() {
         // we need to do a deep equality check by comparing every store key
@@ -112,7 +114,7 @@ export class SearchSidebarSubmitContainer extends React.Component {
     render() {
         return (
             <SearchSidebarSubmit
-                stagedFiltersAreEmpty={isEqual(initialState, this.props.stagedFilters)}
+                stagedFiltersAreEmpty={this.areStagedFiltersEmpty()}
                 filtersChanged={this.state.filtersChanged}
                 requestsComplete={this.props.requestsComplete}
                 applyStagedFilters={this.applyStagedFilters}

--- a/src/js/containers/search/SearchSidebarSubmitContainer.jsx
+++ b/src/js/containers/search/SearchSidebarSubmitContainer.jsx
@@ -44,8 +44,7 @@ export class SearchSidebarSubmitContainer extends React.Component {
         super(props);
 
         this.state = {
-            filtersChanged: false,
-            stagedFiltersAreEmpty: false
+            filtersChanged: false
         };
 
         this.resetFilters = this.resetFilters.bind(this);

--- a/tests/components/search/SearchSideBarSubmit-test.jsx
+++ b/tests/components/search/SearchSideBarSubmit-test.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from 'test-utils';
+import SearchSidebarSubmit from 'components/search/SearchSidebarSubmit';
+
+
+it('should be disabled given no filters are staged', () => {
+    render(<SearchSidebarSubmit
+        stagedFiltersAreEmpty
+        filtersChanged={false}
+        requestsComplete={false}
+        applyStagedFilters={() => {}}
+        resetFilters={() => {}} />);
+    expect(screen.getByText('Submit Search')).toHaveProperty('disabled', true);
+});


### PR DESCRIPTION
**High level description:**

When there are no filters, you will not be able to submit a search.

**Technical details:**

> • check if there are no filters selected before enabling the search submit button.

**JIRA Ticket:**
[DEV-6562](https://federal-spending-transparency.atlassian.net/browse/DEV-6562)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [N/A] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [N/A] Verified mobile/tablet/desktop/monitor responsiveness
- [N/A] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [N/A] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [N/A] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [N/A] Design review complete `if applicable`
- [N/A] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
