### PR TITLE
8301 - Ensure tooltip closes when mousing out from the donut chart

### DIFF
--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -84,6 +84,25 @@ export default function ObligationsByAwardType({
         .attr('class', 'obligations-by-award-type__donut')
         .attr('role', 'list');
 
+    // invisible outer ring to force tooltip to close when mousing out of the donut
+    chart.selectAll()
+        .data(pie)
+        .enter()
+        .append('path')
+        .attr('d', d3.arc()
+            .outerRadius(outerRadius + 75)
+            .innerRadius(outerRadius + 1))
+        .attr('fill', 'white')
+        .style('cursor', 'default')
+        .on('mouseenter', null)
+        .on('mouseenter', () => {
+            // store the award type of the section the user is hovering over
+            setActiveType(null);
+        })
+        .on('mouseleave', () => {
+            setActiveType(null);
+        });
+
     // outer ring.
     chart.selectAll()
         .data(pie)


### PR DESCRIPTION
**High level description:**

Ensure tooltip closes when mousing out from the donut chart.

**Technical details:**

The hit area for the outer ring is so small so the mouseout event to close the tooltip wasn't always getting captured.  I added a padding around the donut so if the user hovers on or over the padding, the tooltip will close.

**JIRA Ticket:**
[DEV-8301](https://federal-spending-transparency.atlassian.net/browse/DEV-8301)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Code review complete
