### PR TITLE
Fix/5713 "tab memory" errors on COVID page

### DIFF
--- a/src/js/containers/covid19/assistanceListing/SpendingByCFDAContainer.jsx
+++ b/src/js/containers/covid19/assistanceListing/SpendingByCFDAContainer.jsx
@@ -285,6 +285,13 @@ const SpendingByCFDAContainer = ({ activeTab, scrollIntoView }) => {
                 cfdaRequest = fetchCfdaLoans(params);
             }
             else {
+                // when not loan tab, if sort is on faceValueOfLoan, make it obligation instead to avoid API error
+                if (sort === 'faceValueOfLoan') {
+                    setSort('obligation');
+                    params.pagination.sort = 'obligation';
+                    setOrder('desc');
+                    params.pagination.order = 'desc';
+                }
                 cfdaRequest = fetchSpendingByCfda(params);
             }
             request.current = cfdaRequest;

--- a/src/js/containers/covid19/recipient/RecipientTableContainer.jsx
+++ b/src/js/containers/covid19/recipient/RecipientTableContainer.jsx
@@ -281,6 +281,11 @@ const RecipientTableContainer = ({ activeTab, prevActiveTab, scrollIntoView }) =
                 prevActiveTab !== activeTab
             );
             if (hasParamChanged) {
+                // when award type changes, if sort was on faceValueOfLoan, make it obligation instead to avoid API error
+                if (prevSort === 'faceValueOfLoan' && activeTab !== 'loans') {
+                    setSort('obligation');
+                    setOrder('desc');
+                }
                 fetchSpendingByRecipientCallback();
             }
         }


### PR DESCRIPTION
**High level description:**

Award Spending by CFDA and Award Spending by Recipient have tables that, if sorted by Face Value of Loans, produce errors when switched to another tab.

**Technical details:**

Current sort is maintained in state then used as API parameter; "face value" is not a valid sort parameter for non-loan requests. This defaults that situation to descending by obligation instead. (note: AwardSpendingAgencyTableContainer was previously corrected)

**JIRA Ticket:**
[DEV-5713](https://federal-spending-transparency.atlassian.net/browse/DEV-5713)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [n/a ] Verified mobile/tablet/desktop/monitor responsiveness
- [n/a ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a ] Design review complete `if applicable`
- [n/a ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
