### PR TITLE
7829 v2 links on awarding agency results

### DIFF
--- a/src/js/components/search/visualizations/rank/chart/ChartGroup.jsx
+++ b/src/js/components/search/visualizations/rank/chart/ChartGroup.jsx
@@ -44,7 +44,7 @@ export default class ChartGroup extends React.Component {
 
     processLink(label) {
         let linkClass = '';
-        if (this.props.linkID !== '') {
+        if (this.props.linkID !== '' && this.props.linkID !== 'agency_v2/') {
             linkClass = ' group-label-link';
         }
         let title = (
@@ -59,7 +59,10 @@ export default class ChartGroup extends React.Component {
 
         /* eslint-disable jsx-a11y/anchor-is-valid */
         // the link is actually valid since the URL root will provide an absolute URL
-        if (this.props.linkID !== '') {
+        /* with ticket 7829, agencies with no agency page will not have an
+        agencySlug but will still have the v2 agencyString in their linkId,
+        so we need to make sure that isn't the case before making the link*/
+        if (this.props.linkID !== '' && this.props.linkID !== 'agency_v2/') {
             title = (
                 <a xlinkHref={`${this.props.urlRoot}${this.props.linkID}`}>
                     <text


### PR DESCRIPTION
**High level description:**

This was returned by testers because agencies with no agency page were being shown as links in the categories tab, with Spending By Awarding Agency chosen from the dropdown.

**Technical details:**

Before this ticket, in ChartGroup.jsx, any time the linkId was '', we would not build a link, but now we're adding the agecy_v2 string to all linkIds, so we need to check for '' and for 'agency_v2' in the linkId before making it a link.

**JIRA Ticket:**
[DEV-1234](https://federal-spending-transparency.atlassian.net/browse/DEV-7829)

**Mockup:**

n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
