### PR TITLE
Fix/dev 7946 recipient details invalid url parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13531,9 +13531,9 @@
             "dev": true
         },
         "json-schema": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
             "dev": true
         },
         "json-schema-traverse": {
@@ -13568,14 +13568,14 @@
             }
         },
         "jsprim": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+            "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
             "dev": true,
             "requires": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
+                "json-schema": "0.4.0",
                 "verror": "1.10.0"
             }
         },
@@ -21382,39 +21382,12 @@
             "dev": true
         },
         "wide-align": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+            "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
             "dev": true,
             "requires": {
-                "string-width": "^1.0.2 || 2"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^3.0.0"
-                    }
-                }
+                "string-width": "^1.0.2 || 2 || 3 || 4"
             }
         },
         "widest-line": {
@@ -21614,8 +21587,7 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "resolved": "",
                     "dev": true
                 },
                 "ansi-styles": {

--- a/src/js/containers/recipient/RecipientContainer.jsx
+++ b/src/js/containers/recipient/RecipientContainer.jsx
@@ -19,6 +19,8 @@ import RecipientPage from 'components/recipient/RecipientPage';
 
 require('pages/recipient/recipientPage.scss');
 
+const defaultFy = 'latest';
+
 export class RecipientContainer extends React.Component {
     static propTypes = {
         setRecipientOverview: PropTypes.func,
@@ -44,16 +46,18 @@ export class RecipientContainer extends React.Component {
     componentDidMount() {
         const params = this.props.match.params;
         if (Object.keys(params).includes('fy')) {
-            if (['latest', 'all'].includes(params.fy) || isFyValid(params.fy)) {
+            if ([defaultFy, 'all'].includes(params.fy) || isFyValid(params.fy)) {
                 this.props.setRecipientFiscalYear(params.fy);
                 this.loadRecipientOverview(params.recipientId, this.props.recipient.fy);
             }
             else {
-                this.props.history.replace(`/recipient/${this.props.match.params.recipientId}/latest`);
+                this.props.history.replace(`/recipient/${this.props.match.params.recipientId}/${defaultFy}`);
+                this.props.setRecipientFiscalYear(defaultFy);
+                this.loadRecipientOverview(params.recipientId, defaultFy);
             }
         }
         else {
-            this.props.history.replace(`/recipient/${this.props.match.params.recipientId}/latest`);
+            this.props.history.replace(`/recipient/${this.props.match.params.recipientId}/${defaultFy}`);
         }
     }
 
@@ -61,7 +65,7 @@ export class RecipientContainer extends React.Component {
         if (this.props.match.params.recipientId !== prevProps.match.params.recipientId) {
             // Reset the FY
             this.props.setRecipientFiscalYear(this.props.match.params.fy);
-            this.loadRecipientOverview(this.props.match.params.recipientId, 'latest');
+            this.loadRecipientOverview(this.props.match.params.recipientId, defaultFy);
         }
         if (prevProps.match.params.fy !== this.props.match.params.fy) {
             this.props.setRecipientFiscalYear(this.props.match.params.fy);
@@ -73,7 +77,7 @@ export class RecipientContainer extends React.Component {
 
     componentWillUnmount() {
         // Reset the FY
-        this.props.setRecipientFiscalYear('latest');
+        this.props.setRecipientFiscalYear(defaultFy);
         this.props.resetRecipient();
     }
 

--- a/src/js/containers/recipient/RecipientContainer.jsx
+++ b/src/js/containers/recipient/RecipientContainer.jsx
@@ -44,7 +44,7 @@ export class RecipientContainer extends React.Component {
     componentDidMount() {
         const params = this.props.match.params;
         if (Object.keys(params).includes('fy')) {
-            if (isFyValid(params.fy) || ['latest', 'all'].includes(params.fy)) {
+            if (['latest', 'all'].includes(params.fy) || isFyValid(params.fy)) {
                 this.props.setRecipientFiscalYear(params.fy);
                 this.loadRecipientOverview(params.recipientId, this.props.recipient.fy);
             }

--- a/src/js/helpers/fiscalYearHelper.js
+++ b/src/js/helpers/fiscalYearHelper.js
@@ -26,6 +26,11 @@ export const currentFiscalYear = () => {
     return currentFY;
 };
 
+export const isFyValid = (fy) => {
+    const fyVal = parseInt(fy, 10);
+    return !!fyVal && fyVal >= earliestFiscalYear;
+};
+
 export const convertFYToDateRange = (fy) => {
     const startingYear = fy - 1;
     const endingYear = fy;

--- a/tests/containers/recipient/RecipientContainer-test.jsx
+++ b/tests/containers/recipient/RecipientContainer-test.jsx
@@ -110,19 +110,6 @@ describe('RecipientContainer', () => {
 
         expect(mockActions.setRecipientFiscalYear).toHaveBeenCalledWith('2009');
     });
-    it('should default to latest fy if fy url param is invalid', () => {
-        jest.clearAllMocks();
-        const props = {
-            ...mockProps,
-            match: {
-                params: {
-                    fy: 'last'
-                }
-            }
-        };
-        mount(<RecipientContainer {...props} {...mockActions} />);
-        expect(mockActions.setRecipientFiscalYear).toHaveBeenCalledWith('latest');
-    });
     it('should make an API call when the fiscal year changes', async () => {
         const container = mount(<RecipientContainer
             {...mockProps}

--- a/tests/containers/recipient/RecipientContainer-test.jsx
+++ b/tests/containers/recipient/RecipientContainer-test.jsx
@@ -110,6 +110,19 @@ describe('RecipientContainer', () => {
 
         expect(mockActions.setRecipientFiscalYear).toHaveBeenCalledWith('2009');
     });
+    it('should default to latest fy if fy url param is invalid', () => {
+        jest.clearAllMocks();
+        const props = {
+            ...mockProps,
+            match: {
+                params: {
+                    fy: 'last'
+                }
+            }
+        };
+        mount(<RecipientContainer {...props} {...mockActions} />);
+        expect(mockActions.setRecipientFiscalYear).toHaveBeenCalledWith('latest');
+    });
     it('should make an API call when the fiscal year changes', async () => {
         const container = mount(<RecipientContainer
             {...mockProps}

--- a/tests/helpers/fiscalYearHelper-test.js
+++ b/tests/helpers/fiscalYearHelper-test.js
@@ -65,6 +65,20 @@ describe('Fiscal Year helper functions', () => {
         });
     });
 
+    describe('isFyValid', () => {
+        it('should recognize valid fiscal year values', () => {
+            expect(FiscalYearHelper.isFyValid(2008)).toEqual(true);
+            expect(FiscalYearHelper.isFyValid('2011')).toEqual(true);
+        });
+
+        it('should recognize invalid fiscal year values', () => {
+            expect(FiscalYearHelper.isFyValid(2007)).toEqual(false);
+            expect(FiscalYearHelper.isFyValid('2007')).toEqual(false);
+            expect(FiscalYearHelper.isFyValid('word')).toEqual(false);
+            expect(FiscalYearHelper.isFyValid()).toEqual(false);
+        });
+    });
+
     describe('convertFYtoDateRange', () => {
         it('should convert a given fiscal year to an array of start, end date strings', () => {
             const fy = '2016';


### PR DESCRIPTION
**High level description:**

fix someone manually changing fy param to invalid value (not a valid year, 'latest' or 'all')

**Technical details:**

just better checks on the param

**JIRA Ticket:**
[DEV-7946](https://federal-spending-transparency.atlassian.net/browse/DEV-7946)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [n/a ] Verified mobile/tablet/desktop/monitor responsiveness
- [n/a ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a ] Design review complete `if applicable`
- [n/a ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
