### PR TITLE
7881 use slug & environment to form link

### DIFF
--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import GlobalConstants from 'GlobalConstants';
 import { isAwardAggregate } from 'helpers/awardSummaryHelper';
 import { awardTableColumnTypes } from 'dataMapping/search/awardTableColumnTypes';
 
@@ -15,19 +16,6 @@ import ResultsTableHeaderCell from './cells/ResultsTableHeaderCell';
 import ResultsTableFormattedCell from './cells/ResultsTableFormattedCell';
 import ResultsTableLinkCell from './cells/ResultsTableLinkCell';
 
-const propTypes = {
-    results: PropTypes.array,
-    columns: PropTypes.object,
-    visibleWidth: PropTypes.number,
-    loadNextPage: PropTypes.func,
-    subaward: PropTypes.bool,
-    tableInstance: PropTypes.string,
-    sort: PropTypes.object,
-    updateSort: PropTypes.func,
-    awardIdClick: PropTypes.func,
-    subAwardIdClick: PropTypes.func
-};
-
 const rowHeight = 40;
 // setting the table height to a partial row prevents double bottom borders and also clearly
 // indicates when there's more data
@@ -35,6 +23,19 @@ const tableHeight = 29.5 * rowHeight;
 const headerHeight = 68; // tall enough for two lines of text since allowing subtitles
 
 export default class ResultsTable extends React.Component {
+    static propTypes = {
+        results: PropTypes.array,
+        columns: PropTypes.object,
+        visibleWidth: PropTypes.number,
+        loadNextPage: PropTypes.func,
+        subaward: PropTypes.bool,
+        tableInstance: PropTypes.string,
+        sort: PropTypes.object,
+        updateSort: PropTypes.func,
+        awardIdClick: PropTypes.func,
+        subAwardIdClick: PropTypes.func
+    };
+
     constructor(props) {
         super(props);
 
@@ -109,8 +110,8 @@ export default class ResultsTable extends React.Component {
         }
         else if (column.columnName === 'Awarding Agency' && this.props.results[rowIndex].awarding_agency_id) {
             cellClass = ResultsTableLinkCell;
-            props.id = this.props.results[rowIndex].awarding_agency_id;
-            props.column = 'agency';
+            props.id = this.props.results[rowIndex].agency_slug || this.props.results[rowIndex].awarding_agency_id;
+            props.column = GlobalConstants.AGENCY_LINK;
         }
         else if (column.columnName === 'Prime Award ID') {
             const primeAwardId = this.props.results[rowIndex].prime_award_generated_internal_id;
@@ -205,5 +206,3 @@ export default class ResultsTable extends React.Component {
         );
     }
 }
-
-ResultsTable.propTypes = propTypes;


### PR DESCRIPTION
**High level description:**

update agency links in account award table to v2 page (not in prod yet)

**Technical details:**

uses new global constants and API data

**JIRA Ticket:**
[DEV-7881](https://federal-spending-transparency.atlassian.net/browse/DEV-7881)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [n/a ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [n/a ] Verified mobile/tablet/desktop/monitor responsiveness
- [n/a ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a ] Design review complete `if applicable`
- [n/a ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
