### PR TITLE
Fix DEV-8168 Covid profile Agency v2 links

### DIFF
--- a/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
+++ b/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
@@ -192,7 +192,7 @@ const AwardSpendingAgencyTableContainer = (props) => {
             if (query) link = replaceString(link, query, 'query-matched');
             const id = awardSpendingByAgencyRow._id;
             const code = awardSpendingByAgencyRow.code;
-            if (AGENCYV2_RELEASED && !slugsError && code && link) {
+            if (AGENCYV2_RELEASED && !slugsError && code && toptierCodes[code] && link) {
                 link = (
                     <Link
                         className="agency-profile__link"

--- a/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
+++ b/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
@@ -243,7 +243,7 @@ const BudgetCategoriesTableContainer = (props) => {
                 );
             }
             else if (link && props.type === 'agency') {
-                if (AGENCYV2_RELEASED && !slugsError && code) {
+                if (AGENCYV2_RELEASED && !slugsError && code && toptierCodes[code]) {
                     link = (
                         <Link
                             className="agency-profile__link"

--- a/tests/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer-test.jsx
+++ b/tests/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer-test.jsx
@@ -183,4 +183,40 @@ describe("AwardSpendingAgencyTableContainer", () => {
                 .toHaveAttribute('href', '/agency_v2/department-of-sandwiches');
         });
     });
+    it('should just display the agency name (with no link) if no slug mapping is available', () => {
+        // Mock the API response
+        jest.spyOn(api, "fetchAwardSpendingByAgency").mockReturnValue({
+            promise: Promise.resolve({
+                data: mockData
+            }),
+            cancel: jest.fn()
+        });
+
+        // Mock the Global Constants
+        jest.mock('GlobalConstants', () => ({
+            AGENCY_LINK: 'agency_v2',
+            AGENCYV2_RELEASED: true
+        }));
+
+        // Mock the custom hook, useAgencySlugs
+        jest.spyOn(hooks, "useAgencySlugs").mockReturnValue([
+            {},
+            { "045": 'department-of-sandwiches' },
+            false,
+            false
+        ]);
+
+        render(
+            <AwardSpendingAgencyTableContainer
+                type="all"
+                scrollIntoView={jest.fn()} />,
+            {
+                initialState: redux
+            }
+        );
+        waitFor(() => {
+            expect(screen.getByText(mockData.results[1].description))
+                .not.toHaveAttribute('href');
+        });
+    });
 });

--- a/tests/containers/covid19/budgetCategories/BudgetCategoriesTableContainer-test.jsx
+++ b/tests/containers/covid19/budgetCategories/BudgetCategoriesTableContainer-test.jsx
@@ -181,4 +181,48 @@ describe("BudgetCategoriesTableContainer", () => {
                 .toHaveAttribute('href', '/agency_v2/department-of-sandwiches');
         });
     });
+    it('should just display the agency name (with no link) if no slug mapping is available', () => {
+        // Mock the API response
+        jest.spyOn(api, "fetchDisasterSpending").mockReturnValue({
+            promise: Promise.resolve({
+                data: {
+                    results: mockResults,
+                    page_metadata: {
+                        total: 20
+                    }
+                }
+            }),
+            cancel: jest.fn()
+        });
+
+        // Mock the Global Constants
+        jest.mock('GlobalConstants', () => ({
+            AGENCY_LINK: 'agency_v2',
+            AGENCYV2_RELEASED: true
+        }));
+
+        // Mock the custom hook, useAgencySlugs
+        jest.spyOn(hooks, "useAgencySlugs").mockReturnValue([
+            {},
+            { "045": 'department-of-sandwiches' },
+            false,
+            false
+        ]);
+
+        render(
+            <BudgetCategoriesTableContainer
+                type="agency"
+                subHeading="sub heading"
+                scrollIntoView={jest.fn()} />,
+            {
+                initialState: {
+                    ...defaultState
+                }
+            }
+        );
+        waitFor(() => {
+            expect(screen.getByText(mockResults[1].description))
+                .not.toHaveAttribute('href');
+        });
+    });
 });


### PR DESCRIPTION
**High level description:**

Fixes a bug that generated links to agencies that don't have profile pages. 

**Technical details:**

We were previously just checking for the existence of `toptier_code`, but an agency can have a toptier code with no profile page (and therefore no `agency_slug` mapping). 

**JIRA Ticket:**
[DEV-8168](https://federal-spending-transparency.atlassian.net/browse/DEV-8168) follow up

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)

Reviewer(s):
- [x] Code review complete