### PR TITLE
Dev-7770: Change the donut hover behavior so that tooltips only show the award types for the selected category

### DIFF
--- a/src/_scss/pages/agencyV2/visualizations/_obligationsByAwardType.scss
+++ b/src/_scss/pages/agencyV2/visualizations/_obligationsByAwardType.scss
@@ -65,14 +65,6 @@
                         }
                     }
                 }
-                &:last-child {
-                    margin-top: rem(5);
-                    border-top: solid 1px $color-gray-lighter;
-                    .usda-table__cell {
-                        font-weight: $font-semibold;
-                        padding-top: rem(8);
-                    }
-                }
             }
         }
     }

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -174,7 +174,9 @@ export default function ObligationsByAwardType({
             .innerRadius(innerRadius / 2)
         )
         .attr('fill', (d, i) => {
-            if (categoryHover && categoryHover === mapToFullCategoryName(d.data.type) && !isMobile) return inner[i].color
+            if (categoryHover && categoryHover === mapToFullCategoryName(d.data.type) && !isMobile) {
+                return inner[i].color;
+            }
 
             // Use the faded color when another section is hovered over
             return ((activeType && activeType !== inner[i].label) && !isMobile) ? inner[i].fadedColor : inner[i].color

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -54,7 +54,7 @@ export default function ObligationsByAwardType({
             setChartHeight(rect.height);
             setChartWidth(rect.width);
         }
-    }, [chartHeight, chartWidth, windowWidth]);
+    }, [windowWidth]);
 
     const labelRadius = Math.min(chartHeight, chartWidth) / 2;
     const outerRadius = labelRadius * 0.7;

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -109,6 +109,24 @@ export default function ObligationsByAwardType({
         .attr('aria-label', (d) => `${d.data.label}: ${d3.format("($,.2f")(d.value)}`)
         .attr('role', 'listitem');
 
+    // white ring
+    chart.selectAll()
+        .data(pie)
+        .enter()
+        .append('path')
+        .attr('d', d3.arc()
+            .outerRadius(outerRadius - outerStrokeWidth)
+            .innerRadius(innerRadius)
+        )
+        .attr('fill', 'white')
+        .on('mouseenter', (d) => {
+            // store the award type of the section the user is hovering over
+            setActiveType(d.data.label);
+        })
+        .on('mouseleave', () => setActiveType(null))
+        .attr('role', 'listitem');
+
+
     // inner ring
     chart.selectAll()
         .data(pie)
@@ -131,22 +149,6 @@ export default function ObligationsByAwardType({
         .on('mouseleave', () => setActiveType(null))
         .attr('role', 'listitem')
         .attr('tabindex', 0);
-
-    // // border between categories
-    // const borders = [[0, outerRadius], [0, 0], [pie[0].endAngle, outerRadius]];
-    // chart.selectAll()
-    //     .data([0]) // one polyline, data in borders
-    //     .enter()
-    //     .append('path')
-    //     .attr('d', d3.lineRadial()(borders))
-    //     .attr('stroke', 'white')
-    //     .attr('stroke-width', 3)
-    //     .attr('fill', 'none')
-    //     .on('mouseenter', (d) => {
-    //         // store the award type of the section the user is hovering over
-    //         setActiveType(d.data.label);
-    //     })
-    //     .on('mouseleave', () => setActiveType(null));
 
     // labels
     const labelPos = (i, yOffset = 0) => {

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -26,7 +26,8 @@ const propTypes = {
         PropTypes.shape({
             label: PropTypes.string.isRequired,
             value: PropTypes.number.isRequired,
-            color: PropTypes.string.isRequired
+            color: PropTypes.string.isRequired,
+            type: PropTypes.string.isRequired
         })
     ).isRequired,
     windowWidth: PropTypes.number.isRequired,
@@ -195,7 +196,9 @@ export default function ObligationsByAwardType({
                 <ObligationsByAwardTypeTooltip
                     awardTypes={inner}
                     fiscalYear={fiscalYear}
-                    activeType={activeType} />)}
+                    activeType={activeType}
+                    category={categoryMapping['All Contracts'].includes(activeType) ? 'contracts' : 'financial'}
+                />)}
             controlledProps={{
                 isControlled: true,
                 isVisible: activeType && !isMobile,

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -54,38 +54,36 @@ export default function ObligationsByAwardType({
             setChartHeight(rect.height);
             setChartWidth(rect.width);
         }
-    }, [windowWidth]);
+    }, [chartHeight, chartWidth, windowWidth]);
 
     const labelRadius = Math.min(chartHeight, chartWidth) / 2;
     const outerRadius = labelRadius * 0.7;
     const outerStrokeWidth = 3;
     const innerRadius = outerRadius - (outerStrokeWidth * 2);
 
-    const mapToFullCategoryName = (categoryType) => {
-        return `All ${categoryType.charAt(0).toUpperCase()}  ${categoryType.slice(1)}`;
-    }
+    const mapToFullCategoryName = (categoryType) => `All ${categoryType.charAt(0).toUpperCase()}  ${categoryType.slice(1)}`;
 
     const getCategoryNameByAwardType = (awardType) => {
         const categoryNames = Object.keys(categoryMapping);
         return categoryMapping[categoryNames[0]].includes(awardType) ? categoryNames[0] : categoryNames[1];
-    }
+    };
 
     const getActiveCategoryType = () => {
-        if(activeType) {
+        if (activeType) {
             const categoryNames = Object.keys(categoryMapping);
             const category = categoryMapping[categoryNames[0]].includes(activeType) ? categoryNames[0] : categoryNames[1];
             return category.replace(/(^All\s)/, '').toLowerCase();
         }
         return '';
-    }
+    };
 
     const getOuterCategoryId = (categoryName) => {
-        for(let i = 0; i < outer.length; i++) {
-            if(outer[i].label.includes(categoryName)) return i;
+        for (let i = 0; i < outer.length; i++) {
+            if (outer[i].label.includes(categoryName)) return i;
         }
 
         return '';
-    }
+    };
 
     // clear & append the svg object to the div
     d3.select('#obl_chart').selectAll('*').remove();
@@ -123,12 +121,10 @@ export default function ObligationsByAwardType({
             const currentCategoryId = getOuterCategoryId(currentCategory);
 
             // Use the faded color when another section is hovered over
-            if(activeType && !isMobile && activeCategory !== currentCategory) {
+            if (activeType && !isMobile && activeCategory !== currentCategory) {
                 return outer[currentCategoryId].fadedColor;
-            } else {
-                return outer[currentCategoryId].color;
             }
-
+            return outer[currentCategoryId].color;
         })
         .style('cursor', 'pointer')
         .on('mouseenter', (d) => {
@@ -159,7 +155,7 @@ export default function ObligationsByAwardType({
             setActiveType(d.data.label);
         })
         .on('mouseleave', () => {
-            setActiveType(null)
+            setActiveType(null);
         })
         .attr('role', 'listitem');
 
@@ -179,7 +175,7 @@ export default function ObligationsByAwardType({
             }
 
             // Use the faded color when another section is hovered over
-            return ((activeType && activeType !== inner[i].label) && !isMobile) ? inner[i].fadedColor : inner[i].color
+            return ((activeType && activeType !== inner[i].label) && !isMobile) ? inner[i].fadedColor : inner[i].color;
         })
         .style('cursor', 'pointer')
         .on('mouseenter', (d) => {
@@ -190,7 +186,6 @@ export default function ObligationsByAwardType({
         .attr('aria-label', (d) => `${d.data.label}: ${d3.format("($,.2f")(d.value)}`)
         .attr('role', 'listitem')
         .attr('tabindex', 0);
-
 
 
     // labels
@@ -257,8 +252,7 @@ export default function ObligationsByAwardType({
                     fiscalYear={fiscalYear}
                     activeType={activeType}
                     categoryType={getActiveCategoryType()}
-                    isCategoryHover={categoryHover?.length > 0}
-                />)}
+                    isCategoryHover={categoryHover?.length > 0} />)}
             controlledProps={{
                 isControlled: true,
                 isVisible: activeType && !isMobile,

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -45,7 +45,7 @@ export default function ObligationsByAwardType({
     const [chartHeight, setChartHeight] = useState(0);
     const [chartWidth, setChartWidth] = useState(0);
     const [activeType, setActiveType] = useState(null);
-    const [hoverOuter, setOuterHover] = useState(null);
+    const [categoryHover, setCategoryHover] = useState(null);
     const chartRef = useRef();
 
     useEffect(() => {
@@ -117,16 +117,16 @@ export default function ObligationsByAwardType({
         .attr('d', d3.arc()
             .outerRadius(outerRadius)
             .innerRadius(outerRadius - outerStrokeWidth))
-        .attr('fill', function(d, i) {
+        .attr('fill', (d, i) => {
             const activeCategory = getCategoryNameByAwardType(activeType);
             const currentCategory = getCategoryNameByAwardType(inner[i].label);
             const currentCategoryId = getOuterCategoryId(currentCategory);
 
             // Use the faded color when another section is hovered over
             if(activeType && !isMobile && activeCategory !== currentCategory) {
-                return outer[currentCategoryId].fadedColor
+                return outer[currentCategoryId].fadedColor;
             } else {
-                return outer[currentCategoryId].color
+                return outer[currentCategoryId].color;
             }
 
         })
@@ -134,11 +134,11 @@ export default function ObligationsByAwardType({
         .on('mouseenter', (d) => {
             // store the award type of the section the user is hovering over
             setActiveType(d.data.label);
-            setOuterHover(mapToFullCategoryName(d.data.type));
+            setCategoryHover(mapToFullCategoryName(d.data.type));
         })
         .on('mouseleave', () => {
-            setActiveType(null)
-            setOuterHover(null)
+            setActiveType(null);
+            setCategoryHover(null);
         })
         .attr('aria-label', (d) => `${d.data.label}: ${d3.format("($,.2f")(d.value)}`)
         .attr('role', 'listitem');
@@ -174,7 +174,7 @@ export default function ObligationsByAwardType({
             .innerRadius(innerRadius / 2)
         )
         .attr('fill', (d, i) => {
-            if (hoverOuter && hoverOuter === mapToFullCategoryName(d.data.type) && !isMobile) return inner[i].color
+            if (categoryHover && categoryHover === mapToFullCategoryName(d.data.type) && !isMobile) return inner[i].color
 
             // Use the faded color when another section is hovered over
             return ((activeType && activeType !== inner[i].label) && !isMobile) ? inner[i].fadedColor : inner[i].color
@@ -255,6 +255,7 @@ export default function ObligationsByAwardType({
                     fiscalYear={fiscalYear}
                     activeType={activeType}
                     categoryType={getActiveCategoryType()}
+                    isCategoryHover={categoryHover?.length > 0}
                 />)}
             controlledProps={{
                 isControlled: true,

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -61,8 +61,8 @@ export default function ObligationsByAwardType({
     const outerStrokeWidth = 3;
     const innerRadius = outerRadius - (outerStrokeWidth * 2);
 
-    const mapToFullCategoryName = (name) => {
-        return `All ${name.charAt(0).toUpperCase()}  ${name.slice(1)}`;
+    const mapToFullCategoryName = (categoryType) => {
+        return `All ${categoryType.charAt(0).toUpperCase()}  ${categoryType.slice(1)}`;
     }
 
     const getCategoryNameByAwardType = (awardType) => {
@@ -202,7 +202,7 @@ export default function ObligationsByAwardType({
     };
 
     const outerLabels = outer.map((d) => d.label);
-    
+
     // Financial Assistance legend
     if (outer[0].value > 0) {
         // circle

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -103,6 +103,7 @@ export default function ObligationsByAwardType({
                 return outer[currentCategory].color
             }
         })
+        .style('cursor', 'pointer')
         .on('mouseenter', (d) => {
             // store the award type of the section the user is hovering over
             setActiveType(d.data.label);
@@ -121,6 +122,7 @@ export default function ObligationsByAwardType({
             .innerRadius(innerRadius)
         )
         .attr('fill', 'white')
+        .style('cursor', 'pointer')
         .on('mouseenter', (d) => {
             // store the award type of the section the user is hovering over
             setActiveType(d.data.label);
@@ -143,14 +145,15 @@ export default function ObligationsByAwardType({
             ((activeType && activeType !== inner[i].label) && !isMobile)
                 ? inner[i].fadedColor : inner[i].color)
         )
-        .attr('aria-label', (d) => `${d.data.label}: ${d3.format("($,.2f")(d.value)}`)
-        .attr('role', 'listitem')
-        .attr('tabindex', 0)
+        .style('cursor', 'pointer')
         .on('mouseenter', (d) => {
             // store the award type of the section the user is hovering over
             setActiveType(d.data.label);
         })
-        .on('mouseleave', () => setActiveType(null));
+        .on('mouseleave', () => setActiveType(null))
+        .attr('aria-label', (d) => `${d.data.label}: ${d3.format("($,.2f")(d.value)}`)
+        .attr('role', 'listitem')
+        .attr('tabindex', 0);
 
 
 

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -65,6 +65,28 @@ export default function ObligationsByAwardType({
         return `All ${name.charAt(0).toUpperCase()}  ${name.slice(1)}`;
     }
 
+    const getCategoryNameByAwardType = (awardType) => {
+        const categoryNames = Object.keys(categoryMapping);
+        return categoryMapping[categoryNames[0]].includes(awardType) ? categoryNames[0] : categoryNames[1];
+    }
+
+    const getActiveCategoryType = () => {
+        if(activeType) {
+            const categoryNames = Object.keys(categoryMapping);
+            const category = categoryMapping[categoryNames[0]].includes(activeType) ? categoryNames[0] : categoryNames[1];
+            return category.replace(/(^All\s)/, '').toLowerCase();
+        }
+        return '';
+    }
+
+    const getOuterCategoryId = (categoryName) => {
+        for(let i = 0; i < outer.length; i++) {
+            if(outer[i].label.includes(categoryName)) return i;
+        }
+
+        return '';
+    }
+
     // clear & append the svg object to the div
     d3.select('#obl_chart').selectAll('*').remove();
     const svg = d3.select('#obl_chart')
@@ -96,16 +118,15 @@ export default function ObligationsByAwardType({
             .outerRadius(outerRadius)
             .innerRadius(outerRadius - outerStrokeWidth))
         .attr('fill', function(d, i) {
-            // 0 is index for 'All Financial' and 1 is index for 'All Contracts' in outer.label array
-            const categories = Object.keys(categoryMapping);
-            const currentCategory = categoryMapping[categories[0]].includes(inner[i].label) ? 1 : 0;
-            const activeCategory = categoryMapping[categories[0]].includes(activeType) ? 1 : 0;
+            const activeCategory = getCategoryNameByAwardType(activeType);
+            const currentCategory = getCategoryNameByAwardType(inner[i].label);
+            const currentCategoryId = getOuterCategoryId(currentCategory);
 
             // Use the faded color when another section is hovered over
             if(activeType && !isMobile && activeCategory !== currentCategory) {
-                return outer[currentCategory].fadedColor
+                return outer[currentCategoryId].fadedColor
             } else {
-                return outer[currentCategory].color
+                return outer[currentCategoryId].color
             }
 
         })
@@ -181,7 +202,7 @@ export default function ObligationsByAwardType({
     };
 
     const outerLabels = outer.map((d) => d.label);
-
+    
     // Financial Assistance legend
     if (outer[0].value > 0) {
         // circle
@@ -224,16 +245,6 @@ export default function ObligationsByAwardType({
             .text((d) => d);
     }
 
-    const getActiveCategory = () => {
-        if(activeType) {
-            // 0 is index for 'All Financial' and 1 is index for 'All Contracts' in outer.label array
-            const categories = Object.keys(categoryMapping);
-            const category = categoryMapping[categories[0]].includes(activeType) ? 'contracts' : 'financial';
-            return category.replace(/(^All\s)/, '').toLowerCase();
-        }
-        return '';
-    }
-
     return (
         <TooltipWrapper
             className="obligations-by-award-type"
@@ -243,7 +254,7 @@ export default function ObligationsByAwardType({
                     awardTypes={inner}
                     fiscalYear={fiscalYear}
                     activeType={activeType}
-                    category={getActiveCategory()}
+                    categoryType={getActiveCategoryType()}
                 />)}
             controlledProps={{
                 isControlled: true,

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -92,9 +92,9 @@ export default function ObligationsByAwardType({
             .innerRadius(outerRadius - outerStrokeWidth))
         .attr('fill', function(d, i) {
             // 0 is index for 'All Financial' and 1 is index for 'All Contracts' in outer.label array
-            const categoryTypes = Object.keys(categoryMapping);
-            const currentCategory = categoryMapping[categoryTypes[0]].includes(inner[i].label) ? 1 : 0;
-            const activeCategory = categoryMapping[categoryTypes[0]].includes(activeType) ? 1 : 0;
+            const categories = Object.keys(categoryMapping);
+            const currentCategory = categoryMapping[categories[0]].includes(inner[i].label) ? 1 : 0;
+            const activeCategory = categoryMapping[categories[0]].includes(activeType) ? 1 : 0;
 
             // Use the faded color when another section is hovered over
             if(activeType && !isMobile && activeCategory !== currentCategory) {

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import * as d3 from 'd3';
 import { TooltipWrapper } from 'data-transparency-ui';
 import ObligationsByAwardTypeTooltip from './ObligationsByAwardTypeTooltip';
+import { mapToFullCategoryName, getCategoryNameByAwardType, getActiveCategoryType, getOuterCategoryId } from 'helpers/agencyV2/visualizations/ObligationsByAwardTypeHelper.js';
 
 const categoryMapping = {
     'All Contracts': ['Contracts', 'IDVs'],
@@ -61,30 +62,6 @@ export default function ObligationsByAwardType({
     const outerStrokeWidth = 3;
     const innerRadius = outerRadius - (outerStrokeWidth * 2);
 
-    const mapToFullCategoryName = (categoryType) => `All ${categoryType.charAt(0).toUpperCase()}  ${categoryType.slice(1)}`;
-
-    const getCategoryNameByAwardType = (awardType) => {
-        const categoryNames = Object.keys(categoryMapping);
-        return categoryMapping[categoryNames[0]].includes(awardType) ? categoryNames[0] : categoryNames[1];
-    };
-
-    const getActiveCategoryType = () => {
-        if (activeType) {
-            const categoryNames = Object.keys(categoryMapping);
-            const category = categoryMapping[categoryNames[0]].includes(activeType) ? categoryNames[0] : categoryNames[1];
-            return category.replace(/(^All\s)/, '').toLowerCase();
-        }
-        return '';
-    };
-
-    const getOuterCategoryId = (categoryName) => {
-        for (let i = 0; i < outer.length; i++) {
-            if (outer[i].label.includes(categoryName)) return i;
-        }
-
-        return '';
-    };
-
     // clear & append the svg object to the div
     d3.select('#obl_chart').selectAll('*').remove();
     const svg = d3.select('#obl_chart')
@@ -116,9 +93,9 @@ export default function ObligationsByAwardType({
             .outerRadius(outerRadius)
             .innerRadius(outerRadius - outerStrokeWidth))
         .attr('fill', (d, i) => {
-            const activeCategory = getCategoryNameByAwardType(activeType);
-            const currentCategory = getCategoryNameByAwardType(inner[i].label);
-            const currentCategoryId = getOuterCategoryId(currentCategory);
+            const activeCategory = getCategoryNameByAwardType(activeType, categoryMapping);
+            const currentCategory = getCategoryNameByAwardType(inner[i].label, categoryMapping);
+            const currentCategoryId = getOuterCategoryId(currentCategory, outer);
 
             // Use the faded color when another section is hovered over
             if (activeType && !isMobile && activeCategory !== currentCategory) {
@@ -251,7 +228,7 @@ export default function ObligationsByAwardType({
                     awardTypes={inner}
                     fiscalYear={fiscalYear}
                     activeType={activeType}
-                    categoryType={getActiveCategoryType()}
+                    categoryType={getActiveCategoryType(activeType, categoryMapping)}
                     isCategoryHover={categoryHover?.length > 0} />)}
             controlledProps={{
                 isControlled: true,

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -97,6 +97,8 @@ export default function ObligationsByAwardType({
             // Use the faded color when another section is hovered over
             ((activeType && !categoryMapping[outer[i].label[0]].includes(activeType)) && !isMobile)
                 ? outer[i].fadedColor : outer[i].color)
+            // ((activeType && activeType !== inner[i].label) && !isMobile)
+            //     ? inner[i].fadedColor : inner[i].color)
         )
         .attr('aria-label', (d) => `${d.data.label}: ${d3.format("($,.2f")(d.value)}`)
         .attr('role', 'listitem');

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -7,8 +7,8 @@ import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import * as d3 from 'd3';
 import { TooltipWrapper } from 'data-transparency-ui';
+import { mapToFullCategoryName, getCategoryNameByAwardType, getActiveCategoryType, getOuterCategoryId } from 'helpers/agencyV2/visualizations/ObligationsByAwardTypeHelper';
 import ObligationsByAwardTypeTooltip from './ObligationsByAwardTypeTooltip';
-import { mapToFullCategoryName, getCategoryNameByAwardType, getActiveCategoryType, getOuterCategoryId } from 'helpers/agencyV2/visualizations/ObligationsByAwardTypeHelper.js';
 
 const categoryMapping = {
     'All Contracts': ['Contracts', 'IDVs'],
@@ -162,7 +162,11 @@ export default function ObligationsByAwardType({
         .on('mouseleave', () => setActiveType(null))
         .attr('aria-label', (d) => `${d.data.label}: ${d3.format("($,.2f")(d.value)}`)
         .attr('role', 'listitem')
-        .attr('tabindex', 0);
+        .attr('tabindex', 0)
+        .on('focus', (d) => {
+            // store the award type of the section the user is hovering over
+            setActiveType(d.data.label);
+        });
 
 
     // labels

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -45,6 +45,7 @@ export default function ObligationsByAwardType({
     const [chartHeight, setChartHeight] = useState(0);
     const [chartWidth, setChartWidth] = useState(0);
     const [activeType, setActiveType] = useState(null);
+    const [hoverOuter, setOuterHover] = useState(null);
     const chartRef = useRef();
 
     useEffect(() => {
@@ -59,6 +60,10 @@ export default function ObligationsByAwardType({
     const outerRadius = labelRadius * 0.7;
     const outerStrokeWidth = 3;
     const innerRadius = outerRadius - (outerStrokeWidth * 2);
+
+    const mapToFullCategoryName = (name) => {
+        return `All ${name.charAt(0).toUpperCase()}  ${name.slice(1)}`;
+    }
 
     // clear & append the svg object to the div
     d3.select('#obl_chart').selectAll('*').remove();
@@ -102,13 +107,18 @@ export default function ObligationsByAwardType({
             } else {
                 return outer[currentCategory].color
             }
+
         })
         .style('cursor', 'pointer')
         .on('mouseenter', (d) => {
             // store the award type of the section the user is hovering over
             setActiveType(d.data.label);
+            setOuterHover(mapToFullCategoryName(d.data.type));
         })
-        .on('mouseleave', () => setActiveType(null))
+        .on('mouseleave', () => {
+            setActiveType(null)
+            setOuterHover(null)
+        })
         .attr('aria-label', (d) => `${d.data.label}: ${d3.format("($,.2f")(d.value)}`)
         .attr('role', 'listitem');
 
@@ -127,7 +137,9 @@ export default function ObligationsByAwardType({
             // store the award type of the section the user is hovering over
             setActiveType(d.data.label);
         })
-        .on('mouseleave', () => setActiveType(null))
+        .on('mouseleave', () => {
+            setActiveType(null)
+        })
         .attr('role', 'listitem');
 
 
@@ -140,11 +152,12 @@ export default function ObligationsByAwardType({
             .outerRadius(innerRadius)
             .innerRadius(innerRadius / 2)
         )
-        .attr('fill', (d, i) => (
+        .attr('fill', (d, i) => {
+            if (hoverOuter && hoverOuter === mapToFullCategoryName(d.data.type) && !isMobile) return inner[i].color
+
             // Use the faded color when another section is hovered over
-            ((activeType && activeType !== inner[i].label) && !isMobile)
-                ? inner[i].fadedColor : inner[i].color)
-        )
+            return ((activeType && activeType !== inner[i].label) && !isMobile) ? inner[i].fadedColor : inner[i].color
+        })
         .style('cursor', 'pointer')
         .on('mouseenter', (d) => {
             // store the award type of the section the user is hovering over

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardTypeTooltip.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardTypeTooltip.jsx
@@ -13,7 +13,8 @@ const propTypes = {
     awardTypes: PropTypes.array,
     fiscalYear: PropTypes.number,
     activeType: PropTypes.string,
-    categoryType: PropTypes.string
+    categoryType: PropTypes.string,
+    isCategoryHover: PropTypes.bool
 };
 
 const columns = [
@@ -34,7 +35,7 @@ const columns = [
 ];
 
 
-const ObligationsByAwardTypeTooltip = ({ awardTypes, fiscalYear, activeType, categoryType }) => {
+const ObligationsByAwardTypeTooltip = ({ awardTypes, fiscalYear, activeType, categoryType, isCategoryHover }) => {
     const { _awardObligations } = useSelector((state) => state.agencyV2);
     const awardTypesByCategory = awardTypes.filter(item => item.type === categoryType);
     const totalByCategory = awardTypesByCategory.reduce((acc, item) =>  acc + item.value, 0);
@@ -45,7 +46,7 @@ const ObligationsByAwardTypeTooltip = ({ awardTypes, fiscalYear, activeType, cat
     }
 
     const rows = awardTypesByCategory.map((type) => {
-        const activeClass = `award-type-tooltip__table-data${type.label === activeType ? ' award-type-tooltip__table-data_active' : ''}`;
+        const activeClass = `award-type-tooltip__table-data${!isCategoryHover && type.label === activeType ? ' award-type-tooltip__table-data_active' : ''}`;
         return [
             (
                 <div className={activeClass}>

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardTypeTooltip.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardTypeTooltip.jsx
@@ -68,13 +68,6 @@ const ObligationsByAwardTypeTooltip = ({ awardTypes, fiscalYear, activeType, cat
         ];
     });
 
-    // Add the "Totals" row
-    // rows.push([
-    //     'Total',
-    //     formatMoney(_awardObligations),
-    //     '100%'
-    // ]);
-
     return (
         <div className="award-type-tooltip">
             <div className="tooltip__title">

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardTypeTooltip.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardTypeTooltip.jsx
@@ -69,11 +69,11 @@ const ObligationsByAwardTypeTooltip = ({ awardTypes, fiscalYear, activeType, cat
     });
 
     // Add the "Totals" row
-    rows.push([
-        'Total',
-        formatMoney(_awardObligations),
-        '100%'
-    ]);
+    // rows.push([
+    //     'Total',
+    //     formatMoney(_awardObligations),
+    //     '100%'
+    // ]);
 
     return (
         <div className="award-type-tooltip">

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardTypeTooltip.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardTypeTooltip.jsx
@@ -13,7 +13,7 @@ const propTypes = {
     awardTypes: PropTypes.array,
     fiscalYear: PropTypes.number,
     activeType: PropTypes.string,
-    category: PropTypes.string
+    categoryType: PropTypes.string
 };
 
 const columns = [
@@ -34,9 +34,9 @@ const columns = [
 ];
 
 
-const ObligationsByAwardTypeTooltip = ({ awardTypes, fiscalYear, activeType, category }) => {
+const ObligationsByAwardTypeTooltip = ({ awardTypes, fiscalYear, activeType, categoryType }) => {
     const { _awardObligations } = useSelector((state) => state.agencyV2);
-    const awardTypesByCategory = awardTypes.filter(item => item.type === category);
+    const awardTypesByCategory = awardTypes.filter(item => item.type === categoryType);
     const totalByCategory = awardTypesByCategory.reduce((acc, item) =>  acc + item.value, 0);
 
     const titles = {
@@ -71,7 +71,7 @@ const ObligationsByAwardTypeTooltip = ({ awardTypes, fiscalYear, activeType, cat
     return (
         <div className="award-type-tooltip">
             <div className="tooltip__title">
-                FY {fiscalYear} {titles[category]}: {formatMoneyWithUnitsShortLabel(totalByCategory)}
+                FY {fiscalYear} {titles[categoryType]}: {formatMoneyWithUnitsShortLabel(totalByCategory)}
             </div>
             <div className="tooltip__text">
                 <Table

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardTypeTooltip.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardTypeTooltip.jsx
@@ -35,15 +35,17 @@ const columns = [
 ];
 
 
-const ObligationsByAwardTypeTooltip = ({ awardTypes, fiscalYear, activeType, categoryType, isCategoryHover }) => {
+const ObligationsByAwardTypeTooltip = ({
+    awardTypes, fiscalYear, activeType, categoryType, isCategoryHover
+}) => {
     const { _awardObligations } = useSelector((state) => state.agencyV2);
-    const awardTypesByCategory = awardTypes.filter(item => item.type === categoryType);
-    const totalByCategory = awardTypesByCategory.reduce((acc, item) =>  acc + item.value, 0);
+    const awardTypesByCategory = awardTypes.filter((item) => item.type === categoryType);
+    const totalByCategory = awardTypesByCategory.reduce((acc, item) => acc + item.value, 0);
 
     const titles = {
-        'contracts': 'Total Contract Obligations',
-        'financial': 'Total Financial Assistance Obligations'
-    }
+        contracts: 'Total Contract Obligations',
+        financial: 'Total Financial Assistance Obligations'
+    };
 
     const rows = awardTypesByCategory.map((type) => {
         const activeClass = `award-type-tooltip__table-data${!isCategoryHover && type.label === activeType ? ' award-type-tooltip__table-data_active' : ''}`;
@@ -51,7 +53,7 @@ const ObligationsByAwardTypeTooltip = ({ awardTypes, fiscalYear, activeType, cat
             (
                 <div className={activeClass}>
                     <svg height="12" width="18">
-                        <circle cx="6" cy="6" r="6" fill={type.color}/>
+                        <circle cx="6" cy="6" r="6" fill={type.color} />
                     </svg>
                     {type.label}
                 </div>

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardTypeTooltip.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardTypeTooltip.jsx
@@ -7,12 +7,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { Table } from 'data-transparency-ui';
-import { calculatePercentage, formatMoney } from 'helpers/moneyFormatter';
+import { calculatePercentage, formatMoney, formatMoneyWithUnitsShortLabel } from 'helpers/moneyFormatter';
 
 const propTypes = {
     awardTypes: PropTypes.array,
     fiscalYear: PropTypes.number,
-    activeType: PropTypes.string
+    activeType: PropTypes.string,
+    category: PropTypes.string
 };
 
 const columns = [
@@ -32,15 +33,24 @@ const columns = [
     }
 ];
 
-const ObligationsByAwardTypeTooltip = ({ awardTypes, fiscalYear, activeType }) => {
+
+const ObligationsByAwardTypeTooltip = ({ awardTypes, fiscalYear, activeType, category }) => {
     const { _awardObligations } = useSelector((state) => state.agencyV2);
-    const rows = awardTypes.map((type) => {
+    const awardTypesByCategory = awardTypes.filter(item => item.type === category);
+    const totalByCategory = awardTypesByCategory.reduce((acc, item) =>  acc + item.value, 0);
+
+    const titles = {
+        'contracts': 'Total Contract Obligations',
+        'financial': 'Total Financial Assistance Obligations'
+    }
+
+    const rows = awardTypesByCategory.map((type) => {
         const activeClass = `award-type-tooltip__table-data${type.label === activeType ? ' award-type-tooltip__table-data_active' : ''}`;
         return [
             (
                 <div className={activeClass}>
                     <svg height="12" width="18">
-                        <circle cx="6" cy="6" r="6" fill={type.color} />
+                        <circle cx="6" cy="6" r="6" fill={type.color}/>
                     </svg>
                     {type.label}
                 </div>
@@ -57,16 +67,18 @@ const ObligationsByAwardTypeTooltip = ({ awardTypes, fiscalYear, activeType }) =
             )
         ];
     });
+
     // Add the "Totals" row
     rows.push([
         'Total',
         formatMoney(_awardObligations),
         '100%'
     ]);
+
     return (
         <div className="award-type-tooltip">
             <div className="tooltip__title">
-                FY {fiscalYear}
+                FY {fiscalYear} {titles[category]}: {formatMoneyWithUnitsShortLabel(totalByCategory)}
             </div>
             <div className="tooltip__text">
                 <Table

--- a/src/js/containers/agencyV2/visualizations/ObligationsByAwardTypeContainer.jsx
+++ b/src/js/containers/agencyV2/visualizations/ObligationsByAwardTypeContainer.jsx
@@ -35,7 +35,7 @@ export default function ObligationsByAwardTypeContainer({ fiscalYear, windowWidt
             obligationsByAwardTypeRequest.current.cancel();
         }
         dispatch(resetAwardObligations());
-    }, []);
+    }, [dispatch]);
 
     const getObligationsByAwardType = () => {
         if (obligationsByAwardTypeRequest.current) {
@@ -110,8 +110,8 @@ export default function ObligationsByAwardTypeContainer({ fiscalYear, windowWidt
                         color: 'rgb(169, 173, 209)',
                         fadedColor: 'rgb(169, 173, 209, 25%)',
                         type: 'contracts'
-                    },
-                ]
+                    }
+                ];
 
                 res.data.results.forEach((d) => {
                     switch (d.category) {
@@ -169,7 +169,7 @@ export default function ObligationsByAwardTypeContainer({ fiscalYear, windowWidt
         if (toptierCode) {
             getObligationsByAwardType();
         }
-    }, [fiscalYear, toptierCode]);
+    }, [dispatch, fiscalYear, getObligationsByAwardType, toptierCode]);
 
 
     return (<>

--- a/src/js/containers/agencyV2/visualizations/ObligationsByAwardTypeContainer.jsx
+++ b/src/js/containers/agencyV2/visualizations/ObligationsByAwardTypeContainer.jsx
@@ -22,7 +22,7 @@ const propTypes = {
 
 export default function ObligationsByAwardTypeContainer({ fiscalYear, windowWidth, isMobile }) {
     const [categoriesForGraph, setCategoriesForGraph] = React.useState([]);
-    const [detailsForGraph, setDetailsForGraph] = React.useState({});
+    const [detailsForGraph, setDetailsForGraph] = React.useState([]);
     const [loading, setLoading] = React.useState(true);
     const [error, setError] = React.useState(false);
     const [noData, setNoData] = React.useState(false);

--- a/src/js/containers/agencyV2/visualizations/ObligationsByAwardTypeContainer.jsx
+++ b/src/js/containers/agencyV2/visualizations/ObligationsByAwardTypeContainer.jsx
@@ -22,7 +22,7 @@ const propTypes = {
 
 export default function ObligationsByAwardTypeContainer({ fiscalYear, windowWidth, isMobile }) {
     const [categoriesForGraph, setCategoriesForGraph] = React.useState([]);
-    const [detailsForGraph, setDetailsForGraph] = React.useState([]);
+    const [detailsForGraph, setDetailsForGraph] = React.useState({});
     const [loading, setLoading] = React.useState(true);
     const [error, setError] = React.useState(false);
     const [noData, setNoData] = React.useState(false);
@@ -73,38 +73,46 @@ export default function ObligationsByAwardTypeContainer({ fiscalYear, windowWidt
                         fadedColor: 'rgb(84, 91, 163, 25%)'
                     }
                 ];
+
                 const details = [
                     {
                         label: 'Grants',
                         color: 'rgb(230, 111, 14)',
-                        fadedColor: 'rgb(230, 111, 14, 25%)'
+                        fadedColor: 'rgb(230, 111, 14, 25%)',
+                        type: 'financial'
                     },
                     {
                         label: 'Loans',
                         color: 'rgb(255, 188, 120)',
-                        fadedColor: 'rgb(255, 188, 120, 25%)'
+                        fadedColor: 'rgb(255, 188, 120, 25%)',
+                        type: 'financial'
                     },
                     {
                         label: 'Direct Payments',
                         color: 'rgb(250, 148, 65)',
-                        fadedColor: 'rgb(250, 148, 65, 25%)'
+                        fadedColor: 'rgb(250, 148, 65, 25%)',
+                        type: 'financial'
                     },
                     {
                         label: 'Other Financial Assistance',
                         color: 'rgb(252, 226, 197)',
-                        fadedColor: 'rgb(252, 226, 197, 25%)'
+                        fadedColor: 'rgb(252, 226, 197, 25%)',
+                        type: 'financial'
                     },
                     {
                         label: 'Contracts',
                         color: 'rgb(127, 132, 186)',
-                        fadedColor: 'rgb(127, 132, 186, 25%)'
+                        fadedColor: 'rgb(127, 132, 186, 25%)',
+                        type: 'contracts'
                     },
                     {
                         label: 'IDVs',
                         color: 'rgb(169, 173, 209)',
-                        fadedColor: 'rgb(169, 173, 209, 25%)'
-                    }
-                ];
+                        fadedColor: 'rgb(169, 173, 209, 25%)',
+                        type: 'contracts'
+                    },
+                ]
+
                 res.data.results.forEach((d) => {
                     switch (d.category) {
                         case 'grants':

--- a/src/js/containers/agencyV2/visualizations/ObligationsByAwardTypeContainer.jsx
+++ b/src/js/containers/agencyV2/visualizations/ObligationsByAwardTypeContainer.jsx
@@ -35,7 +35,7 @@ export default function ObligationsByAwardTypeContainer({ fiscalYear, windowWidt
             obligationsByAwardTypeRequest.current.cancel();
         }
         dispatch(resetAwardObligations());
-    }, [dispatch]);
+    }, []);
 
     const getObligationsByAwardType = () => {
         if (obligationsByAwardTypeRequest.current) {
@@ -169,7 +169,7 @@ export default function ObligationsByAwardTypeContainer({ fiscalYear, windowWidt
         if (toptierCode) {
             getObligationsByAwardType();
         }
-    }, [dispatch, fiscalYear, getObligationsByAwardType, toptierCode]);
+    }, [fiscalYear, toptierCode]);
 
 
     return (<>

--- a/src/js/containers/agencyV2/visualizations/RecipientDistributionContainer.jsx
+++ b/src/js/containers/agencyV2/visualizations/RecipientDistributionContainer.jsx
@@ -31,7 +31,7 @@ const RecipientDistributionContainer = ({ fiscalYear, data }) => {
             request.current.cancel();
         }
         dispatch(resetAgencyRecipients());
-    }, []);
+    }, [dispatch]);
 
     const getRecipientDistribution = () => {
         if (request.current) {
@@ -69,7 +69,7 @@ const RecipientDistributionContainer = ({ fiscalYear, data }) => {
         if (toptierCode) {
             getRecipientDistribution();
         }
-    }, [fiscalYear, toptierCode]);
+    }, [fiscalYear, getRecipientDistribution, toptierCode]);
 
     return (
         <div className="recipient-distribution-visualization-container">

--- a/src/js/containers/agencyV2/visualizations/RecipientDistributionContainer.jsx
+++ b/src/js/containers/agencyV2/visualizations/RecipientDistributionContainer.jsx
@@ -31,7 +31,7 @@ const RecipientDistributionContainer = ({ fiscalYear, data }) => {
             request.current.cancel();
         }
         dispatch(resetAgencyRecipients());
-    }, [dispatch]);
+    }, []);
 
     const getRecipientDistribution = () => {
         if (request.current) {
@@ -69,7 +69,7 @@ const RecipientDistributionContainer = ({ fiscalYear, data }) => {
         if (toptierCode) {
             getRecipientDistribution();
         }
-    }, [fiscalYear, getRecipientDistribution, toptierCode]);
+    }, [fiscalYear, toptierCode]);
 
     return (
         <div className="recipient-distribution-visualization-container">

--- a/src/js/helpers/agencyV2/visualizations/ObligationsByAwardTypeHelper.js
+++ b/src/js/helpers/agencyV2/visualizations/ObligationsByAwardTypeHelper.js
@@ -1,0 +1,30 @@
+/**
+ * ObligationsByAwardTypeHelper.js
+ * Created by Andrea Blackwell 12/15/2021
+ */
+
+
+export const mapToFullCategoryName = (categoryType) => `All ${categoryType.charAt(0).toUpperCase()}${categoryType.slice(1)}`;
+
+export const getCategoryNameByAwardType = (awardType, categoryMapping) => {
+    const categoryNames = Object.keys(categoryMapping);
+    return categoryMapping[categoryNames[0]].includes(awardType) ? categoryNames[0] : categoryNames[1];
+};
+
+export const getActiveCategoryType = (activeType, categoryMapping) => {
+    if (activeType?.length > 0) {
+        const categoryNames = Object.keys(categoryMapping);
+        const category = categoryMapping[categoryNames[0]].includes(activeType) ? categoryNames[0] : categoryNames[1];
+        return category.replace(/(^All\s)/, '').toLowerCase();
+    }
+    return '';
+};
+
+export const getOuterCategoryId = (categoryName, outer) => {
+    for (let i = 0; i < outer.length; i++) {
+        if (outer[i].label.includes(categoryName)) return i;
+    }
+
+    return '';
+};
+

--- a/tests/components/agency/visualizations/ObligationsByAwardTypeTooltip-test.jsx
+++ b/tests/components/agency/visualizations/ObligationsByAwardTypeTooltip-test.jsx
@@ -11,32 +11,38 @@ const mockAwardTypes = [
     {
         label: 'Grants',
         color: '#E66F0E',
-        value: -50
+        value: -50,
+        type: 'financial'
     },
     {
         label: 'Loans',
         color: '#FFBC78',
-        value: 4567890
+        value: 4567890,
+        type: 'financial'
     },
     {
         label: 'Direct Payments',
         color: '#FA9441',
-        value: 30
+        value: 30,
+        type: 'financial'
     },
     {
         label: 'Other Financial Assistance',
         color: '#FCE2C5',
-        value: 20
+        value: 20,
+        type: 'financial'
     },
     {
         label: 'Contracts',
         color: '#7F84BA',
-        value: 10
+        value: 10,
+        type: 'contracts'
     },
     {
         label: 'IDVs',
         color: '#A9ADD1',
-        value: 0
+        value: 0,
+        type: 'contracts'
     }
 ];
 
@@ -51,10 +57,12 @@ test('displays the currently selected fiscal year in the tooltip heading', () =>
         <ObligationsByAwardTypeTooltip
             awardTypes={mockAwardTypes}
             fiscalYear={1999}
-            activeType="Contracts" />,
+            activeType="Contracts"
+            category="contracts"
+        />,
         { initialState: mockStore }
     );
-    const heading = screen.queryByText('FY 1999');
+    const heading = screen.queryByText(/^FY 1999/);
     expect(heading).toBeTruthy();
     expect(heading.classList.contains('tooltip__title')).toBeTruthy();
 });
@@ -64,7 +72,9 @@ test('formats the award obligations', () => {
         <ObligationsByAwardTypeTooltip
             awardTypes={mockAwardTypes}
             fiscalYear={1999}
-            activeType="Contracts" />,
+            activeType="Direct Payments"
+            category="financial"
+        />,
         { initialState: mockStore }
     );
     const loansValue = screen.queryByText('$4,567,890');
@@ -76,7 +86,9 @@ test('formats the percent of total', () => {
         <ObligationsByAwardTypeTooltip
             awardTypes={mockAwardTypes}
             fiscalYear={1999}
-            activeType="Contracts" />,
+            activeType="Loans"
+            category="financial"
+        />,
         { initialState: mockStore }
     );
     const directPaymentsPercent = screen.queryByText('30%');
@@ -88,7 +100,9 @@ test('adds an active class to the hovered award type', () => {
         <ObligationsByAwardTypeTooltip
             awardTypes={mockAwardTypes}
             fiscalYear={1999}
-            activeType="Contracts" />,
+            activeType="Contracts"
+            category="contracts"
+        />,
         { initialState: mockStore }
     );
     const contractsAmount = screen.queryByText('$10');
@@ -100,7 +114,9 @@ test('displays -- as the percent for negative obligations', () => {
         <ObligationsByAwardTypeTooltip
             awardTypes={mockAwardTypes}
             fiscalYear={1999}
-            activeType="Contracts" />,
+            activeType="Loans"
+            category="financial"
+        />,
         { initialState: mockStore }
     );
     expect(screen.queryByText('--')).toBeTruthy();

--- a/tests/components/agency/visualizations/ObligationsByAwardTypeTooltip-test.jsx
+++ b/tests/components/agency/visualizations/ObligationsByAwardTypeTooltip-test.jsx
@@ -58,7 +58,7 @@ test('displays the currently selected fiscal year in the tooltip heading', () =>
             awardTypes={mockAwardTypes}
             fiscalYear={1999}
             activeType="Contracts"
-            category="contracts"
+            categoryType="contracts"
         />,
         { initialState: mockStore }
     );
@@ -73,7 +73,7 @@ test('formats the award obligations', () => {
             awardTypes={mockAwardTypes}
             fiscalYear={1999}
             activeType="Direct Payments"
-            category="financial"
+            categoryType="financial"
         />,
         { initialState: mockStore }
     );
@@ -87,7 +87,7 @@ test('formats the percent of total', () => {
             awardTypes={mockAwardTypes}
             fiscalYear={1999}
             activeType="Loans"
-            category="financial"
+            categoryType="financial"
         />,
         { initialState: mockStore }
     );
@@ -101,7 +101,7 @@ test('adds an active class to the hovered award type', () => {
             awardTypes={mockAwardTypes}
             fiscalYear={1999}
             activeType="Contracts"
-            category="contracts"
+            categoryType="contracts"
         />,
         { initialState: mockStore }
     );
@@ -115,7 +115,7 @@ test('displays -- as the percent for negative obligations', () => {
             awardTypes={mockAwardTypes}
             fiscalYear={1999}
             activeType="Loans"
-            category="financial"
+            categoryType="financial"
         />,
         { initialState: mockStore }
     );

--- a/tests/helpers/agencyV2/visualizations/ObligationsByAwardTypeHelper-test.js
+++ b/tests/helpers/agencyV2/visualizations/ObligationsByAwardTypeHelper-test.js
@@ -1,0 +1,88 @@
+/**
+ * ObligationsByAwardTypeHelper.js
+ * Created by Andrea Blackwell 12/15/2021
+ */
+
+import { mapToFullCategoryName, getCategoryNameByAwardType, getActiveCategoryType, getOuterCategoryId } from 'helpers/agencyV2/visualizations/ObligationsByAwardTypeHelper.js';
+
+const mockCategories = [
+    {
+        label: ['All Financial', 'Assistance'], // line break between words
+        value: 0,
+        color: 'rgb(192, 86, 0)',
+        fadedColor: 'rgb(192, 86, 0, 25%)'
+    },
+    {
+        label: ['All Contracts', ''], // so each cat label array is same length
+        value: 0,
+        color: 'rgb(84, 91, 163)',
+        fadedColor: 'rgb(84, 91, 163, 25%)'
+    }
+];
+
+const mockDetails = [
+    {
+        label: 'Grants',
+        color: 'rgb(230, 111, 14)',
+        fadedColor: 'rgb(230, 111, 14, 25%)',
+        type: 'financial'
+    },
+    {
+        label: 'Loans',
+        color: 'rgb(255, 188, 120)',
+        fadedColor: 'rgb(255, 188, 120, 25%)',
+        type: 'financial'
+    },
+    {
+        label: 'Direct Payments',
+        color: 'rgb(250, 148, 65)',
+        fadedColor: 'rgb(250, 148, 65, 25%)',
+        type: 'financial'
+    },
+    {
+        label: 'Other Financial Assistance',
+        color: 'rgb(252, 226, 197)',
+        fadedColor: 'rgb(252, 226, 197, 25%)',
+        type: 'financial'
+    },
+    {
+        label: 'Contracts',
+        color: 'rgb(127, 132, 186)',
+        fadedColor: 'rgb(127, 132, 186, 25%)',
+        type: 'contracts'
+    },
+    {
+        label: 'IDVs',
+        color: 'rgb(169, 173, 209)',
+        fadedColor: 'rgb(169, 173, 209, 25%)',
+        type: 'contracts'
+    }
+];
+
+const mockCategoryMapping = {
+    'All Contracts': ['Contracts', 'IDVs'],
+    'All Financial': ['Grants', 'Loans', 'Direct Payments', 'Other Financial Assistance']
+};
+
+describe('Obligations By Award Type Visualization', () => {
+
+    it('should return a full category name from short category name', () => {
+        expect(mapToFullCategoryName('contracts'))
+            .toEqual('All Contracts');
+    });
+
+    it('should return a full category name by award type', () => {
+        expect(getCategoryNameByAwardType('IDVs', mockCategoryMapping))
+            .toEqual('All Contracts');
+    });
+
+    it('should get the active category type from the active award type', () => {
+        expect(getActiveCategoryType('Loans', mockCategoryMapping))
+            .toEqual('financial');
+    });
+
+    it('should an id from a full category name', () => {
+        expect(getOuterCategoryId('All Financial', mockCategories))
+            .toEqual(0);
+    });
+});

--- a/tests/helpers/agencyV2/visualizations/ObligationsByAwardTypeHelper-test.js
+++ b/tests/helpers/agencyV2/visualizations/ObligationsByAwardTypeHelper-test.js
@@ -7,82 +7,56 @@ import { mapToFullCategoryName, getCategoryNameByAwardType, getActiveCategoryTyp
 
 const mockCategories = [
     {
-        label: ['All Financial', 'Assistance'], // line break between words
-        value: 0,
-        color: 'rgb(192, 86, 0)',
-        fadedColor: 'rgb(192, 86, 0, 25%)'
+        label: ['All Category1'],
     },
     {
-        label: ['All Contracts', ''], // so each cat label array is same length
-        value: 0,
-        color: 'rgb(84, 91, 163)',
-        fadedColor: 'rgb(84, 91, 163, 25%)'
+        label: ['All Category2']
     }
 ];
 
 const mockDetails = [
     {
         label: 'Grants',
-        color: 'rgb(230, 111, 14)',
-        fadedColor: 'rgb(230, 111, 14, 25%)',
-        type: 'financial'
+        type: 'category2'
     },
     {
         label: 'Loans',
-        color: 'rgb(255, 188, 120)',
-        fadedColor: 'rgb(255, 188, 120, 25%)',
-        type: 'financial'
-    },
-    {
-        label: 'Direct Payments',
-        color: 'rgb(250, 148, 65)',
-        fadedColor: 'rgb(250, 148, 65, 25%)',
-        type: 'financial'
-    },
-    {
-        label: 'Other Financial Assistance',
-        color: 'rgb(252, 226, 197)',
-        fadedColor: 'rgb(252, 226, 197, 25%)',
-        type: 'financial'
+        type: 'category2'
     },
     {
         label: 'Contracts',
-        color: 'rgb(127, 132, 186)',
-        fadedColor: 'rgb(127, 132, 186, 25%)',
-        type: 'contracts'
+        type: 'category1'
     },
     {
         label: 'IDVs',
-        color: 'rgb(169, 173, 209)',
-        fadedColor: 'rgb(169, 173, 209, 25%)',
-        type: 'contracts'
+        type: 'category1'
     }
 ];
 
 const mockCategoryMapping = {
-    'All Contracts': ['Contracts', 'IDVs'],
-    'All Financial': ['Grants', 'Loans', 'Direct Payments', 'Other Financial Assistance']
+    'All Category1': ['Contracts', 'IDVs'],
+    'All Category2': ['Grants', 'Loans']
 };
 
 describe('Obligations By Award Type Visualization', () => {
 
-    it('should return a full category name from short category name', () => {
-        expect(mapToFullCategoryName('contracts'))
-            .toEqual('All Contracts');
+    it('should return a full category name from category type', () => {
+        expect(mapToFullCategoryName(mockDetails[2].type))
+            .toEqual('All Category1');
     });
 
     it('should return a full category name by award type', () => {
-        expect(getCategoryNameByAwardType('IDVs', mockCategoryMapping))
-            .toEqual('All Contracts');
+        expect(getCategoryNameByAwardType(mockDetails[3].label, mockCategoryMapping))
+            .toEqual('All Category1');
     });
 
     it('should get the active category type from the active award type', () => {
-        expect(getActiveCategoryType('Loans', mockCategoryMapping))
-            .toEqual('financial');
+        expect(getActiveCategoryType(mockDetails[1].label, mockCategoryMapping))
+            .toEqual('category2');
     });
 
     it('should an id from a full category name', () => {
-        expect(getOuterCategoryId('All Financial', mockCategories))
+        expect(getOuterCategoryId('All Category1', mockCategories))
             .toEqual(0);
     });
 });

--- a/tests/helpers/agencyV2/visualizations/ObligationsByAwardTypeHelper-test.js
+++ b/tests/helpers/agencyV2/visualizations/ObligationsByAwardTypeHelper-test.js
@@ -3,11 +3,11 @@
  * Created by Andrea Blackwell 12/15/2021
  */
 
-import { mapToFullCategoryName, getCategoryNameByAwardType, getActiveCategoryType, getOuterCategoryId } from 'helpers/agencyV2/visualizations/ObligationsByAwardTypeHelper.js';
+import { mapToFullCategoryName, getCategoryNameByAwardType, getActiveCategoryType, getOuterCategoryId } from 'helpers/agencyV2/visualizations/ObligationsByAwardTypeHelper';
 
 const mockCategories = [
     {
-        label: ['All Category1'],
+        label: ['All Category1']
     },
     {
         label: ['All Category2']
@@ -39,7 +39,6 @@ const mockCategoryMapping = {
 };
 
 describe('Obligations By Award Type Visualization', () => {
-
     it('should return a full category name from category type', () => {
         expect(mapToFullCategoryName(mockDetails[2].type))
             .toEqual('All Category1');


### PR DESCRIPTION
**High level description:**
Changed the donut hover behavior so that tooltips only show the award types for the 'hovered' category (ie. either All Financial or All Contracts).  Updated the tooltip design slightly according to mock attached to the JIRA ticket.  Also, the following decisions were made after meeting with the designers - https://data-transparency-bfs.slack.com/archives/GGRP4UMAT/p1639507404028600

**Technical details:**
- Added a type field to each object in the "details" array in the container to help determine which category the award type belonged to
- The requirements changed some so needed to access the data objects for this feature in different ways than what was intended when this feature was first developed.  
- Added mouseover / out events to outer donut ring and white donut ring
- Updated the award type tooltip for this feature to only show the award types for the selected category


**JIRA Ticket:**
[DEV-7770](https://federal-spending-transparency.atlassian.net/browse/DEV-7770)

**Mockup:**
https://bahdigital.invisionapp.com/share/BSIAHSLA9PE#/screens/296067034

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [x] Code review complete
