### PR TITLE
7926 fix arp filter for recipient info boxes

### DIFF
--- a/src/js/containers/covid19/recipient/SummaryInsightsContainer.jsx
+++ b/src/js/containers/covid19/recipient/SummaryInsightsContainer.jsx
@@ -76,26 +76,21 @@ const SummaryInsightsContainer = ({ activeFilter }) => {
                         : { award_type_codes: awardTypeGroups[activeFilter] }
                 }
             };
+
             recipientCountRequest.current = fetchDisasterSpendingCount('recipient', params);
-            if (activeFilter === 'all') {
-                setAwardObligations(allAwardTypeTotals?.obligation);
-                setAwardOutlays(allAwardTypeTotals?.outlay);
-                setNumberOfAwards(allAwardTypeTotals?.awardCount);
-            }
-            else {
-                // Reset any existing counts
-                setAwardOutlays(null);
-                setAwardObligations(null);
-                setNumberOfAwards(null);
-                setNumberOfRecipients(null);
-                awardAmountRequest.current = fetchAwardAmounts(params);
-                awardAmountRequest.current.promise
-                    .then((res) => {
-                        setAwardObligations(res.data.obligation);
-                        setAwardOutlays(res.data.outlay);
-                        setNumberOfAwards(res.data.award_count);
-                    });
-            }
+
+            // Reset any existing counts
+            setAwardOutlays(null);
+            setAwardObligations(null);
+            setNumberOfAwards(null);
+            setNumberOfRecipients(null);
+            awardAmountRequest.current = fetchAwardAmounts(params);
+            awardAmountRequest.current.promise
+                .then((res) => {
+                    setAwardObligations(res.data.obligation);
+                    setAwardOutlays(res.data.outlay);
+                    setNumberOfAwards(res.data.award_count);
+                });
             recipientCountRequest.current.promise
                 .then((res) => {
                     setNumberOfRecipients(res.data.count);


### PR DESCRIPTION
**High level description:**

fixes "map-mode" recipient info boxes

**Technical details:**

The map has its own separate SummaryInsightsContainer, which works totally different than the other. This adjusts it to use the page-level law (def codes) filter.

**JIRA Ticket:**
[DEV-7926](https://federal-spending-transparency.atlassian.net/browse/DEV-7926)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [n/a] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [n/a] Verified mobile/tablet/desktop/monitor responsiveness
- [n/a] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a] Design review complete `if applicable`
- [n/a] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
