### PR TITLE
DEV-8168 Covid Profile Agency v2 links

### DIFF
--- a/src/js/components/covid19/Covid19Page.jsx
+++ b/src/js/components/covid19/Covid19Page.jsx
@@ -37,10 +37,10 @@ import PublicLawPicker from './PublicLawPicker';
 require('pages/covid19/index.scss');
 
 const propTypes = {
-    areDefCodesLoading: PropTypes.bool
+    loading: PropTypes.bool
 };
 
-const Covid19Page = ({ areDefCodesLoading }) => {
+const Covid19Page = ({ loading }) => {
     const query = useQueryParams();
     const history = useHistory();
     const [activeSection, setActiveSection] = useState('overview');
@@ -99,7 +99,7 @@ const Covid19Page = ({ areDefCodesLoading }) => {
                     onShareOptionClick={handleShare} />,
                 <DownloadButtonContainer />
             ]}>
-            <LoadingWrapper isLoading={areDefCodesLoading}>
+            <LoadingWrapper isLoading={loading}>
                 <main id="main-content" className="main-content usda__flex-row">
                     <div className="sidebar">
                         <div className="sidebar__content">

--- a/src/js/containers/covid19/Covid19Container.jsx
+++ b/src/js/containers/covid19/Covid19Container.jsx
@@ -3,7 +3,7 @@
  * Created by Jonathan Hill 06/02/20
  */
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import GlobalConstants from 'GlobalConstants';
@@ -11,6 +11,7 @@ import { useQueryParams } from 'helpers/queryParams';
 import BaseOverview from 'models/v2/covid19/BaseOverview';
 import { fetchOverview, fetchAwardAmounts } from 'apis/disaster';
 import { useDefCodes } from 'containers/covid19/WithDefCodes';
+import { useAgencySlugs } from 'containers/agencyV2/WithAgencySlugs';
 import { setOverview, setTotals, setDefcParams, resetOverview } from 'redux/actions/covid19/covid19Actions';
 import { defcByPublicLaw } from 'dataMapping/covid19/covid19';
 import Covid19Page from 'components/covid19/Covid19Page';
@@ -20,8 +21,11 @@ require('pages/covid19/index.scss');
 const Covid19Container = () => {
     const [, areDefCodesLoading, defCodes] = useDefCodes();
     const { defcParams } = useSelector((state) => state.covid19);
+    const [, , slugsLoading] = useAgencySlugs();
     const overviewRequest = useRef(null);
+    const [overviewLoading, setOverviewLoading] = useState(true);
     const awardAmountRequest = useRef(null);
+    const [amountsLoading, setAmountsLoading] = useState(true);
     const dispatch = useDispatch();
     const history = useHistory();
     let { publicLaw } = useQueryParams();
@@ -65,9 +69,11 @@ const Covid19Container = () => {
                 const newOverview = Object.create(BaseOverview);
                 newOverview.populate(data);
                 dispatch(setOverview(newOverview));
+                setOverviewLoading(false);
             }
             catch (e) {
                 console.error(' Error Overview : ', e.message);
+                setOverviewLoading(false);
             }
         };
         const getAllAwardTypesAmount = async () => {
@@ -87,9 +93,11 @@ const Covid19Container = () => {
                     faceValueOfLoan: data.face_value_of_loan
                 };
                 dispatch(setTotals('', totals));
+                setAmountsLoading(false);
             }
             catch (e) {
                 console.error(' Error Amounts : ', e.message);
+                setAmountsLoading(false);
             }
         };
         if (defcParams && defcParams.length) {
@@ -109,7 +117,7 @@ const Covid19Container = () => {
     }, [defCodes, defcParams, dispatch]);
 
     return (
-        <Covid19Page areDefCodesLoading={areDefCodesLoading} />
+        <Covid19Page loading={areDefCodesLoading || slugsLoading || overviewLoading || amountsLoading} />
     );
 };
 

--- a/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
+++ b/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
@@ -127,7 +127,7 @@ const AwardSpendingAgencyTableContainer = (props) => {
     const errorOrLoadingWrapperRef = useRef(null);
     const request = useRef(null);
     const [unlinkedDataClass, setUnlinkedDataClass] = useState(false);
-    const [, toptierCodes, slugsLoading, slugsError] = useAgencySlugs();
+    const [, toptierCodes, , slugsError] = useAgencySlugs();
 
     const clickedAgencyProfile = (agencyName) => {
         Analytics.event({
@@ -192,7 +192,7 @@ const AwardSpendingAgencyTableContainer = (props) => {
             if (query) link = replaceString(link, query, 'query-matched');
             const id = awardSpendingByAgencyRow._id;
             const code = awardSpendingByAgencyRow.code;
-            if (AGENCYV2_RELEASED && !slugsLoading && !slugsError && code && link) {
+            if (AGENCYV2_RELEASED && !slugsError && code && link) {
                 link = (
                     <Link
                         className="agency-profile__link"
@@ -308,7 +308,7 @@ const AwardSpendingAgencyTableContainer = (props) => {
         else {
             changeCurrentPage(1);
         }
-    }, [pageSize, sort, order, defcParams, query, slugsLoading]);
+    }, [pageSize, sort, order, defcParams, query]);
 
     useEffect(() => {
         fetchSpendingByCategoryCallback();

--- a/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
+++ b/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
@@ -227,7 +227,7 @@ const AwardSpendingAgencyTableContainer = (props) => {
         return addUnlinkedData(parsedData, totals);
     };
 
-    const fetchSpendingByCategoryCallback = useCallback(() => {
+    const fetchSpendingByAgencyCallback = useCallback(() => {
         if (request.current) {
             request.current.cancel();
         }
@@ -286,14 +286,14 @@ const AwardSpendingAgencyTableContainer = (props) => {
         // when award type changes, sort is on faceValueOfLoan for loans; otherwise, obligation
         if (props.type === 'loans' && sort === 'faceValueOfLoan' && order === 'desc') {
             changeCurrentPage(1);
-            fetchSpendingByCategoryCallback();
+            fetchSpendingByAgencyCallback();
         }
         else if (props.type === 'loans') {
             updateSort('faceValueOfLoan', 'desc');
         }
         else if (sort === 'obligation' && order === 'desc') {
             changeCurrentPage(1);
-            fetchSpendingByCategoryCallback();
+            fetchSpendingByAgencyCallback();
         }
         else {
             updateSort('obligation', 'desc');
@@ -303,7 +303,7 @@ const AwardSpendingAgencyTableContainer = (props) => {
     useEffect(() => {
         // Reset to the first page
         if (currentPage === 1) {
-            fetchSpendingByCategoryCallback();
+            fetchSpendingByAgencyCallback();
         }
         else {
             changeCurrentPage(1);
@@ -311,7 +311,7 @@ const AwardSpendingAgencyTableContainer = (props) => {
     }, [pageSize, sort, order, defcParams, query]);
 
     useEffect(() => {
-        fetchSpendingByCategoryCallback();
+        fetchSpendingByAgencyCallback();
     }, [currentPage]);
 
     useEffect(() => {

--- a/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
+++ b/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
@@ -9,7 +9,6 @@ import { useSelector } from 'react-redux';
 import { isCancel } from 'axios';
 import PropTypes from 'prop-types';
 import { Table, Pagination, Picker, TooltipWrapper } from 'data-transparency-ui';
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { Link } from 'react-router-dom';
 
 import { AGENCY_LINK, AGENCYV2_RELEASED } from 'GlobalConstants';
@@ -25,8 +24,6 @@ import {
 import { fetchDisasterSpending, fetchLoanSpending } from 'apis/disaster';
 import { handleSort, calculateUnlinkedTotals } from 'helpers/covid19Helper';
 
-import ResultsTableLoadingMessage from 'components/search/table/ResultsTableLoadingMessage';
-import ResultsTableErrorMessage from 'components/search/table/ResultsTableErrorMessage';
 import BaseBudgetCategoryRow from 'models/v2/covid19/BaseBudgetCategoryRow';
 import { useAgencySlugs } from 'containers/agencyV2/WithAgencySlugs';
 import { SpendingTypesTT } from 'components/covid19/Covid19Tooltips';
@@ -36,8 +33,6 @@ const propTypes = {
     subHeading: PropTypes.string,
     scrollIntoView: PropTypes.func.isRequired
 };
-
-let tableHeight = 'auto';
 
 const budgetDropdownColumns = {
     total_spending: [
@@ -380,17 +375,6 @@ const BudgetCategoriesTableContainer = (props) => {
         Analytics.event({ category: 'covid-19 - profile', action: `total spending - ${props.type} - ${spendingCategory}` });
     };
 
-    if (loading) {
-        if (tableRef.current) {
-            tableHeight = tableRef.current.offsetHeight;
-        }
-    }
-    else if (error) {
-        if (tableRef.current) {
-            tableHeight = tableRef.current.offsetHeight;
-        }
-    }
-
     const spendingViewPicker = () => (
         <div className="budget-categories-table__header">
             <label htmlFor="usa-dt-picker">Show amounts based on: </label>
@@ -413,41 +397,6 @@ const BudgetCategoriesTableContainer = (props) => {
         </div>
     );
 
-    if (loading || error) {
-        return (
-            <div ref={errorOrLoadingWrapperRef}>
-                {spendingViewPicker()}
-                <Pagination
-                    currentPage={currentPage}
-                    changePage={changeCurrentPage}
-                    changeLimit={changePageSize}
-                    limitSelector
-                    resultsText
-                    pageSize={pageSize}
-                    totalItems={totalItems} />
-                <TransitionGroup>
-                    <CSSTransition
-                        classNames="table-message-fade"
-                        timeout={{ exit: 225, enter: 195 }}
-                        exit>
-                        <div className="results-table-message-container" style={{ height: tableHeight }}>
-                            {error && <ResultsTableErrorMessage />}
-                            {loading && <ResultsTableLoadingMessage />}
-                        </div>
-                    </CSSTransition>
-                </TransitionGroup>
-                <Pagination
-                    currentPage={currentPage}
-                    changePage={changeCurrentPage}
-                    changeLimit={changePageSize}
-                    limitSelector
-                    resultsText
-                    pageSize={pageSize}
-                    totalItems={totalItems} />
-            </div>
-        );
-    }
-
     return (
         <div ref={tableWrapperRef}>
             {spendingViewPicker()}
@@ -466,7 +415,9 @@ const BudgetCategoriesTableContainer = (props) => {
                     columns={renderColumns()}
                     currentSort={{ field: sort, direction: order }}
                     updateSort={updateSort}
-                    divider={props.subHeading} />
+                    divider={props.subHeading}
+                    loading={loading}
+                    error={error} />
             </div>
             <Pagination
                 currentPage={currentPage}

--- a/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
+++ b/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
@@ -113,7 +113,6 @@ const budgetDropdownColumns = {
     ]
 };
 
-
 const totalBudgetaryResourcesColumn = {
     title: 'totalBudgetaryResources',
     displayName: (
@@ -144,9 +143,9 @@ const BudgetCategoriesTableContainer = (props) => {
     const errorOrLoadingWrapperRef = useRef(null);
     const request = useRef(null);
     const [unlinkedDataClass, setUnlinkedDataClass] = useState(false);
-    const [, toptierCodes, slugsLoading, slugsError] = useAgencySlugs();
+    const [, toptierCodes, , slugsError] = useAgencySlugs();
 
-    const { overview, defcParams, allAwardTypeTotals } = useSelector((state) => state.covid19);
+    const { overview, defcParams } = useSelector((state) => state.covid19);
 
     const clickedAgencyProfile = (agencyName) => {
         Analytics.event({
@@ -244,7 +243,7 @@ const BudgetCategoriesTableContainer = (props) => {
                 );
             }
             else if (link && props.type === 'agency') {
-                if (AGENCYV2_RELEASED && !slugsLoading && !slugsError && code) {
+                if (AGENCYV2_RELEASED && !slugsError && code) {
                     link = (
                         <Link
                             className="agency-profile__link"
@@ -343,7 +342,7 @@ const BudgetCategoriesTableContainer = (props) => {
             fetchBudgetSpendingCallback();
         }
         changeCurrentPage(1);
-    }, [pageSize, sort, order, defcParams, overview, allAwardTypeTotals, slugsLoading]);
+    }, [pageSize, sort, order, defcParams]);
 
     useEffect(() => {
         fetchBudgetSpendingCallback();

--- a/tests/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer-test.jsx
+++ b/tests/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer-test.jsx
@@ -1,69 +1,83 @@
 /**
- * BudgetCategoriesTableContainer-test.js
- * Created by Lizzie Salita 10/15/21
+ * AwardSpendingAgencyTableContainer-test.js
+ * Created by Lizzie Salita 12/15/21
  * */
 
 import React from "react";
 import { render, waitFor, screen } from "test-utils";
 import "@testing-library/jest-dom/extend-expect";
-import BudgetCategoriesTableContainer from "containers/covid19/budgetCategories/BudgetCategoriesTableContainer";
+import AwardSpendingAgencyTableContainer from "containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer";
 import * as api from "apis/disaster";
 import * as hooks from "containers/agencyV2/WithAgencySlugs";
 import { defaultState } from "../../../testResources/defaultReduxFilters";
 
-const mockResults = [{
-    id: 123,
-    code: "045",
-    description: "Department of Sandwiches",
-    children: [],
-    award_count: 25,
-    obligation: 2000,
-    outlay: 1500,
-    total_budgetary_resources: 2500
-}, {
-    id: 789,
-    code: "000",
-    description: "Ministry of Magic",
-    children: [],
-    award_count: 23,
-    obligation: 1000,
-    outlay: 700,
-    total_budgetary_resources: 2000
-}];
+const mockData = {
+    totals: {
+        obligation: 2000,
+        outlay: 3000,
+        total_budgetary_resources: 6000
+    },
+    results: [{
+        id: 123,
+        code: "045",
+        description: "Department of Sandwiches",
+        children: [],
+        award_count: 25,
+        obligation: 2000,
+        outlay: 1500,
+        total_budgetary_resources: 2500
+    }, {
+        id: 789,
+        code: "000",
+        description: "Ministry of Magic",
+        children: [],
+        award_count: 23,
+        obligation: 1000,
+        outlay: 700,
+        total_budgetary_resources: 2000
+    }],
+    page_metadata: {
+        page: 1,
+        total: 44,
+        limit: 10
+    }
+};
 
 let spy;
+
+const redux = {
+    ...defaultState,
+    covid19: {
+        defcParams: ["A", "B", "C"],
+        spendingByAgencyTotals: {
+            obligation: 2000,
+            outlay: 1600,
+            awardCount: 250
+        }
+    }
+};
 
 beforeEach(() => {
     jest.clearAllMocks();
 });
 
-describe("BudgetCategoriesTableContainer", () => {
+describe("AwardSpendingAgencyTableContainer", () => {
+    window.scrollTo = jest.fn();
     it("should make an API call when the DEFC params change", () => {
         // spy on the API request helper functions
-        spy = jest.spyOn(api, "fetchDisasterSpending").mockReturnValue({
+        spy = jest.spyOn(api, "fetchAwardSpendingByAgency").mockReturnValue({
             promise: Promise.resolve({
-                data: {
-                    results: mockResults,
-                    page_metadata: {
-                        total: 20
-                    }
-                }
+                data: mockData
             }),
             cancel: jest.fn()
         });
 
         const { rerender } = render(
-            <BudgetCategoriesTableContainer
-                type="agency"
-                subHeading="sub heading"
+            <AwardSpendingAgencyTableContainer
+                type="all"
                 scrollIntoView={jest.fn()} />,
             {
-                initialState: {
-                    ...defaultState,
-                    covid19: {
-                        defcParams: ["A", "B", "C"]
-                    }
-                }
+                initialState: redux
             }
         );
         waitFor(() => {
@@ -71,15 +85,19 @@ describe("BudgetCategoriesTableContainer", () => {
         });
         // re-render with different defcParams
         rerender(
-            <BudgetCategoriesTableContainer
-                type="agency"
-                subHeading="sub heading"
+            <AwardSpendingAgencyTableContainer
+                type="all"
                 scrollIntoView={jest.fn()} />,
             {
                 initialState: {
                     ...defaultState,
                     covid19: {
-                        defcParams: ["Z"]
+                        defcParams: ["Z"],
+                        spendingByAgencyTotals: {
+                            obligation: 2000,
+                            outlay: 1600,
+                            awardCount: 250
+                        }
                     }
                 }
             }
@@ -90,14 +108,9 @@ describe("BudgetCategoriesTableContainer", () => {
     });
     it('should use agency id for agency URLs if Agency Profile v2 has not been released', () => {
         // Mock the API response
-        jest.spyOn(api, "fetchDisasterSpending").mockReturnValue({
+        jest.spyOn(api, "fetchAwardSpendingByAgency").mockReturnValue({
             promise: Promise.resolve({
-                data: {
-                    results: mockResults,
-                    page_metadata: {
-                        total: 20
-                    }
-                }
+                data: mockData
             }),
             cancel: jest.fn()
         });
@@ -119,31 +132,23 @@ describe("BudgetCategoriesTableContainer", () => {
             false
         ]);
         render(
-            <BudgetCategoriesTableContainer
-                type="agency"
-                subHeading="sub heading"
+            <AwardSpendingAgencyTableContainer
+                type="all"
                 scrollIntoView={jest.fn()} />,
             {
-                initialState: {
-                    ...defaultState
-                }
+                initialState: redux
             }
         );
         waitFor(() => {
-            expect(screen.getByText(mockResults[0].description))
-                .toHaveAttribute('href', `/agency/${mockResults[0].id}`);
+            expect(screen.getByText(mockData.results[0].description))
+                .toHaveAttribute('href', `/agency/${mockData.results[0].id}`);
         });
     });
     it('should use agency slug for the agency URLs if Agency Profile v2 has been released', () => {
         // Mock the API response
-        jest.spyOn(api, "fetchDisasterSpending").mockReturnValue({
+        jest.spyOn(api, "fetchAwardSpendingByAgency").mockReturnValue({
             promise: Promise.resolve({
-                data: {
-                    results: mockResults,
-                    page_metadata: {
-                        total: 20
-                    }
-                }
+                data: mockData
             }),
             cancel: jest.fn()
         });
@@ -166,18 +171,15 @@ describe("BudgetCategoriesTableContainer", () => {
         ]);
 
         render(
-            <BudgetCategoriesTableContainer
-                type="agency"
-                subHeading="sub heading"
+            <AwardSpendingAgencyTableContainer
+                type="all"
                 scrollIntoView={jest.fn()} />,
             {
-                initialState: {
-                    ...defaultState
-                }
+                initialState: redux
             }
         );
         waitFor(() => {
-            expect(screen.getByText(mockResults[0].description))
+            expect(screen.getByText(mockData.results[0].description))
                 .toHaveAttribute('href', '/agency_v2/department-of-sandwiches');
         });
     });


### PR DESCRIPTION
**High level description:**

Updates Agency Profile links on the Covid Profile page to use the v2 version of the URL based on our Global Constants for the Agency v2 release.  

**Technical details:**

- Uses the toptier code --> agency slug mapping added to the `useAgencySlugs` hook by #2826 
- Updates the Covid 19 container to show the loading indicator until API requests for page-level data (now including the Agency Slugs) have completed. This reduces the number of re-renders farther down the DOM hierarchy. 
- Utilize the Loading and Error states built into the component library `Table`

**JIRA Ticket:**
[DEV-8168](https://federal-spending-transparency.atlassian.net/browse/DEV-8168)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)

Reviewer(s):
- [ ] Code review complete
