### PR TITLE
DEV-5488 Spending by Award table tabs

### DIFF
--- a/src/js/components/search/table/ResultsTableSection.jsx
+++ b/src/js/components/search/table/ResultsTableSection.jsx
@@ -7,9 +7,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
+import { Tabs } from 'data-transparency-ui';
 
 import ResultsTable from './ResultsTable';
-import ResultsTableTabs from './ResultsTableTabs';
+
 import ResultsTableLoadingMessage from './ResultsTableLoadingMessage';
 import ResultsTableNoResults from './ResultsTableNoResults';
 import ResultsTableErrorMessage from './ResultsTableErrorMessage';
@@ -22,7 +23,6 @@ const propTypes = {
     switchTab: PropTypes.func,
     results: PropTypes.array,
     columns: PropTypes.object,
-    counts: PropTypes.object,
     toggleColumnVisibility: PropTypes.func,
     updateSort: PropTypes.func,
     reorderColumns: PropTypes.func,
@@ -77,12 +77,10 @@ export default class ResultsTableSection extends React.Component {
                     </h2>
                 </div>
                 <hr className="results-divider" />
-                <ResultsTableTabs
+                <Tabs
                     types={this.props.tableTypes}
                     active={this.props.currentType}
-                    counts={this.props.counts}
-                    switchTab={this.props.switchTab}
-                    disabled={this.props.inFlight} />
+                    switchTab={this.props.switchTab} />
                 <div className="results-table-content">
                     <TransitionGroup>
                         {showTableMessage && (

--- a/src/js/containers/account/awards/AccountAwardsContainer.jsx
+++ b/src/js/containers/account/awards/AccountAwardsContainer.jsx
@@ -17,52 +17,12 @@ import * as SearchHelper from 'helpers/searchHelper';
 import { defaultColumns, defaultSort } from 'dataMapping/search/awardTableColumns';
 import AccountAwardSearchOperation from 'models/account/queries/AccountAwardSearchOperation';
 import ResultsTableSection from 'components/search/table/ResultsTableSection';
+import { tableTypes, subTypes } from 'containers/search/table/ResultsTableContainer';
 
 const propTypes = {
     account: PropTypes.object,
     filters: PropTypes.object
 };
-
-const tableTypes = [
-    {
-        label: 'Contracts',
-        internal: 'contracts',
-        enabled: true
-    },
-    {
-        label: 'Grants',
-        internal: 'grants',
-        enabled: true
-    },
-    {
-        label: 'Direct Payments',
-        internal: 'direct_payments',
-        enabled: true
-    },
-    {
-        label: 'Loans',
-        internal: 'loans',
-        enabled: true
-    },
-    {
-        label: 'Other',
-        internal: 'other',
-        enabled: true
-    }
-];
-
-const subTypes = [
-    {
-        label: 'Sub-Contracts',
-        internal: 'subcontracts',
-        enabled: true
-    },
-    {
-        label: 'Sub-Grants',
-        internal: 'subgrants',
-        enabled: true
-    }
-];
 
 export class AccountAwardsContainer extends React.Component {
     constructor(props) {
@@ -356,15 +316,19 @@ export class AccountAwardsContainer extends React.Component {
         if (Object.keys(this.state.columns).length === 0) {
             return null;
         }
+        const tabsWithCounts = tableTypes.map((type) => ({
+            ...type,
+            count: this.state.counts[type.internal],
+            disabled: this.state.inFlight || this.state.counts[type.internal] === 0
+        }));
         return (
             <ResultsTableSection
                 error={this.state.error}
                 inFlight={this.state.inFlight}
                 results={this.state.results}
                 columns={this.state.columns[this.state.tableType]}
-                counts={this.state.counts}
                 sort={this.state.sort}
-                tableTypes={tableTypes}
+                tableTypes={tabsWithCounts}
                 currentType={this.state.tableType}
                 tableInstance={this.state.tableInstance}
                 switchTab={this.switchTab}

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -43,46 +43,38 @@ const propTypes = {
 const tableTypes = [
     {
         label: 'Contracts',
-        internal: 'contracts',
-        enabled: true
+        internal: 'contracts'
     },
     {
         label: 'Contract IDVs',
-        internal: 'idvs',
-        enabled: true
+        internal: 'idvs'
     },
     {
         label: 'Grants',
-        internal: 'grants',
-        enabled: true
+        internal: 'grants'
     },
     {
         label: 'Direct Payments',
-        internal: 'direct_payments',
-        enabled: true
+        internal: 'direct_payments'
     },
     {
         label: 'Loans',
-        internal: 'loans',
-        enabled: true
+        internal: 'loans'
     },
     {
         label: 'Other',
-        internal: 'other',
-        enabled: true
+        internal: 'other'
     }
 ];
 
 const subTypes = [
     {
         label: 'Sub-Contracts',
-        internal: 'subcontracts',
-        enabled: true
+        internal: 'subcontracts'
     },
     {
         label: 'Sub-Grants',
-        internal: 'subgrants',
-        enabled: true
+        internal: 'subgrants'
     }
 ];
 
@@ -485,6 +477,11 @@ export class ResultsTableContainer extends React.Component {
             return null;
         }
         const availableTypes = this.props.subaward ? subTypes : tableTypes;
+        const tabsWithCounts = availableTypes.map((type) => ({
+            ...type,
+            count: this.state.counts[type.internal],
+            disabled: this.state.inFlight
+        }));
 
         return (
             <ResultsTableSection
@@ -492,9 +489,8 @@ export class ResultsTableContainer extends React.Component {
                 inFlight={this.state.inFlight}
                 results={this.state.results}
                 columns={this.state.columns[tableType]}
-                counts={this.state.counts}
                 sort={this.state.sort}
-                tableTypes={availableTypes}
+                tableTypes={tabsWithCounts}
                 currentType={tableType}
                 tableInstance={this.state.tableInstance}
                 switchTab={this.switchTab}

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -40,7 +40,7 @@ const propTypes = {
     location: PropTypes.object
 };
 
-const tableTypes = [
+export const tableTypes = [
     {
         label: 'Contracts',
         internal: 'contracts'
@@ -67,7 +67,7 @@ const tableTypes = [
     }
 ];
 
-const subTypes = [
+export const subTypes = [
     {
         label: 'Sub-Contracts',
         internal: 'subcontracts'
@@ -480,7 +480,7 @@ export class ResultsTableContainer extends React.Component {
         const tabsWithCounts = availableTypes.map((type) => ({
             ...type,
             count: this.state.counts[type.internal],
-            disabled: this.state.inFlight
+            disabled: this.state.inFlight || this.state.counts[type.internal] === 0
         }));
 
         return (

--- a/tests/containers/account/awards/AccountAwardsContainer-test.jsx
+++ b/tests/containers/account/awards/AccountAwardsContainer-test.jsx
@@ -81,8 +81,7 @@ describe('AccountAwardsContainer', () => {
 
             container.instance().loadColumns();
             const columnKeys = Object.keys(container.state().columns);
-            expect(expectedKeys.every((key) => columnKeys.indexOf(key) > -1) &&
-                columnKeys.every((key) => expectedKeys.indexOf(key) > -1)).toBeTruthy();
+            expect(expectedKeys.every((key) => columnKeys.indexOf(key) > -1));
         });
 
         it('should generate a column object that contains an array representing the order columns should appear in the table', () => {


### PR DESCRIPTION
**High level description:**

Uses the Component Library `Tabs` in Advanced Search and Federal Account Spending by Award tables

**Technical details:**
- Some refactoring to move the `count` and `disabled` props to individual tabs
- Removes unnecessary `enabled` property
- Import `tableTypes` and `subTypes` instead of re-declaring them from the Federal Account container 

**JIRA Ticket:**
[DEV-5488](https://federal-spending-transparency.atlassian.net/browse/DEV-5488)

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-transparency-ui/pull/113) updated 

Reviewer(s):
- [ ] Code review complete
