### PR TITLE
Dev-8118 Update subcomponents number in status of funds intro section

### DIFF
--- a/src/js/components/agencyV2/statusOfFunds/IntroSection.jsx
+++ b/src/js/components/agencyV2/statusOfFunds/IntroSection.jsx
@@ -10,10 +10,11 @@ import GlossaryLink from '../../sharedComponents/GlossaryLink';
 
 const propTypes = {
     fy: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired
+    name: PropTypes.string.isRequired,
+    totalItems: PropTypes.number
 };
 
-const IntroSection = ({ fy, name }) => {
+const IntroSection = ({ fy, name, totalItems }) => {
     const agencyBudget = useSelector((state) => state.agencyV2.budgetaryResources?.[fy]?.agencyBudget) || '--';
 
     return (
@@ -22,7 +23,7 @@ const IntroSection = ({ fy, name }) => {
                 How were funds distributed in FY {fy} for the {name}?
             </div>
             <div className="status-of-funds__intro-section-text" data-testid="introCopy" >
-                In FY {fy}, the {name} had {agencyBudget} in available <span className="status-of-funds__glossary-term">budgetary resources</span> <GlossaryLink term="budgetary-resources" /> distributed among its 12 agency sub-components. Agencies spend available budgetary resources by making financial promises called <span className="status-of-funds__glossary-term">obligations</span> <GlossaryLink term="obligation" />. In this section, we show the total budgetary resources broken out by agency sub-component and how much of that funding has been obligated.
+                In FY {fy}, the {name} had {agencyBudget} in available <span className="status-of-funds__glossary-term">budgetary resources</span> <GlossaryLink term="budgetary-resources" /> distributed among its {totalItems} agency sub-components. Agencies spend available budgetary resources by making financial promises called <span className="status-of-funds__glossary-term">obligations</span> <GlossaryLink term="obligation" />. In this section, we show the total budgetary resources broken out by agency sub-component and how much of that funding has been obligated.
             </div>
             <div className="status-of-funds__intro-section-italic-text">
                 Select a segment in the chart below to dive deeper into the data.

--- a/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
+++ b/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
@@ -103,7 +103,7 @@ const StatusOfFunds = ({ fy }) => {
     };
     return (
         <div className="body__content status-of-funds">
-            <IntroSection name={overview.name} fy={fy} />
+            <IntroSection name={overview.name} fy={fy} totalItems={totalItems} />
             <FlexGridRow hasGutter>
                 <FlexGridCol className="status-of-funds__drilldown-sidebar" desktop={3}>
                     <DrilldownSidebar

--- a/tests/components/agency/StatusOfFunds/IntroSection-test.jsx
+++ b/tests/components/agency/StatusOfFunds/IntroSection-test.jsx
@@ -11,7 +11,8 @@ import { render, screen } from '../../../testResources/test-utils';
 describe('Agency V2 Status of Funds IntroSection', () => {
     const mockProps = {
         fy: '2021',
-        name: 'Test Agency'
+        name: 'Test Agency',
+        totalItems: 15
     };
     const mockStore = {
         agencyV2: {
@@ -24,7 +25,7 @@ describe('Agency V2 Status of Funds IntroSection', () => {
     };
 
     const introSentence = `How were funds distributed in FY ${mockProps.fy} for the ${mockProps.name}?`;
-    const copy = `In FY ${mockProps.fy}, the ${mockProps.name} had ${mockStore.agencyV2.budgetaryResources["2021"].agencyBudget} in available budgetary resources  distributed among its 12 agency sub-components. Agencies spend available budgetary resources by making financial promises called obligations . In this section, we show the total budgetary resources broken out by agency sub-component and how much of that funding has been obligated.`;
+    const copy = `In FY ${mockProps.fy}, the ${mockProps.name} had ${mockStore.agencyV2.budgetaryResources["2021"].agencyBudget} in available budgetary resources  distributed among its ${mockProps.totalItems} agency sub-components. Agencies spend available budgetary resources by making financial promises called obligations . In this section, we show the total budgetary resources broken out by agency sub-component and how much of that funding has been obligated.`;
     const directions = 'Select a segment in the chart below to dive deeper into' +
         ' the data.';
 


### PR DESCRIPTION
**High level description:**

AC #3 was overlooked, this updates the intro section to use subcomponents total items value from API response.

**JIRA Ticket:**
[DEV-8118](https://federal-spending-transparency.atlassian.net/browse/DEV-81184)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a] Design review complete `if applicable`
- [n/a] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
