### PR TITLE
8265 update table link to agency v2 page

### DIFF
--- a/src/js/components/agencyLanding/table/cells/AgencyLinkCell.jsx
+++ b/src/js/components/agencyLanding/table/cells/AgencyLinkCell.jsx
@@ -7,16 +7,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import replaceString from 'helpers/replaceString';
 import { Link } from 'react-router-dom';
-
-const propTypes = {
-    name: PropTypes.string,
-    rowIndex: PropTypes.number,
-    column: PropTypes.string,
-    id: PropTypes.number,
-    agencySearchString: PropTypes.string
-};
+import GlobalConstants from 'GlobalConstants';
 
 export default class AgencyLinkCell extends React.Component {
+    static propTypes = {
+        name: PropTypes.string,
+        column: PropTypes.string,
+        id: PropTypes.number,
+        agencySearchString: PropTypes.string
+    };
+
     render() {
         let name = this.props.name;
         // highlight the matched string if applicable
@@ -27,7 +27,7 @@ export default class AgencyLinkCell extends React.Component {
         return (
             <div className={`agency-link-cell column-${this.props.column}`}>
                 <div className="cell-content">
-                    <Link to={`/agency/${this.props.id}`}>
+                    <Link to={`/${GlobalConstants.AGENCY_LINK}/${this.props.id}`}>
                         {name}
                     </Link>
                 </div>
@@ -35,5 +35,3 @@ export default class AgencyLinkCell extends React.Component {
         );
     }
 }
-
-AgencyLinkCell.propTypes = propTypes;

--- a/src/js/containers/agencyLanding/AgencyLandingContainer.jsx
+++ b/src/js/containers/agencyLanding/AgencyLandingContainer.jsx
@@ -153,7 +153,7 @@ export class AgencyLandingContainer extends React.Component {
             }
 
             const agency = {
-                agency_id: item.agency_id,
+                agency_id: item.agency_slug || item.agency_id,
                 agency_name: `${item.agency_name} ${abbreviation}`,
                 budget_authority_amount: item.budget_authority_amount,
                 percentage_of_total_budget_authority: item.percentage_of_total_budget_authority,


### PR DESCRIPTION
**High level description:**

change agency links on landing page to v2 format

**Technical details:**

uses slug instead of ID when available, uses global link

**JIRA Ticket:**
[DEV-8265](https://federal-spending-transparency.atlassian.net/browse/DEV-8265)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [n/a ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [n/a ] Verified mobile/tablet/desktop/monitor responsiveness
- [n/a ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a ] Design review complete `if applicable`
- [n/a ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
