### PR TITLE
8037 - changed the link to use <a> instead of ExternalLink

### DIFF
--- a/src/js/components/about/DataQuality.jsx
+++ b/src/js/components/about/DataQuality.jsx
@@ -49,9 +49,14 @@ const DataQuality = () => (
             <p>
                 To ensure that contract data is accurate, the Office of Management and
                 Budget issues the&nbsp;
-                <ExternalLink url="https://www.fsd.gov/gsafsd_sp?id=kb_article_view&sysparm_article=KB0048871">
+                <a
+                    href="https://www.fsd.gov/gsafsd_sp?id=kb_article_view&sysparm_article=KB0048871"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="https://www.fsd.gov/gsafsd_sp?id=kb_article_view&sysparm_article=KB0048871"
+                    title="https://www.fsd.gov/gsafsd_sp?id=kb_article_view&sysparm_article=KB0048871">
                     Federal Government Procurement Data Quality Summary
-                </ExternalLink>
+                </a>
                 &nbsp;about data submitted by the agencies to the Federal Procurement
                 Data System (FPDS). If there are any discrepancies in procurement data, FPDS
                 is the authoritative source.


### PR DESCRIPTION
**High level description:**

Change one link in the About page bc it was getting a 404 before. Also make sure it does not open the redirect modal when clicked. 

**Technical details:**

Updated the link and changed from ExternalLink component to an <a>.

**JIRA Ticket:**
[DEV-8037](https://federal-spending-transparency.atlassian.net/browse/DEV-1234)

**Mockup:**

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [x ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
