### PR TITLE
[DEV 7913] Left-align Covid Profile headings & descriptions

### DIFF
--- a/src/_scss/components/_footerLinkToAdvancedSearch.scss
+++ b/src/_scss/components/_footerLinkToAdvancedSearch.scss
@@ -12,7 +12,8 @@
         margin: 0 rem(20);
         h4,
         p {
-            text-align: center;
+            text-align: left;
+            margin-left: rem(5);
         }
         h4 {
             font-size: rem(38);

--- a/src/_scss/pages/covid19/index.scss
+++ b/src/_scss/pages/covid19/index.scss
@@ -108,21 +108,14 @@
         .body__content {
           width: 100%; // Fixes an IE Flexbox bug
           h3.body__narrative {
-            text-align: center;
+            text-align: left;
             font-weight: $font-semibold;
             font-size: 3rem;
-            @include media($medium-screen) {
-              padding-left: 15%;
-              padding-right: 15%;
-            }
           }
 
           .body__narrative-description {
             font-size: $small-font-size;
-            text-align: center;
-            @include media($medium-screen) {
-              max-width: 70%;
-            }
+            text-align: left;
             margin: auto;
             padding-bottom: 5rem;
             .footnotes {
@@ -170,7 +163,7 @@
 
         .heading__container {
           border-radius: 0.5rem 0.5rem 0 0;
-          @include display(flex);
+          @include display(block);
           flex-wrap: wrap;
           text-align: left;
           width: 100%;
@@ -209,11 +202,11 @@
               font-weight: $font-semibold;
             }
           }
+          .aligned-heading {
+            display: flex;
+            align-items: flex-end;
+          }
           .heading__img-wrapper {
-            @include display(block);
-            object-fit: contain;
-            max-width: 100%;
-            height: auto;
             .heading__img-mobile {
               display: block;
               @include media(560px) {
@@ -223,19 +216,19 @@
             .heading__img {
               display: none;
               @include media(560px) {
-                display: block;
+                display: flex;
                 transform: scaleX(-1);
               }
               @include media($medium-screen) {
-                display: block;
+                display: flex;
                 transform: scaleX(-1);
               }
               @include media($large-screen) {
-                display: block;
+                display: flex;
                 transform: scaleX(-1);
               }
               @include media($x-large-screen) {
-                display: block;
+                display: flex;
                 transform: scaleX(-1);
               }
             }
@@ -261,7 +254,7 @@
           .award-question__container {
             @include display(flex);
             flex-wrap: wrap;
-            text-align: center;
+            text-align: left;
             width: 100%;
             .information-top {
               height: 0.5rem;
@@ -277,10 +270,10 @@
               font-weight: $font-semibold;
               letter-spacing: 0;
               line-height: 4.5rem;
-              text-align: center;
-              padding: 6.2rem 2.5% 3.1rem;
+              text-align: left;
+              padding: 3rem 5% 0;
               @media (min-width: $medium-screen) {
-                padding: 6.2rem 15% 3.1rem;
+                padding: 3rem 5% 0;
               }
               width: 100%;
             }
@@ -288,13 +281,13 @@
               font-size: 1.4rem;
               letter-spacing: 0;
               line-height: 2.2rem;
-              text-align: center;
-              padding: 0 2.5%;
+              text-align: left;
+              padding: 0 5% 2rem;
               @media (min-width: $medium-screen) {
-                padding: 0 15% 6.1rem;
+                padding: 0 5% 2rem;
               }
               .award-question__sub-section_paragraph:first-of-type {
-                margin-top: 0;
+                margin-top: 1.6rem;
               }
             }
           }

--- a/src/_scss/pages/covid19/index.scss
+++ b/src/_scss/pages/covid19/index.scss
@@ -171,7 +171,6 @@
         .heading__container {
           border-radius: 0.5rem 0.5rem 0 0;
           @include display(block);
-          flex-wrap: wrap;
           text-align: left;
           .heading__top {
             height: 1.66rem;

--- a/src/_scss/pages/covid19/index.scss
+++ b/src/_scss/pages/covid19/index.scss
@@ -105,12 +105,18 @@
           background: $color-gray;
           border: none;
         }
+        .usda-section-title__container {
+          .usda-section-title__title-icon {
+            margin-left: 0;
+          }
+        }
         .body__content {
           width: 100%; // Fixes an IE Flexbox bug
           h3.body__narrative {
             text-align: left;
             font-weight: $font-semibold;
             font-size: 3rem;
+            padding-left: 4.5rem;
           }
 
           .body__narrative-description {
@@ -118,6 +124,7 @@
             text-align: left;
             margin: auto;
             padding-bottom: 5rem;
+            padding-left: 4.5rem;
             .footnotes {
               font-size: $smallest-font-size;
               .usda-external-link {
@@ -175,10 +182,10 @@
             letter-spacing: 0;
             line-height: 4.5rem;
             text-align: left;
-            padding: 3rem 4.5% 0;
+            padding: 3rem 5.5% 0;
             margin-top: 2rem;
             @media (min-width: $medium-screen) {
-              padding: 3rem 4.5% 0;
+              padding: 3rem 5.5% 0;
             }
             width: 100%;
           }
@@ -187,9 +194,9 @@
             letter-spacing: 0;
             line-height: 2.2rem;
             text-align: left;
-            padding: 0 5% 2rem;
+            padding: 0 6% 2rem;
             @media (min-width: $medium-screen) {
-              padding: 0 5% 2rem;
+              padding: 0 6% 2rem;
             }
             .footnotes {
               font-size: $smallest-font-size;
@@ -235,6 +242,7 @@
           letter-spacing: 0;
           line-height: 1.5rem;
           margin-left: rem(5);
+          padding-left: 3rem;
           @media (min-width: $medium-screen) {
             margin-left: rem(15);
           }
@@ -263,10 +271,7 @@
               letter-spacing: 0;
               line-height: 4.5rem;
               text-align: left;
-              padding: 3rem 5% 0;
-              @media (min-width: $medium-screen) {
-                padding: 3rem 5% 0;
-              }
+              padding: 5rem 5% 0;
               width: 100%;
             }
             .award-question__sub-section {
@@ -275,9 +280,6 @@
               line-height: 2.2rem;
               text-align: left;
               padding: 0 5% 2rem;
-              @media (min-width: $medium-screen) {
-                padding: 0 5% 2rem;
-              }
               .award-question__sub-section_paragraph:first-of-type {
                 margin-top: 1.6rem;
               }

--- a/src/_scss/pages/covid19/index.scss
+++ b/src/_scss/pages/covid19/index.scss
@@ -175,10 +175,10 @@
             letter-spacing: 0;
             line-height: 4.5rem;
             text-align: left;
-            padding: 3rem 5% 0;
+            padding: 3rem 4.5% 0;
             margin-top: 2rem;
             @media (min-width: $medium-screen) {
-              padding: 3rem 5% 0;
+              padding: 3rem 4.5% 0;
             }
             width: 100%;
           }
@@ -202,10 +202,10 @@
             }
           }
           .aligned-heading {
-            display: flex;
-            align-items: flex-end;
-            @media(max-width: 560px) {
-              display: block;
+            display: block;
+            @include media(560px) {
+              display: flex;
+              align-items: flex-end;
             }
           }
           .heading__img-wrapper {

--- a/src/_scss/pages/covid19/index.scss
+++ b/src/_scss/pages/covid19/index.scss
@@ -172,7 +172,7 @@
           border-radius: 0.5rem 0.5rem 0 0;
           @include display(flex);
           flex-wrap: wrap;
-          text-align: center;
+          text-align: left;
           width: 100%;
           .heading__top {
             height: 1.66rem;
@@ -182,19 +182,11 @@
             font-weight: $font-semibold;
             letter-spacing: 0;
             line-height: 4.5rem;
-            text-align: center;
-            padding-top: 2rem;
-            padding-bottom: 1rem;
-            padding: 1rem;
-            @media (max-width: 559px) {
-              text-align: left;
-              margin-left: 1rem;
-            }
-            @media (max-width: $medium-screen) {
-              margin-top: 1rem;
-            }
+            text-align: left;
+            padding: 3rem 5% 0;
+            margin-top: 2rem;
             @media (min-width: $medium-screen) {
-              padding: 2rem 15% 2rem;
+              padding: 3rem 5% 0;
             }
             width: 100%;
           }
@@ -202,15 +194,10 @@
             font-size: 1.4rem;
             letter-spacing: 0;
             line-height: 2.2rem;
-            text-align: center;
-            padding: 0 23% 2rem;
-            @media (max-width: 559px) {
-              text-align: left;
-              margin-left: 1rem;
-              padding: 1rem;
-            }
+            text-align: left;
+            padding: 0 5% 2rem;
             @media (min-width: $medium-screen) {
-              padding: 0 15% 2rem;
+              padding: 0 5% 2rem;
             }
             .footnotes {
               font-size: $smallest-font-size;
@@ -224,12 +211,11 @@
           }
           .heading__img-wrapper {
             @include display(block);
-            max-height: 10vh;
+            object-fit: contain;
+            max-width: 100%;
+            height: auto;
             .heading__img-mobile {
               display: block;
-              width: 130px;
-              margin-top: -40px;
-              min-height: 10vh;
               @include media(560px) {
                 display: none;
               }
@@ -238,27 +224,19 @@
               display: none;
               @include media(560px) {
                 display: block;
-                width: 32%;
-                margin-top: -110px;
-                min-height: 10vh;
+                transform: scaleX(-1);
               }
               @include media($medium-screen) {
                 display: block;
-                width: 32%;
-                margin-top: -100px;
-                min-height: 10vh;
+                transform: scaleX(-1);
               }
               @include media($large-screen) {
                 display: block;
-                width: 33%;
-                margin-top: -120px;
-                min-height: 10vh;
+                transform: scaleX(-1);
               }
               @include media($x-large-screen) {
                 display: block;
-                width: 35%;
-                margin-top: -120px;
-                min-height: 10vh;
+                transform: scaleX(-1);
               }
             }
           }

--- a/src/_scss/pages/covid19/index.scss
+++ b/src/_scss/pages/covid19/index.scss
@@ -166,7 +166,6 @@
           @include display(block);
           flex-wrap: wrap;
           text-align: left;
-          width: 100%;
           .heading__top {
             height: 1.66rem;
           }
@@ -205,10 +204,15 @@
           .aligned-heading {
             display: flex;
             align-items: flex-end;
+            @media(max-width: 560px) {
+              display: block;
+            }
           }
           .heading__img-wrapper {
             .heading__img-mobile {
               display: block;
+              margin-left: auto;
+              max-height: 10vh;
               @include media(560px) {
                 display: none;
               }
@@ -216,18 +220,6 @@
             .heading__img {
               display: none;
               @include media(560px) {
-                display: flex;
-                transform: scaleX(-1);
-              }
-              @include media($medium-screen) {
-                display: flex;
-                transform: scaleX(-1);
-              }
-              @include media($large-screen) {
-                display: flex;
-                transform: scaleX(-1);
-              }
-              @include media($x-large-screen) {
                 display: flex;
                 transform: scaleX(-1);
               }

--- a/src/_scss/pages/covid19/visualizations/_amounts.scss
+++ b/src/_scss/pages/covid19/visualizations/_amounts.scss
@@ -55,7 +55,7 @@
                   line-height: rem(25);
                   font-size: rem(20);
                   margin-bottom: 0;
-                  margin-top: 0;
+                  margin-top: 2rem;
                 }
                 .amounts-viz__sub-title {
                   font-size: rem(16);

--- a/src/js/components/covid19/Heading.jsx
+++ b/src/js/components/covid19/Heading.jsx
@@ -15,23 +15,25 @@ const Heading = () => {
             <div className="heading__title">
                 The Federal Response to <span className="color-purple">COVID-19</span>
             </div>
-            <div className="heading__description">
-                <p>In early 2020, the U.S. Congress appropriated funds in response to the COVID-19 pandemic. These funds were made possible through the Coronavirus Aid, Relief, and Economic Security (CARES) Act and other supplemental legislation. In March of 2021, additional funds were appropriated through the American Rescue Plan Act.</p>
-                <p>
-                    Visit our <button className="usa-button-link" onClick={jumpToDataSources}>Data Sources & Methodology</button> section to learn more about the underlying data and find resources about COVID-19 from other agencies.
-                </p>
-            </div>
-            <div style={{ marginLeft: "auto" }} className="heading__img-wrapper">
-                <img
-                    className="heading__img"
-                    src="img/desktop@2x.png"
-                    alt="" />
-            </div>
-            <div style={{ marginLeft: "auto" }} className="heading__img-wrapper">
-                <img
-                    className="heading__img-mobile"
-                    src="img/mobile@2x.png"
-                    alt="" />
+            <div className="aligned-heading">
+                <div className="heading__description">
+                    <p>In early 2020, the U.S. Congress appropriated funds in response to the COVID-19 pandemic. These funds were made possible through the Coronavirus Aid, Relief, and Economic Security (CARES) Act and other supplemental legislation. In March of 2021, additional funds were appropriated through the American Rescue Plan Act.</p>
+                    <p>
+                        Visit our <button className="usa-button-link" onClick={jumpToDataSources}>Data Sources & Methodology</button> section to learn more about the underlying data and find resources about COVID-19 from other agencies.
+                    </p>
+                </div>
+                <div className="heading__img-wrapper">
+                    <img
+                        className="heading__img"
+                        src="img/desktop@2x.png"
+                        alt="" />
+                </div>
+                <div className="heading__img-wrapper">
+                    <img
+                        className="heading__img-mobile"
+                        src="img/mobile@2x.png"
+                        alt="" />
+                </div>
             </div>
         </div>
     );

--- a/src/js/components/covid19/Heading.jsx
+++ b/src/js/components/covid19/Heading.jsx
@@ -21,7 +21,7 @@ const Heading = () => {
                     Visit our <button className="usa-button-link" onClick={jumpToDataSources}>Data Sources & Methodology</button> section to learn more about the underlying data and find resources about COVID-19 from other agencies.
                 </p>
             </div>
-            <div className="heading__img-wrapper">
+            <div style={{ marginLeft: "auto" }} className="heading__img-wrapper">
                 <img
                     className="heading__img"
                     src="img/desktop@2x.png"


### PR DESCRIPTION
**High level description:**

For each section heading of the Covid profile that is currently center-aligned, the text is updated to match the latest mockup (left-aligned) 

*note this is prep work for ARP branding ticket https://federal-spending-transparency.atlassian.net/browse/DEV-7877

**JIRA Ticket:**
[DEV-7913](https://federal-spending-transparency.atlassian.net/browse/DEV-7913)

**Mockup:**
https://bahdigital.invisionapp.com/share/4HIAGPS7T3X#/screens

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a] Design review complete `if applicable`
- [n/a] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
