### PR TITLE
[DEV-8147] adjust CFDA limit, add scrollbar to autocomplete dropdown

### DIFF
--- a/src/_scss/elements/filters/_typeahead.scss
+++ b/src/_scss/elements/filters/_typeahead.scss
@@ -33,6 +33,8 @@
         list-style-type: none;
         margin: 0;
         padding: 0;
+        max-height: rem(400);
+        overflow-y: scroll;
         li {
             line-height: rem(20);
             font-size: $small-font-size;

--- a/src/js/components/sharedComponents/autocomplete/Autocomplete.jsx
+++ b/src/js/components/sharedComponents/autocomplete/Autocomplete.jsx
@@ -33,7 +33,7 @@ const defaultProps = {
     placeholder: '',
     errorHeader: '',
     errorMessage: '',
-    maxSuggestions: 10,
+    maxSuggestions: 1000,
     label: '',
     noResults: false,
     characterLimit: 524288, // default for HTML input elements

--- a/src/js/containers/search/filters/cfda/CFDAListContainer.jsx
+++ b/src/js/containers/search/filters/cfda/CFDAListContainer.jsx
@@ -70,7 +70,8 @@ export default class CFDAListContainer extends React.Component {
             }
 
             const cfdaSearchParams = {
-                search_text: this.state.cfdaSearchString
+                search_text: this.state.cfdaSearchString,
+                limit: 1000
             };
 
             this.cfdaSearchRequest = SearchHelper.fetchCFDA(cfdaSearchParams);
@@ -86,16 +87,15 @@ export default class CFDAListContainer extends React.Component {
                     search.addIndex(['program_title']);
                     search.addDocuments(data);
                     const results = search.search(this.state.cfdaSearchString);
-                    const improvedResults = slice(results, 0, 10);
 
                     // Filter out any selected CFDA that may be in the result set
                     const selectedCFDA =
                     this.props.selectedCFDA.toArray().map((cfda) => omit(cfda, 'identifier'));
-                    if (improvedResults && improvedResults.length > 0) {
-                        autocompleteData = differenceWith(improvedResults, selectedCFDA, isEqual);
+                    if (results && results.length > 0) {
+                        autocompleteData = differenceWith(results, selectedCFDA, isEqual);
                     }
                     else {
-                        autocompleteData = improvedResults;
+                        autocompleteData = results;
                     }
 
                     this.setState({

--- a/src/js/containers/search/filters/cfda/CFDAListContainer.jsx
+++ b/src/js/containers/search/filters/cfda/CFDAListContainer.jsx
@@ -4,7 +4,7 @@
 **/
 
 import React from 'react';
-import { isEqual, omit, differenceWith, slice } from 'lodash';
+import { isEqual, omit, differenceWith } from 'lodash';
 import { isCancel } from 'axios';
 import { Search, PrefixIndexStrategy } from 'js-search';
 import PropTypes from 'prop-types';


### PR DESCRIPTION
**High level description:**

Increases the limit to the number of CFDA results returned by the autocomplete search, as well as adding a scrollbar to the autocomplete results dropdown


**JIRA Ticket:**
[DEV-8147](https://federal-spending-transparency.atlassian.net/browse/DEV-8147)

The following are ALL required for the PR to be merged:

Author:
- [X] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [X] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [X] Verified mobile/tablet/desktop/monitor responsiveness
- [X] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [x] Code review complete
