### PR TITLE
Mod/dev 5083 agency links on state profile

### DIFF
--- a/src/js/GlobalConstants.js
+++ b/src/js/GlobalConstants.js
@@ -17,6 +17,7 @@ const globalConstants = {
     MAPBOX_TOKEN: process.env.MAPBOX_TOKEN,
     QAT: (process.env.ENV === 'qat' || process.env.ENV === 'sandbox'),
     STAGING: (process.env.ENV === 'staging'),
+    PROD: process.env.ENV === 'prod',
     FILES_SERVER_BASE_URL: filesServerUrlByEnv[process.env.ENV],
     ARP_RELEASED: process.env.ENV !== 'prod',
     AGENCY_LINK: process.env.ENV === 'prod' ? 'agency' : 'agency_v2'

--- a/src/js/components/state/topFive/TopFiveRow.jsx
+++ b/src/js/components/state/topFive/TopFiveRow.jsx
@@ -16,13 +16,15 @@ const TopFiveRow = (props) => {
 
     const percent = isNaN(percentValue) ? '--' : `${Math.round(percentValue * 100) / 100}%`;
 
+    const name = [];
+    name.push(props.data.name);
     return (
         <tr
             className="category-table__table-row">
             <td
                 className="category-table__table-cell"
                 title={props.data.name}>
-                {props.data.name}
+                {name}
             </td>
             <td
                 className="category-table__table-cell category-table__table-cell_centered"

--- a/src/js/components/state/topFive/TopFiveRow.jsx
+++ b/src/js/components/state/topFive/TopFiveRow.jsx
@@ -23,7 +23,7 @@ const TopFiveRow = (props) => {
             <td
                 className="category-table__table-cell"
                 title={props.data.name}>
-                {GlobalConstants.ARP_RELEASED && props.data._slug ?
+                {!GlobalConstants.PROD && props.data._slug ?
                     props.data.linkedName
                     : props.data.name}
             </td>

--- a/src/js/components/state/topFive/TopFiveRow.jsx
+++ b/src/js/components/state/topFive/TopFiveRow.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import GlobalConstants from 'GlobalConstants';
 
 const propTypes = {
     data: PropTypes.object,
@@ -16,15 +17,15 @@ const TopFiveRow = (props) => {
 
     const percent = isNaN(percentValue) ? '--' : `${Math.round(percentValue * 100) / 100}%`;
 
-    const name = [];
-    name.push(props.data.name);
     return (
         <tr
             className="category-table__table-row">
             <td
                 className="category-table__table-cell"
                 title={props.data.name}>
-                {name}
+                {GlobalConstants.ARP_RELEASED && props.data._slug ?
+                    props.data.linkedName
+                    : props.data.name}
             </td>
             <td
                 className="category-table__table-cell category-table__table-cell_centered"

--- a/src/js/components/state/topFive/TopFiveRow.jsx
+++ b/src/js/components/state/topFive/TopFiveRow.jsx
@@ -23,7 +23,7 @@ const TopFiveRow = (props) => {
             <td
                 className="category-table__table-cell"
                 title={props.data.name}>
-                {!GlobalConstants.PROD && props.data._slug ?
+                {GlobalConstants.AGENCYV2_RELEASED && props.data._slug ?
                     props.data.linkedName
                     : props.data.name}
             </td>

--- a/src/js/containers/state/topFive/TopFiveContainer.jsx
+++ b/src/js/containers/state/topFive/TopFiveContainer.jsx
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { isCancel } from 'axios';
 
-import GlobalConstants from 'GlobalConstants';
 import { getTrailingTwelveMonths, convertFYToDateRange } from 'helpers/fiscalYearHelper';
 import * as SearchHelper from 'helpers/searchHelper';
 import BaseStateCategoryResult from 'models/v2/state/BaseStateCategoryResult';
@@ -133,6 +132,7 @@ export class TopFiveContainer extends React.Component {
         const parsed = data.map((item, index) => {
             const result = Object.create(BaseStateCategoryResult);
             result.populate(item, index + 1);
+
             // use a special naming template for DUNS
             if (type === 'recipient_duns') {
                 result.nameTemplate = (code, name) => {
@@ -142,8 +142,6 @@ export class TopFiveContainer extends React.Component {
                     return name;
                 };
             }
-
-            // make agency names links to agency page
             else if (type === 'awarding_agency' || type === 'awarding_subagency') {
                 result.nameTemplate = (code, name) => {
                     if (code) {

--- a/src/js/containers/state/topFive/TopFiveContainer.jsx
+++ b/src/js/containers/state/topFive/TopFiveContainer.jsx
@@ -145,22 +145,12 @@ export class TopFiveContainer extends React.Component {
 
             // make agency names links to agency page
             else if (type === 'awarding_agency' || type === 'awarding_subagency') {
-                if (GlobalConstants.ARP_RELEASED) {
-                    result.nameTemplate = (code, name, slug) => {
-                        if (code) {
-                            return <a href={slug}>${name} (${code})</a>;
-                        }
-                        return name;
-                    };
-                }
-                else {
-                    result.nameTemplate = (code, name) => {
-                        if (code) {
-                            return `${name} (${code})`;
-                        }
-                        return name;
-                    };
-                }
+                result.nameTemplate = (code, name) => {
+                    if (code) {
+                        return `${name} (${code})`;
+                    }
+                    return name;
+                };
             }
             else if (type === 'county' || type === 'district') {
                 result.nameTemplate = (code, name) => (name);

--- a/src/js/containers/state/topFive/TopFiveContainer.jsx
+++ b/src/js/containers/state/topFive/TopFiveContainer.jsx
@@ -8,26 +8,22 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { isCancel } from 'axios';
 
-import {
-    getTrailingTwelveMonths,
-    convertFYToDateRange
-} from 'helpers/fiscalYearHelper';
+import GlobalConstants from 'GlobalConstants';
+import { getTrailingTwelveMonths, convertFYToDateRange } from 'helpers/fiscalYearHelper';
 import * as SearchHelper from 'helpers/searchHelper';
 import BaseStateCategoryResult from 'models/v2/state/BaseStateCategoryResult';
-
 import { awardTypeGroups } from 'dataMapping/search/awardType';
-
 import TopFive from 'components/state/topFive/TopFive';
 
-const propTypes = {
-    code: PropTypes.string,
-    total: PropTypes.number,
-    category: PropTypes.string,
-    fy: PropTypes.string,
-    type: PropTypes.string
-};
-
 export class TopFiveContainer extends React.Component {
+    static propTypes = {
+        code: PropTypes.string,
+        total: PropTypes.number,
+        category: PropTypes.string,
+        fy: PropTypes.string,
+        type: PropTypes.string
+    };
+
     constructor(props) {
         super(props);
 
@@ -137,7 +133,6 @@ export class TopFiveContainer extends React.Component {
         const parsed = data.map((item, index) => {
             const result = Object.create(BaseStateCategoryResult);
             result.populate(item, index + 1);
-
             // use a special naming template for DUNS
             if (type === 'recipient_duns') {
                 result.nameTemplate = (code, name) => {
@@ -147,13 +142,25 @@ export class TopFiveContainer extends React.Component {
                     return name;
                 };
             }
+
+            // make agency names links to agency page
             else if (type === 'awarding_agency' || type === 'awarding_subagency') {
-                result.nameTemplate = (code, name) => {
-                    if (code) {
-                        return `${name} (${code})`;
-                    }
-                    return name;
-                };
+                if (GlobalConstants.ARP_RELEASED) {
+                    result.nameTemplate = (code, name, slug) => {
+                        if (code) {
+                            return <a href={slug}>${name} (${code})</a>;
+                        }
+                        return name;
+                    };
+                }
+                else {
+                    result.nameTemplate = (code, name) => {
+                        if (code) {
+                            return `${name} (${code})`;
+                        }
+                        return name;
+                    };
+                }
             }
             else if (type === 'county' || type === 'district') {
                 result.nameTemplate = (code, name) => (name);
@@ -186,5 +193,3 @@ export default connect(
         fy: state.stateProfile.fy
     })
 )(TopFiveContainer);
-
-TopFiveContainer.propTypes = propTypes;

--- a/src/js/models/v2/state/BaseStateCategoryResult.js
+++ b/src/js/models/v2/state/BaseStateCategoryResult.js
@@ -19,6 +19,7 @@ const BaseStateCategoryResult = {
         this.index = index;
         this._name = data.name || '--';
         this._code = data.code || '';
+        this._slug = data.agency_slug;
         this._amount = data.amount || 0;
 
         this._nameTemplate = defaultNameTemplate;
@@ -34,7 +35,7 @@ const BaseStateCategoryResult = {
         return MoneyFormatter.formatMoneyWithPrecision(this._amount, 0);
     },
     get combinedName() {
-        return this._nameTemplate(this._code, this._name);
+        return this._nameTemplate(this._code, this._name, this._slug);
     },
     get name() {
         return `${this.index}. ${this.combinedName}`;

--- a/src/js/models/v2/state/BaseStateCategoryResult.jsx
+++ b/src/js/models/v2/state/BaseStateCategoryResult.jsx
@@ -1,10 +1,11 @@
 /**
- * BaseStateCategoryResult.js
+ * BaseStateCategoryResult.jsx
  * Created by Kevin Li 5/16/18
  */
 
+import React from 'react';
 import * as MoneyFormatter from 'helpers/moneyFormatter';
-
+import GlobalConstants from 'GlobalConstants';
 
 export const defaultNameTemplate = (code, name) => {
     if (code) {
@@ -39,6 +40,9 @@ const BaseStateCategoryResult = {
     },
     get name() {
         return `${this.index}. ${this.combinedName}`;
+    },
+    get linkedName() {
+        return <a href={`/${GlobalConstants.AGENCY_LINK}/${this._slug}`}>{this.name}</a>;
     }
 };
 

--- a/tests/models/state/BaseStateCategoryResult-test.js
+++ b/tests/models/state/BaseStateCategoryResult-test.js
@@ -76,7 +76,7 @@ describe('BaseStateCategoryResult', () => {
             result.nameTemplate = jest.fn(() => 'test');
             const output = result.combinedName;
             expect(result._nameTemplate).toHaveBeenCalledTimes(1);
-            expect(result._nameTemplate).toHaveBeenLastCalledWith('1234', 'Banana');
+            expect(result._nameTemplate).toHaveBeenLastCalledWith('1234', 'Banana', "banana");
             expect(output).toEqual('test');
         });
     });

--- a/tests/models/state/mockStateApi.js
+++ b/tests/models/state/mockStateApi.js
@@ -26,7 +26,8 @@ export const mockStateCategoryApi = {
             id: 1,
             name: "Banana",
             code: "1234",
-            amount: 1.01
+            amount: 1.01,
+            agency_slug: "banana"
         },
         {
             id: 2,


### PR DESCRIPTION
**High level description:**

create links to agency page for Top 5 Awarding Agencies

**Technical details:**

adds linkedName to BaseStateCategoryResult for agency names with slugs; used by TopFiveRow if v2 released (or in lower environs)

**JIRA Ticket:**
[DEV-5083](https://federal-spending-transparency.atlassian.net/browse/DEV-5083)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [n/a ] Verified mobile/tablet/desktop/monitor responsiveness
- [n/a ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a ] Design review complete `if applicable`
- [n/a ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
