### PR TITLE
7762 - added code to return hard-coded responses when congressional d…

### DIFF
--- a/src/js/models/v2/CoreLocation.js
+++ b/src/js/models/v2/CoreLocation.js
@@ -58,6 +58,10 @@ const CoreLocation = {
             country = this._country && `${this._country} `;
         }
 
+        if (this._congressionalDistrict === '90') {
+            return 'MULTI-STATE';
+        }
+
         const postCode = this._zip;
         return `${city}${adminArea}${country}${postCode}`;
     },
@@ -106,7 +110,10 @@ const CoreLocation = {
         return '';
     },
     get fullCongressionalDistrict() {
-        return this.congressionalDistrict && `\nCongressional District: ${this.congressionalDistrict}`;
+        if (this._congressionalDistrict === '90') {
+            return 'CONGRESSIONAL DISTRICT: 90 (Multiple Districts)';
+        }
+        return this.congressionalDistrict && `\nCONGRESSIONAL DISTRICT: ${this.congressionalDistrict}`;
     },
     get recipientCongressionalDistrict() {
         return this.congressionalDistrict

--- a/tests/models/CoreLocation-test.js
+++ b/tests/models/CoreLocation-test.js
@@ -23,6 +23,26 @@ const locationData = {
 const location = Object.create(CoreLocation);
 location.populateCore(locationData);
 
+const multiLocationData = {
+    address1: '',
+    address2: '',
+    province: '',
+    city: '',
+    county: '',
+    countyCode: '',
+    stateCode: '',
+    zip5: '',
+    countryCode: 'USA',
+    country: 'USA',
+    state: '',
+    congressionalDistrict: '90'
+};
+
+const multiLocation = Object.create(CoreLocation);
+multiLocation.populateCore(multiLocationData);
+const multiLocationAddress = 'MULTI-STATE';
+const multiLocationDistrict = 'CONGRESSIONAL DISTRICT: 90 (Multiple Districts)';
+
 const foreignLocationData = {
     province: 'Quebec',
     city: 'Montreal',
@@ -101,6 +121,10 @@ describe('Core Location getter functions', () => {
 
             expect(partialLocation.regionalAddress).toEqual('Pawnee, IN 12345');
         });
+        it('should set regional address to "MULTI-STATE" when' +
+            ' congressionalDistrict is 90', () => {
+            expect(multiLocation.regionalAddress).toEqual(multiLocationAddress);
+        });
     });
     describe('Recipient Regional Address Contracts & IDV', () => {
         it('should use state name property when foreign', () => {
@@ -128,7 +152,8 @@ describe('Core Location getter functions', () => {
     });
     describe('Full Congressional District', () => {
         it('should format the congressional district with a prefix', () => {
-            expect(location.fullCongressionalDistrict).toEqual('\nCongressional District: IN-04');
+            expect(location.fullCongressionalDistrict).toEqual('\nCONGRESSIONAL' +
+                ' DISTRICT: IN-04');
         });
         it('should handle a null congressional district', () => {
             const missingData = Object.assign({}, locationData, {
@@ -138,6 +163,10 @@ describe('Core Location getter functions', () => {
             partialLocation.populateCore(missingData);
 
             expect(partialLocation.fullCongressionalDistrict).toEqual('');
+        });
+        it('should set fullCongressionalDistrict to a predetermined value if' +
+            ' congressionalDistrict is 90', () => {
+            expect(multiLocation.fullCongressionalDistrict).toEqual(multiLocationDistrict);
         });
     });
     describe('Recipient Congressional District', () => {
@@ -175,7 +204,8 @@ describe('Core Location getter functions', () => {
     });
     describe('Full Address', () => {
         it('should format the full address', () => {
-            expect(location.fullAddress).toEqual('602 Trumball Street\nApt 2\nPawnee, IN 12345\nCongressional District: IN-04');
+            expect(location.fullAddress).toEqual('602 Trumball Street\nApt' +
+                ' 2\nPawnee, IN 12345\nCONGRESSIONAL DISTRICT: IN-04');
         });
         it('should handle a null street address', () => {
             const missingData = Object.assign({}, locationData, {
@@ -185,7 +215,7 @@ describe('Core Location getter functions', () => {
             const partialLocation = Object.create(CoreLocation);
             partialLocation.populateCore(missingData);
 
-            expect(partialLocation.fullAddress).toEqual('Pawnee, IN 12345\nCongressional District: IN-04');
+            expect(partialLocation.fullAddress).toEqual('Pawnee, IN 12345\nCONGRESSIONAL DISTRICT: IN-04');
         });
         it('should handle a null city', () => {
             const missingData = Object.assign({}, locationData, {
@@ -194,7 +224,7 @@ describe('Core Location getter functions', () => {
             const partialLocation = Object.create(CoreLocation);
             partialLocation.populateCore(missingData);
 
-            expect(partialLocation.fullAddress).toEqual('602 Trumball Street\nApt 2\nIN 12345\nCongressional District: IN-04');
+            expect(partialLocation.fullAddress).toEqual('602 Trumball Street\nApt 2\nIN 12345\nCONGRESSIONAL DISTRICT: IN-04');
         });
         it('should handle a null state', () => {
             const missingData = Object.assign({}, locationData, {
@@ -214,7 +244,7 @@ describe('Core Location getter functions', () => {
             const partialLocation = Object.create(CoreLocation);
             partialLocation.populateCore(missingData);
 
-            expect(partialLocation.fullAddress).toEqual('602 Trumball Street\nApt 2\nPawnee, IN 12345\nCongressional District: IN-04');
+            expect(partialLocation.fullAddress).toEqual('602 Trumball Street\nApt 2\nPawnee, IN 12345\nCONGRESSIONAL DISTRICT: IN-04');
         });
         it('should handle a two part zip code', () => {
             const data = Object.assign({}, locationData, {


### PR DESCRIPTION
…istrict is 90; changed 'Congressional District' to uppercase; updated unit tests

**High level description:**

For Award Summary Pages, when Congressional District is 90, return a preset address to appear in the Place of Performance accordion, in the Additional Details section of the page.

**Technical details:**

Added if blocks to return hard-coded values when district is 90.

**JIRA Ticket:**
[DEV-1234](https://federal-spending-transparency.atlassian.net/browse/DEV-7762)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
