### PR TITLE
7672 allow funding agency to be null

### DIFF
--- a/src/js/components/award/shared/federalAccounts/FederalAccountsTable.jsx
+++ b/src/js/components/award/shared/federalAccounts/FederalAccountsTable.jsx
@@ -15,20 +15,20 @@ import ResultsTableLoadingMessage from 'components/search/table/ResultsTableLoad
 import ResultsTableErrorMessage from 'components/search/table/ResultsTableErrorMessage';
 import NoResultsMessage from 'components/sharedComponents/NoResultsMessage';
 
-const propTypes = {
-    page: PropTypes.number,
-    limit: PropTypes.number,
-    sort: PropTypes.string,
-    order: PropTypes.string,
-    total: PropTypes.number,
-    federalAccounts: PropTypes.array,
-    changePage: PropTypes.func,
-    updateSort: PropTypes.func,
-    inFlight: PropTypes.bool,
-    error: PropTypes.bool
-};
-
 export default class FederalAccountsTable extends React.Component {
+    static propTypes = {
+        page: PropTypes.number,
+        limit: PropTypes.number,
+        sort: PropTypes.string,
+        order: PropTypes.string,
+        total: PropTypes.number,
+        federalAccounts: PropTypes.array,
+        changePage: PropTypes.func,
+        updateSort: PropTypes.func,
+        inFlight: PropTypes.bool,
+        error: PropTypes.bool
+    };
+
     getHeaders() {
         const { sort, order, updateSort } = this.props;
         return map(tableMapping, (header) => (
@@ -64,11 +64,13 @@ export default class FederalAccountsTable extends React.Component {
                         );
                     }
                     else if (key === 'fundingAgencyName') {
-                        cellData = (
-                            <Link to={`/agency/${account._fundingAgencyId}`}>
-                                {`(${account._fundingAgencyAbbreviation}) ${account[key]}`}
-                            </Link>
-                        );
+                        cellData = account._fundingAgencyId ?
+                            (
+                                <Link to={`/agency/${account._fundingAgencyId}`}>
+                                    {`(${account._fundingAgencyAbbreviation}) ${account[key]}`}
+                                </Link>
+                            )
+                            : '--';
                     }
                     return (
                         <td
@@ -144,5 +146,3 @@ export default class FederalAccountsTable extends React.Component {
         );
     }
 }
-
-FederalAccountsTable.propTypes = propTypes;


### PR DESCRIPTION
**High level description:**

When API returned null for funding agency (previously unexpected), table would show "()" and bad link. This corrects that situation to "--"

**Technical details:**

none

**JIRA Ticket:**
[DEV-7672](https://federal-spending-transparency.atlassian.net/browse/DEV-7672)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [n/a] Verified mobile/tablet/desktop/monitor responsiveness
- [n/a] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a] Design review complete `if applicable`
- [n/a] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
