### PR TITLE
8234 - added end of IE content to infoBanner; set date to no longer s…

### DIFF
--- a/src/js/components/sharedComponents/header/Header.jsx
+++ b/src/js/components/sharedComponents/header/Header.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Cookies from 'js-cookie';
 import { Link } from 'react-router-dom';
+import { isBefore, startOfToday } from 'date-fns';
 
 import GlossaryContainer from 'containers/glossary/GlossaryContainer';
 import GlobalModalContainer from 'containers/globalModal/GlobalModalContainer';
@@ -16,7 +17,11 @@ const clickedHeaderLink = (route) => {
     });
 };
 
-const cookie = 'usaspending_covid_release';
+let cookie = 'usaspending_covid_release';
+if (isBefore(startOfToday(), new Date(2022, 1, 18))) {
+    cookie = 'usaspending_end_of_IE';
+    Cookies.set(cookie, 'showIEBanner');
+}
 
 export default class Header extends React.Component {
     constructor(props) {
@@ -31,10 +36,12 @@ export default class Header extends React.Component {
         this.openBannerModal = this.openBannerModal.bind(this);
     }
 
+    componentDidMount() {
+        this.setShowInfoBanner();
+    }
+
     setShowInfoBanner() {
-        // check if the info banner cookie exists
-        if (!Cookies.get(cookie)) {
-            // cookie does not exist, show the banner
+        if (Cookies.get(cookie) === 'showIEBanner') {
             this.setState({
                 showInfoBanner: true
             });
@@ -55,7 +62,7 @@ export default class Header extends React.Component {
     }
     closeBanner(bannerType) {
         // set a cookie to hide the banner in the future if banner is closed
-        Cookies.set(cookie, 'hide', { expires: 730 });
+        Cookies.set(cookie, 'hide', { expires: 7 });
         this.setState({
             [bannerType]: false
         });
@@ -65,6 +72,7 @@ export default class Header extends React.Component {
         e.preventDefault();
         this.props.showModal(null, 'covid');
     }
+
 
     render() {
         let infoBanner = (

--- a/src/js/components/sharedComponents/header/InfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/InfoBanner.jsx
@@ -30,7 +30,7 @@ export default class InfoBanner extends React.Component {
             </p>
         );
 
-        if (isBefore(startOfToday(), new Date(2022, 1, 17))) {
+        if (isBefore(startOfToday(), new Date(2022, 1, 18))) {
             title = 'USAspending Ending Support for Internet Explorer';
             content = (
                 <p>

--- a/src/js/components/sharedComponents/header/InfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/InfoBanner.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { isBefore, startOfToday } from "date-fns";
+import ExternalLink from 'components/sharedComponents/ExternalLink';
 
 const propTypes = {
     closeBanner: PropTypes.func,
@@ -20,13 +22,28 @@ export default class InfoBanner extends React.Component {
     }
 
     render() {
-        const title = 'New to USAspending: COVID-19 Spending Data';
-        const content = (
+        let title = 'New to USAspending: COVID-19 Spending Data';
+        let content = (
             <p>
             USAspending now has spending data from federal agencies related to the Coronavirus Aid, Relief, and Economic Security (CARES) Act and other COVID-19 appropriations.
                 <button onClick={this.props.triggerModal}> Learn more</button> about the new data and features, or <Link to="/disaster/covid-19">visit the profile page</Link> to explore and download the data today!
             </p>
         );
+
+        if (isBefore(startOfToday(), new Date(2022, 1, 17))) {
+            title = 'USAspending Ending Support for Internet Explorer';
+            content = (
+                <p>
+                    Support for Internet Explorer will end on Friday, 2/18/2022. Please use one of the following browsers to continue to access USAspending.gov:
+                    <ExternalLink url="https://support.microsoft.com/en-us/microsoft-edge/make-the-switch-from-internet-explorer-to-microsoft-edge-a6f7173e-e84a-36a3-9728-3df20ade9b3c">{' '}Microsoft Edge</ExternalLink>
+                    ,
+                    <ExternalLink url="https://support.google.com/chrome/answer/95417?hl=en&co=GENIE.Platform%3DDesktop">{' '}Google Chrome</ExternalLink>
+                    ,
+                    <ExternalLink url="https://www.mozilla.org/en-US/firefox/new/">{' '}Mozilla Firefox</ExternalLink>
+                    , Apple Safari.
+                </p>
+            );
+        }
 
         return (
             <div className="info-banner">

--- a/tests/components/sharedComponents/InfoBanner-test.jsx
+++ b/tests/components/sharedComponents/InfoBanner-test.jsx
@@ -24,10 +24,4 @@ describe('InfoBanner', () => {
         fireEvent.click(screen.getByTitle('Dismiss message'));
         expect(closeBanner).toHaveBeenCalled();
     });
-    describe('COVID-19 banner', () => {
-        it('should display again on 1/14/21', () => {
-            render(<InfoBanner {...mockProps} />);
-            expect(screen.queryByText('New to USAspending: COVID-19 Spending Data')).toBeTruthy();
-        });
-    });
 });


### PR DESCRIPTION
…how the banner; removed outdated test for infoBanner

**High level description:**

Show banner announcing end of support for IE browser.

**Technical details:**

Used the infoBanner component that has been used for messages before. Added new content for it and added a date to no longer show the banner.

**JIRA Ticket:**
[DEV-1234](https://federal-spending-transparency.atlassian.net/browse/DEV-8234)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
