### PR TITLE
8167 links to agency pages

### DIFF
--- a/src/js/components/aboutTheData/AgencyDetailsPage.jsx
+++ b/src/js/components/aboutTheData/AgencyDetailsPage.jsx
@@ -20,11 +20,13 @@ import BaseAgencyOverview from 'models/v2/agency/BaseAgencyOverview';
 import ExternalLink from 'components/sharedComponents/ExternalLink';
 import { agencyNotes } from './componentMapping/agencyNotes';
 import AboutTheDataModal from './AboutTheDataModal';
+import { useAgencySlugs } from "../../containers/agencyV2/WithAgencySlugs";
 
 require('pages/aboutTheData/aboutTheData.scss');
 
 const AgencyDetailsPage = () => {
     const { agencyCode } = useParams();
+    const [agencySlugs, topTierCodes, slugsLoading, slugsError] = useAgencySlugs();
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');
@@ -32,6 +34,8 @@ const AgencyDetailsPage = () => {
     const [showModal, setShowModal] = useState('');
     const [modalData, setModalData] = useState(null);
     const overviewRequest = useRef(null);
+
+    console.log(topTierCodes);
 
     const modalClick = (modalType, agencyData) => {
         setModalData(agencyData);

--- a/src/js/components/aboutTheData/AgencyDetailsPage.jsx
+++ b/src/js/components/aboutTheData/AgencyDetailsPage.jsx
@@ -36,6 +36,8 @@ const AgencyDetailsPage = () => {
     const [modalData, setModalData] = useState(null);
     const overviewRequest = useRef(null);
 
+    console.log(topTierCodes);
+
     let slug = '';
     if (agencyOverview && agencyOverview.toptierCode) {
         slug = topTierCodes[agencyOverview.toptierCode];

--- a/src/js/components/aboutTheData/AgencyDetailsPage.jsx
+++ b/src/js/components/aboutTheData/AgencyDetailsPage.jsx
@@ -21,12 +21,13 @@ import ExternalLink from 'components/sharedComponents/ExternalLink';
 import { agencyNotes } from './componentMapping/agencyNotes';
 import AboutTheDataModal from './AboutTheDataModal';
 import { useAgencySlugs } from "../../containers/agencyV2/WithAgencySlugs";
+import GlobalConstants from '../../GlobalConstants';
 
 require('pages/aboutTheData/aboutTheData.scss');
 
 const AgencyDetailsPage = () => {
     const { agencyCode } = useParams();
-    const [agencySlugs, topTierCodes, slugsLoading, slugsError] = useAgencySlugs();
+    const [, topTierCodes] = useAgencySlugs();
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');
@@ -35,7 +36,11 @@ const AgencyDetailsPage = () => {
     const [modalData, setModalData] = useState(null);
     const overviewRequest = useRef(null);
 
-    console.log(topTierCodes);
+    let slug = '';
+    if (agencyOverview && agencyOverview.toptierCode) {
+        slug = topTierCodes[agencyOverview.toptierCode];
+    }
+    const agencyString = GlobalConstants.AGENCY_LINK;
 
     const modalClick = (modalType, agencyData) => {
         setModalData(agencyData);
@@ -127,7 +132,7 @@ const AgencyDetailsPage = () => {
                                             <h5>Agency Profile Page</h5>
                                             <div className="more-info-note">Learn more about this Agency&#39;s spending</div>
                                             <div className="agency-info__website">
-                                                <Link to={`/agency/${agencyOverview.id}`}>
+                                                <Link to={`/${agencyString}/${slug}`}>
                                                     {agencyOverview.name}
                                                 </Link>
                                             </div>

--- a/src/js/components/aboutTheData/AgencyDetailsPage.jsx
+++ b/src/js/components/aboutTheData/AgencyDetailsPage.jsx
@@ -36,8 +36,6 @@ const AgencyDetailsPage = () => {
     const [modalData, setModalData] = useState(null);
     const overviewRequest = useRef(null);
 
-    console.log(topTierCodes);
-
     let slug = '';
     if (agencyOverview && agencyOverview.toptierCode) {
         slug = topTierCodes[agencyOverview.toptierCode];

--- a/src/js/components/aboutTheData/DrilldownCell.jsx
+++ b/src/js/components/aboutTheData/DrilldownCell.jsx
@@ -25,12 +25,9 @@ const DrilldownCell = ({
     searchTerm
 }) => (
     <div className="action-cell">
-        {/* <span className="action-cell__text">*/}
-        {/*    {searchTerm ? replaceString(data, searchTerm, 'matched-str') : data}*/}
-        {/* </span>*/}
-        <Link to={`/${agencyString}/${id}`} >
+        <span className="action-cell__text">
             {searchTerm ? replaceString(data, searchTerm, 'matched-str') : data}
-        </Link>
+        </span>
         <Link
             to={`/submission-statistics/agency/${id}`}
             className="action-cell__button"

--- a/src/js/components/aboutTheData/DrilldownCell.jsx
+++ b/src/js/components/aboutTheData/DrilldownCell.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes, { oneOfType } from 'prop-types';
 import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import GlobalConstants from 'GlobalConstants';
 
 import replaceString from 'helpers/replaceString';
 
@@ -16,15 +17,20 @@ const propTypes = {
     searchTerm: PropTypes.string
 };
 
+const agencyString = GlobalConstants.AGENCY_LINK;
+
 const DrilldownCell = ({
     data,
     id,
     searchTerm
 }) => (
     <div className="action-cell">
-        <span className="action-cell__text">
+        {/* <span className="action-cell__text">*/}
+        {/*    {searchTerm ? replaceString(data, searchTerm, 'matched-str') : data}*/}
+        {/* </span>*/}
+        <Link to={`/${agencyString}/${id}`} >
             {searchTerm ? replaceString(data, searchTerm, 'matched-str') : data}
-        </span>
+        </Link>
         <Link
             to={`/submission-statistics/agency/${id}`}
             className="action-cell__button"

--- a/src/js/components/aboutTheData/DrilldownCell.jsx
+++ b/src/js/components/aboutTheData/DrilldownCell.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 import PropTypes, { oneOfType } from 'prop-types';
 import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import GlobalConstants from 'GlobalConstants';
 
 import replaceString from 'helpers/replaceString';
 
@@ -16,8 +15,6 @@ const propTypes = {
     data: oneOfType([PropTypes.string, PropTypes.object]),
     searchTerm: PropTypes.string
 };
-
-const agencyString = GlobalConstants.AGENCY_LINK;
 
 const DrilldownCell = ({
     data,

--- a/src/js/containers/agencyV2/AgencyContainerV2.jsx
+++ b/src/js/containers/agencyV2/AgencyContainerV2.jsx
@@ -23,7 +23,7 @@ export const AgencyProfileV2 = () => {
     const { fy: currentUrlFy } = useQueryParams(['fy']);
     const [selectedFy, setSelectedFy] = useValidTimeBasedQueryParams(currentUrlFy, null, ['fy']);
     // Use a custom hook to get the { agency slug: toptier code } mapping, or request it if not yet available
-    const [agencySlugs, slugsLoading, slugsError] = useAgencySlugs();
+    const [agencySlugs, , slugsLoading, slugsError] = useAgencySlugs();
     const [isLoading, setLoading] = useState(true);
     const [isError, setError] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');

--- a/src/js/redux/actions/agencyV2/agencyV2Actions.js
+++ b/src/js/redux/actions/agencyV2/agencyV2Actions.js
@@ -50,9 +50,10 @@ export const setSubagencyTotals = (spendingBySubagencyTotals) => ({
     spendingBySubagencyTotals
 });
 
-export const setAgencySlugs = (agencySlugs) => ({
+export const setAgencySlugs = (agencySlugs, topTierCodes) => ({
     type: 'SET_AGENCY_SLUGS',
-    agencySlugs
+    agencySlugs,
+    topTierCodes
 });
 
 export const resetSubagencyTotals = () => ({

--- a/src/js/redux/reducers/agencyV2/agencyV2Reducer.js
+++ b/src/js/redux/reducers/agencyV2/agencyV2Reducer.js
@@ -28,6 +28,7 @@ export const initialState = {
     subagencyCount,
     spendingBySubagencyTotals,
     agencySlugs: {},
+    topTierCodes: {},
     selectedSubcomponent: null
 };
 
@@ -86,7 +87,8 @@ const agencyReducer = (state = initialState, action) => {
         case 'SET_AGENCY_SLUGS':
             return {
                 ...state,
-                agencySlugs: action.agencySlugs
+                agencySlugs: action.agencySlugs,
+                topTierCodes: action.topTierCodes
             };
         case 'RESET_SUBAGENCY_TOTALS':
             return {

--- a/tests/containers/agencyV2/WithAgencySlugs-test.jsx
+++ b/tests/containers/agencyV2/WithAgencySlugs-test.jsx
@@ -10,7 +10,7 @@ import * as redux from 'react-redux';
 import * as api from 'apis/agencyV2';
 import * as actions from 'redux/actions/agencyV2/agencyV2Actions';
 
-import { parseAgencySlugs, useAgencySlugs } from 'containers/agencyV2/WithAgencySlugs';
+import { mapSlugToTopTierCode, mapTopTierCodeToSlug, useAgencySlugs } from 'containers/agencyV2/WithAgencySlugs';
 
 let mockFetch;
 let mockUseSelector;
@@ -29,10 +29,14 @@ const mockAPIResponse = {
     ]
 };
 
-// eslint-disable-next-line import/prefer-default-export
-export const expectedMapping = {
+const mockSlugsMapping = {
     'department-of-sandwiches': '123',
     'ministry-of-magic': '456'
+};
+
+const mockTopTierMapping = {
+    123: 'department-of-sandwiches',
+    456: 'ministry-of-magic'
 };
 
 beforeEach(() => {
@@ -49,18 +53,23 @@ test('useAgencySlugs: fetches agency slugs when they are not populated', async (
     renderHook(() => useAgencySlugs());
     expect(mockFetch).toHaveBeenCalledTimes(1);
     await waitFor(() => {
-        expect(mockAction).toHaveBeenCalledWith(expectedMapping);
+        expect(mockAction).toHaveBeenCalledWith(mockSlugsMapping, mockTopTierMapping);
     });
 });
 
 test('useAgencySlugs: does not fetch agency slugs when they are populated', () => {
-    mockUseSelector.mockReturnValue({ agencySlugs: expectedMapping });
+    mockUseSelector.mockReturnValue({ agencySlugs: mockSlugsMapping });
     const { result } = renderHook(() => useAgencySlugs());
     expect(mockFetch).toHaveBeenCalledTimes(0);
-    expect(result.current[0]).toEqual(expectedMapping);
+    expect(result.current[0]).toEqual(mockSlugsMapping);
 });
 
-test('parseAgencySlugs: returns a mapping of agency_slug: toptier_code', () => {
-    const result = parseAgencySlugs(mockAPIResponse.results);
-    expect(result).toEqual(expectedMapping);
+test('mapSlugToTopTierCode: returns a mapping of agency_slug: toptier_code', () => {
+    const result = mapSlugToTopTierCode(mockAPIResponse.results);
+    expect(result).toEqual(mockSlugsMapping);
+});
+
+test('mapTopTierCodeToSlug: returns a mapping of toptier_code: agency_slug', () => {
+    const result = mapTopTierCodeToSlug(mockAPIResponse.results);
+    expect(result).toEqual(mockTopTierMapping);
 });


### PR DESCRIPTION
**High level description:**

Add links to the Agency Profile Page on the Agency Submission Statistics individual Agency Profile page. 

**Technical details:**

Updated the useAgencySlugs custom hook to also return topTierCodes so we can get either from that return object. Updated the link on the AgencyDetailsPage to use the agencyString from GlobalConstants and the agency slug from useAgencySlugs.

**JIRA Ticket:**
[DEV-1234](https://federal-spending-transparency.atlassian.net/browse/DEV-8167)

**Mockup:**

n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
