### PR TITLE
[DEV-8052] Status of funds click through functionality

### DIFF
--- a/src/_scss/pages/agencyV2/statusOfFunds/_visualizationSection.scss
+++ b/src/_scss/pages/agencyV2/statusOfFunds/_visualizationSection.scss
@@ -12,6 +12,11 @@
             height: 100% !important;
             width: 100% !important;
         }
+        .parent-g { visibility: hidden; rect#hlines { fill-opacity: 0; }}
+        .parent-g > * { visibility: visible; rect#hlines { fill-opacity: 0; }}
+        .parent-g > * { transition: opacity 150ms ease-in-out 100ms; }
+        .parent-g:hover > * { opacity: 0.4; }
+        .parent-g > *:hover { cursor: pointer; opacity: 1; transition-delay: 0ms, 0ms; rect#hlines { filter: drop-shadow(0px 3px 3px rgba(0, 0, 0, 0.4)); fill-opacity: 1; stroke: none }}
         text.y-axis-labels {
             font-size: rem(20);
             @media(max-width: 1499px) {

--- a/src/js/apis/agencyV2.js
+++ b/src/js/apis/agencyV2.js
@@ -52,3 +52,7 @@ export const fetchAgencySlugs = () => apiRequest({
 export const fetchSubcomponentsList = (code, fy, page) => apiRequest({
     url: `v2/agency/${code}/sub_components/${fy ? `?fiscal_year=${fy}` : ''}${page ? `&page=${page}` : ''}`
 });
+
+export const fetchFederalAccountsList = (code, slug, fy, page) => apiRequest({
+    url: `v2/agency/${code}/sub_components/${slug}/${fy ? `?fiscal_year=${fy}` : ''}${page ? `&page=${page}` : ''}`
+});

--- a/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
+++ b/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
@@ -35,6 +35,10 @@ const StatusOfFunds = ({ fy }) => {
     const [results, setResults] = useState([]);
     const { overview, selectedSubcomponent } = useSelector((state) => state.agencyV2);
 
+    const updateResults = (resData) => {
+        setResults(resData);
+    };
+
     useEffect(() => {
         if (request.current) {
             request.current.cancel();
@@ -114,7 +118,7 @@ const StatusOfFunds = ({ fy }) => {
                         selectedSubcomponent={selectedSubcomponent} />
                 </FlexGridCol>
                 <FlexGridCol className="status-of-funds__visualization" desktop={9}>
-                    { results.length !== 0 ? <VisualizationSection level={level} agencyId={overview.toptierCode} agencyName={overview.name} fy={fy} results={results} /> : <LoadingMessage /> }
+                    { results.length !== 0 ? <VisualizationSection level={level} agencyId={overview.toptierCode} agencyName={overview.name} fy={fy} results={results} updateResults={updateResults} /> : <LoadingMessage /> }
                     <Pagination
                         currentPage={currentPage}
                         changePage={changeCurrentPage}

--- a/src/js/components/agencyV2/statusOfFunds/VisualizationSection.jsx
+++ b/src/js/components/agencyV2/statusOfFunds/VisualizationSection.jsx
@@ -14,19 +14,21 @@ const propTypes = {
     agencyId: PropTypes.string,
     agencyName: PropTypes.string,
     fy: PropTypes.string,
-    results: PropTypes.array
+    results: PropTypes.array,
+    updateResults: PropTypes.func
 };
 
 const VisualizationSection = ({
     level,
     agencyName,
     fy,
-    results
+    results,
+    updateResults
 }) => (
     <div className="status-of-funds__visualization">
         <h6>{agencyName} by <strong>{levels[level]}</strong> for FY {fy}</h6>
         <div className="status-of-funds__visualization-chart">
-            <StatusOfFundsChart fy={fy} results={results} />
+            <StatusOfFundsChart fy={fy} results={results} updateResults={updateResults} />
         </div>
     </div>
 );

--- a/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
@@ -62,12 +62,14 @@ const StatusOfFundsChart = ({ results, fy, updateResults }) => {
             limit: pageSize,
             page: currentPage
         };
-        request.current = await fetchFederalAccountsList(overview.toptierCode, agencySlug, fy, params.page);
+        request.current = fetchFederalAccountsList(overview.toptierCode, agencySlug, fy, params.page);
         const federalAccountsRequest = request.current;
         federalAccountsRequest.promise
             .then((res) => {
                 const parsedData = parseRows(res.data.results);
                 setDrilldownResults(parsedData);
+                updateResults(parsedData);
+                console.log(parsedData);
                 dispatch(setFederalAccountsList(parsedData));
                 setTotalItems(res.data.page_metadata.total);
                 setLoading(false);
@@ -80,8 +82,6 @@ const StatusOfFundsChart = ({ results, fy, updateResults }) => {
 
     const handleClick = (id) => {
         fetchFederalAccounts(id);
-        updateResults(drilldownResults);
-        console.log('res', results);
     };
 
     useEffect(() => {

--- a/src/js/redux/actions/agencyV2/agencyV2Actions.js
+++ b/src/js/redux/actions/agencyV2/agencyV2Actions.js
@@ -70,6 +70,15 @@ export const resetAgencySubcomponents = () => ({
     type: 'RESET_SUBCOMPONENTS_LIST'
 });
 
+export const setFederalAccountsList = (agencyFederalAccountsList) => ({
+    type: 'SET_FEDERAL_ACC_LIST',
+    agencyFederalAccountsList
+});
+
+export const resetFederalAccountsList = () => ({
+    type: 'RESET_FEDERAL_ACC_LIST'
+});
+
 export const resetAgency = () => ({
     type: 'RESET_AGENCY'
 });

--- a/src/js/redux/reducers/agencyV2/agencyV2Reducer.js
+++ b/src/js/redux/reducers/agencyV2/agencyV2Reducer.js
@@ -112,6 +112,16 @@ const agencyReducer = (state = initialState, action) => {
                 ...state,
                 agencySubcomponentsList: initialState.agencySubcomponentsList
             };
+        case 'SET_FEDERAL_ACC_LIST':
+            return {
+                ...state,
+                agencySubcomponentsList: action.agencySubcomponentsList
+            };
+        case 'RESET_FEDERAL_ACC_LIST':
+            return {
+                ...state,
+                agencySubcomponentsList: initialState.agencySubcomponentsList
+            };
         case 'RESET_AGENCY':
             return Object.assign({}, initialState);
         default:


### PR DESCRIPTION
**High level description:**

As a user, I want to be able to drill down into a sub-component to see data broken down by federal account.

**Technical details:**
Updating parent state from child to make d3 fetch and rerender on click

**JIRA Ticket:**
[DEV-8052](https://federal-spending-transparency.atlassian.net/browse/DEV-8052)

**Mockup:**
https://bahdigital.invisionapp.com/share/BSIAHSLA9PE#/screens

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
