### PR TITLE
dev-8118 integrate api status of funds subcomponents, refactor to use endpoint, update tests

### DIFF
--- a/src/js/apis/agencyV2.js
+++ b/src/js/apis/agencyV2.js
@@ -48,3 +48,7 @@ export const fetchSubagencySummary = (code, fy, params) => apiRequest({
 export const fetchAgencySlugs = () => apiRequest({
     url: 'v2/references/toptier_agencies'
 });
+
+export const fetchSubcomponentsList = (code, fy, page) => apiRequest({
+    url: `v2/agency/${code}/sub_components/${fy ? `?fiscal_year=${fy}` : ''}${page ? `&page=${page}` : ''}`
+});

--- a/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
+++ b/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
@@ -28,8 +28,8 @@ const StatusOfFunds = ({ fy }) => {
     const [level, setLevel] = useState(0);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(false);
-    const [currentPage, changeCurrentPage] = useStateWithPrevious(1);
-    const [pageSize, changePageSize] = useStateWithPrevious(10);
+    const [prevPage, currentPage, changeCurrentPage] = useStateWithPrevious(1);
+    const [prevPageSize, pageSize, changePageSize] = useStateWithPrevious(10);
     const [totalItems, setTotalItems] = useState(0);
     const request = useRef(null);
     const [results, setResults] = useState([]);
@@ -73,7 +73,12 @@ const StatusOfFunds = ({ fy }) => {
     };
 
     useEffect(() => {
-        fetchAgencySubcomponents();
+        const hasParamChanged = (
+            prevPage !== currentPage || prevPageSize !== pageSize
+        );
+        if (hasParamChanged) {
+            fetchAgencySubcomponents();
+        }
     }, [currentPage]);
 
     useEffect(() => {
@@ -115,7 +120,7 @@ const StatusOfFunds = ({ fy }) => {
                         changePage={changeCurrentPage}
                         changeLimit={changePageSize}
                         resultsText
-                        pageSize={pageSize}
+                        pageSize={10}
                         totalItems={totalItems} />
                 </FlexGridCol>
             </FlexGridRow>

--- a/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
+++ b/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
@@ -28,8 +28,8 @@ const StatusOfFunds = ({ fy }) => {
     const [level, setLevel] = useState(0);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(false);
-    const [prevPage, currentPage, changeCurrentPage] = useStateWithPrevious(1);
-    const [prevPageSize, pageSize, changePageSize] = useStateWithPrevious(10);
+    const [currentPage, changeCurrentPage] = useStateWithPrevious(1);
+    const [pageSize, changePageSize] = useStateWithPrevious(10);
     const [totalItems, setTotalItems] = useState(0);
     const request = useRef(null);
     const [results, setResults] = useState([]);

--- a/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
+++ b/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
@@ -3,11 +3,14 @@
  * Created by Lizzie Salita 10/27/21
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
-import { FlexGridRow, FlexGridCol } from 'data-transparency-ui';
-import { setSelectedSubcomponent } from 'redux/actions/agencyV2/agencyV2Actions';
+import { FlexGridRow, FlexGridCol, Pagination, LoadingMessage } from 'data-transparency-ui';
+import { setSelectedSubcomponent, setAgencySubcomponents, resetAgencySubcomponents } from 'redux/actions/agencyV2/agencyV2Actions';
+import { fetchSubcomponentsList } from 'apis/agencyV2';
+import { parseRows } from 'helpers/agencyV2/StatusOfFundsVizHelper';
+import { useStateWithPrevious } from 'helpers';
 import BaseStatusOfFundsLevel from 'models/v2/agency/BaseStatusOfFundsLevel';
 import Note from 'components/sharedComponents/Note';
 import DrilldownSidebar from './DrilldownSidebar';
@@ -20,75 +23,65 @@ const propTypes = {
 
 export const levels = ['Sub-Component', 'Federal Account'];
 
-// TODO: Replace mock data with API response once endpoints are available
-export const mockChartData = {
-    page_metadata: {
-        page: 1,
-        total: 1,
-        limit: 2,
-        next: 2,
-        previous: null,
-        hasNext: true,
-        hasPrevious: false
-    },
-    results: [
-        {
-            name: "National Oceanic and Atmospheric Administration",
-            total_budgetary_resources: 8000000000,
-            total_obligations: 6000000000
-        },
-        {
-            name: "Bureau of the Census",
-            total_budgetary_resources: 4400000000,
-            total_obligations: 2500000000
-        },
-        {
-            name: "U.S. Patent and Trademark Office",
-            total_budgetary_resources: 4200000000,
-            total_obligations: 2700000000
-        },
-        {
-            name: "Economic Development Administration",
-            total_budgetary_resources: 4150000000,
-            total_obligations: 1300000000
-        },
-        {
-            name: "National Telecommunications and Information Administration",
-            total_budgetary_resources: 2100000000,
-            total_obligations: 50000000
-        },
-        {
-            name: "National Institute of Standards and Technology",
-            total_budgetary_resources: 1900000000,
-            total_obligations: 1560000000
-        },
-        {
-            name: "International Trade Administration",
-            total_budgetary_resources: 1010000000,
-            total_obligations: 960000000
-        },
-        {
-            name: "Departmental Management",
-            total_budgetary_resources: 100500000,
-            total_obligations: 905000000
-        },
-        {
-            name: "Bureau of Industry and Security",
-            total_budgetary_resources: 10500000,
-            total_obligations: 9050000
-        },
-        {
-            name: "Bureau of Economic Analysis",
-            total_budgetary_resources: 5000000,
-            total_obligations: 4000000
-        }
-    ]
-};
-
 const StatusOfFunds = ({ fy }) => {
     const dispatch = useDispatch();
     const [level, setLevel] = useState(0);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(false);
+    const [prevPage, currentPage, changeCurrentPage] = useStateWithPrevious(1);
+    const [prevPageSize, pageSize, changePageSize] = useStateWithPrevious(10);
+    const [totalItems, setTotalItems] = useState(0);
+    const request = useRef(null);
+    const [results, setResults] = useState([]);
     const { overview, selectedSubcomponent } = useSelector((state) => state.agencyV2);
+
+    useEffect(() => {
+        if (request.current) {
+            request.current.cancel();
+        }
+        dispatch(resetAgencySubcomponents());
+    }, []);
+
+    const fetchAgencySubcomponents = async () => {
+        if (request.current) {
+            request.current.cancel();
+        }
+        if (error) {
+            setError(false);
+        }
+        if (!loading) {
+            setLoading(true);
+        }
+        const params = {
+            limit: pageSize,
+            page: currentPage
+        };
+        request.current = fetchSubcomponentsList(overview.toptierCode, fy, params.page);
+        const agencySubcomponentsListRequest = request.current;
+        agencySubcomponentsListRequest.promise
+            .then((res) => {
+                const parsedData = parseRows(res.data.results);
+                setResults(parsedData);
+                dispatch(setAgencySubcomponents(parsedData));
+                setTotalItems(res.data.page_metadata.total);
+                setLoading(false);
+            }).catch((err) => {
+                setError(true);
+                setLoading(false);
+                console.error(err);
+            });
+    };
+
+    useEffect(() => {
+        fetchAgencySubcomponents();
+    }, [currentPage]);
+
+    useEffect(() => {
+        if (fy && overview.toptierCode) {
+            fetchAgencySubcomponents();
+        }
+    }, [fy, overview.toptierCode]);
+
     // TODO - remove mock data when DEV-8052 is implemented
     const mockData = {
         name: "Bureau of the Census",
@@ -116,7 +109,14 @@ const StatusOfFunds = ({ fy }) => {
                         selectedSubcomponent={selectedSubcomponent} />
                 </FlexGridCol>
                 <FlexGridCol className="status-of-funds__visualization" desktop={9}>
-                    <VisualizationSection level={level} agencyId={overview.toptierCode} agencyName={overview.name} fy={fy} data={mockChartData} />
+                    { results.length !== 0 ? <VisualizationSection level={level} agencyId={overview.toptierCode} agencyName={overview.name} fy={fy} results={results} /> : <LoadingMessage /> }
+                    <Pagination
+                        currentPage={currentPage}
+                        changePage={changeCurrentPage}
+                        changeLimit={changePageSize}
+                        resultsText
+                        pageSize={pageSize}
+                        totalItems={totalItems} />
                 </FlexGridCol>
             </FlexGridRow>
             <Note message={

--- a/src/js/components/agencyV2/statusOfFunds/VisualizationSection.jsx
+++ b/src/js/components/agencyV2/statusOfFunds/VisualizationSection.jsx
@@ -6,7 +6,6 @@
 // eslint-disable-next-line no-unused-vars
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Pagination } from 'data-transparency-ui';
 import { levels } from './StatusOfFunds';
 import StatusOfFundsChart from '../visualizations/StatusOfFundsChart';
 
@@ -15,27 +14,19 @@ const propTypes = {
     agencyId: PropTypes.string,
     agencyName: PropTypes.string,
     fy: PropTypes.string,
-    data: PropTypes.object
+    results: PropTypes.array
 };
 
 const VisualizationSection = ({
     level,
     agencyName,
     fy,
-    data
+    results
 }) => (
     <div className="status-of-funds__visualization">
         <h6>{agencyName} by <strong>{levels[level]}</strong> for FY {fy}</h6>
         <div className="status-of-funds__visualization-chart">
-            <StatusOfFundsChart data={data} fy={fy} />
-        </div>
-        <div className="status-of-funds__visualization-pagination">
-            <Pagination // TODO: replace mock props data with pagination data from API when endpoints are available
-                resultsText
-                changePage={() => {}}
-                currentPage={1}
-                pageSize={10}
-                totalItems={12} />
+            <StatusOfFundsChart fy={fy} results={results} />
         </div>
     </div>
 );

--- a/src/js/helpers/agencyV2/StatusOfFundsVizHelper.js
+++ b/src/js/helpers/agencyV2/StatusOfFundsVizHelper.js
@@ -1,0 +1,31 @@
+import BaseAgencySubcomponentsList from 'models/v2/agency/BaseAgencySubcomponentsList';
+
+// eslint-disable-next-line import/prefer-default-export
+export const parseRows = (data) => {
+    const dataAndTotalObligation = data.map((d) => {
+        let dataChildrenAndTotalObligation = [];
+        if (d.children && d.children.length > 0) {
+            dataChildrenAndTotalObligation = d.children.map((child) => ({
+                ...child
+            }));
+        }
+
+        if (dataChildrenAndTotalObligation.length > 0) {
+            return {
+                ...d,
+                children: dataChildrenAndTotalObligation
+            };
+        }
+
+        return {
+            ...d
+        };
+    });
+    const parsedData = dataAndTotalObligation.map((item) => {
+        const agencySubcomponents = Object.create(BaseAgencySubcomponentsList);
+        agencySubcomponents.populate(item);
+
+        return agencySubcomponents;
+    });
+    return parsedData;
+};

--- a/src/js/models/v2/agency/BaseAgencySubcomponentsList.js
+++ b/src/js/models/v2/agency/BaseAgencySubcomponentsList.js
@@ -1,0 +1,23 @@
+/**
+ * BaseAgencySubcomponentsList.js
+ * Created by Afna Saifudeen 12/14/21
+ */
+import { formatMoneyWithUnitsShortLabel } from 'helpers/moneyFormatter';
+
+const BaseAgencySubcomponentsList = {
+    populate(data) {
+        this.id = data?.id || '';
+        this.name = data?.name || '';
+        /* eslint-disable camelcase */
+        this._budgetaryResources = data?.total_budgetary_resources || 0;
+        this._obligations = data?.total_obligations || 0;
+    },
+    get budgetaryResources() {
+        return formatMoneyWithUnitsShortLabel(this._budgetaryResources, 1);
+    },
+    get obligations() {
+        return formatMoneyWithUnitsShortLabel(this._obligations, 1);
+    }
+};
+
+export default BaseAgencySubcomponentsList;

--- a/src/js/redux/actions/agencyV2/agencyV2Actions.js
+++ b/src/js/redux/actions/agencyV2/agencyV2Actions.js
@@ -60,6 +60,15 @@ export const resetSubagencyTotals = () => ({
     type: 'RESET_SUBAGENCY_TOTALS'
 });
 
+export const setAgencySubcomponents = (agencySubcomponentsList) => ({
+    type: 'SET_SUBCOMPONENTS_LIST',
+    agencySubcomponentsList
+});
+
+export const resetAgencySubcomponents = () => ({
+    type: 'RESET_SUBCOMPONENTS_LIST'
+});
+
 export const resetAgency = () => ({
     type: 'RESET_AGENCY'
 });

--- a/src/js/redux/reducers/agencyV2/agencyV2Reducer.js
+++ b/src/js/redux/reducers/agencyV2/agencyV2Reducer.js
@@ -6,6 +6,7 @@
 import BaseAgencyRecipients from 'models/v2/agency/BaseAgencyRecipients';
 import BaseAgencySubagencyCount from 'models/v2/agency/BaseAgencySubagencyCount';
 import BaseSubagencySpendingRow from 'models/v2/agency/BaseSubagencySpendingRow';
+import BaseAgencySubcomponentsList from 'models/v2/agency/BaseAgencySubcomponentsList';
 
 // Create an empty recipient object for the initial state
 const recipientDistribution = Object.create(BaseAgencyRecipients);
@@ -16,6 +17,9 @@ subagencyCount.populate();
 
 const spendingBySubagencyTotals = Object.create(BaseSubagencySpendingRow);
 spendingBySubagencyTotals.populate();
+
+const agencySubcomponentsList = Object.create(BaseAgencySubcomponentsList);
+agencySubcomponentsList.populate();
 
 export const initialState = {
     overview: {
@@ -29,7 +33,8 @@ export const initialState = {
     spendingBySubagencyTotals,
     agencySlugs: {},
     topTierCodes: {},
-    selectedSubcomponent: null
+    selectedSubcomponent: null,
+    agencySubcomponentsList
 };
 
 const agencyReducer = (state = initialState, action) => {
@@ -94,6 +99,16 @@ const agencyReducer = (state = initialState, action) => {
             return {
                 ...state,
                 spendingBySubagencyTotals: initialState.spendingBySubagencyTotals
+            };
+        case 'SET_SUBCOMPONENTS_LIST':
+            return {
+                ...state,
+                agencySubcomponentsList: action.agencySubcomponentsList
+            };
+        case 'RESET_SUBCOMPONENTS_LIST':
+            return {
+                ...state,
+                agencySubcomponentsList: initialState.agencySubcomponentsList
             };
         case 'RESET_AGENCY':
             return Object.assign({}, initialState);

--- a/tests/components/agency/visualizations/StatusOfFundsChart-test.jsx
+++ b/tests/components/agency/visualizations/StatusOfFundsChart-test.jsx
@@ -76,14 +76,23 @@ const toptierCode = '012';
 const name = 'Department of Agriculture';
 describe('Status of Funds Chart Viz Agency v2', () => {
     it('should display formatted amount used for max x axis value', () => {
-        render(<StatusOfFundsChart data={mockChartData} fy={fy} />);
+        render(<StatusOfFundsChart results={mockChartData.results} fy={fy} />);
         // set timeout to wait for expect() to pass after call to render
         setTimeout(() => {
             expect(screen.getByText('$9.1B').toBeInTheDocument());
         }, 1000);
     });
+    it('should display subcomponent names as y axis labels', () => {
+        render(<StatusOfFundsChart results={mockChartData.results} fy={fy} />);
+        // set timeout to wait for expect() to pass after call to render
+        setTimeout(() => {
+            for (let i = 0; i < mockChartData.results.length; i++) {
+                expect(screen.getByText(mockChartData.results[i].name).toBeInTheDocument());
+            }
+        }, 1000);
+    });
     it('should display fy, agency name, and level in chart title', () => {
-        render(<VisualizationSection agencyId={toptierCode} agencyName={name} fy={fy} data={mockChartData} level={0} />);
+        render(<VisualizationSection agencyId={toptierCode} agencyName={name} fy={fy} results={mockChartData.results} level={0} />);
         // set timeout to wait for expect() to pass after call to render
         setTimeout(() => {
             expect(screen.getByText(`${name} by Sub-Component for FY 2021`).toBeInTheDocument());

--- a/tests/models/agency/BaseAgencySubcomponentsList-test.js
+++ b/tests/models/agency/BaseAgencySubcomponentsList-test.js
@@ -1,0 +1,21 @@
+import BaseAgencySubcomponentsList from 'models/v2/agency/BaseAgencySubcomponentsList';
+
+// eslint-disable-next-line import/prefer-default-export
+export const mockSubcomponent = {
+    name: "Bureau of the Census",
+    id: "bureau_of_the_census",
+    total_budgetary_resources: 5000000,
+    total_obligations: 3000000.72
+};
+
+const subcomponent = Object.create(BaseAgencySubcomponentsList);
+subcomponent.populate(mockSubcomponent);
+
+describe('BaseAgencySubcomponentsList', () => {
+    it('should format the budgetary resources', () => {
+        expect(subcomponent.budgetaryResources).toEqual('$5.0M');
+    });
+    it('should format the obligations', () => {
+        expect(subcomponent.obligations).toEqual('$3.0M');
+    });
+});


### PR DESCRIPTION
**High level description:**

Replace mock data used to build status of funds chart with data from subcomponents endpoint.

**JIRA Ticket:**
[DEV-8118](https://federal-spending-transparency.atlassian.net/browse/DEV-8118)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)

Reviewer(s):
- [ ] Code review complete
