### PR TITLE
DEV-8145 standard agency logo size

### DIFF
--- a/src/_scss/pages/agencyV2/overview/_overview.scss
+++ b/src/_scss/pages/agencyV2/overview/_overview.scss
@@ -46,7 +46,10 @@
             
         }
         .agency-overview__image {
+            max-width: rem(90);
+            max-height: rem(90);
             height: 100%;
+            object-fit: contain;
         }
         @include media($medium-screen) {
             // switch the position of the logo and title in desktop


### PR DESCRIPTION
**High level description:**

Fixes a bug that caused the SBA logo to display too large on its v2 profile page.

**Technical details:**

Previously, we expected all the logo images whose URLs are returned by the API to be a standard size. This PR adds some CSS to ensure the image does not exceed 9rem in height or width. (The 100% height is required for IE)

**JIRA Ticket:**
[DEV-8145](https://federal-spending-transparency.atlassian.net/browse/DEV-8145)

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness

Reviewer(s):
- [ ] Code review complete
