### PR TITLE
Fix/dev 8113 overlap agency charts tooltips the right way

### DIFF
--- a/src/_scss/pages/agencyV2/overview/_overview.scss
+++ b/src/_scss/pages/agencyV2/overview/_overview.scss
@@ -44,7 +44,7 @@
                 }
             }
             .covid-19-flag {
-                z-index: 15;
+                z-index: 15; // in front of page's charts
             }
         }
         .agency-overview__image {

--- a/src/_scss/pages/agencyV2/overview/_overview.scss
+++ b/src/_scss/pages/agencyV2/overview/_overview.scss
@@ -1,5 +1,5 @@
 .agency-overview {
-    @import './fySummary';
+    @import "./fySummary";
     width: 100%; // fix for IE
     .agency-overview__top {
         // Wrapper including the logo
@@ -43,7 +43,9 @@
                     display: none;
                 }
             }
-            
+            .covid-19-flag {
+                z-index: 15;
+            }
         }
         .agency-overview__image {
             max-width: rem(90);
@@ -67,11 +69,11 @@
                         padding-right: 1.5rem;
                     }
                     .agency-overview__sub-agencies {
-                        font-size: 1.8rem;                        
+                        font-size: 1.8rem;
                     }
                 }
                 .agency-overview__tooltip {
-                    @include flex (0 0 auto);
+                    @include flex(0 0 auto);
                     > div:first-of-type {
                         width: 100%;
                     }
@@ -79,7 +81,7 @@
                         cursor: pointer;
                     }
                     .tooltip-spacer {
-                         @include media($tablet-screen) {
+                        @include media($tablet-screen) {
                             margin-left: rem(10);
                             @include display(flex);
                         }
@@ -113,16 +115,17 @@
         }
     }
     .agency-overview__data {
-        @import 'components/externalLink';
+        @import "components/externalLink";
         h4 {
             font-weight: $font-semibold;
             margin: 0;
             font-size: 1.6rem;
             line-height: normal;
         }
-        p, .usda-external-link {
+        p,
+        .usda-external-link {
             font-size: $small-font-size;
-            margin: .5rem 0 1.5rem;
+            margin: 0.5rem 0 1.5rem;
         }
         .usda-external-link {
             white-space: nowrap;
@@ -132,6 +135,6 @@
         @include button-link;
         margin-top: 0.5rem;
     }
-    @import '../visualizations/totalObligationsOverTime';
-    @import '../visualizations/recipientDistribution';
+    @import "../visualizations/totalObligationsOverTime";
+    @import "../visualizations/recipientDistribution";
 }


### PR DESCRIPTION
**High level description:**
AV2 chart(s) overlaps COVID badge tip (chart tips overlap each other as expected)

**Technical details:**
adds higher z-index to badge's tip

**JIRA Ticket:**
[DEV-8113](https://federal-spending-transparency.atlassian.net/browse/DEV-8113)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [n/a ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a ] Design review complete `if applicable`
- [n/a ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
