### PR TITLE
8234 end of ie banner

### DIFF
--- a/src/js/components/sharedComponents/header/Header.jsx
+++ b/src/js/components/sharedComponents/header/Header.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Cookies from 'js-cookie';
 import { Link } from 'react-router-dom';
 import { isBefore, startOfToday } from 'date-fns';
+import { isIe } from "helpers/browser";
 
 import GlossaryContainer from 'containers/glossary/GlossaryContainer';
 import GlobalModalContainer from 'containers/globalModal/GlobalModalContainer';
@@ -18,7 +19,7 @@ const clickedHeaderLink = (route) => {
 };
 
 let cookie = 'usaspending_covid_release';
-if (isBefore(startOfToday(), new Date(2022, 1, 18))) {
+if (isIe() && isBefore(startOfToday(), new Date(2022, 1, 18))) {
     cookie = 'usaspending_end_of_IE';
     Cookies.set(cookie, 'showIEBanner');
 }

--- a/src/js/components/sharedComponents/header/InfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/InfoBanner.jsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { isBefore, startOfToday } from "date-fns";
+import { isIe } from "helpers/browser";
 import ExternalLink from 'components/sharedComponents/ExternalLink';
 
 const propTypes = {
@@ -30,7 +31,7 @@ export default class InfoBanner extends React.Component {
             </p>
         );
 
-        if (isBefore(startOfToday(), new Date(2022, 1, 18))) {
+        if (isIe() && isBefore(startOfToday(), new Date(2022, 1, 18))) {
             title = 'USAspending Ending Support for Internet Explorer';
             content = (
                 <p>


### PR DESCRIPTION
**High level description:**

This was returned by testing because the banner was showing in all browsers. It should only show in IE.

**Technical details:**

I added checks for IE in the if blocks that check the date.

**JIRA Ticket:**
[DEV-8234](https://federal-spending-transparency.atlassian.net/browse/DEV-8234)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
