### PR TITLE
DEV-7218 budget category table ARP integration

### DIFF
--- a/src/js/components/covid19/budgetCategories/BudgetCategories.jsx
+++ b/src/js/components/covid19/budgetCategories/BudgetCategories.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import BudgetCategoriesTableContainer from 'containers/covid19/budgetCategories/BudgetCategoriesTableContainer';
 import DateNote from 'components/covid19/DateNote';
 import { fetchDisasterSpendingCount } from 'apis/disaster';
-import { Tabs, InformationBoxes } from "data-transparency-ui";
+import { Tabs, InformationBoxes } from 'data-transparency-ui';
 import GlossaryLink from 'components/sharedComponents/GlossaryLink';
 import { scrollIntoView } from 'containers/covid19/helpers/scrollHelper';
 import Analytics from 'helpers/analytics/Analytics';
@@ -137,7 +137,7 @@ const BudgetCategories = ({ publicLaw }) => {
                 <InformationBoxes
                     boxes={overviewData.map((data) => ({
                         ...data,
-                        isLoading: data.type === 'count' && inFlight,
+                        isLoading: (data.type === 'count' && inFlight) || !amounts[data.type],
                         amount: amounts[data.type]
                     }))} />
             </div>

--- a/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
+++ b/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
@@ -14,7 +14,6 @@ import { Link } from 'react-router-dom';
 
 import Analytics from 'helpers/analytics/Analytics';
 
-
 import {
     budgetColumns,
     budgetDropdownFieldValues,
@@ -34,13 +33,7 @@ import { SpendingTypesTT } from 'components/covid19/Covid19Tooltips';
 const propTypes = {
     type: PropTypes.string.isRequired,
     subHeading: PropTypes.string,
-    scrollIntoView: PropTypes.func.isRequired,
-    totals: PropTypes.shape({
-        count: PropTypes.number,
-        totalBudgetaryResources: PropTypes.number,
-        totalObligations: PropTypes.number,
-        totalOutlays: PropTypes.number
-    })
+    scrollIntoView: PropTypes.func.isRequired
 };
 
 let tableHeight = 'auto';
@@ -156,7 +149,7 @@ const BudgetCategoriesTableContainer = (props) => {
     const request = useRef(null);
     const [unlinkedDataClass, setUnlinkedDataClass] = useState(false);
 
-    const { overview, defCodes, allAwardTypeTotals } = useSelector((state) => state.covid19);
+    const { overview, defcParams, allAwardTypeTotals } = useSelector((state) => state.covid19);
 
     const clickedAgencyProfile = (agencyName) => {
         Analytics.event({
@@ -285,11 +278,11 @@ const BudgetCategoriesTableContainer = (props) => {
         }
 
         setLoading(true);
-        if (defCodes && defCodes.length > 0 && spendingCategory && overview) {
+        if (defcParams && defcParams.length > 0 && spendingCategory && overview) {
             const apiSortField = sort === 'name' ? budgetCategoriesNameSort[props.type] : snakeCase(sort);
             const params = {
                 filter: {
-                    def_codes: defCodes.map((defc) => defc.code)
+                    def_codes: defcParams
                 },
                 pagination: {
                     limit: pageSize,
@@ -342,7 +335,7 @@ const BudgetCategoriesTableContainer = (props) => {
             fetchBudgetSpendingCallback();
         }
         changeCurrentPage(1);
-    }, [pageSize, sort, order, defCodes, overview, allAwardTypeTotals]);
+    }, [pageSize, sort, order, defcParams, overview, allAwardTypeTotals]);
 
     useEffect(() => {
         fetchBudgetSpendingCallback();

--- a/tests/containers/covid19/budgetCategories/BudgetCategoriesTableContainer-test.jsx
+++ b/tests/containers/covid19/budgetCategories/BudgetCategoriesTableContainer-test.jsx
@@ -1,0 +1,90 @@
+/**
+ * BudgetCategoriesTableContainer-test.js
+ * Created by Lizzie Salita 10/15/21
+ * */
+
+import React from "react";
+import { render, waitFor } from "test-utils";
+import "@testing-library/jest-dom/extend-expect";
+import BudgetCategoriesTableContainer from "containers/covid19/budgetCategories/BudgetCategoriesTableContainer";
+import * as api from "apis/disaster";
+import { defaultState } from "../../../testResources/defaultReduxFilters";
+
+const mockResults = [{
+    id: 123,
+    code: "020",
+    description: "Department of the Treasury",
+    children: [],
+    award_count: 25,
+    obligation: 2000,
+    outlay: 1500,
+    total_budgetary_resources: 2500
+}, {
+    id: 123,
+    code: "020",
+    description: "Small Business Administration",
+    children: [],
+    award_count: 23,
+    obligation: 1000,
+    outlay: 700,
+    total_budgetary_resources: 2000
+}];
+
+let spy;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe("BudgetCategoriesTableContainer", () => {
+    it("should make an API call when the DEFC params change", () => {
+        // spy on the API request helper functions
+        spy = jest.spyOn(api, "fetchDisasterSpending").mockReturnValue({
+            promise: Promise.resolve({
+                data: {
+                    results: mockResults,
+                    page_metadata: {
+                        total: 20
+                    }
+                }
+            }),
+            cancel: jest.fn()
+        });
+
+        const { rerender } = render(
+            <BudgetCategoriesTableContainer
+                type="agency"
+                subHeading="sub heading"
+                scrollIntoView={jest.fn()} />,
+            {
+                initialState: {
+                    ...defaultState,
+                    covid19: {
+                        defcParams: ["A", "B", "C"]
+                    }
+                }
+            }
+        );
+        waitFor(() => {
+            expect(spy).toHaveBeenCalledTimes(1);
+        });
+        // re-render with different defcParams
+        rerender(
+            <BudgetCategoriesTableContainer
+                type="agency"
+                subHeading="sub heading"
+                scrollIntoView={jest.fn()} />,
+            {
+                initialState: {
+                    ...defaultState,
+                    covid19: {
+                        defcParams: ["Z"]
+                    }
+                }
+            }
+        );
+        waitFor(() => {
+            expect(spy).toHaveBeenCalledTimes(2);
+        });
+    });
+});


### PR DESCRIPTION
**High level description:**

Connects the Spending by Budget Category table to the public law filter.

**Technical details:**

Utilize `defcParams` in Redux instead of all Covid 19 DEF codes.

**JIRA Ticket:**
[DEV-7218](https://federal-spending-transparency.atlassian.net/browse/DEV-7218)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)

Reviewer(s):
- [ ] Code review complete
