### PR TITLE
8113 remove layering causing chart to overlap covid tip

### DIFF
--- a/src/_scss/pages/agencyV2/overview/_overview.scss
+++ b/src/_scss/pages/agencyV2/overview/_overview.scss
@@ -43,9 +43,6 @@
                     display: none;
                 }
             }
-            .covid-19-flag {
-                z-index: 15; // in front of page's charts
-            }
         }
         .agency-overview__image {
             max-width: rem(90);

--- a/src/_scss/pages/agencyV2/visualizations/_obligationsByAwardType.scss
+++ b/src/_scss/pages/agencyV2/visualizations/_obligationsByAwardType.scss
@@ -33,7 +33,6 @@
     // Tooltip content
     .award-type-tooltip {
         position: relative;
-        z-index: 15;
         .tooltip__text {
             display: block;
         }

--- a/src/_scss/pages/agencyV2/visualizations/_totalObligationsOverTime.scss
+++ b/src/_scss/pages/agencyV2/visualizations/_totalObligationsOverTime.scss
@@ -1,6 +1,5 @@
 .total-obligations-over-time-visualization-container {
     width: 100%;
-    z-index: 10; //prevent tooltips from intersecting other visualizations
     overflow: visible;
     .total-obligations-over-time-svg {
         overflow: visible;


### PR DESCRIPTION
**High level description:**
AV2 chart(s) overlaps COVID badge tip (chart tips overlap each other as expected)

**Technical details:**
removes errant z-indexes causing the problem

**JIRA Ticket:**
[DEV-8113](https://federal-spending-transparency.atlassian.net/browse/DEV-8113)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [n/a ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a ] Design review complete `if applicable`
- [n/a ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
