### PR TITLE
Hotfix DEV-8156 Covid Profile Summary Insights request params

### DIFF
--- a/src/js/containers/covid19/SummaryInsightsContainer.jsx
+++ b/src/js/containers/covid19/SummaryInsightsContainer.jsx
@@ -71,7 +71,7 @@ const SummaryInsightsContainer = ({
                     def_codes: defcParams
                 }
             };
-            if (activeTab === 'all') {
+            if (activeTab === 'all' && assistanceOnly) {
                 params.filter.award_type = 'assistance';
             }
             else {

--- a/tests/containers/covid19/SummaryInsightsContainer-test.jsx
+++ b/tests/containers/covid19/SummaryInsightsContainer-test.jsx
@@ -1,0 +1,78 @@
+/**
+ * SummaryInsightsContainer-test.jsx
+ * Created by Lizzie Salita 11/30/21
+ */
+
+import React from 'react';
+import { render } from 'test-utils';
+import '@testing-library/jest-dom/extend-expect';
+import * as redux from 'react-redux';
+import * as apis from 'apis/disaster';
+import SummaryInsightsContainer from 'containers/covid19/SummaryInsightsContainer';
+import { mockDefcParams } from '../../mockData/helpers/disasterHelper';
+
+describe('COVID-19 Summary Insights Container', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+    const mockCFDAProps = {
+        activeTab: 'all',
+        resultsCount: 20,
+        overviewData: [
+            { type: "resultsCount", title: "CFDA Programs" },
+            { type: "awardObligations", title: "Award Obligations", isMonetary: true },
+            { type: "awardOutlays", title: "Award Outlays", isMonetary: true },
+            { type: "numberOfAwards", title: "Number of Awards" }
+        ],
+        assistanceOnly: true
+    };
+    const mockRecipientProps = {
+        ...mockCFDAProps,
+        assistanceOnly: false,
+        recipientOnly: true
+    };
+    it(`should request assistance award types for the CFDA section "All Awards" tab`, () => {
+        const spy = jest.spyOn(apis, 'fetchAwardAmounts');
+        render(<SummaryInsightsContainer {...mockCFDAProps} />, { initialState: { covid19: { defcParams: mockDefcParams } } });
+        expect(spy).toHaveBeenCalledWith({
+            filter: {
+                award_type: 'assistance',
+                def_codes: mockDefcParams
+            }
+        });
+    });
+    it(`should leave out the assistance award types param for other sections' "All Awards" tab`, () => {
+        const spy = jest.spyOn(apis, 'fetchAwardAmounts');
+        
+        render(<SummaryInsightsContainer {...mockRecipientProps} />, { initialState: { covid19: { defcParams: mockDefcParams } } });
+        expect(spy).toHaveBeenCalledWith({
+            filter: {
+                def_codes: mockDefcParams
+            }
+        });
+    });
+    it(`should make a new API request when the DEFC params change`, () => {
+        const spy = jest.spyOn(apis, 'fetchAwardAmounts');
+        jest.spyOn(redux, 'useSelector').mockReturnValue({
+            defcParams: mockDefcParams
+        });
+        const { rerender } = render(<SummaryInsightsContainer {...mockRecipientProps} />);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith({
+            filter: {
+                def_codes: mockDefcParams
+            }
+        });
+        const differentDefcParams = ['Q', 'R'];
+        jest.spyOn(redux, 'useSelector').mockReturnValue({
+            defcParams: differentDefcParams
+        });
+        rerender(<SummaryInsightsContainer {...mockRecipientProps} />);
+        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenLastCalledWith({
+            filter: {
+                def_codes: differentDefcParams
+            }
+        });
+    });
+});

--- a/tests/containers/covid19/recipient/RecipientTableContainer-test.jsx
+++ b/tests/containers/covid19/recipient/RecipientTableContainer-test.jsx
@@ -12,6 +12,10 @@ import * as api from 'apis/disaster';
 import * as redux from 'react-redux';
 import { defaultState } from '../../../testResources/defaultReduxFilters';
 
+// Mock the child component so we can isolate functionality of the container
+jest.mock('containers/covid19/SummaryInsightsContainer', () =>
+    jest.fn(() => null));
+
 const mockResults = [
     {
         code: "987654321",


### PR DESCRIPTION
**High level description:**

Updates the Award Spending by Recipient and Award Spending by Sub-Agency summary insights API requests such that they are **not** filtered by financial assistance award types when viewing the "All Awards" tab.

**JIRA Ticket:**
[DEV-8156](https://federal-spending-transparency.atlassian.net/browse/DEV-8156)

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Verified in Sandbox
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)

Reviewer(s):
- [ ] Code review complete
