### PR TITLE
DEV-6390 change Agency v2 URLs

### DIFF
--- a/src/js/apis/agencyV2.js
+++ b/src/js/apis/agencyV2.js
@@ -44,3 +44,7 @@ export const fetchSubagencyNewAwardsCount = (code, fy, params) => apiRequest({
 export const fetchSubagencySummary = (code, fy, params) => apiRequest({
     url: `v2/agency/${code}/awards/${fy ? `?fiscal_year=${fy}` : ''}${params ? `&award_type_codes=[${params}]` : ''}`
 });
+
+export const fetchAgencySlugs = () => apiRequest({
+    url: 'v2/references/toptier_agencies'
+});

--- a/src/js/components/agencyV2/AgencyPage.jsx
+++ b/src/js/components/agencyV2/AgencyPage.jsx
@@ -63,7 +63,7 @@ export const AgencyProfileV2 = ({
             name: 'status-of-funds',
             display: 'Status of Funds',
             icon: 'money-check-alt',
-            component: <StatusOfFunds fy={selectedFy} agencyId={agencyId} />
+            component: <StatusOfFunds fy={selectedFy} />
         },
         {
             name: 'sub-agency',

--- a/src/js/components/agencyV2/AgencyPage.jsx
+++ b/src/js/components/agencyV2/AgencyPage.jsx
@@ -9,10 +9,10 @@ import {
     ComingSoon,
     ErrorMessage,
     FiscalYearPicker,
-    ShareIcon,
-    DownloadIconButton
+    ShareIcon
 } from 'data-transparency-ui';
 import { useSelector } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 
 import { getStickyBreakPointForSidebar } from 'helpers/stickyHeaderHelper';
 import { agencyPageMetaTags } from 'helpers/metaTagHelper';
@@ -31,7 +31,6 @@ const scrollPositionOfSiteHeader = getStickyBreakPointForSidebar();
 
 const propTypes = {
     toptierCode: PropTypes.string,
-    agencySlug: PropTypes.string,
     selectedFy: PropTypes.string,
     latestFy: PropTypes.number,
     setSelectedFy: PropTypes.func,
@@ -43,7 +42,6 @@ const propTypes = {
 export const AgencyProfileV2 = ({
     selectedFy,
     toptierCode,
-    agencySlug,
     setSelectedFy,
     isError,
     errorMessage,
@@ -58,7 +56,7 @@ export const AgencyProfileV2 = ({
             name: 'overview',
             display: 'Overview',
             icon: 'chart-area',
-            component: <AgencyOverview fy={selectedFy} toptierCode={toptierCode} />
+            component: <AgencyOverview fy={selectedFy} />
         },
         {
             name: 'budget-category',
@@ -100,12 +98,13 @@ export const AgencyProfileV2 = ({
         setActiveSection(matchedSection.name);
     };
 
-    const slug = `agency_v2/${agencySlug}`;
+    const { pathname, search } = useLocation();
+    const path = `${pathname.substring(1)}${search}`;
 
     const handleShare = (optionName) => {
-        handleShareOptionClick(optionName, slug, {
+        handleShareOptionClick(optionName, path, {
             subject: `USAspending.gov Agency Profile: ${name}`,
-            body: `View the spending activity for this Agency on USAspending.gov: ${getBaseUrl(slug)}/?fy=${selectedFy}`
+            body: `View the spending activity for this Agency on USAspending.gov: ${getBaseUrl(path)}`
         });
     };
 
@@ -118,8 +117,7 @@ export const AgencyProfileV2 = ({
             metaTagProps={isLoading ? {} : agencyPageMetaTags({ id: toptierCode, name })}
             toolBarComponents={[
                 <FiscalYearPicker selectedFy={selectedFy} latestFy={latestFy} handleFyChange={(fy) => setSelectedFy({ fy })} />,
-                <ShareIcon url={getBaseUrl(slug)} onShareOptionClick={handleShare} />,
-                <DownloadIconButton downloadInFlight={false} onClick={() => {}} />
+                <ShareIcon url={getBaseUrl(path)} onShareOptionClick={handleShare} />
             ]}>
             <main id="main-content" className="main-content usda__flex-row">
                 <div className="sidebar usda__flex-col">

--- a/src/js/components/agencyV2/AgencyPage.jsx
+++ b/src/js/components/agencyV2/AgencyPage.jsx
@@ -30,23 +30,23 @@ require('pages/agencyV2/index.scss');
 const scrollPositionOfSiteHeader = getStickyBreakPointForSidebar();
 
 const propTypes = {
-    toptierCode: PropTypes.string,
     selectedFy: PropTypes.string,
     latestFy: PropTypes.number,
     setSelectedFy: PropTypes.func,
     isError: PropTypes.bool,
     isLoading: PropTypes.bool,
-    errorMessage: PropTypes.string
+    errorMessage: PropTypes.string,
+    agencySlug: PropTypes.string
 };
 
 export const AgencyProfileV2 = ({
     selectedFy,
-    toptierCode,
     setSelectedFy,
     isError,
     errorMessage,
     isLoading,
-    latestFy
+    latestFy,
+    agencySlug
 }) => {
     const [activeSection, setActiveSection] = useState('overview');
     const { name } = useSelector((state) => state.agencyV2.overview);
@@ -68,7 +68,7 @@ export const AgencyProfileV2 = ({
             name: 'sub-agency',
             display: 'Award Spending',
             icon: 'hand-holding-usd',
-            component: <AwardSpendingSubagency fy={`${selectedFy}`} toptierCode={toptierCode} />
+            component: <AwardSpendingSubagency fy={`${selectedFy}`} />
         }
     ];
 
@@ -114,7 +114,7 @@ export const AgencyProfileV2 = ({
             classNames="usa-da-agency-page-v2"
             overLine="Agency Profile"
             title={name}
-            metaTagProps={isLoading ? {} : agencyPageMetaTags({ id: toptierCode, name })}
+            metaTagProps={isLoading ? {} : agencyPageMetaTags({ id: agencySlug, name })}
             toolBarComponents={[
                 <FiscalYearPicker selectedFy={selectedFy} latestFy={latestFy} handleFyChange={(fy) => setSelectedFy({ fy })} />,
                 <ShareIcon url={getBaseUrl(path)} onShareOptionClick={handleShare} />

--- a/src/js/components/agencyV2/AgencyPage.jsx
+++ b/src/js/components/agencyV2/AgencyPage.jsx
@@ -30,19 +30,23 @@ require('pages/agencyV2/index.scss');
 const scrollPositionOfSiteHeader = getStickyBreakPointForSidebar();
 
 const propTypes = {
-    agencyId: PropTypes.string,
+    toptierCode: PropTypes.string,
+    agencySlug: PropTypes.string,
     selectedFy: PropTypes.string,
     latestFy: PropTypes.number,
     setSelectedFy: PropTypes.func,
     isError: PropTypes.bool,
-    isLoading: PropTypes.bool
+    isLoading: PropTypes.bool,
+    errorMessage: PropTypes.string
 };
 
 export const AgencyProfileV2 = ({
     selectedFy,
-    agencyId,
+    toptierCode,
+    agencySlug,
     setSelectedFy,
     isError,
+    errorMessage,
     isLoading,
     latestFy
 }) => {
@@ -54,7 +58,7 @@ export const AgencyProfileV2 = ({
             name: 'overview',
             display: 'Overview',
             icon: 'chart-area',
-            component: <AgencyOverview fy={selectedFy} isLoading={isLoading} agencyId={agencyId} />
+            component: <AgencyOverview fy={selectedFy} toptierCode={toptierCode} />
         },
         {
             name: 'budget-category',
@@ -66,7 +70,7 @@ export const AgencyProfileV2 = ({
             name: 'sub-agency',
             display: 'Award Spending',
             icon: 'hand-holding-usd',
-            component: <AwardSpendingSubagency fy={`${selectedFy}`} agencyId={agencyId} />
+            component: <AwardSpendingSubagency fy={`${selectedFy}`} toptierCode={toptierCode} />
         }
     ];
 
@@ -96,7 +100,7 @@ export const AgencyProfileV2 = ({
         setActiveSection(matchedSection.name);
     };
 
-    const slug = `agency_v2/${agencyId}`;
+    const slug = `agency_v2/${agencySlug}`;
 
     const handleShare = (optionName) => {
         handleShareOptionClick(optionName, slug, {
@@ -111,7 +115,7 @@ export const AgencyProfileV2 = ({
             classNames="usa-da-agency-page-v2"
             overLine="Agency Profile"
             title={name}
-            metaTagProps={isLoading ? {} : agencyPageMetaTags({ id: agencyId, name })}
+            metaTagProps={isLoading ? {} : agencyPageMetaTags({ id: toptierCode, name })}
             toolBarComponents={[
                 <FiscalYearPicker selectedFy={selectedFy} latestFy={latestFy} handleFyChange={(fy) => setSelectedFy({ fy })} />,
                 <ShareIcon url={getBaseUrl(slug)} onShareOptionClick={handleShare} />,
@@ -134,7 +138,7 @@ export const AgencyProfileV2 = ({
                 </div>
                 <div className="body usda__flex-col">
                     {isError
-                        ? <ErrorMessage />
+                        ? <ErrorMessage description={errorMessage} />
                         : sections.map((section) => (
                             <AgencySection key={section.name} section={section} isLoading={isLoading} icon={section.icon}>
                                 {section.component || <ComingSoon />}

--- a/src/js/components/agencyV2/AgencySection.jsx
+++ b/src/js/components/agencyV2/AgencySection.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { SectionTitle } from 'data-transparency-ui';
+import { LoadingMessage, SectionTitle } from 'data-transparency-ui';
 
 const propTypes = {
     section: PropTypes.shape({
@@ -23,7 +23,8 @@ const TooltipComponent = () => (
 const AgencySection = ({
     section,
     icon = "chart-area",
-    children
+    children,
+    isLoading
 }) => (
     <SectionTitle
         id={`agency-v2-${section.name}`}
@@ -33,7 +34,7 @@ const AgencySection = ({
         overLine={section?.overLine}
         description={<span className="usda-section-title__desc">Data Sources</span>}
         descTooltip={{ component: <TooltipComponent /> }}>
-        {children}
+        {isLoading ? <LoadingMessage /> : children}
     </SectionTitle>
 
 );

--- a/src/js/components/agencyV2/awardSpending/AwardSpendingSubagency.jsx
+++ b/src/js/components/agencyV2/awardSpending/AwardSpendingSubagency.jsx
@@ -13,8 +13,7 @@ import SubagencyTableContainer from 'containers/agencyV2/awardSpending/Subagency
 import { useStateWithPrevious } from 'helpers';
 
 const propTypes = {
-    fy: PropTypes.string,
-    toptierCode: PropTypes.string
+    fy: PropTypes.string
 };
 
 export const awardTabs = [
@@ -69,7 +68,7 @@ const initialActiveTabState = {
     subtitle: awardTabs[0].label
 };
 
-const AwardSpendingSubagency = ({ toptierCode, fy }) => {
+const AwardSpendingSubagency = ({ fy }) => {
     const { subagencyCount } = useSelector((state) => state.agencyV2);
     const [prevActiveTab, activeTab, setActiveTab] = useStateWithPrevious(initialActiveTabState);
 
@@ -93,13 +92,11 @@ const AwardSpendingSubagency = ({ toptierCode, fy }) => {
                 <Tabs active={activeTab.internal} types={awardTabs} switchTab={changeActiveTab} />
             </div>
             <SubAgencySummaryContainer
-                toptierCode={toptierCode}
                 fy={fy}
                 summaryData={summaryData}
                 data={subagencyData}
                 activeTab={activeTab.internal} />
             <SubagencyTableContainer
-                toptierCode={toptierCode}
                 fy={fy}
                 type={activeTab.internal}
                 prevType={prevActiveTab.internal}

--- a/src/js/components/agencyV2/awardSpending/AwardSpendingSubagency.jsx
+++ b/src/js/components/agencyV2/awardSpending/AwardSpendingSubagency.jsx
@@ -14,7 +14,7 @@ import { useStateWithPrevious } from 'helpers';
 
 const propTypes = {
     fy: PropTypes.string,
-    agencyId: PropTypes.string
+    toptierCode: PropTypes.string
 };
 
 export const awardTabs = [
@@ -69,7 +69,7 @@ const initialActiveTabState = {
     subtitle: awardTabs[0].label
 };
 
-const AwardSpendingSubagency = ({ agencyId, fy }) => {
+const AwardSpendingSubagency = ({ toptierCode, fy }) => {
     const { subagencyCount } = useSelector((state) => state.agencyV2);
     const [prevActiveTab, activeTab, setActiveTab] = useStateWithPrevious(initialActiveTabState);
 
@@ -93,13 +93,13 @@ const AwardSpendingSubagency = ({ agencyId, fy }) => {
                 <Tabs active={activeTab.internal} types={awardTabs} switchTab={changeActiveTab} />
             </div>
             <SubAgencySummaryContainer
-                agencyId={agencyId}
+                toptierCode={toptierCode}
                 fy={fy}
                 summaryData={summaryData}
                 data={subagencyData}
                 activeTab={activeTab.internal} />
             <SubagencyTableContainer
-                agencyId={agencyId}
+                toptierCode={toptierCode}
                 fy={fy}
                 type={activeTab.internal}
                 prevType={prevActiveTab.internal}

--- a/src/js/components/agencyV2/overview/AgencyOverview.jsx
+++ b/src/js/components/agencyV2/overview/AgencyOverview.jsx
@@ -55,13 +55,11 @@ CovidTooltip.propTypes = {
 };
 
 const propTypes = {
-    fy: PropTypes.string,
-    toptierCode: PropTypes.string
+    fy: PropTypes.string
 };
 
 const AgencyOverview = ({
-    fy,
-    toptierCode
+    fy
 }) => {
     const {
         name,
@@ -172,7 +170,7 @@ const AgencyOverview = ({
                 {image}
             </div>
             {content}
-            <FySummary fy={fy} windowWidth={windowWidth} isMobile={isMobile} toptierCode={toptierCode} />
+            <FySummary fy={fy} windowWidth={windowWidth} isMobile={isMobile} />
         </div>
     );
 };

--- a/src/js/components/agencyV2/overview/AgencyOverview.jsx
+++ b/src/js/components/agencyV2/overview/AgencyOverview.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { throttle } from 'lodash';
-import { LoadingMessage, TooltipWrapper, TooltipComponent } from 'data-transparency-ui';
+import { TooltipWrapper, TooltipComponent } from 'data-transparency-ui';
 
 import { DEFC_OBJECT } from 'propTypes';
 
@@ -55,15 +55,13 @@ CovidTooltip.propTypes = {
 };
 
 const propTypes = {
-    isLoading: PropTypes.bool,
     fy: PropTypes.string,
-    agencyId: PropTypes.string
+    toptierCode: PropTypes.string
 };
 
 const AgencyOverview = ({
-    isLoading,
     fy,
-    agencyId
+    toptierCode
 }) => {
     const {
         name,
@@ -155,31 +153,26 @@ const AgencyOverview = ({
                 </div>
             </div>
         </>;
-
-    const overview = isLoading ? <LoadingMessage /> : <>
-        <div className="agency-overview__top">
-            <div className="agency-overview__title">
-                <div className="agency-overview__name">
-                    <h3>{name}</h3>
-                    <div className="agency-overview__sub-agencies">Includes {subtierCount} awarding sub-agencies</div>
-                </div>
-                {name && covidDefCodes.length > 0 &&
-                    <TooltipWrapper className="agency-overview__tooltip covid-19-flag" tooltipComponent={<CovidTooltip fy={fy} codes={covidDefCodes} />}>
-                        <span className="covid-spending-flag">
-                            COVID-19 Spending
-                        </span>
-                    </TooltipWrapper>
-                }
-            </div>
-            {image}
-        </div>
-        {content}
-    </>;
-
     return (
         <div className="agency-overview">
-            {overview}
-            <FySummary fy={fy} windowWidth={windowWidth} isMobile={isMobile} agencyId={agencyId} />
+            <div className="agency-overview__top">
+                <div className="agency-overview__title">
+                    <div className="agency-overview__name">
+                        <h3>{name}</h3>
+                        <div className="agency-overview__sub-agencies">Includes {subtierCount} awarding sub-agencies</div>
+                    </div>
+                    {name && covidDefCodes.length > 0 &&
+                        <TooltipWrapper className="agency-overview__tooltip covid-19-flag" tooltipComponent={<CovidTooltip fy={fy} codes={covidDefCodes} />}>
+                            <span className="covid-spending-flag">
+                                COVID-19 Spending
+                            </span>
+                        </TooltipWrapper>
+                    }
+                </div>
+                {image}
+            </div>
+            {content}
+            <FySummary fy={fy} windowWidth={windowWidth} isMobile={isMobile} toptierCode={toptierCode} />
         </div>
     );
 };

--- a/src/js/components/agencyV2/overview/AgencyOverview.jsx
+++ b/src/js/components/agencyV2/overview/AgencyOverview.jsx
@@ -27,7 +27,7 @@ const CovidTooltip = ({
         .map(({ code, public_law: pl, title }) => {
             const parsedPublicLaw = `${pl.includes('Non-emergency') ? 'Not designated as emergency' : 'Designated as emergency'}`;
             return (
-                <li>
+                <li key={pl}>
                     <strong>{`DEFC: ${code}`}</strong>
                     <p>{`${parsedPublicLaw}; ${pl.replace(replaceEmergencyPl, 'Public Law')}, ${title.toUpperCase()}`}</p>
                 </li>

--- a/src/js/components/agencyV2/overview/FySummary.jsx
+++ b/src/js/components/agencyV2/overview/FySummary.jsx
@@ -130,10 +130,8 @@ const FySummary = ({
                 : (
                     <FlexGridRow hasGutter className="fy-summary__row">
                         {sections.map((viz, i) => (
-                            <FlexGridCol tablet={6} className="fy-summary__col">
-                                <div key={`FY-Summary-${i}`}>
-                                    {viz}
-                                </div>
+                            <FlexGridCol tablet={6} className="fy-summary__col" key={`FY-Summary-${i}`}>
+                                {viz}
                             </FlexGridCol>
                         ))}
                     </FlexGridRow>

--- a/src/js/components/agencyV2/overview/FySummary.jsx
+++ b/src/js/components/agencyV2/overview/FySummary.jsx
@@ -22,14 +22,14 @@ const propTypes = {
     fy: PropTypes.string,
     windowWidth: PropTypes.number,
     isMobile: PropTypes.bool,
-    agencyId: PropTypes.string
+    toptierCode: PropTypes.string
 };
 
 const FySummary = ({
     fy,
     windowWidth,
     isMobile,
-    agencyId
+    toptierCode
 }) => {
     const dispatch = useDispatch();
     const [isLoading, setIsLoading] = useState(true);
@@ -47,10 +47,10 @@ const FySummary = ({
     }, []);
 
     useEffect(() => {
-        if (agencyId) {
+        if (toptierCode) {
             setIsLoading(true);
             setIsError(false);
-            budgetaryResourcesRequest.current = fetchBudgetaryResources(agencyId);
+            budgetaryResourcesRequest.current = fetchBudgetaryResources(toptierCode);
             budgetaryResourcesRequest.current.promise
                 .then(({ data }) => {
                     budgetaryResourcesRequest.current = null;
@@ -73,7 +73,7 @@ const FySummary = ({
                     throw e;
                 });
         }
-    }, [agencyId]);
+    }, [toptierCode]);
 
     const totalBudgetaryResources = budgetaryResources[fy]?.agencyBudget || '--';
     const percentOfFederalBudget = budgetaryResources[fy]?.percentOfFederalBudget || '--';

--- a/src/js/components/agencyV2/overview/FySummary.jsx
+++ b/src/js/components/agencyV2/overview/FySummary.jsx
@@ -21,23 +21,23 @@ import BarChart from './BarChart';
 const propTypes = {
     fy: PropTypes.string,
     windowWidth: PropTypes.number,
-    isMobile: PropTypes.bool,
-    toptierCode: PropTypes.string
+    isMobile: PropTypes.bool
 };
 
 const FySummary = ({
     fy,
     windowWidth,
-    isMobile,
-    toptierCode
+    isMobile
 }) => {
     const dispatch = useDispatch();
     const [isLoading, setIsLoading] = useState(true);
     const [isError, setIsError] = useState(true);
     const {
         budgetaryResources,
-        _awardObligations
+        _awardObligations,
+        overview
     } = useSelector((state) => state.agencyV2);
+    const { toptierCode } = overview;
     const budgetaryResourcesRequest = useRef(null);
 
     useEffect(() => () => {

--- a/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
+++ b/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
@@ -5,25 +5,26 @@
 
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import { FlexGridRow, FlexGridCol, FlexGridContainer } from 'data-transparency-ui';
 import DrilldownSidebar from './DrilldownSidebar';
 import VisualizationSection from './VisualizationSection';
 
 const propTypes = {
-    agencyId: PropTypes.string,
     fy: PropTypes.string
 };
 
 export const levels = ['Subcomponent', 'Federal Account'];
 
-const StatusOfFunds = ({ agencyId, fy }) => {
+const StatusOfFunds = ({ fy }) => {
     const [level, setLevel] = useState(0);
+    const { toptierCode } = useSelector((state) => state.agencyV2.overview);
     return (
         <div className="body__content status-of-funds">
             <FlexGridContainer>
                 <FlexGridRow className="status-of-funds__intro" hasGutter>
                     <FlexGridCol>
-                        DEV-8046 Intro: agency {agencyId}, FY {fy}
+                        DEV-8046 Intro: agency {toptierCode}, FY {fy}
                     </FlexGridCol>
                 </FlexGridRow>
                 <FlexGridRow hasGutter>
@@ -31,7 +32,7 @@ const StatusOfFunds = ({ agencyId, fy }) => {
                         <DrilldownSidebar level={level} setLevel={setLevel} />
                     </FlexGridCol>
                     <FlexGridCol className="status-of-funds__visualization" tablet={9}>
-                        <VisualizationSection level={level} agencyId={agencyId} fy={fy} />
+                        <VisualizationSection level={level} agencyId={toptierCode} fy={fy} />
                     </FlexGridCol>
                 </FlexGridRow>
             </FlexGridContainer>

--- a/src/js/containers/agencyV2/AgencyContainerV2.jsx
+++ b/src/js/containers/agencyV2/AgencyContainerV2.jsx
@@ -82,7 +82,6 @@ export const AgencyProfileV2 = () => {
             latestFy={latestFy}
             selectedFy={selectedFy}
             toptierCode={toptierCode}
-            agencySlug={agencySlug}
             isLoading={isLoading}
             isError={isError}
             errorMessage={errorMessage} />

--- a/src/js/containers/agencyV2/AgencyContainerV2.jsx
+++ b/src/js/containers/agencyV2/AgencyContainerV2.jsx
@@ -81,7 +81,7 @@ export const AgencyProfileV2 = () => {
             setSelectedFy={setSelectedFy}
             latestFy={latestFy}
             selectedFy={selectedFy}
-            toptierCode={toptierCode}
+            agencySlug={agencySlug}
             isLoading={isLoading}
             isError={isError}
             errorMessage={errorMessage} />

--- a/src/js/containers/agencyV2/AgencyContainerV2.jsx
+++ b/src/js/containers/agencyV2/AgencyContainerV2.jsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect, useRef } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Redirect } from 'react-router-dom';
 import { isCancel } from 'axios';
 import { useDispatch } from 'react-redux';
 
@@ -27,6 +27,7 @@ export const AgencyProfileV2 = () => {
     const [isLoading, setLoading] = useState(true);
     const [isError, setError] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');
+    const [redirect, setRedirect] = useState(false);
     const request = useRef(null);
     const dispatch = useDispatch();
     const [toptierCode, setToptierCode] = useState(agencySlugs[agencySlug]);
@@ -67,8 +68,7 @@ export const AgencyProfileV2 = () => {
                 setToptierCode(code);
             }
             else {
-                setErrorMessage('Invalid Agency');
-                setError(true);
+                setRedirect(true);
             }
         }
         else if (slugsError) {
@@ -76,6 +76,9 @@ export const AgencyProfileV2 = () => {
         }
     }, [agencySlugs, slugsLoading, slugsError]);
 
+    if (redirect) {
+        return <Redirect to="/404" />;
+    }
     return (
         <AgencyPage
             setSelectedFy={setSelectedFy}

--- a/src/js/containers/agencyV2/AgencyContainerV2.jsx
+++ b/src/js/containers/agencyV2/AgencyContainerV2.jsx
@@ -15,12 +15,17 @@ import { setAgencyOverview } from 'redux/actions/agencyV2/agencyV2Actions';
 
 import { useValidTimeBasedQueryParams, useLatestAccountData } from 'containers/account/WithLatestFy';
 import AgencyPage from 'components/agencyV2/AgencyPage';
+import { useAgencySlugs } from './WithAgencySlugs';
 
 export const AgencyProfileV2 = () => {
     const { agencyId } = useParams();
     const [, , { year: latestFy }] = useLatestAccountData();
     const { fy: currentUrlFy } = useQueryParams(['fy']);
     const [selectedFy, setSelectedFy] = useValidTimeBasedQueryParams(currentUrlFy, null, ['fy']);
+    const [agencySlugs, slugsLoading, slugsError] = useAgencySlugs();
+    if (!slugsLoading && !slugsError) {
+        console.log(agencySlugs);
+    }
     const [isLoading, setLoading] = useState(true);
     const [isError, setError] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');

--- a/src/js/containers/agencyV2/AgencyContainerV2.jsx
+++ b/src/js/containers/agencyV2/AgencyContainerV2.jsx
@@ -18,22 +18,21 @@ import AgencyPage from 'components/agencyV2/AgencyPage';
 import { useAgencySlugs } from './WithAgencySlugs';
 
 export const AgencyProfileV2 = () => {
-    const { agencyId } = useParams();
+    const { agencySlug } = useParams();
     const [, , { year: latestFy }] = useLatestAccountData();
     const { fy: currentUrlFy } = useQueryParams(['fy']);
     const [selectedFy, setSelectedFy] = useValidTimeBasedQueryParams(currentUrlFy, null, ['fy']);
+    // Use a custom hook to get the { agency slug: toptier code } mapping, or request it if not yet available
     const [agencySlugs, slugsLoading, slugsError] = useAgencySlugs();
-    if (!slugsLoading && !slugsError) {
-        console.log(agencySlugs);
-    }
     const [isLoading, setLoading] = useState(true);
     const [isError, setError] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');
     const request = useRef(null);
     const dispatch = useDispatch();
+    const [toptierCode, setToptierCode] = useState(agencySlugs[agencySlug]);
 
     useEffect(() => {
-        if (selectedFy) {
+        if (selectedFy && toptierCode) {
             if (request.current) {
                 request.current.cancel();
             }
@@ -41,7 +40,7 @@ export const AgencyProfileV2 = () => {
             setError(false);
             setErrorMessage('');
             // request overview data for this agency
-            request.current = fetchAgencyOverview(agencyId, selectedFy);
+            request.current = fetchAgencyOverview(toptierCode, selectedFy);
             request.current.promise
                 .then((res) => {
                     setLoading(false);
@@ -58,14 +57,32 @@ export const AgencyProfileV2 = () => {
                     }
                 });
         }
-    }, [agencyId, selectedFy]);
+    }, [toptierCode, selectedFy]);
+
+    useEffect(() => {
+        if (!slugsLoading && !slugsError) {
+            // Lookup the toptier code for this agency and validate it
+            const code = agencySlugs[agencySlug];
+            if (code) {
+                setToptierCode(code);
+            }
+            else {
+                setErrorMessage('Invalid Agency');
+                setError(true);
+            }
+        }
+        else if (slugsError) {
+            setError(true);
+        }
+    }, [agencySlugs, slugsLoading, slugsError]);
 
     return (
         <AgencyPage
             setSelectedFy={setSelectedFy}
             latestFy={latestFy}
             selectedFy={selectedFy}
-            agencyId={agencyId}
+            toptierCode={toptierCode}
+            agencySlug={agencySlug}
             isLoading={isLoading}
             isError={isError}
             errorMessage={errorMessage} />

--- a/src/js/containers/agencyV2/WithAgencySlugs.jsx
+++ b/src/js/containers/agencyV2/WithAgencySlugs.jsx
@@ -21,7 +21,7 @@ export const useAgencySlugs = () => {
     const request = useRef();
 
     useEffect(() => {
-        if (agencySlugs.size && loading) {
+        if (!isEmpty(agencySlugs) && loading) {
             setLoading(false);
         }
         if (isEmpty(agencySlugs)) {
@@ -43,6 +43,11 @@ export const useAgencySlugs = () => {
                     request.current = null;
                 });
         }
+        return () => {
+            if (request.current) {
+                request.current.cancel();
+            }
+        };
     }, [agencySlugs]);
 
     return [agencySlugs, loading, error];

--- a/src/js/containers/agencyV2/WithAgencySlugs.jsx
+++ b/src/js/containers/agencyV2/WithAgencySlugs.jsx
@@ -47,3 +47,16 @@ export const useAgencySlugs = () => {
 
     return [agencySlugs, loading, error];
 };
+
+const withAgencySlugs = (WrappedComponent) => (props) => {
+    const [agencySlugs, loading, error] = useAgencySlugs();
+    return (
+        <WrappedComponent
+            {...props}
+            agencySlugs={agencySlugs}
+            loading={loading}
+            error={error} />
+    );
+};
+
+export default withAgencySlugs;

--- a/src/js/containers/agencyV2/WithAgencySlugs.jsx
+++ b/src/js/containers/agencyV2/WithAgencySlugs.jsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { isEmpty } from 'lodash';
+import { fetchAgencySlugs } from 'apis/agencyV2';
+import { setAgencySlugs } from 'redux/actions/agencyV2/agencyV2Actions';
+
+export const parseAgencySlugs = (results) => (
+    results.reduce((acc, agency) => {
+        /* eslint-disable camelcase */
+        const { agency_slug, toptier_code } = agency;
+        return { ...acc, [agency_slug]: toptier_code };
+        /* eslint-enable camelcase */
+    }, {})
+);
+
+export const useAgencySlugs = () => {
+    const dispatch = useDispatch();
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(false);
+    const { agencySlugs } = useSelector((state) => state.agencyV2);
+    const request = useRef();
+
+    useEffect(() => {
+        if (agencySlugs.size && loading) {
+            setLoading(false);
+        }
+        if (isEmpty(agencySlugs)) {
+            setLoading(true);
+            setError(false);
+            request.current = fetchAgencySlugs();
+            request.current.promise
+                .then(({ data }) => {
+                    const slugsMapping = parseAgencySlugs(data.results);
+                    dispatch(setAgencySlugs(slugsMapping));
+                    setLoading(false);
+                    setError(false);
+                    request.current = null;
+                })
+                .catch((e) => {
+                    setLoading(false);
+                    setError(true);
+                    console.error(e);
+                    request.current = null;
+                });
+        }
+    }, [agencySlugs]);
+
+    return [agencySlugs, loading, error];
+};

--- a/src/js/containers/agencyV2/awardSpending/SubAgencySummaryContainer.jsx
+++ b/src/js/containers/agencyV2/awardSpending/SubAgencySummaryContainer.jsx
@@ -6,12 +6,11 @@ import { InformationBoxes } from "data-transparency-ui";
 import { awardTypeGroups } from 'dataMapping/search/awardType';
 import { fetchSubagencyNewAwardsCount, fetchSubagencySummary } from 'apis/agencyV2';
 import BaseAgencySubagencyCount from 'models/v2/agency/BaseAgencySubagencyCount';
+import { useSelector } from 'react-redux';
 
 const propTypes = {
     fy: PropTypes.string,
-    toptierCode: PropTypes.string,
     activeTab: PropTypes.string,
-    prevTab: PropTypes.string,
     summaryData: PropTypes.arrayOf(PropTypes.shape({
         type: PropTypes.string,
         title: PropTypes.string
@@ -22,7 +21,6 @@ const propTypes = {
 const SubAgencySummaryContainer = ({
     activeTab,
     fy,
-    toptierCode,
     summaryData,
     data
 }) => {
@@ -34,6 +32,7 @@ const SubAgencySummaryContainer = ({
     const [numberOfAwards, setNumberOfAwards] = useState(null);
     const [numberOfTransactions, setNumberOfTransactions] = useState(null);
     const [awardObligations, setAwardObligations] = useState(null);
+    const { toptierCode } = useSelector((state) => state.agencyV2.overview);
 
     useEffect(() => {
         if (request.current) {

--- a/src/js/containers/agencyV2/awardSpending/SubAgencySummaryContainer.jsx
+++ b/src/js/containers/agencyV2/awardSpending/SubAgencySummaryContainer.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useSelector } from 'react-redux';
 import { isCancel } from 'axios';
 import PropTypes from 'prop-types';
 
@@ -10,7 +9,7 @@ import BaseAgencySubagencyCount from 'models/v2/agency/BaseAgencySubagencyCount'
 
 const propTypes = {
     fy: PropTypes.string,
-    agencyId: PropTypes.string,
+    toptierCode: PropTypes.string,
     activeTab: PropTypes.string,
     prevTab: PropTypes.string,
     summaryData: PropTypes.arrayOf(PropTypes.shape({
@@ -23,6 +22,7 @@ const propTypes = {
 const SubAgencySummaryContainer = ({
     activeTab,
     fy,
+    toptierCode,
     summaryData,
     data
 }) => {
@@ -31,7 +31,6 @@ const SubAgencySummaryContainer = ({
     const [loading, setLoading] = React.useState(true);
     const [error, setError] = React.useState(false);
     const request = React.useRef(null);
-    const { toptierCode } = useSelector((state) => state.agencyV2.overview);
     const [numberOfAwards, setNumberOfAwards] = useState(null);
     const [numberOfTransactions, setNumberOfTransactions] = useState(null);
     const [awardObligations, setAwardObligations] = useState(null);

--- a/src/js/containers/agencyV2/awardSpending/SubAgencySummaryContainer.jsx
+++ b/src/js/containers/agencyV2/awardSpending/SubAgencySummaryContainer.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { isCancel } from 'axios';
 import PropTypes from 'prop-types';
 
@@ -6,7 +7,6 @@ import { InformationBoxes } from "data-transparency-ui";
 import { awardTypeGroups } from 'dataMapping/search/awardType';
 import { fetchSubagencyNewAwardsCount, fetchSubagencySummary } from 'apis/agencyV2';
 import BaseAgencySubagencyCount from 'models/v2/agency/BaseAgencySubagencyCount';
-import { useSelector } from 'react-redux';
 
 const propTypes = {
     fy: PropTypes.string,

--- a/src/js/containers/agencyV2/awardSpending/SubagencyTableContainer.jsx
+++ b/src/js/containers/agencyV2/awardSpending/SubagencyTableContainer.jsx
@@ -17,7 +17,7 @@ import { parseRows } from 'helpers/agencyV2/AwardSpendingSubagencyHelper';
 import { useStateWithPrevious } from 'helpers';
 
 const propTypes = {
-    agencyId: PropTypes.string,
+    toptierCode: PropTypes.string,
     fy: PropTypes.string,
     type: PropTypes.string.isRequired,
     prevType: PropTypes.string,
@@ -26,7 +26,7 @@ const propTypes = {
 
 const SubagencyTableContainer = ({
     fy,
-    agencyId,
+    toptierCode,
     type,
     prevType,
     subHeading
@@ -66,7 +66,7 @@ const SubagencyTableContainer = ({
             order
         };
         const typeParam = awardTypeGroups[type];
-        request.current = fetchSubagencySpendingList(agencyId, fy, typeParam, params);
+        request.current = fetchSubagencySpendingList(toptierCode, fy, typeParam, params);
         const awardSpendingSubagencyRequest = request.current;
         awardSpendingSubagencyRequest.promise
             .then((res) => {
@@ -99,7 +99,7 @@ const SubagencyTableContainer = ({
                 fetchSpendingBySubagencyCallback();
             }
         }
-    }, [type, fy, agencyId, pageSize, sort, order]);
+    }, [type, fy, toptierCode, pageSize, sort, order]);
 
     useEffect(() => {
         if (fy) {

--- a/src/js/containers/agencyV2/awardSpending/SubagencyTableContainer.jsx
+++ b/src/js/containers/agencyV2/awardSpending/SubagencyTableContainer.jsx
@@ -4,7 +4,7 @@
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Table, Pagination } from 'data-transparency-ui';
 import { subagencyColumns, subagencyFields } from 'dataMapping/agency/tableColumns';
 import { awardTypeGroups } from 'dataMapping/search/awardType';
@@ -17,7 +17,6 @@ import { parseRows } from 'helpers/agencyV2/AwardSpendingSubagencyHelper';
 import { useStateWithPrevious } from 'helpers';
 
 const propTypes = {
-    toptierCode: PropTypes.string,
     fy: PropTypes.string,
     type: PropTypes.string.isRequired,
     prevType: PropTypes.string,
@@ -26,7 +25,6 @@ const propTypes = {
 
 const SubagencyTableContainer = ({
     fy,
-    toptierCode,
     type,
     prevType,
     subHeading
@@ -45,6 +43,7 @@ const SubagencyTableContainer = ({
     const [error, setError] = useState(false);
     const request = useRef(null);
     const dispatch = useDispatch();
+    const { toptierCode } = useSelector((state) => state.agencyV2.overview);
 
     useEffect(() => {
         if (request.current) {
@@ -99,13 +98,13 @@ const SubagencyTableContainer = ({
                 fetchSpendingBySubagencyCallback();
             }
         }
-    }, [type, fy, toptierCode, pageSize, sort, order]);
+    }, [type, fy, pageSize, sort, order]);
 
     useEffect(() => {
-        if (fy) {
+        if (fy && toptierCode) {
             fetchSpendingBySubagencyCallback();
         }
-    }, [currentPage, fy]);
+    }, [currentPage, fy, toptierCode]);
 
     return (
         <>

--- a/src/js/containers/covid19/WithDefCodes.jsx
+++ b/src/js/containers/covid19/WithDefCodes.jsx
@@ -38,7 +38,6 @@ export const useDefCodes = () => {
         }
         return () => {
             if (request.current) {
-                console.info('cancelling request, fetchDEFCodes');
                 request.current.cancel();
             }
         };

--- a/src/js/containers/router/RouterRoutes.js
+++ b/src/js/containers/router/RouterRoutes.js
@@ -168,7 +168,7 @@ export const routes = [
         exact: true
     },
     {
-        path: '/agency_v2/:agencyId',
+        path: '/agency_v2/:agencySlug',
         component: AgencyProfileV2,
         exact: true
     },

--- a/src/js/redux/actions/agencyV2/agencyV2Actions.js
+++ b/src/js/redux/actions/agencyV2/agencyV2Actions.js
@@ -45,6 +45,11 @@ export const setSubagencyTotals = (spendingBySubagencyTotals) => ({
     spendingBySubagencyTotals
 });
 
+export const setAgencySlugs = (agencySlugs) => ({
+    type: 'SET_AGENCY_SLUGS',
+    agencySlugs
+});
+
 export const resetSubagencyTotals = () => ({
     type: 'RESET_SUBAGENCY_TOTALS'
 });

--- a/src/js/redux/reducers/agencyV2/agencyV2Reducer.js
+++ b/src/js/redux/reducers/agencyV2/agencyV2Reducer.js
@@ -31,7 +31,8 @@ export const initialState = {
         programActivity: null,
         federalAccount: null
     },
-    spendingBySubagencyTotals
+    spendingBySubagencyTotals,
+    agencySlugs: {}
 };
 
 const agencyReducer = (state = initialState, action) => {
@@ -80,6 +81,11 @@ const agencyReducer = (state = initialState, action) => {
             return {
                 ...state,
                 spendingBySubagencyTotals: action.spendingBySubagencyTotals
+            };
+        case 'SET_AGENCY_SLUGS':
+            return {
+                ...state,
+                agencySlugs: action.agencySlugs
             };
         case 'RESET_SUBAGENCY_TOTALS':
             return {

--- a/tests/components/agency/overview/FYSummary-test.jsx
+++ b/tests/components/agency/overview/FYSummary-test.jsx
@@ -37,7 +37,10 @@ beforeEach(() => {
             }
         },
         _agencyObligations: 123456789.10,
-        recipientDistribution
+        recipientDistribution,
+        overview: {
+            toptierCode: '010'
+        }
     });
 });
 
@@ -51,7 +54,7 @@ test('No duplicate API requests', () => {
         cancel: () => {}
     });
 
-    render(<FYSummary isMobile={false} fy="2020" agencyId="10" windowWidth={1200} />);
+    render(<FYSummary isMobile={false} fy="2020" windowWidth={1200} />);
     return waitFor(() => {
         expect(spy).toHaveBeenCalledTimes(1);
     });
@@ -66,23 +69,9 @@ test('No API request on FY change', () => {
         })),
         cancel: () => {}
     });
-    const { rerender } = render(<FYSummary isMobile={false} fy="2020" agencyId="10" windowWidth={1200} />);
+    const { rerender } = render(<FYSummary isMobile={false} fy="2020" windowWidth={1200} />);
     spy.mockReset();
 
-    rerender(<FYSummary isMobile={false} fy="2021" agencyId="10" windowWidth={1200} />);
+    rerender(<FYSummary isMobile={false} fy="2021" windowWidth={1200} />);
     expect(spy).not.toHaveBeenCalled();
-});
-
-test('Extra API request on Agency ID change', () => {
-    const spy = jest.spyOn(helpers, 'fetchBudgetaryResources').mockReturnValue({
-        promise: new Promise((resolve) => resolve({
-            data: {
-                agency_data_by_year: mockTotalBudgetaryResources
-            }
-        })),
-        cancel: () => {}
-    });
-    const { rerender } = render(<FYSummary isMobile={false} fy="2020" agencyId="10" />);
-    rerender(<FYSummary isMobile={false} fy="2021" agencyId="11" windowWidth={1200} />);
-    expect(spy).toHaveBeenCalledTimes(2);
 });

--- a/tests/containers/account/WithLatestFy-test.js
+++ b/tests/containers/account/WithLatestFy-test.js
@@ -1,5 +1,5 @@
 /**
- * WitLatestFy-test.js
+ * WithLatestFy-test.js
  * Created by Max Kendall 02/5/2021
 * */
 

--- a/tests/containers/agencyV2/AgencyContainerV2-test.jsx
+++ b/tests/containers/agencyV2/AgencyContainerV2-test.jsx
@@ -9,6 +9,7 @@ import { Route } from 'react-router-dom';
 import * as agencyV2 from 'apis/agencyV2';
 import * as accountHooks from 'containers/account/WithLatestFy';
 import * as queryParamHelpers from 'helpers/queryParams';
+import * as agencyHooks from 'containers/agencyV2/WithAgencySlugs';
 
 import AgencyContainerV2 from 'containers/agencyV2/AgencyContainerV2';
 import { mockAgency } from '../../models/agency/BaseAgencyOverview-test';
@@ -34,9 +35,15 @@ beforeEach(() => {
     jest.spyOn(queryParamHelpers, "useQueryParams").mockImplementation(() => [
         { fy: 2020 }
     ]);
+    jest.spyOn(agencyHooks, "useAgencySlugs").mockImplementation(() => [
+        {
+            'department-of-sandwiches': '123',
+            'ministry-of-magic': '456'
+        }
+    ]);
 });
 
-test('an API request is made for the agency code in the URL', () => {
+test('an API request is made for the agency code mapped to the slug in the URL', () => {
     const mockResponse = {
         promise: new Promise((resolve) => {
             process.nextTick(() => (
@@ -47,7 +54,7 @@ test('an API request is made for the agency code in the URL', () => {
     // spy.mockClear();
     spy = jest.spyOn(agencyV2, 'fetchAgencyOverview').mockReturnValueOnce(mockResponse);
     render((
-        <Route path="/agency_v2/:agencyId" location={{ pathname: '/agency_v2/123' }}>
+        <Route path="/agency_v2/:agencySlug" location={{ pathname: '/agency_v2/department-of-sandwiches' }}>
             <AgencyContainerV2 />
         </Route >
     ));

--- a/tests/containers/agencyV2/AgencyContainerV2-test.jsx
+++ b/tests/containers/agencyV2/AgencyContainerV2-test.jsx
@@ -51,7 +51,6 @@ test('an API request is made for the agency code mapped to the slug in the URL',
             ));
         })
     };
-    // spy.mockClear();
     spy = jest.spyOn(agencyV2, 'fetchAgencyOverview').mockReturnValueOnce(mockResponse);
     render((
         <Route path="/agency_v2/:agencySlug" location={{ pathname: '/agency_v2/department-of-sandwiches' }}>

--- a/tests/containers/agencyV2/WithAgencySlugs-test.jsx
+++ b/tests/containers/agencyV2/WithAgencySlugs-test.jsx
@@ -1,0 +1,66 @@
+/**
+ * WithAgencySlugs-test.js
+ * Created by Lizzie Salita 11/8/21
+* */
+
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { waitFor } from 'test-utils';
+import * as redux from 'react-redux';
+import * as api from 'apis/agencyV2';
+import * as actions from 'redux/actions/agencyV2/agencyV2Actions';
+
+import { parseAgencySlugs, useAgencySlugs } from 'containers/agencyV2/WithAgencySlugs';
+
+let mockFetch;
+let mockUseSelector;
+let mockAction;
+
+const mockAPIResponse = {
+    results: [
+        {
+            toptier_code: "123",
+            agency_slug: "department-of-sandwiches"
+        },
+        {
+            toptier_code: "456",
+            agency_slug: "ministry-of-magic"
+        }
+    ]
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export const expectedMapping = {
+    'department-of-sandwiches': '123',
+    'ministry-of-magic': '456'
+};
+
+beforeEach(() => {
+    jest.spyOn(redux, 'useDispatch').mockReturnValue(() => (fn) => fn()).mockClear();
+    mockFetch = jest.spyOn(api, 'fetchAgencySlugs').mockReturnValue({
+        promise: Promise.resolve({ data: mockAPIResponse }),
+        cancel: () => jest.fn()
+    }).mockClear();
+    mockUseSelector = jest.spyOn(redux, 'useSelector').mockReturnValue({ agencySlugs: {} }).mockClear();
+    mockAction = jest.spyOn(actions, 'setAgencySlugs').mockClear();
+});
+
+test('useAgencySlugs: fetches agency slugs when they are not populated', async () => {
+    renderHook(() => useAgencySlugs());
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+        expect(mockAction).toHaveBeenCalledWith(expectedMapping);
+    });
+});
+
+test('useAgencySlugs: does not fetch agency slugs when they are populated', () => {
+    mockUseSelector.mockReturnValue({ agencySlugs: expectedMapping });
+    const { result } = renderHook(() => useAgencySlugs());
+    expect(mockFetch).toHaveBeenCalledTimes(0);
+    expect(result.current[0]).toEqual(expectedMapping);
+});
+
+test('parseAgencySlugs: returns a mapping of agency_slug: toptier_code', () => {
+    const result = parseAgencySlugs(mockAPIResponse.results);
+    expect(result).toEqual(expectedMapping);
+});

--- a/tests/containers/agencyV2/awardSpending/SubagencyTableContainer-test.jsx
+++ b/tests/containers/agencyV2/awardSpending/SubagencyTableContainer-test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, waitFor } from 'test-utils';
-
+import * as redux from 'react-redux';
 import * as apis from 'apis/agencyV2';
 import * as helpers from 'helpers/agencyV2/AwardSpendingSubagencyHelper';
 import SubagencyTableContainer from 'containers/agencyV2/awardSpending/SubagencyTableContainer';
@@ -44,11 +44,14 @@ export const mockResponse = {
 };
 
 const defaultProps = {
-    agencyId: '012',
     fy: '2020',
     type: 'all',
     subHeading: 'test'
 };
+
+jest.spyOn(redux, 'useSelector').mockReturnValue({
+    toptierCode: '073'
+});
 
 afterEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
**High level description:**

Use the agency name slug (e.g. `department-of-the-treasury`) instead of the toptier code (e.g. `020`) in (dark-released) Agency Profile v2 URLs

**Technical details:**
- Implements a custom hook, `useAgencySlugs`, which returns a mapping of `agency_slug` to `toptier_code` if it exists in Redux. If it does not exist in Redux yet, it makes an API request to the endpoint `v2/references/toptier_agencies`
- Handles the loading state for each section of the page in `AgencySection.jsx` instead of per-component
- Fixes a few console errors about unique keys
- In the containers, get `toptierCode` from the `agencyV2.overview` object Redux (instead of passing it down as a prop or getting it from the URL)
- Bonus! Removes the download button from the page header to match the latest mocks, since I was already in there editing the share button logic

**JIRA Ticket:**
[DEV-6390](https://federal-spending-transparency.atlassian.net/browse/DEV-6390)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Provided instructions for testing in JIRA
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)

Reviewer(s):
- [x] Code review complete
