### PR TITLE
dev7253 fix about page back nav

### DIFF
--- a/src/js/components/about/AboutContent.jsx
+++ b/src/js/components/about/AboutContent.jsx
@@ -72,18 +72,11 @@ const AboutContent = () => {
     const [activeSection, setActiveSection] = useState(query.section || 'mission');
 
     const jumpToSection = (section = '') => {
-        // we've been provided a section to jump to
-        // check if it's a valid section
-        const matchedSection = find(aboutSections, {
-            section
-        });
-
-        if (!matchedSection) {
-            // no matching section
+        if (!find(aboutSections, { section })) { // not a known page section
             return;
         }
+
         setActiveSection(section);
-        // scroll to the correct section
         const sectionDom = document.querySelector(`#about-${section}`);
         if (!sectionDom) {
             return;
@@ -106,7 +99,7 @@ const AboutContent = () => {
         if (urlSection) {
             jumpToSection(urlSection);
             // remove the query param from the url after scrolling to the given section
-            history.push(`/about`);
+            history.replace(`/about`);
         }
     }, [location.search]);
 


### PR DESCRIPTION
**High level description:**

Navigating to /about with a query param section scrolled to the section, but added an entry to history that trapped people using back button.

**Technical details:**

react-router-dom replace instead of push to prevent the trap

**JIRA Ticket:**
[DEV-7253](https://federal-spending-transparency.atlassian.net/browse/DEV-7253)

**Mockup:**
na

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ na] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ na] Verified mobile/tablet/desktop/monitor responsiveness
- [ na] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ na] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ na] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ na] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ na] Design review complete `if applicable`
- [ na] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
