### PR TITLE
Fix/dev 8100 av2 invalid fy behavior

### DIFF
--- a/src/js/containers/account/WithLatestFy.jsx
+++ b/src/js/containers/account/WithLatestFy.jsx
@@ -83,6 +83,12 @@ export const useLatestAccountData = () => {
 export const useValidTimeBasedQueryParams = (currentUrlFy, currentUrlPeriod = null, requiredParams = ['fy', 'period']) => {
     const history = useHistory();
     const existingParams = useQueryParams();
+    if (existingParams.fy && !Number.isInteger(existingParams.fy)) {
+        existingParams.fy = null;
+    }
+    if (existingParams.period && !Number.isInteger(existingParams.period)) {
+        existingParams.period = null;
+    }
     const [, submissionPeriods, latestSubmission] = useLatestAccountData();
     const { year: latestFy, period: latestPeriod } = latestSubmission;
     const [{ period, fy }, setYearAndPeriod] = useState({ period: '', fy: '' });

--- a/src/js/containers/agencyV2/AgencyContainerV2.jsx
+++ b/src/js/containers/agencyV2/AgencyContainerV2.jsx
@@ -19,10 +19,10 @@ import AgencyPage from "components/agencyV2/AgencyPage";
 import { useAgencySlugs } from "./WithAgencySlugs";
 
 export const AgencyProfileV2 = () => {
-    if (location.search !== "") {
-        const checkQueryString = stripUrlParams(location.search, "fy");
-        if (checkQueryString !== location.search) {
-            const history = useHistory();
+    const history = useHistory();
+    if (window.location.search !== "") {
+        const checkQueryString = stripUrlParams(window.location.search, "fy");
+        if (checkQueryString !== window.location.search) {
             history.replace({
                 search: checkQueryString,
             });
@@ -111,7 +111,7 @@ export const AgencyProfileV2 = () => {
 };
 
 AgencyProfileV2.propTypes = {
-    history: PropTypes.object,
+    history: PropTypes.object
 };
 
 export default AgencyProfileV2;

--- a/src/js/containers/agencyV2/AgencyContainerV2.jsx
+++ b/src/js/containers/agencyV2/AgencyContainerV2.jsx
@@ -24,7 +24,7 @@ export const AgencyProfileV2 = () => {
         const checkQueryString = stripUrlParams(window.location.search, "fy");
         if (checkQueryString !== window.location.search) {
             history.replace({
-                search: checkQueryString,
+                search: checkQueryString
             });
         }
     }
@@ -105,8 +105,7 @@ export const AgencyProfileV2 = () => {
             agencySlug={agencySlug}
             isLoading={isLoading}
             isError={isError}
-            errorMessage={errorMessage}
-        />
+            errorMessage={errorMessage} />
     );
 };
 

--- a/src/js/containers/agencyV2/AgencyContainerV2.jsx
+++ b/src/js/containers/agencyV2/AgencyContainerV2.jsx
@@ -3,30 +3,41 @@
  * Created by Maxwell Kendall 01/31/2020
  */
 
-import React, { useState, useEffect, useRef } from 'react';
-import { useParams, Redirect } from 'react-router-dom';
-import { isCancel } from 'axios';
-import { useDispatch } from 'react-redux';
+import React, { useState, useEffect, useRef } from "react";
+import PropTypes from "prop-types";
+import { useHistory, useParams, Redirect } from "react-router-dom";
+import { isCancel } from "axios";
+import { useDispatch } from "react-redux";
 
-import { fetchAgencyOverview } from 'apis/agencyV2';
-import { useQueryParams } from 'helpers/queryParams';
-import BaseAgencyOverview from 'models/v2/agency/BaseAgencyOverview';
-import { setAgencyOverview, resetAgency } from 'redux/actions/agencyV2/agencyV2Actions';
+import { fetchAgencyOverview } from "apis/agencyV2";
+import { useQueryParams, stripUrlParams } from "helpers/queryParams";
+import BaseAgencyOverview from "models/v2/agency/BaseAgencyOverview";
+import { setAgencyOverview, resetAgency } from "redux/actions/agencyV2/agencyV2Actions";
 
-import { useValidTimeBasedQueryParams, useLatestAccountData } from 'containers/account/WithLatestFy';
-import AgencyPage from 'components/agencyV2/AgencyPage';
-import { useAgencySlugs } from './WithAgencySlugs';
+import { useValidTimeBasedQueryParams, useLatestAccountData } from "containers/account/WithLatestFy";
+import AgencyPage from "components/agencyV2/AgencyPage";
+import { useAgencySlugs } from "./WithAgencySlugs";
 
 export const AgencyProfileV2 = () => {
+    if (location.search !== "") {
+        const checkQueryString = stripUrlParams(location.search, "fy");
+        if (checkQueryString !== location.search) {
+            const history = useHistory();
+            history.replace({
+                search: checkQueryString,
+            });
+        }
+    }
     const { agencySlug } = useParams();
     const [, , { year: latestFy }] = useLatestAccountData();
-    const { fy: currentUrlFy } = useQueryParams(['fy']);
-    const [selectedFy, setSelectedFy] = useValidTimeBasedQueryParams(currentUrlFy, null, ['fy']);
+    const { fy: currentUrlFy } = useQueryParams(["fy"]);
+    const [selectedFy, setSelectedFy] = useValidTimeBasedQueryParams(currentUrlFy, null, ["fy"]);
+
     // Use a custom hook to get the { agency slug: toptier code } mapping, or request it if not yet available
     const [agencySlugs, , , slugsLoading, slugsError] = useAgencySlugs();
     const [isLoading, setLoading] = useState(true);
     const [isError, setError] = useState(false);
-    const [errorMessage, setErrorMessage] = useState('');
+    const [errorMessage, setErrorMessage] = useState("");
     const [redirect, setRedirect] = useState(false);
     const request = useRef(null);
     const dispatch = useDispatch();
@@ -39,7 +50,7 @@ export const AgencyProfileV2 = () => {
             }
             setLoading(true);
             setError(false);
-            setErrorMessage('');
+            setErrorMessage("");
             // request overview data for this agency
             request.current = fetchAgencyOverview(toptierCode, selectedFy);
             request.current.promise
@@ -48,7 +59,8 @@ export const AgencyProfileV2 = () => {
                     const agencyOverview = Object.create(BaseAgencyOverview);
                     agencyOverview.populate(res.data);
                     dispatch(setAgencyOverview(agencyOverview));
-                }).catch((err) => {
+                })
+                .catch((err) => {
                     if (!isCancel(err)) {
                         setError(true);
                         setErrorMessage(err.message);
@@ -66,20 +78,21 @@ export const AgencyProfileV2 = () => {
             const code = agencySlugs[agencySlug];
             if (code) {
                 setToptierCode(code);
-            }
-            else {
+            } else {
                 setRedirect(true);
             }
-        }
-        else if (slugsError) {
+        } else if (slugsError) {
             setError(true);
         }
     }, [agencySlugs, slugsLoading, slugsError]);
 
-    useEffect(() => () => {
-        // cleanup
-        dispatch(resetAgency());
-    }, [agencySlug]);
+    useEffect(
+        () => () => {
+            // cleanup
+            dispatch(resetAgency());
+        },
+        [agencySlug]
+    );
 
     if (redirect) {
         return <Redirect to="/404" />;
@@ -92,8 +105,13 @@ export const AgencyProfileV2 = () => {
             agencySlug={agencySlug}
             isLoading={isLoading}
             isError={isError}
-            errorMessage={errorMessage} />
+            errorMessage={errorMessage}
+        />
     );
+};
+
+AgencyProfileV2.propTypes = {
+    history: PropTypes.object,
 };
 
 export default AgencyProfileV2;

--- a/src/js/helpers/queryParams.js
+++ b/src/js/helpers/queryParams.js
@@ -8,3 +8,19 @@ export const combineQueryParams = (existingParams, newParams) => Object
     .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), existingParams);
 
 export const getQueryParamString = (obj) => `?${new URLSearchParams(obj).toString()}`;
+
+/**
+ * remove unrecognized URL parameters; update the history
+ * @param {string} queryString current URL query string to be processed (first char assumed to be "?")
+ * @param {string[]} allowedParams array of parameter names that are recognized (remove all others)
+ *
+ * returns same querystring with parameters not in allowedParams removed
+ */
+export const stripUrlParams = (queryString, allowedParams) => {
+    if (queryString.length < 2) {
+        return queryString;
+    }
+    const queryParams = queryString.slice(1).split('&');
+    const allowedQuery = queryParams.filter((i) => allowedParams.includes(i.slice(0, i.indexOf('='))));
+    return `?${allowedQuery.join('&')}`;
+};

--- a/tests/containers/account/WithLatestFy-test.js
+++ b/tests/containers/account/WithLatestFy-test.js
@@ -70,7 +70,8 @@ test.each([
     ['0000', '0', 2020, 12, ['fy', 'period']],
     [null, null, 2020, 12, ['fy', 'period']],
     ['2021', '0', 2020, 12, ['fy', 'period']],
-    ['2012', '14', 2020, 12, ['fy', 'period']]
+    ['2012', '14', 2020, 12, ['fy', 'period']],
+    ['2021cats', 'toast', 2020, 12, ['fy', 'period']]
 ])(
     'useValidTimeBasedQueryParams: when fy is %s and period is %s, URL is updated 👌👌👌',
     (currentFy, currentPeriod, latestFy, latestPeriod, requiredParams) => {

--- a/tests/helpers/queryParams-test.js
+++ b/tests/helpers/queryParams-test.js
@@ -3,7 +3,7 @@
  * Created by Maxwell Kendall
 */
 
-import { combineQueryParams } from 'helpers/queryParams';
+import { combineQueryParams, stripUrlParams } from 'helpers/queryParams';
 
 // NOTE: Not testing the helper fns that utilize URLSearchParams because that is not defined outside the browser.
 
@@ -12,4 +12,18 @@ test.each([
     [{ tab: '' }, { fy: '2020', period: '12' }, { fy: '2020', period: '12', tab: '' }]
 ])('combineQueryParams takes two objects and combines them as expected', (existingParams, newParams, rtrn) => {
     expect(combineQueryParams(existingParams, newParams)).toEqual(rtrn);
+});
+
+describe('queryParams', () => {
+    it('should remove invalid URL parameters', () => {
+        const queryString = '?a=1&b=2&three=beef_wellington';
+        const allowedParams = ['three', 'b', 'd'];
+        expect(stripUrlParams(queryString, allowedParams)).toEqual('?b=2&three=beef_wellington');
+    });
+
+    it('should not change if all parameters are valid', () => {
+        const queryString = '?a=1&b=2&three=beef_wellington';
+        const allowedParams = ['b', 'three', 'a'];
+        expect(stripUrlParams(queryString, allowedParams)).toEqual('?a=1&b=2&three=beef_wellington');
+    });
 });


### PR DESCRIPTION
**High level description:**
problems with agency v2 handling of invalid URL parameters

**Technical details:**

updates WithLatestFy to ignore non-integer values for FY and period parameters
adds query param helper function to validate query string against list of recognized parameters

**JIRA Ticket:**
[DEV-8100](https://federal-spending-transparency.atlassian.net/browse/DEV-8100)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [n/a ] Verified mobile/tablet/desktop/monitor responsiveness
- [n/a ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a ] Design review complete `if applicable`
- [n/a ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
