### PR TITLE
dev-7481 Fix spending explorer broken link table view

### DIFF
--- a/src/js/components/explorer/detail/visualization/table/TableRow.jsx
+++ b/src/js/components/explorer/detail/visualization/table/TableRow.jsx
@@ -23,7 +23,7 @@ export default class TableRow extends React.PureComponent {
             rowClass = 'row-odd';
         }
         const cells = this.props.columns.map((column) => {
-            if (column.columnName === 'name' && (this.props.item.id || this.props.item.name === "Unreported Data")) {
+            if (column.columnName === 'name' && (this.props.item.id || this.props.item.name === "Unreported Data") && this.props.item.id !== 'undefined') {
                 // show the link cell
                 return (
                     <td


### PR DESCRIPTION
**High level description:**

Fix broken link in table view for non-award spending, tree view was fixed in previous PR

**JIRA Ticket:**
[DEV-7481](https://federal-spending-transparency.atlassian.net/browse/DEV-7481)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [n/a] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a] Design review complete `if applicable`
- [n/a] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
