### PR TITLE
Change download max up to 100k

### DIFF
--- a/src/js/components/search/header/NoDownloadHover.jsx
+++ b/src/js/components/search/header/NoDownloadHover.jsx
@@ -10,7 +10,7 @@ import { TooltipComponent } from 'data-transparency-ui';
 const NoDownloadHover = () => (
     <TooltipComponent title="Advanced Search Download">
         <div className="message">
-            Our Advanced Search limits downloads to 10,000 records.
+            Our Advanced Search limits downloads to 100,000 records.
             Narrow your search using additional filters, or grab larger files from
             our <Link to="/download_center/award_data_archive">Award Data Archive</Link>.
         </div>


### PR DESCRIPTION
**High level description:**

Update the download hover to text to match the new max of 100k transactions per download.

Reviewer(s):
- [ ] Code review complete
