### PR TITLE
DEV-7526 fix COVID page back nav

### DIFF
--- a/src/js/components/covid19/Covid19Page.jsx
+++ b/src/js/components/covid19/Covid19Page.jsx
@@ -61,12 +61,12 @@ const Covid19Page = ({ areDefCodesLoading }) => {
         if (isRecipientMapLoaded && query.section) {
             handleJumpToSection(query.section);
             const newParams = getQueryParamString(omit(query, ['section']));
-            history.push({
+            history.replace({
                 pathname: '/disaster/covid-19',
                 search: newParams
             });
         }
-    }, [isRecipientMapLoaded]);
+    }, [history, isRecipientMapLoaded, query]);
 
 
     const handleExternalLinkClick = (url) => {


### PR DESCRIPTION
**High level description:**

Navigating to a specific section of COVID page was adding a 2nd layer to browser history, so back button needed to be hit twice.

**Technical details:**

changed history.push to history.replace

**JIRA Ticket:**
[DEV-7526](https://federal-spending-transparency.atlassian.net/browse/DEV-7526)

**Mockup:**
na

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ na] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ na] Verified mobile/tablet/desktop/monitor responsiveness
- [ na] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ na] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ na] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ na] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ na] Design review complete `if applicable`
- [ na] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
