### PR TITLE
8100 use parseInt for value comparison

### DIFF
--- a/src/js/containers/account/WithLatestFy.jsx
+++ b/src/js/containers/account/WithLatestFy.jsx
@@ -83,10 +83,12 @@ export const useLatestAccountData = () => {
 export const useValidTimeBasedQueryParams = (currentUrlFy, currentUrlPeriod = null, requiredParams = ['fy', 'period']) => {
     const history = useHistory();
     const existingParams = useQueryParams();
-    if (existingParams.fy && !Number.isInteger(existingParams.fy)) {
+    // eslint-disable-next-line eqeqeq
+    if (existingParams.fy && existingParams.fy != parseInt(existingParams.fy, 10)) {
         existingParams.fy = null;
     }
-    if (existingParams.period && !Number.isInteger(existingParams.period)) {
+    // eslint-disable-next-line eqeqeq
+    if (existingParams.period && existingParams.period != parseInt(existingParams.period, 10)) {
         existingParams.period = null;
     }
     const [, submissionPeriods, latestSubmission] = useLatestAccountData();


### PR DESCRIPTION
**High level description:**
when FY selected from picker, reverts to latest FY

**Technical details:**
change previous fix to use value comparison

**JIRA Ticket:**
[DEV-8100](https://federal-spending-transparency.atlassian.net/browse/DEV-8100)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [n/a ] Verified mobile/tablet/desktop/monitor responsiveness
- [n/a ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a ] Design review complete `if applicable`
- [n/a ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
