### PR TITLE
Disallow robots to recognize query params as separate pages

### DIFF
--- a/scripts/sitemaps/buildSitemap.js
+++ b/scripts/sitemaps/buildSitemap.js
@@ -66,10 +66,10 @@ const createSitemapEntry = (xml, pageData, pageInfo) => {
 const createRobots = () => {
     fs.writeFile(
         path.resolve(__dirname, `./sitemapFiles/robots.txt`),
-        `User-agent: * \nDisallow: /*.php*\nDisallow: /*?glossary=*\n\nSitemap: ${siteUrl}/sitemap.xml`,
+        `User-agent: * \nDisallow: /*.php*\nDisallow: /*?*\n\nSitemap: ${siteUrl}/sitemap.xml`,
         (e) => {
             if (e) {
-                console.log(' Error : ', e);
+                console.error(' Error : ', e);
                 throw e.message;
             }
             console.log("robots.txt successfully created!");


### PR DESCRIPTION
**High level description:**
improve seo by disallowing query params (now considered to be separate pages, which gives many duplicate contents)

**Technical details:**
replaced rule to disallow glossary with this to ignore all query params
deployed to qat; resulting file is: https://qat.usaspending.gov/robots.txt

**JIRA Ticket:**
[DEV-7465](https://federal-spending-transparency.atlassian.net/browse/DEV-7465)

**Mockup:**
 na

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] na Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] na Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] na Verified mobile/tablet/desktop/monitor responsiveness
- [x] na Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] na Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [x] na [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [x] na [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] na Design review complete `if applicable`
- [x] na [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
