### PR TITLE
[DEV-8147] Fix CFDA autocomplete sorting

### DIFF
--- a/src/js/containers/search/filters/cfda/CFDAListContainer.jsx
+++ b/src/js/containers/search/filters/cfda/CFDAListContainer.jsx
@@ -6,7 +6,6 @@
 import React from 'react';
 import { isEqual, omit, differenceWith } from 'lodash';
 import { isCancel } from 'axios';
-import { Search, PrefixIndexStrategy } from 'js-search';
 import PropTypes from 'prop-types';
 
 import * as SearchHelper from 'helpers/searchHelper';
@@ -78,15 +77,8 @@ export default class CFDAListContainer extends React.Component {
 
             this.cfdaSearchRequest.promise
                 .then((res) => {
-                    const data = res.data.results;
+                    const results = res.data.results;
                     let autocompleteData = [];
-                    const search = new Search('program_number');
-                    // ordering by prefix if there are matches returned that begin w/ the exact text
-                    search.indexStrategy = new PrefixIndexStrategy();
-                    search.addIndex(['program_number']);
-                    search.addIndex(['program_title']);
-                    search.addDocuments(data);
-                    const results = search.search(this.state.cfdaSearchString);
 
                     // Filter out any selected CFDA that may be in the result set
                     const selectedCFDA =
@@ -97,7 +89,6 @@ export default class CFDAListContainer extends React.Component {
                     else {
                         autocompleteData = results;
                     }
-
                     this.setState({
                         noResults: autocompleteData.length === 0
                     });


### PR DESCRIPTION
**High level description:**
Removes use of js-search from the CFDA autocomplete component, since the backend is now sorting the results by program number and the sorting was not working on the frontend in the first place.

**Technical details:**
Removes the use of the `Search()` object and just returns the results from the API

**JIRA Ticket:**
[DEV-8147](https://federal-spending-transparency.atlassian.net/browse/DEV-8147)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)

Reviewer(s):
- [ ] Design review complete `if applicable`
- [x] Code review complete
