### PR TITLE
Component library update & DEV-8102

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6763,8 +6763,8 @@
             }
         },
         "data-transparency-ui": {
-            "version": "github:fedspendingtransparency/data-transparency-ui#aa5d48a874f03d26d890a9094b44fb9e53cfd1dc",
-            "from": "github:fedspendingtransparency/data-transparency-ui#v3.2.3",
+            "version": "github:fedspendingtransparency/data-transparency-ui#fa47e1bc601cb45de2018ed572e9685b25b21264",
+            "from": "github:fedspendingtransparency/data-transparency-ui#v3.2.4",
             "requires": {
                 "@fortawesome/fontawesome-svg-core": "^1.2.25",
                 "@fortawesome/free-brands-svg-icons": "^5.15.3",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         "d3-hierarchy": "^1.1.4",
         "d3-interpolate": "^1.1.4",
         "d3-scale": "^1.0.4",
-        "data-transparency-ui": "github:fedspendingtransparency/data-transparency-ui#v3.2.3",
+        "data-transparency-ui": "github:fedspendingtransparency/data-transparency-ui#v3.2.4",
         "date-fns": "^2.16.1",
         "file-loader": "^3.0.1",
         "history": "^4.6.1",

--- a/src/_scss/mixins/profilePage.scss
+++ b/src/_scss/mixins/profilePage.scss
@@ -1,0 +1,8 @@
+@mixin profile-page-wrap {
+    padding-left: 0;
+    padding-right: 0;
+    @media (min-width: $medium-screen) {
+        padding-left: 4rem;
+        padding-right: 4rem;
+    }
+}

--- a/src/_scss/pages/agencyV2/index.scss
+++ b/src/_scss/pages/agencyV2/index.scss
@@ -3,6 +3,7 @@
 	@import 'layouts/default/default';
 	@import 'components/pageLoading';
 	@import 'layouts/default/stickyHeader/header';
+    @import 'mixins/profilePage';
 
 	@include display(flex);
 	@include justify-content(flex-start);
@@ -86,10 +87,7 @@
             @import './statusOfFunds/statusOfFunds';
             @import 'components/Note';
             .default-note {
-                @media (min-width: $medium-screen) {
-                    padding-left: 4rem;
-                    padding-right: 4rem;
-                }
+                @include profile-page-wrap;
             }
         }
     }

--- a/src/_scss/pages/agencyV2/index.scss
+++ b/src/_scss/pages/agencyV2/index.scss
@@ -70,12 +70,6 @@
                     background-color: $color-white;
                 }
             }
-            .usda-section-title__container {
-                .usda-section-title__title-icon {
-                  margin-left: 0;
-                  width: 3.2rem;
-                }
-            }
             .body__content {
                 margin-top: rem(32);
                 .table-wrapper {

--- a/src/_scss/pages/agencyV2/overview/_overview.scss
+++ b/src/_scss/pages/agencyV2/overview/_overview.scss
@@ -1,8 +1,8 @@
 .agency-overview {
+    @import 'mixins/profilePage';
     @import './fySummary';
     .agency-overview__row {
-        padding-left: 4rem;
-        padding-right: 4rem;
+        @include profile-page-wrap;
         .usa-dt-flex-grid__col-4 {
             padding-left: 3.2rem;
         }

--- a/src/_scss/pages/agencyV2/statusOfFunds/_introSection.scss
+++ b/src/_scss/pages/agencyV2/statusOfFunds/_introSection.scss
@@ -1,9 +1,8 @@
+@import 'mixins/profilePage';
+
 .status-of-funds__intro-wrapper {
     padding-bottom: 4rem;
-    @media (min-width: $medium-screen) {
-        padding-left: 4rem;
-        padding-right: 4rem;
-    }
+    @include profile-page-wrap;
 }
 
 .status-of-funds__intro-section-title {

--- a/src/_scss/pages/covid19/index.scss
+++ b/src/_scss/pages/covid19/index.scss
@@ -109,7 +109,7 @@
         }
         .body__content {
           width: 100%; // Fixes an IE Flexbox bug
-          h3.body__narrative {
+          h4.body__narrative {
             text-align: left;
             font-weight: $font-semibold;
             font-size: 2rem;

--- a/src/_scss/pages/covid19/index.scss
+++ b/src/_scss/pages/covid19/index.scss
@@ -4,6 +4,7 @@
   @import "layouts/default/stickyHeader/header";
   @import "components/pageLoading";
   @import "./header";
+  @import "mixins/profilePage";
   
   @include display(flex);
   @include justify-content(flex-start);
@@ -112,7 +113,7 @@
             text-align: left;
             font-weight: $font-semibold;
             font-size: 2rem;
-            padding-left: 4.5rem;
+            @include profile-page-wrap;
           }
 
           .body__narrative-description {
@@ -120,7 +121,7 @@
             text-align: left;
             margin: auto;
             padding-bottom: 5rem;
-            padding-left: 4.5rem;
+            @include profile-page-wrap;
             .footnotes {
               font-size: $smallest-font-size;
               .usda-external-link {
@@ -270,7 +271,7 @@
           font-style: italic;
           letter-spacing: 0;
           line-height: 1.5rem;
-          padding-left: 5rem;
+          @include profile-page-wrap;
         }
         &.award_question {
           .body__header {

--- a/src/_scss/pages/covid19/index.scss
+++ b/src/_scss/pages/covid19/index.scss
@@ -195,6 +195,7 @@
             padding-left: 6.8rem;
             padding-right: 5rem;
             padding-top: 5rem;
+            margin: 0;
             @media (max-width: $tablet-screen) {
               padding-left: 6rem;
             }

--- a/src/_scss/pages/covid19/index.scss
+++ b/src/_scss/pages/covid19/index.scss
@@ -106,12 +106,6 @@
           background: $color-gray;
           border: none;
         }
-        .usda-section-title__container {
-          .usda-section-title__title-icon {
-            margin-left: 0;
-            width: 4rem;
-          }
-        }
         .body__content {
           width: 100%; // Fixes an IE Flexbox bug
           h3.body__narrative {

--- a/src/js/components/covid19/Heading.jsx
+++ b/src/js/components/covid19/Heading.jsx
@@ -18,12 +18,12 @@ const Heading = ({ publicLaw }) => {
     return (
         <div className={`heading__container ${publicLaw === 'american-rescue-plan' ? 'information-body-arp' : 'information-body'}`}>
             {publicLaw === 'american-rescue-plan' ?
-                <div className="heading__title">
+                <h2 className="heading__title">
                     The Federal Response to COVID-19: <span className="color-blue-arp">The American Rescue Plan</span>
-                </div> :
-                <div className="heading__title">
+                </h2> :
+                <h2 className="heading__title">
                     The Federal Response to <span className="color-purple">COVID-19</span>
-                </div>
+                </h2>
             }
             <div className="aligned-heading">
                 {publicLaw === 'american-rescue-plan' ?

--- a/src/js/components/covid19/amountsVisualization/AmountsVisualization.jsx
+++ b/src/js/components/covid19/amountsVisualization/AmountsVisualization.jsx
@@ -138,13 +138,13 @@ const AmountsVisualization = ({
                     items={[
                         <div>
                             {publicLaw === 'american-rescue-plan' ?
-                                <h3 className="body__narrative amounts-viz__title">
+                                <h4 className="body__narrative amounts-viz__title">
                                     This is how much was <strong>spent</strong> so far through the American Rescue Plan
-                                </h3>
+                                </h4>
                                 :
-                                <h3 className="body__narrative amounts-viz__title">
+                                <h4 className="body__narrative amounts-viz__title">
                                     This is how much was <strong>spent</strong> so far in response to COVID-19
-                                </h3>
+                                </h4>
                             }
                             <svg height={amountsHeight} width={width} className="amounts-viz__svg">
                                 <DefaultAmountViz
@@ -184,9 +184,9 @@ const AmountsVisualization = ({
                             }
                         </div>,
                         <div>
-                            <h3 className="body__narrative amounts-viz__title">
+                            <h4 className="body__narrative amounts-viz__title">
                                     Total Budgetary Resources
-                            </h3>
+                            </h4>
                             <svg height={amountsHeight} width={width} className="amounts-viz__svg">
                                 <DefaultAmountViz
                                     displayTooltip={displayTooltip}
@@ -205,9 +205,9 @@ const AmountsVisualization = ({
                             </div>
                         </div>,
                         <div>
-                            <h3 className="body__narrative amounts-viz__title">
+                            <h4 className="body__narrative amounts-viz__title">
                                     Total Obligations
-                            </h3>
+                            </h4>
                             <svg height={amountsHeight} width={width} className="amounts-viz__svg">
                                 <DefaultAmountViz
                                     displayTooltip={displayTooltip}
@@ -235,9 +235,9 @@ const AmountsVisualization = ({
                             </div>
                         </div>,
                         <div>
-                            <h3 className="body__narrative amounts-viz__title">
+                            <h4 className="body__narrative amounts-viz__title">
                                     Total Outlays
-                            </h3>
+                            </h4>
                             <svg height={amountsHeight} width={width} className="amounts-viz__svg">
                                 <DefaultAmountViz
                                     displayTooltip={displayTooltip}

--- a/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
+++ b/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
@@ -132,12 +132,12 @@ const SpendingByCFDA = ({ publicLaw, handleExternalLinkClick }) => {
         <div className="body__content assistance-listing">
             <DateNote />
             {publicLaw === 'american-rescue-plan' ?
-                <h3 className="body__narrative">
+                <h4 className="body__narrative">
                     <strong>Which CFDA Programs (Assistance Listings)</strong> supported the American Rescue Plan?
-                </h3> :
-                <h3 className="body__narrative">
+                </h4> :
+                <h4 className="body__narrative">
                     <strong>Which CFDA Programs (Assistance Listings)</strong> supported the response to COVID-19?
-                </h3>
+                </h4>
             }
             <div className="body__narrative-description">
                 <p>

--- a/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
+++ b/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
@@ -138,12 +138,12 @@ const AwardSpendingAgency = ({ publicLaw }) => {
         <div className="body__content spending-by-agency">
             <DateNote />
             {publicLaw === 'american-rescue-plan' ?
-                <h3 className="body__narrative">
+                <h4 className="body__narrative">
                     <strong>Which agencies</strong> issued awards using American Rescue Plan funds?
-                </h3> :
-                <h3 className="body__narrative">
+                </h4> :
+                <h4 className="body__narrative">
                     <strong>Which agencies</strong> issued awards using COVID-19 funds?
-                </h3>
+                </h4>
             }
             <div className="body__narrative-description">
                 {publicLaw === 'american-rescue-plan' ?

--- a/src/js/components/covid19/budgetCategories/BudgetCategories.jsx
+++ b/src/js/components/covid19/budgetCategories/BudgetCategories.jsx
@@ -115,9 +115,9 @@ const BudgetCategories = ({ publicLaw }) => {
         <div className="body__content budget-categories">
             <DateNote />
             {publicLaw === 'american-rescue-plan' ?
-                <h3 className="body__narrative">How is <strong>total spending</strong> from the American Rescue Plan categorized?</h3>
+                <h4 className="body__narrative">How is <strong>total spending</strong> from the American Rescue Plan categorized?</h4>
                 :
-                <h3 className="body__narrative">How is <strong>total COVID-19 spending</strong> categorized?</h3>
+                <h4 className="body__narrative">How is <strong>total COVID-19 spending</strong> categorized?</h4>
             }
             <div className="body__narrative-description">
                 {publicLaw === 'american-rescue-plan' ?

--- a/src/js/components/covid19/recipient/RecipientSection.jsx
+++ b/src/js/components/covid19/recipient/RecipientSection.jsx
@@ -28,12 +28,12 @@ const RecipientSection = ({ publicLaw }) => {
         <div className="body__content recipient__container">
             <DateNote />
             {publicLaw === 'american-rescue-plan' ?
-                <h3 className="body__narrative">
+                <h4 className="body__narrative">
                     <strong>Who</strong> received funding through American Rescue Plan awards?
-                </h3> :
-                <h3 className="body__narrative">
+                </h4> :
+                <h4 className="body__narrative">
                     <strong>Who</strong> received funding through COVID-19 awards?
-                </h3>
+                </h4>
             }
             <div className="body__narrative-description">
                 <p>


### PR DESCRIPTION
**High level description:**

During design review of [DEV-8171](https://federal-spending-transparency.atlassian.net/browse/DEV-8171), we determined that the styling for the Section Title component should be updated to better reflect the latest mockups so that the text in the title aligns with the profile page padded section content (in desktop). 
This PR:

- Updates USAS to use the version of the component library where the Section Title styling has been adjusted [PR #117](https://github.com/fedspendingtransparency/data-transparency-ui/pull/117)
- Standardizes padding around the text content between Agency v2 and Covid-19 Profiles, which resolves [DEV-8102](https://federal-spending-transparency.atlassian.net/browse/DEV-8102)
- Includes some accessibility improvements

**JIRA Ticket:**
[DEV-8102](https://federal-spending-transparency.atlassian.net/browse/DEV-8102)
also relates to [DEV-8171](https://federal-spending-transparency.atlassian.net/browse/DEV-8171)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Code review complete
