### PR TITLE
dev 7770 - update agency v2 donut chart tooltip text

### DIFF
--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardTypeTooltip.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardTypeTooltip.jsx
@@ -24,12 +24,12 @@ const columns = [
     },
     {
         title: 'obligations',
-        displayName: 'Award Obligations',
+        displayName: ["Award", <br />, "Obligations"],
         right: true
     },
     {
         title: 'percent',
-        displayName: '% of Total',
+        displayName: ["% of", <br />, "Total"],
         right: true
     }
 ];
@@ -74,7 +74,7 @@ const ObligationsByAwardTypeTooltip = ({
     return (
         <div className="award-type-tooltip">
             <div className="tooltip__title">
-                FY {fiscalYear} {titles[categoryType]}: {formatMoneyWithUnitsShortLabel(totalByCategory)}
+                FY{fiscalYear} - {titles[categoryType]}: {formatMoneyWithUnitsShortLabel(totalByCategory)}
             </div>
             <div className="tooltip__text">
                 <Table

--- a/tests/components/agency/visualizations/ObligationsByAwardTypeTooltip-test.jsx
+++ b/tests/components/agency/visualizations/ObligationsByAwardTypeTooltip-test.jsx
@@ -62,7 +62,7 @@ test('displays the currently selected fiscal year in the tooltip heading', () =>
         />,
         { initialState: mockStore }
     );
-    const heading = screen.queryByText(/^FY 1999/);
+    const heading = screen.queryByText(/^FY1999/);
     expect(heading).toBeTruthy();
     expect(heading.classList.contains('tooltip__title')).toBeTruthy();
 });


### PR DESCRIPTION
**High level description:**

Added the hyphen where “FY2021 - Total…. “ for both Contract and Assistance tooltips.  Removed the space between fy and the year to match the mocks.  Changed “Award Obligations” to display in two lines for the contract tooltip to match the mockup and be consistent with the assistance tooltip.

**Technical details:**

Text changes.

**JIRA Ticket:**
[DEV-7770](https://federal-spending-transparency.atlassian.net/browse/DEV-7770) follow-up


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness

Reviewer(s):
- [ ] Code review complete
