### PR TITLE
8039 update covid law filter

### DIFF
--- a/src/_scss/pages/covid19/_header.scss
+++ b/src/_scss/pages/covid19/_header.scss
@@ -74,6 +74,11 @@
                 overflow-y: hidden;
                 box-shadow: 0 2px 6px 0 rgba(78,78,78,0.5);
 
+                .usa-dt-picker__item:first-of-type {
+                    height: 100%;
+                    padding: rem(24) rem(20);
+                }
+
                 .usa-dt-picker__list-item .usa-dt-picker__item {
                     padding: rem(16) rem(20);
 
@@ -93,18 +98,17 @@
                     p {
                         font-size: rem(15);
                         margin: 0;
-                        .usda-glossary-link svg {
-                            margin-left: 5px;
-                            color: $color-gray-light;
-                        }
                     }
                 }
+
                 li.usa-dt-picker__list-item {
                     border-bottom: solid thin $color-gray-lightest;
+                    height: 80px;
 
                     p {
                         font-size: rem(14);
                     }
+
                 }
             }
 

--- a/src/js/components/sharedComponents/GlossaryLink.jsx
+++ b/src/js/components/sharedComponents/GlossaryLink.jsx
@@ -21,7 +21,11 @@ const GlossaryLink = ({ term }) => {
         e.stopPropagation();
     };
     return (
-        <Link className="usda-glossary-link" to={newUrl} aria-label="Open the Glossary" onClick={stopBubble}>
+        <Link
+            className="usda-glossary-link"
+            to={newUrl}
+            aria-label="Open the Glossary"
+            onClick={stopBubble}>
             <FontAwesomeIcon icon="book" />
         </Link>
     );


### PR DESCRIPTION
**High level description:**

QA pointed out that AC#3 had been overlooked.

**Technical details:**

Set height for all items in the dropdown; made a new css block for only the first item in the dropdown, to reset height and padding; 

**JIRA Ticket:**
[DEV-8039](https://federal-spending-transparency.atlassian.net/browse/DEV-1234)

**Mockup:**

N/A

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [x ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
