### PR TITLE
dev-8118 Status of funds Testing fix-- fix height of bars when pagination shows less than 10 results

### DIFF
--- a/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
@@ -204,7 +204,7 @@ const StatusOfFundsChart = ({ results, fy }) => {
         .style("font-family", 'Source Sans Pro')
         .call(isLargeScreen ? wrapTextMobile : wrapText, 270);
     const tickLabelsY = d3.selectAll(".y-axis-labels");
-    tickLabelsY.each(function removeTicks(d, i) {
+    tickLabelsY.each(function removeTicks(d) {
         if (!isNaN(d)) {
             d3.select(this).remove();
         }

--- a/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
@@ -137,7 +137,7 @@ const StatusOfFundsChart = ({ results, fy }) => {
     }
     if (sortedNums.length < 10) {
         for (let i = sortedNums.length; i < 10; i++) {
-            resultNames = resultNames.concat(' ');
+            resultNames.push(i);
         }
     }
     y.domain(resultNames);
@@ -203,6 +203,12 @@ const StatusOfFundsChart = ({ results, fy }) => {
         .style('fill', '#555')
         .style("font-family", 'Source Sans Pro')
         .call(isLargeScreen ? wrapTextMobile : wrapText, 270);
+    const tickLabelsY = d3.selectAll(".y-axis-labels");
+    tickLabelsY.each(function removeTicks(d, i) {
+        if (!isNaN(d)) {
+            d3.select(this).remove();
+        }
+    });
     svg.selectAll("horizontalGridlines")
         .attr('transform', tickMobileXAxis)
         .data(sortedNums)


### PR DESCRIPTION
**High level description:**
Testing find - fix bars height on pages with less than 10 results. Bars are currently too large 
Example agency (page 2 bars were too large) /agency_v2/department-of-commerce?fy=2021

**Technical details:**
Since bar heights scale relatively to the length of results array and chart height, we push descending numbers to the Y axis labels so they fill the height below

**JIRA Ticket:**
[DEV-8118](https://federal-spending-transparency.atlassian.net/browse/DEV-8118)

**Mockup:**
https://bahdigital.invisionapp.com/share/BSIAHSLA9PE#/screens

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a] Design review complete `if applicable`
- [n/a] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
