### PR TITLE
8266 - Reposition the agency v2 donut chart tooltip based on browser width

### DIFF
--- a/src/_scss/pages/agencyV2/visualizations/_obligationsByAwardType.scss
+++ b/src/_scss/pages/agencyV2/visualizations/_obligationsByAwardType.scss
@@ -16,6 +16,17 @@
             left: rem(60);
         }
     }
+
+    @media (min-width: 991px) and (max-width: 1200px) {
+        &.tooltip-wrapper .tooltip-spacer {
+            left: -15rem !important;
+        }
+
+        .tooltip-pointer.bottom {
+            left: 26rem !important;
+        }
+    }
+
     .obligations-by-award-type__chart {
         text.obligations-by-award-type__label {
             font-size: 1.2rem;
@@ -23,6 +34,9 @@
             font-weight: $font-semibold;
         }
         .obligations-by-award-type__donut {
+
+
+
             @include media($medium-screen) {
                 &:hover {
                     cursor: pointer;

--- a/src/_scss/pages/agencyV2/visualizations/_obligationsByAwardType.scss
+++ b/src/_scss/pages/agencyV2/visualizations/_obligationsByAwardType.scss
@@ -17,13 +17,13 @@
         }
     }
 
-    @media (min-width: 991px) and (max-width: 1200px) {
+    @media (min-width: 991px) and (max-width: 1400px) {
         &.tooltip-wrapper .tooltip-spacer {
-            left: -15rem !important;
+            left: -15rem;
         }
 
         .tooltip-pointer.bottom {
-            left: 26rem !important;
+            left: 26rem;
         }
     }
 

--- a/src/_scss/pages/agencyV2/visualizations/_obligationsByAwardType.scss
+++ b/src/_scss/pages/agencyV2/visualizations/_obligationsByAwardType.scss
@@ -1,3 +1,5 @@
+
+
 .obligations-by-award-type {
     // Tooltip wrapper
     width: 100%;
@@ -17,13 +19,19 @@
         }
     }
 
-    @media (min-width: 991px) and (max-width: 1400px) {
+    @media (max-width: 1400px) {
         &.tooltip-wrapper .tooltip-spacer {
             left: -15rem;
         }
 
         .tooltip-pointer.bottom {
-            left: 26rem;
+            left: 28rem;
+        }
+    }
+
+    @media (min-width: 1401px) {
+        .tooltip-pointer.bottom {
+            left: 18rem;
         }
     }
 


### PR DESCRIPTION
**High level description:**

Reposition agency v2 page donut chart tooltip and tooltip caret for 13" or smaller screen sizes.

**Technical details:**

Added css overrides to the tooltips that are using the 'obligations-by-award-type' class to reposition the tooltip and the tooltip caret based on the browser width.

**JIRA Ticket:**
[DEV-8266](https://federal-spending-transparency.atlassian.net/browse/DEV-8266)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)


Reviewer(s):
- [ ] Code review complete
