### PR TITLE
8037 - changed css on a tags to nowrap; changed some nbsp to ' ' to p…

### DIFF
--- a/src/_scss/pages/about/_section.scss
+++ b/src/_scss/pages/about/_section.scss
@@ -33,7 +33,7 @@
     .about-section-content {
         margin-bottom: rem(25);
         a {
-          word-break: break-all;
+            white-space: nowrap;
         }
         p {
             font-size: rem(18);

--- a/src/js/components/about/Careers.jsx
+++ b/src/js/components/about/Careers.jsx
@@ -25,7 +25,7 @@ const Careers = () => (
                 of the Chief Data Officer (Bureau of the Fiscal Service, U.S. Department of the Treasury)
                 is always on the lookout for talented analysts, marketers, and product managers. If you or
                 someone you know is interested in joining our team, please send an email
-                to&nbsp;
+                to{' '}
                 <a href={mailToString}>
                     USAspending.Help@fiscal.treasury.gov
                 </a>.

--- a/src/js/components/about/DataQuality.jsx
+++ b/src/js/components/about/DataQuality.jsx
@@ -48,7 +48,7 @@ const DataQuality = () => (
             </ul>
             <p>
                 To ensure that contract data is accurate, the Office of Management and
-                Budget issues the&nbsp;
+                Budget issues the{' '}
                 <a
                     href="https://www.fsd.gov/gsafsd_sp?id=kb_article_view&sysparm_article=KB0048871"
                     target="_blank"

--- a/src/js/components/about/Development.jsx
+++ b/src/js/components/about/Development.jsx
@@ -27,7 +27,7 @@ export default class Development extends React.Component {
                 </h2>
                 <div className="about-section-content">
                     <p>
-                        USAspending.gov is developed using agile methods. Our current release approach is a two-week development sprint, followed by a two-week testing period, followed by public release. We begin coding the next sprint at the same time we&rsquo;re testing the first sprint, so updates are published to the website about every two weeks. If you want us to send you the Release Notes when an update goes out, please&nbsp;
+                        USAspending.gov is developed using agile methods. Our current release approach is a two-week development sprint, followed by a two-week testing period, followed by public release. We begin coding the next sprint at the same time we&rsquo;re testing the first sprint, so updates are published to the website about every two weeks. If you want us to send you the Release Notes when an update goes out, please{' '}
                         <a
                             href="mailto:join-usaspending@lists.fiscal.treasury.gov?subject=Yes!%20I'd%20like%20to%20receive%20updates.">
                             sign up here

--- a/src/js/components/about/MoreInfo.jsx
+++ b/src/js/components/about/MoreInfo.jsx
@@ -16,14 +16,14 @@ const MoreInfo = () => (
         </h2>
         <div className="about-section-content">
             <p>
-                For more information about the data, see the&nbsp;
+                For more information about the data, see the{' '}
                 <a
                     target="_blank"
                     rel="noopener noreferrer"
                     href="https://usaspending-help.zendesk.com/hc/en-us/sections/115000739433-Frequently-Ask-Questions-">
                     FAQs
                 </a>
-                &nbsp;and the&nbsp;
+                &nbsp;and the{' '}
                 <Link to="/data-dictionary">
                     Data Dictionary
                 </Link>

--- a/src/js/components/aboutTheData/DataSourcesAndMethodologiesPage.jsx
+++ b/src/js/components/aboutTheData/DataSourcesAndMethodologiesPage.jsx
@@ -174,7 +174,7 @@ const DataSourcesAndMethodologiesPage = () => {
                                             url="https://www.whitehouse.gov/wp-content/uploads/2020/04/Implementation-Guidance-for-Supplemental-Funding-Provided-in-Response.pdf">
                                                 OMB’s Memorandum M-20-21 (Appendix A, Section III).
                                         </ExternalLink>
-                                            The full schedule of deadlines for agency submissions is found on the&nbsp;
+                                            The full schedule of deadlines for agency submissions is found on the{' '}
                                         <a
                                             className="usda-external-link"
                                             href="https://fiscal.treasury.gov/data-transparency/resources.html"


### PR DESCRIPTION
**High level description:**

This time was to make sure the text in the link wraps together when the window size causes it to wrap.

**Technical details:**

Changed the css on the a tags within the 'about-section-content' class to be nowrap. Also removed some nbsp preceding some a tags affected by this, so the word preceding the a tag doesn't also wrap.

**JIRA Ticket:**
[DEV-8037](https://federal-spending-transparency.atlassian.net/browse/DEV-1234)

**Mockup:**

N/A

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [x ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
