### PR TITLE
dev7775 add percent to award type labels

### DIFF
--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -137,10 +137,10 @@ export default function ObligationsByAwardType({
     const labelPos = (i, yOffset = 0) => {
         if (i === 0) {
             // Financial Assistance, bottom right
-            return [labelRadius - 62, (chartHeight / 2) - (25 + yOffset)];
+            return [labelRadius - 62, ((chartHeight / 2) - 25) + yOffset];
         }
         // Contracts, top left
-        return [-(labelRadius) + 18, -(chartHeight / 2) + (29 + yOffset)];
+        return [-(labelRadius) + 18, -(chartHeight / 2) + 29 + yOffset];
     };
 
     const outerLabels = outer.map((d) => d.label);

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -137,10 +137,10 @@ export default function ObligationsByAwardType({
     const labelPos = (i, yOffset = 0) => {
         if (i === 0) {
             // Financial Assistance, bottom right
-            return [labelRadius - 62, ((chartHeight / 2) - 25) + yOffset];
+            return [labelRadius - 62, (chartHeight / 2) - 25 + yOffset];
         }
         // Contracts, top left
-        return [-(labelRadius) + 18, -(chartHeight / 2) + 29];
+        return [-(labelRadius) + 18, -(chartHeight / 2) + 29 + yOffset];
     };
 
     const outerLabels = outer.map((d) => d.label);
@@ -158,12 +158,12 @@ export default function ObligationsByAwardType({
             .style("fill", outer[0].color);
         // text
         svg.selectAll()
-            .data(outerPie)
+            .data(outerLabels[0])
             .enter()
             .append('text')
-            .attr('transform', (d, i) => `translate(${labelPos(i)})`)
+            .attr('transform', (d, i) => `translate(${labelPos(0, i * 12)})`)
             .attr('class', 'obligations-by-award-type__label')
-            .text((d, i) => outerLabels[i][0]);
+            .text((d) => d);
     }
 
     // Contracts legend
@@ -179,12 +179,12 @@ export default function ObligationsByAwardType({
             .style("fill", outer[1].color);
         // text
         svg.selectAll()
-            .data(outerPie)
+            .data(outerLabels[1])
             .enter()
             .append('text')
-            .attr('transform', (d, i) => `translate(${labelPos(i, 12)})`)
+            .attr('transform', (d, i) => `translate(${labelPos(1, i * 12)})`)
             .attr('class', 'obligations-by-award-type__label')
-            .text((d, i) => outerLabels[i][1]);
+            .text((d) => d);
     }
 
     return (

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -51,7 +51,7 @@ export default function ObligationsByAwardType({
         if (rect.height !== chartHeight || rect.width !== chartWidth) {
             setChartHeight(rect.height);
             setChartWidth(rect.width);
-        };
+        }
     }, [windowWidth]);
 
     const labelRadius = Math.min(chartHeight, chartWidth) / 2;
@@ -137,10 +137,10 @@ export default function ObligationsByAwardType({
     const labelPos = (i, yOffset = 0) => {
         if (i === 0) {
             // Financial Assistance, bottom right
-            return [labelRadius - 62, (chartHeight / 2) - 25 + yOffset];
+            return [labelRadius - 62, (chartHeight / 2) - (25 + yOffset)];
         }
         // Contracts, top left
-        return [-(labelRadius) + 18, -(chartHeight / 2) + 29 + yOffset];
+        return [-(labelRadius) + 18, -(chartHeight / 2) + (29 + yOffset)];
     };
 
     const outerLabels = outer.map((d) => d.label);

--- a/src/js/containers/agencyV2/visualizations/ObligationsByAwardTypeContainer.jsx
+++ b/src/js/containers/agencyV2/visualizations/ObligationsByAwardTypeContainer.jsx
@@ -12,6 +12,7 @@ import ObligationsByAwardType from 'components/agencyV2/visualizations/Obligatio
 import { LoadingMessage, ErrorMessage, NoResultsMessage } from 'data-transparency-ui';
 import { fetchObligationsByAwardType } from 'apis/agencyV2';
 import { setAwardObligations, resetAwardObligations } from 'redux/actions/agencyV2/agencyV2Actions';
+import { calculatePercentage } from 'helpers/moneyFormatter';
 
 const propTypes = {
     fiscalYear: PropTypes.number.isRequired,
@@ -42,13 +43,13 @@ export default function ObligationsByAwardTypeContainer({ fiscalYear, windowWidt
         }
         if (error) {
             setError(false);
-        };
+        }
         if (noData) {
             setNoData(false);
-        };
+        }
         if (!loading) {
             setLoading(true);
-        };
+        }
         obligationsByAwardTypeRequest.current = fetchObligationsByAwardType(toptierCode, fiscalYear);
         obligationsByAwardTypeRequest.current.promise.then((res) => {
             if (Object.keys(res.data).length === 0) {
@@ -135,6 +136,11 @@ export default function ObligationsByAwardTypeContainer({ fiscalYear, windowWidt
                             setError(true);
                     }
                 });
+
+                // add % of total to category labels
+                categories[0].label[2] = ` ${calculatePercentage(categories[0].value, categories[0].value + categories[1].value)}`;
+                categories[1].label[1] = ` ${calculatePercentage(categories[1].value, categories[0].value + categories[1].value)}`;
+
                 setCategoriesForGraph(categories);
                 setDetailsForGraph(details);
                 setLoading(false);


### PR DESCRIPTION
**High level description:**

add percentage of total to by award type outer ring labels

**Technical details:**

had to rework label drawing a bit

**JIRA Ticket:**
[DEV-7775](https://federal-spending-transparency.atlassian.net/browse/DEV-7775)

**Mockup:**
in ticket

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] n/a Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] n/a Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] n/a Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [x] n/a [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [x] n/a [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [x] n/a [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
