### PR TITLE
7393 - object class treeview

### DIFF
--- a/src/js/components/agency/visualizations/objectClass/MinorObjectClasses.jsx
+++ b/src/js/components/agency/visualizations/objectClass/MinorObjectClasses.jsx
@@ -50,13 +50,8 @@ export default class MinorObjectClasses extends React.Component {
 
     componentDidUpdate(prevProps) {
         if (!isEqual(prevProps, this.props) && this.props.minorObjectClasses.children.length > 0) {
-            this.buildTree(this.props);
-        }
-        // Clear out the finalNodes if props change and there are no minorObjectClasses.
-        // This will occur when the treemap has previously rendered and we're loading
-        // a different set of minorObjectClasses from the API.
-        else if (this.state.finalNodes.length > 0) {
             this.clearFinalNodes();
+            this.buildTree(this.props);
         }
     }
 
@@ -238,6 +233,7 @@ export default class MinorObjectClasses extends React.Component {
 
         return tooltip;
     }
+
 
     render() {
         const value = parseFloat(this.props.majorObjectClass.obligated_amount);


### PR DESCRIPTION
**High level description:**

On the Agency Profile page, in the Object Classes section, when clicking on a Major Object class to show the Minor Object classes below it, the tree viz was only showing a gray box. 

**Technical details:**

I traced the problem to the clearFinalNodes function call in the componentDidUpdate function. It was clearing the nodes for the Minor Object classes just after the tree viz was drawn on the page, causing it to redraw with no data. So I moved the clearFinalNodes call to just before buildTree is called, to clear the old nodes when a new tree viz needs to be drawn.

**JIRA Ticket:**
[DEV-7393](https://federal-spending-transparency.atlassian.net/browse/DEV-1234)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [x ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
