### PR TITLE
7675 add listings for old agency pages to redirect

### DIFF
--- a/src/js/dataMapping/agencyV2/agencyIdsToSlugs.js
+++ b/src/js/dataMapping/agencyV2/agencyIdsToSlugs.js
@@ -1,0 +1,440 @@
+/*
+    * agencyIdsToSlugs.js
+    * Created by Brett Varney 11/30/2021
+    * Translation/redirects from agency pages by ID to "URL-friendly" slugs
+*/
+
+export default [
+    {
+        agency_id: 1146,
+        agency_slug: "access-board"
+    },
+    {
+        agency_id: 1136,
+        agency_slug: "administrative-conference-of-the-us"
+    },
+    {
+        agency_id: 1144,
+        agency_slug: "advisory-council-on-historic-preservation"
+    },
+    {
+        agency_id: 1527,
+        agency_slug: "african-development-foundation"
+    },
+    {
+        agency_id: 801,
+        agency_slug: "agency-for-international-development"
+    },
+    {
+        agency_id: 805,
+        agency_slug: "american-battle-monuments-commission"
+    },
+    {
+        agency_id: 1416,
+        agency_slug: "appalachian-regional-commission"
+    },
+    {
+        agency_id: 879,
+        agency_slug: "armed-forces-retirement-home"
+    },
+    {
+        agency_id: 1159,
+        agency_slug: "barry-goldwater-scholarship-and-excellence-in-education-foundation"
+    },
+    {
+        agency_id: 1528,
+        agency_slug: "csosa"
+    },
+    {
+        agency_id: 1426,
+        agency_slug: "commission-for-the-preservation-of-americas-heritage-abroad"
+    },
+    {
+        agency_id: 1149,
+        agency_slug: "commission-of-fine-arts"
+    },
+    {
+        agency_id: 1138,
+        agency_slug: "commission-on-civil-rights"
+    },
+    {
+        agency_id: 1139,
+        agency_slug: "committee-for-purchase-from-people-who-are-blind-or-severely-disabled"
+    },
+    {
+        agency_id: 1129,
+        agency_slug: "commodity-futures-trading-commission"
+    },
+    {
+        agency_id: 1158,
+        agency_slug: "consumer-financial-protection-bureau"
+    },
+    {
+        agency_id: 694,
+        agency_slug: "consumer-product-safety-commission"
+    },
+    {
+        agency_id: 1166,
+        agency_slug: "corporation-for-national-and-community-service"
+    },
+    {
+        agency_id: 1205,
+        agency_slug: "corps-of-engineers-civil-works"
+    },
+    {
+        agency_id: 1132,
+        agency_slug: "council-of-the-inspectors-general-on-integrity-and-efficiency"
+    },
+    {
+        agency_id: 1137,
+        agency_slug: "defense-nuclear-facilities-safety-board"
+    },
+    {
+        agency_id: 1156,
+        agency_slug: "delta-regional-authority"
+    },
+    {
+        agency_id: 1165,
+        agency_slug: "denali-commission"
+    },
+    {
+        agency_id: 95,
+        agency_slug: "department-of-agriculture"
+    },
+    {
+        agency_id: 183,
+        agency_slug: "department-of-commerce"
+    },
+    {
+        agency_id: 1173,
+        agency_slug: "department-of-defense"
+    },
+    {
+        agency_id: 1068,
+        agency_slug: "department-of-education"
+    },
+    {
+        agency_id: 930,
+        agency_slug: "department-of-energy"
+    },
+    {
+        agency_id: 806,
+        agency_slug: "department-of-health-and-human-services"
+    },
+    {
+        agency_id: 766,
+        agency_slug: "department-of-homeland-security"
+    },
+    {
+        agency_id: 882,
+        agency_slug: "department-of-housing-and-urban-development"
+    },
+    {
+        agency_id: 252,
+        agency_slug: "department-of-justice"
+    },
+    {
+        agency_id: 267,
+        agency_slug: "department-of-labor"
+    },
+    {
+        agency_id: 315,
+        agency_slug: "department-of-state"
+    },
+    {
+        agency_id: 731,
+        agency_slug: "department-of-transportation"
+    },
+    {
+        agency_id: 561,
+        agency_slug: "department-of-veterans-affairs"
+    },
+    {
+        agency_id: 209,
+        agency_slug: "department-of-the-interior"
+    },
+    {
+        agency_id: 456,
+        agency_slug: "department-of-the-treasury"
+    },
+    {
+        agency_id: 1523,
+        agency_slug: "district-of-columbia-courts"
+    },
+    {
+        agency_id: 1141,
+        agency_slug: "election-assistance-commission"
+    },
+    {
+        agency_id: 700,
+        agency_slug: "environmental-protection-agency"
+    },
+    {
+        agency_id: 611,
+        agency_slug: "equal-employment-opportunity-commission"
+    },
+    {
+        agency_id: 48,
+        agency_slug: "executive-office-of-the-president"
+    },
+    {
+        agency_id: 878,
+        agency_slug: "export-import-bank-of-the-united-states"
+    },
+    {
+        agency_id: 860,
+        agency_slug: "farm-credit-system-insurance-corporation"
+    },
+    {
+        agency_id: 538,
+        agency_slug: "federal-communications-commission"
+    },
+    {
+        agency_id: 682,
+        agency_slug: "federal-deposit-insurance-corporation"
+    },
+    {
+        agency_id: 1128,
+        agency_slug: "federal-election-commission"
+    },
+    {
+        agency_id: 1161,
+        agency_slug: "federal-financial-institutions-examination-council"
+    },
+    {
+        agency_id: 685,
+        agency_slug: "federal-labor-relations-authority"
+    },
+    {
+        agency_id: 699,
+        agency_slug: "federal-maritime-commission"
+    },
+    {
+        agency_id: 1125,
+        agency_slug: "federal-mediation-and-conciliation-service"
+    },
+    {
+        agency_id: 1127,
+        agency_slug: "federal-mine-safety-and-health-review-commission"
+    },
+    {
+        agency_id: 1524,
+        agency_slug: "federal-permitting-improvement-steering-council"
+    },
+    {
+        agency_id: 552,
+        agency_slug: "federal-trade-commission"
+    },
+    {
+        agency_id: 614,
+        agency_slug: "general-services-administration"
+    },
+    {
+        agency_id: 11,
+        agency_slug: "government-accountability-office"
+    },
+    {
+        agency_id: 1147,
+        agency_slug: "gulf-coast-ecosystem-restoration-council"
+    },
+    {
+        agency_id: 1131,
+        agency_slug: "harry-s-truman-scholarship-foundation"
+    },
+    {
+        agency_id: 1423,
+        agency_slug: "institute-of-museum-and-library-services"
+    },
+    {
+        agency_id: 1526,
+        agency_slug: "inter-american-foundation"
+    },
+    {
+        agency_id: 560,
+        agency_slug: "international-trade-commission"
+    },
+    {
+        agency_id: 1152,
+        agency_slug: "james-madison-memorial-fellowship-foundation"
+    },
+    {
+        agency_id: 1133,
+        agency_slug: "japan-united-states-friendship-commission"
+    },
+    {
+        agency_id: 558,
+        agency_slug: "john-f-kennedy-center-for-the-performing-arts"
+    },
+    {
+        agency_id: 1134,
+        agency_slug: "marine-mammal-commission"
+    },
+    {
+        agency_id: 610,
+        agency_slug: "merit-systems-protection-board"
+    },
+    {
+        agency_id: 1154,
+        agency_slug: "millennium-challenge-corporation"
+    },
+    {
+        agency_id: 1155,
+        agency_slug: "morris-k-udall-and-stewart-l-udall-foundation"
+    },
+    {
+        agency_id: 862,
+        agency_slug: "national-aeronautics-and-space-administration"
+    },
+    {
+        agency_id: 925,
+        agency_slug: "national-archives-and-records-administration"
+    },
+    {
+        agency_id: 1126,
+        agency_slug: "national-capital-planning-commission"
+    },
+    {
+        agency_id: 1417,
+        agency_slug: "national-council-on-disability"
+    },
+    {
+        agency_id: 535,
+        agency_slug: "national-credit-union-administration"
+    },
+    {
+        agency_id: 687,
+        agency_slug: "national-endowment-for-the-arts"
+    },
+    {
+        agency_id: 692,
+        agency_slug: "national-endowment-for-the-humanities"
+    },
+    {
+        agency_id: 697,
+        agency_slug: "national-labor-relations-board"
+    },
+    {
+        agency_id: 1142,
+        agency_slug: "national-mediation-board"
+    },
+    {
+        agency_id: 655,
+        agency_slug: "national-science-foundation"
+    },
+    {
+        agency_id: 1130,
+        agency_slug: "national-transportation-safety-board"
+    },
+    {
+        agency_id: 1431,
+        agency_slug: "northern-border-regional-commission"
+    },
+    {
+        agency_id: 554,
+        agency_slug: "nuclear-regulatory-commission"
+    },
+    {
+        agency_id: 654,
+        agency_slug: "nuclear-waste-technical-review-board"
+    },
+    {
+        agency_id: 1135,
+        agency_slug: "occupational-safety-and-health-review-commission"
+    },
+    {
+        agency_id: 1157,
+        agency_slug: "office-of-government-ethics"
+    },
+    {
+        agency_id: 650,
+        agency_slug: "office-of-navajo-and-hopi-indian-relocation"
+    },
+    {
+        agency_id: 503,
+        agency_slug: "office-of-personnel-management"
+    },
+    {
+        agency_id: 695,
+        agency_slug: "office-of-special-counsel"
+    },
+    {
+        agency_id: 800,
+        agency_slug: "overseas-private-investment-corporation"
+    },
+    {
+        agency_id: 1516,
+        agency_slug: "patient-centered-outcomes-research-trust-fund"
+    },
+    {
+        agency_id: 89,
+        agency_slug: "peace-corps"
+    },
+    {
+        agency_id: 308,
+        agency_slug: "pension-benefit-guaranty-corporation"
+    },
+    {
+        agency_id: 1164,
+        agency_slug: "presidio-trust"
+    },
+    {
+        agency_id: 1143,
+        agency_slug: "privacy-and-civil-liberties-oversight-board"
+    },
+    {
+        agency_id: 1495,
+        agency_slug: "public-buildings-reform-board"
+    },
+    {
+        agency_id: 693,
+        agency_slug: "railroad-retirement-board"
+    },
+    {
+        agency_id: 680,
+        agency_slug: "securities-and-exchange-commission"
+    },
+    {
+        agency_id: 1067,
+        agency_slug: "selective-service-system"
+    },
+    {
+        agency_id: 803,
+        agency_slug: "small-business-administration"
+    },
+    {
+        agency_id: 539,
+        agency_slug: "social-security-administration"
+    },
+    {
+        agency_id: 1422,
+        agency_slug: "surface-transportation-board"
+    },
+    {
+        agency_id: 1163,
+        agency_slug: "us-agency-for-global-media"
+    },
+    {
+        agency_id: 651,
+        agency_slug: "us-interagency-council-on-homelessness"
+    },
+    {
+        agency_id: 1522,
+        agency_slug: "us-international-development-finance-corporation"
+    },
+    {
+        agency_id: 1162,
+        agency_slug: "united-states-chemical-safety-board"
+    },
+    {
+        agency_id: 1169,
+        agency_slug: "united-states-court-of-appeals-for-veterans-claims"
+    },
+    {
+        agency_id: 90,
+        agency_slug: "united-states-trade-and-development-agency"
+    },
+    {
+        agency_id: 1418,
+        agency_slug: "vietnam-education-foundation"
+    }
+];


### PR DESCRIPTION
**High level description:**

When agency v2 page is released, URLs will use "slug" name instead of ID. This adds that translation to the server's 301 list.

**Technical details:**

I tried to use an API call so this list would not need to be updated, but it wouldn't work. The static list probably won't change anyway, unless an agency changes their official name.

**JIRA Ticket:**
[DEV-7675](https://federal-spending-transparency.atlassian.net/browse/DEV-7675)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [n/a ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [n/a ] Verified mobile/tablet/desktop/monitor responsiveness
- [n/a ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a ] Design review complete `if applicable`
- [n/a ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
