### PR TITLE
DEV-7960 fix advanced search glossary links

### DIFF
--- a/src/_scss/pages/search/_filterExpand.scss
+++ b/src/_scss/pages/search/_filterExpand.scss
@@ -25,6 +25,7 @@
             height: rem(16);
             width: rem(16);
             margin-right: rem(5);
+            pointer-events: none;
         }
         @import './tooltips';
 

--- a/src/_scss/pages/search/_filterExpand.scss
+++ b/src/_scss/pages/search/_filterExpand.scss
@@ -6,70 +6,43 @@
     .filter-toggle__button {
         @include button-unstyled;
         @include display(flex);
-        @include justify-content(center);
         @include align-items(center);
         @include flex(1 1 auto);
         padding: rem(15);
 
+        @include h6;
+        color: $color-gray;
+        font-size: $small-font-size;
+        font-weight: $font-semibold;
+        height: 100%;
+        line-height: 1;
+        margin: 0;
+        @include media($large-screen) {
+            font-size: $base-font-size;
+        }
         svg {
             @include flex(0 0 auto);
-            cursor: pointer;
-            pointer-events: none;
-            fill: $color-gray;
-            height: rem(11);
-            width: rem(11);
-            @include media($large-screen) {
-                width: rem(12);
-                height: rem(12);
-            }
+            height: rem(16);
+            width: rem(16);
+            margin-right: rem(5);
         }
-
-        .filter-toggle__name {
-            @include h6;
-            @include display(flex);
-            @include align-items(center);
-            @include flex(1 1 auto);
-            color: $color-gray;
-            font-size: $small-font-size;
-            font-weight: $font-semibold;
-            height: 100%;
-            line-height: 1;
-            margin: 0;
-            padding-left: rem(6);
-            @include media($large-screen) {
-                font-size: $base-font-size;
-            }
-            span {
-                padding-right: rem(5);
-            }
-            @import "./tooltips";
-        }
+        @import './tooltips';
 
         &:hover {
             cursor: pointer;
-            svg {
-                cursor: pointer;
-                fill: $color-black;
-                @include transition(all 0.25s $ease-in-out-sine);
-            }
         }
     }
     .filter-toggle__accessory {
         @include display(flex);
         @include align-items(flex-start);
-        @import "../../components/newBadge";
+        @import 'components/newBadge';
     }
     .filter-toggle__glossary {
         @include display(flex);
         @include flex(0 0 auto);
         padding-right: rem(15);
-        a {
-            font-size: $small-font-size;
-            color: $color-gray-light;
-            &:hover {
-                color: $color-gray;
-            }
-        }
+        padding-left: rem(5);
+        @import 'components/glossaryLink';
     }
 }
 

--- a/src/js/components/search/SearchSidebar.jsx
+++ b/src/js/components/search/SearchSidebar.jsx
@@ -29,7 +29,6 @@ import DEFCheckboxTree, { NewBadge } from 'containers/search/filters/def/DEFChec
 
 import {
     KeyWordTooltip,
-    withAdvancedSearchTooltip,
     DEFTooltip
 } from 'components/search/filters/tooltips/AdvancedSearchTooltip';
 
@@ -43,10 +42,7 @@ const staticFilters = {
     options: [
         {
             title: 'Keyword',
-            tooltip: withAdvancedSearchTooltip({
-                icon: "info",
-                tooltipComponent: <KeyWordTooltip />
-            })
+            tooltip: <KeyWordTooltip />
         },
         {
             title: 'Time Period'
@@ -80,10 +76,7 @@ const staticFilters = {
         },
         {
             title: 'Disaster Emergency Fund Code (DEFC)',
-            tooltip: withAdvancedSearchTooltip({
-                icon: 'info',
-                tooltipComponent: <DEFTooltip />
-            }),
+            tooltip: <DEFTooltip />,
             className: 'def-sidebar'
         },
         {

--- a/src/js/components/search/SearchSidebar.jsx
+++ b/src/js/components/search/SearchSidebar.jsx
@@ -76,8 +76,7 @@ const staticFilters = {
         },
         {
             title: 'Disaster Emergency Fund Code (DEFC)',
-            tooltip: <DEFTooltip />,
-            className: 'def-sidebar'
+            tooltip: <DEFTooltip />
         },
         {
             title: 'North American Industry Classification System (NAICS)'
@@ -153,7 +152,6 @@ const staticFilters = {
 };
 
 const propTypes = {
-    hash: PropTypes.string,
     filters: PropTypes.object
 };
 
@@ -162,8 +160,7 @@ const defaultProps = {
 };
 
 const SearchSidebar = ({
-    filters,
-    hash
+    filters
 }) => {
     const indexOfUnreleased = staticFilters.options.findIndex((option) => (
         Object.keys(option).includes('isReleased') &&
@@ -203,8 +200,7 @@ const SearchSidebar = ({
             </div>
             <FilterSidebar
                 {...releasedFilters}
-                expanded={expanded}
-                hash={hash} />
+                expanded={expanded} />
             <div className="sidebar-bottom-submit">
                 <SearchSidebarSubmitContainer />
             </div>

--- a/src/js/components/search/filters/tooltips/AdvancedSearchTooltip.jsx
+++ b/src/js/components/search/filters/tooltips/AdvancedSearchTooltip.jsx
@@ -6,7 +6,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { TooltipWrapper } from 'data-transparency-ui';
 
 export const KeyWordTooltip = () => (
     <div className="advanced-search-tt">
@@ -44,11 +43,6 @@ export const DEFTooltip = () => (
             <p>By selecting DEFC in this filter and clicking the &quot;Submit Search&quot; button, awards that received funding categorized by DEFC will be displayed in the &quot;Spending by Prime Award&quot; table to the right. The &quot;COVID-19 Obligations&quot; and &quot;COVID-19 Outlays&quot; columns in this table show specific spending amounts for each award.</p>
         </div>
     </div>
-);
-
-
-export const withAdvancedSearchTooltip = (props) => () => (
-    <TooltipWrapper {...props} />
 );
 
 const CSSOnlyTooltipProps = {

--- a/src/js/components/sharedComponents/GlossaryLink.jsx
+++ b/src/js/components/sharedComponents/GlossaryLink.jsx
@@ -16,7 +16,7 @@ const propTypes = {
 
 const GlossaryLink = ({ term }) => {
     const { pathname, search } = useLocation();
-    const newUrl = getNewUrlForGlossary(pathname, `/?glossary=${term}`, search);
+    const newUrl = getNewUrlForGlossary(pathname, `?glossary=${term}`, search);
     const stopBubble = (e) => {
         e.stopPropagation();
     };

--- a/src/js/components/sharedComponents/filterSidebar/FilterExpandButton.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterExpandButton.jsx
@@ -5,116 +5,71 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { AngleRight, AngleDown } from 'components/sharedComponents/icons/Icons';
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Link } from 'react-router-dom';
+import { TooltipWrapper } from 'data-transparency-ui';
 
 const propTypes = {
     hideArrow: PropTypes.bool,
     toggleFilter: PropTypes.func,
     arrowState: PropTypes.string,
     name: PropTypes.string,
-    // functional component!
     tooltip: PropTypes.func,
     disabled: PropTypes.bool,
     accessory: PropTypes.func,
-    glossaryUrl: PropTypes.string,
+    glossarySlug: PropTypes.string,
     className: PropTypes.string
 };
 
 const ariaDescription = 'accessory-view';
 
-export default class FilterExpandButton extends React.Component {
-    constructor(props) {
-        super(props);
+const FilterExpandButton = (props) => {
+    const hiddenClass = props.hideArrow ? ' hide' : '';
 
-        this.state = {
-            showAccessory: false
-        };
+    const icon = props.arrowState === 'expanded' ?
+        <FontAwesomeIcon icon="angle-down" /> : <FontAwesomeIcon icon="angle-right" />;
 
-        this.showAccessory = this.showAccessory.bind(this);
-        this.hideAccessory = this.hideAccessory.bind(this);
-        this.toggleAccessory = this.toggleAccessory.bind(this);
-    }
+    // TODO
+    const glossaryLink = props.glossarySlug ? (
+        <div className="filter-toggle__glossary">
+            <Link to="/search"><FontAwesomeIcon icon="book" /></Link>
+        </div>
+    ) : null;
 
-    focusedElement() {
-        if (!this.props.disabled && this.props.accessory && this.props.arrowState !== 'expanded') {
-            this.setState({
-                showAccessory: true
-            });
-        }
-    }
+    const filterClassName = props.className ? ` ${props.className}` : '';
 
-    toggleAccessory() {
-        this.setState({
-            showAccessory: !this.state.showAccessory
-        });
-    }
-
-    showAccessory() {
-        this.setState({
-            showAccessory: true
-        });
-    }
-
-    hideAccessory() {
-        this.setState({
-            showAccessory: false
-        });
-    }
-
-    render() {
-        let hiddenClass = '';
-        if (this.props.hideArrow) {
-            hiddenClass = ' hide';
-        }
-
-        let icon = <AngleRight />;
-        if (this.props.arrowState === 'expanded') {
-            icon = <AngleDown />;
-        }
-
-        let glossaryLink = null;
-        if (this.props.glossaryUrl) {
-            glossaryLink = (
-                <div className="filter-toggle__glossary">
-                    <Link to={this.props.glossaryUrl}><FontAwesomeIcon icon="book" /></Link>
-                </div>
-            );
-        }
-        const filterClassName = this.props.className ? ` ${this.props.className}` : '';
-        return (
-            <div className="filter-toggle">
-                <div
-                    role="button"
-                    className={`filter-toggle__button ${hiddenClass}`}
-                    onClick={this.props.toggleFilter}
-                    onKeyDown={this.props.toggleFilter}
-                    disabled={this.props.disabled}
-                    title={this.props.name}
-                    aria-label={this.props.name}
-                    aria-expanded={this.props.arrowState === 'expanded'}
-                    aria-describedby={this.props.accessory ? ariaDescription : ''}>
-                    {icon}
-                    <div className={`filter-toggle__name${filterClassName}`}>
-                        <span>{this.props.name}</span>
-                        {this.props.tooltip && <this.props.tooltip />}
-                    </div>
-                </div>
-                {glossaryLink}
-                <div className="filter-toggle__accessory">
-                    {this.props.accessory && (
-                        <div
-                            tabIndex="0"
-                            id="accessory-view"
-                            role="toolbar">
-                            <this.props.accessory />
-                        </div>
-                    )}
+    return (
+        <div className="filter-toggle">
+            <div
+                role="button"
+                className={`filter-toggle__button ${hiddenClass}`}
+                onClick={props.toggleFilter}
+                onKeyDown={props.toggleFilter}
+                disabled={props.disabled}
+                title={props.name}
+                aria-label={props.name}
+                aria-expanded={props.arrowState === 'expanded'}
+                aria-describedby={props.accessory ? ariaDescription : ''}>
+                {icon}
+                <div className={`filter-toggle__name${filterClassName}`}>
+                    <span>{props.name}</span>
+                    {props.tooltip && <TooltipWrapper icon="info" tooltipComponent={props.tooltip} /> }
                 </div>
             </div>
-        );
-    }
-}
+            {glossaryLink}
+            <div className="filter-toggle__accessory">
+                {props.accessory && (
+                    <div
+                        tabIndex="0"
+                        id="accessory-view"
+                        role="toolbar">
+                        <props.accessory />
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
 
 FilterExpandButton.propTypes = propTypes;
+export default FilterExpandButton;

--- a/src/js/components/sharedComponents/filterSidebar/FilterExpandButton.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterExpandButton.jsx
@@ -17,8 +17,7 @@ const propTypes = {
     tooltip: PropTypes.element,
     disabled: PropTypes.bool,
     accessory: PropTypes.func,
-    glossarySlug: PropTypes.string,
-    className: PropTypes.string
+    glossarySlug: PropTypes.string
 };
 
 const ariaDescription = 'accessory-view';
@@ -29,37 +28,30 @@ const FilterExpandButton = (props) => {
     const icon = props.arrowState === 'expanded' ?
         <FontAwesomeIcon icon="angle-down" /> : <FontAwesomeIcon icon="angle-right" />;
 
-    const filterClassName = props.className ? ` ${props.className}` : '';
-
     return (
         <div className="filter-toggle">
-            <div
-                role="button"
+            <button
                 className={`filter-toggle__button ${hiddenClass}`}
                 onClick={props.toggleFilter}
-                onKeyDown={props.toggleFilter}
                 disabled={props.disabled}
                 title={props.name}
                 aria-label={props.name}
                 aria-expanded={props.arrowState === 'expanded'}
                 aria-describedby={props.accessory ? ariaDescription : ''}>
                 {icon}
-                <div className={`filter-toggle__name${filterClassName}`}>
-                    <span>{props.name}</span>
-                    {props.tooltip && <TooltipWrapper icon="info" tooltipComponent={props.tooltip} /> }
+                {props.name}
+                {props.tooltip && <TooltipWrapper icon="info" tooltipComponent={props.tooltip} /> }
+            </button>
+            {props.glossarySlug && <div className="filter-toggle__glossary"><GlossaryLink term={props.glossarySlug} /></div>}
+            {props.accessory && (
+                <div
+                    className="filter-toggle__accessory"
+                    tabIndex="0"
+                    id="accessory-view"
+                    role="toolbar">
+                    <props.accessory />
                 </div>
-            </div>
-            {props.glossarySlug && <GlossaryLink term={props.glossarySlug} />}
-            <div className="filter-toggle__accessory">
-                {props.accessory && (
-                    <div
-                        tabIndex="0"
-                        id="accessory-view"
-                        role="toolbar">
-                        <props.accessory />
-                    </div>
-                )}
-            </div>
+            )}
         </div>
     );
 };

--- a/src/js/components/sharedComponents/filterSidebar/FilterExpandButton.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterExpandButton.jsx
@@ -10,7 +10,6 @@ import { TooltipWrapper } from 'data-transparency-ui';
 import GlossaryLink from 'components/sharedComponents/GlossaryLink';
 
 const propTypes = {
-    hideArrow: PropTypes.bool,
     toggleFilter: PropTypes.func,
     arrowState: PropTypes.string,
     name: PropTypes.string,
@@ -23,15 +22,13 @@ const propTypes = {
 const ariaDescription = 'accessory-view';
 
 const FilterExpandButton = (props) => {
-    const hiddenClass = props.hideArrow ? ' hide' : '';
-
     const icon = props.arrowState === 'expanded' ?
         <FontAwesomeIcon icon="angle-down" /> : <FontAwesomeIcon icon="angle-right" />;
 
     return (
         <div className="filter-toggle">
             <button
-                className={`filter-toggle__button ${hiddenClass}`}
+                className="filter-toggle__button"
                 onClick={props.toggleFilter}
                 disabled={props.disabled}
                 title={props.name}

--- a/src/js/components/sharedComponents/filterSidebar/FilterExpandButton.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterExpandButton.jsx
@@ -6,15 +6,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Link } from 'react-router-dom';
 import { TooltipWrapper } from 'data-transparency-ui';
+import GlossaryLink from 'components/sharedComponents/GlossaryLink';
 
 const propTypes = {
     hideArrow: PropTypes.bool,
     toggleFilter: PropTypes.func,
     arrowState: PropTypes.string,
     name: PropTypes.string,
-    tooltip: PropTypes.func,
+    tooltip: PropTypes.element,
     disabled: PropTypes.bool,
     accessory: PropTypes.func,
     glossarySlug: PropTypes.string,
@@ -28,13 +28,6 @@ const FilterExpandButton = (props) => {
 
     const icon = props.arrowState === 'expanded' ?
         <FontAwesomeIcon icon="angle-down" /> : <FontAwesomeIcon icon="angle-right" />;
-
-    // TODO
-    const glossaryLink = props.glossarySlug ? (
-        <div className="filter-toggle__glossary">
-            <Link to="/search"><FontAwesomeIcon icon="book" /></Link>
-        </div>
-    ) : null;
 
     const filterClassName = props.className ? ` ${props.className}` : '';
 
@@ -56,7 +49,7 @@ const FilterExpandButton = (props) => {
                     {props.tooltip && <TooltipWrapper icon="info" tooltipComponent={props.tooltip} /> }
                 </div>
             </div>
-            {glossaryLink}
+            {props.glossarySlug && <GlossaryLink term={props.glossarySlug} />}
             <div className="filter-toggle__accessory">
                 {props.accessory && (
                     <div

--- a/src/js/components/sharedComponents/filterSidebar/FilterOption.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterOption.jsx
@@ -12,9 +12,9 @@ import FilterExpandButton from './FilterExpandButton';
 
 const propTypes = {
     name: PropTypes.string,
-    tooltip: PropTypes.func,
+    tooltip: PropTypes.element,
     className: PropTypes.string,
-    component: PropTypes.object,
+    component: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     disabled: PropTypes.bool,
     defaultExpand: PropTypes.bool,
     accessory: PropTypes.func,

--- a/src/js/components/sharedComponents/filterSidebar/FilterOption.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterOption.jsx
@@ -12,14 +12,13 @@ import FilterExpandButton from './FilterExpandButton';
 
 const propTypes = {
     name: PropTypes.string,
-    // functional component!
     tooltip: PropTypes.func,
     className: PropTypes.string,
     component: PropTypes.object,
     disabled: PropTypes.bool,
     defaultExpand: PropTypes.bool,
     accessory: PropTypes.func,
-    glossaryUrl: PropTypes.string
+    glossarySlug: PropTypes.string
 };
 
 const defaultProps = {
@@ -127,7 +126,7 @@ export default class FilterOption extends React.Component {
                     tooltip={this.props.tooltip}
                     className={this.props.className}
                     disabled={disabledStatus}
-                    glossaryUrl={this.props.glossaryUrl} />
+                    glossarySlug={this.props.glossarySlug} />
                 {searchOption}
                 {comingSoon}
             </div>

--- a/src/js/components/sharedComponents/filterSidebar/FilterOption.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterOption.jsx
@@ -13,7 +13,6 @@ import FilterExpandButton from './FilterExpandButton';
 const propTypes = {
     name: PropTypes.string,
     tooltip: PropTypes.element,
-    className: PropTypes.string,
     component: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     disabled: PropTypes.bool,
     defaultExpand: PropTypes.bool,
@@ -124,7 +123,6 @@ export default class FilterOption extends React.Component {
                     arrowState={this.state.arrowState}
                     name={this.props.name}
                     tooltip={this.props.tooltip}
-                    className={this.props.className}
                     disabled={disabledStatus}
                     glossarySlug={this.props.glossarySlug} />
                 {searchOption}

--- a/src/js/components/sharedComponents/filterSidebar/FilterSidebar.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterSidebar.jsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes, { arrayOf, oneOfType } from 'prop-types';
 
 import FilterOption from './FilterOption';
 
@@ -17,16 +17,15 @@ const defaultProps = {
 };
 
 const propTypes = {
-    options: PropTypes.arrayOf(PropTypes.shape({
+    options: arrayOf(PropTypes.shape({
         title: PropTypes.string.isRequired,
-        tooltip: PropTypes.func,
+        tooltip: PropTypes.element,
         className: PropTypes.string
     })),
-    components: PropTypes.arrayOf(PropTypes.object),
-    expanded: PropTypes.arrayOf(PropTypes.bool),
-    accessories: PropTypes.arrayOf(PropTypes.func),
-    glossaryEntries: PropTypes.arrayOf(PropTypes.string),
-    hash: PropTypes.string
+    components: arrayOf(oneOfType([PropTypes.func, PropTypes.object])),
+    expanded: arrayOf(PropTypes.bool),
+    accessories: arrayOf(PropTypes.func),
+    glossaryEntries: arrayOf(PropTypes.string)
 };
 
 export default class FilterSidebar extends React.Component {

--- a/src/js/components/sharedComponents/filterSidebar/FilterSidebar.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterSidebar.jsx
@@ -41,11 +41,6 @@ export default class FilterSidebar extends React.Component {
                 const component = this.props.components[i];
                 const accessory = this.props.accessories[i];
                 const glossarySlug = this.props.glossaryEntries[i];
-                let glossaryUrl;
-                if (glossarySlug) {
-                    const hash = this.props.hash ? `/search/${this.props.hash}` : '/search';
-                    glossaryUrl = `${hash}?glossary=${glossarySlug}`;
-                }
                 return (<FilterOption
                     name={title}
                     tooltip={tooltip}
@@ -55,7 +50,7 @@ export default class FilterSidebar extends React.Component {
                     accessory={accessory}
                     defaultExpand={this.props.expanded[i]}
                     disabled={component === null}
-                    glossaryUrl={glossaryUrl} />);
+                    glossarySlug={glossarySlug} />);
             });
 
         return (

--- a/src/js/components/sharedComponents/filterSidebar/FilterSidebar.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterSidebar.jsx
@@ -19,8 +19,7 @@ const defaultProps = {
 const propTypes = {
     options: arrayOf(PropTypes.shape({
         title: PropTypes.string.isRequired,
-        tooltip: PropTypes.element,
-        className: PropTypes.string
+        tooltip: PropTypes.element
     })),
     components: arrayOf(oneOfType([PropTypes.func, PropTypes.object])),
     expanded: arrayOf(PropTypes.bool),
@@ -33,17 +32,15 @@ export default class FilterSidebar extends React.Component {
         const optionsList = this.props.options
             .map((obj) => ({
                 title: obj.title,
-                tooltip: obj.tooltip || null,
-                className: obj.className || ''
+                tooltip: obj.tooltip || null
             }))
-            .map(({ title, tooltip, className }, i) => {
+            .map(({ title, tooltip }, i) => {
                 const component = this.props.components[i];
                 const accessory = this.props.accessories[i];
                 const glossarySlug = this.props.glossaryEntries[i];
                 return (<FilterOption
                     name={title}
                     tooltip={tooltip}
-                    className={className}
                     key={title}
                     component={component}
                     accessory={accessory}


### PR DESCRIPTION
**High level description:**

Fixes a bug that prevented the Advanced Search page from handing glossary links after a search had been performed

**Technical details:**
- Refactors `FilterExpandButton.jsx`  into a functional component and simplifies its props and jsx
- Utilizes the shared `GlossaryLink` component, which has built in logic for maintaining other query params
- Fixes some prop type warnings
- Replaces custom SVG icons with FontAwesome

**JIRA Ticket:**
[DEV-7960](https://federal-spending-transparency.atlassian.net/browse/DEV-7960)

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Code review complete
