### PR TITLE
[DEV-8103] Limit download row size

### DIFF
--- a/src/js/components/search/header/NoDownloadHover.jsx
+++ b/src/js/components/search/header/NoDownloadHover.jsx
@@ -10,7 +10,7 @@ import { TooltipComponent } from 'data-transparency-ui';
 const NoDownloadHover = () => (
     <TooltipComponent title="Advanced Search Download">
         <div className="message">
-            Our Advanced Search limits downloads to 500,000 records.
+            Our Advanced Search limits downloads to 10,000 records.
             Narrow your search using additional filters, or grab larger files from
             our <Link to="/download_center/award_data_archive">Award Data Archive</Link>.
         </div>


### PR DESCRIPTION
**High level description:**
Updates text on Advanced Search/Keyword search pages to reflect new download size limit

Part of: https://github.com/fedspendingtransparency/usaspending-api/pull/3285

**Technical details:**

Technical details for the knowledge of other developers.

**JIRA Ticket:**
[DEV-8103](https://federal-spending-transparency.atlassian.net/browse/DEV-8103)

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
