### PR TITLE
8313 - Fix the Status of Funds text size to remain constant when changing the browser width

### DIFF
--- a/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
@@ -22,7 +22,7 @@ const StatusOfFundsChart = ({
     const [isMobile, setIsMobile] = useState(window.innerWidth < 600);
     const [sortedNums, setSortedNums] = useState(null);
     const viewHeight = 760;
-    const viewWidth = 920;
+    const viewWidth = 1000;
     const margins = {
         top: 40, right: 10, bottom: 10, left: isLargeScreen ? 180 : 245
     };
@@ -57,7 +57,7 @@ const StatusOfFundsChart = ({
     // Wrap y axis labels - reference https://bl.ocks.org/mbostock/7555321
     function wrapText(text) {
         text.each(function w() {
-            const textWidth = chartRef.current.getBoundingClientRect().width * 0.315;
+            const textWidth = chartRef.current.getBoundingClientRect().width * 0.3125;
             const textNode = d3.select(this);
             const words = textNode.text().split(/\s+/).reverse();
             let word;

--- a/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
@@ -57,7 +57,7 @@ const StatusOfFundsChart = ({
     // Wrap y axis labels - reference https://bl.ocks.org/mbostock/7555321
     function wrapText(text) {
         text.each(function w() {
-            const textWidth = chartRef.current.getBoundingClientRect().width * 0.3125;
+            const textWidth = chartRef.current.getBoundingClientRect().width * 0.3;
             const textNode = d3.select(this);
             const words = textNode.text().split(/\s+/).reverse();
             let word;
@@ -184,7 +184,7 @@ const StatusOfFundsChart = ({
             .style("font-size", isMobile ? 36 : fontSizeScreenWidth())
             .style("font-family", 'Source Sans Pro')
             .style('fill', '#555')
-            .style('font-size', '1.4rem')
+            .style('font-size', '1.45rem')
             .attr("transform", `scale(${textScale} ${textScale})`);
 
         // d3 axis.ticks method does not precisely render tick count so we call a
@@ -228,7 +228,7 @@ const StatusOfFundsChart = ({
             .attr('aria-describedby', (d) => `y axis label-${d}`)
             .style('fill', '#555')
             .style("font-family", 'Source Sans Pro')
-            .style('font-size', '1.4rem')
+            .style('font-size', '1.45rem')
             .attr("transform", `scale(${textScale} ${textScale})`)
             .text((d) => truncateTextLabel(d))
             .call(isLargeScreen ? wrapTextMobile : wrapText);

--- a/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
@@ -153,7 +153,7 @@ const StatusOfFundsChart = ({
             .attr('transform', `translate(${isLargeScreen ? margins.left - 40 : margins.left}, ${margins.top})`);
 
         const tickMobileXAxis = isLargeScreen ? 'translate(-130,0)' : 'translate(90, 0)';
-        const tickMobileYAxis = isLargeScreen ? 'translate(-150,0)' : 'translate(60, 0)';
+        const tickMobileYAxis = isLargeScreen ? 'translate(-150,16)' : 'translate(60, 0)';
         // scale to x and y data points
         x.domain([0, Math.max(sortedNums[0]._budgetaryResources, sortedNums[0]._obligations)]);
         // extract sorted agency names

--- a/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
@@ -19,10 +19,10 @@ const StatusOfFundsChart = ({
     const [windowWidth, setWindowWidth] = useState(0);
 
     const [isLargeScreen, setIsLargeScreen] = useState(window.innerWidth < largeScreen);
-    const [isLargeFontBreak, setIsLargeFontBreak] = useState(window.innerWidth < 1501);
     const [isMobile, setIsMobile] = useState(window.innerWidth < 600);
+    const [sortedNums, setSortedNums] = useState(null);
     const viewHeight = 760;
-    const viewWidth = 1000;
+    const viewWidth = 920;
     const margins = {
         top: 40, right: 10, bottom: 10, left: isLargeScreen ? 180 : 245
     };
@@ -31,29 +31,33 @@ const StatusOfFundsChart = ({
     let resultNames = [];
     let resultIds = [];
 
+    const [textScale, setTextScale] = useState(viewWidth / viewWidth);
+
     const handleClick = (data) => {
         setLevel(1, data);
     };
 
     useEffect(() => {
+        setTextScale(viewWidth / chartRef.current.getBoundingClientRect().width);
+
         const handleResize = throttle(() => {
+            setTextScale(viewWidth / chartRef.current.getBoundingClientRect().width);
             const newWidth = window.innerWidth;
             if (windowWidth !== newWidth) {
                 setWindowWidth(newWidth);
                 setIsLargeScreen(newWidth < largeScreen);
-                setIsLargeFontBreak(newWidth < 1500);
                 setIsMobile(newWidth < 600);
             }
         }, 50);
         window.addEventListener('resize', handleResize);
         return () => window.removeEventListener('resize', handleResize);
-    }, [windowWidth]);
+    }, []);
 
 
     // Wrap y axis labels - reference https://bl.ocks.org/mbostock/7555321
-    function wrapText(text, width) {
+    function wrapText(text) {
         text.each(function w() {
-            const textWidth = isLargeFontBreak ? 310 : width;
+            const textWidth = chartRef.current.getBoundingClientRect().width * 0.315;
             const textNode = d3.select(this);
             const words = textNode.text().split(/\s+/).reverse();
             let word;
@@ -130,8 +134,6 @@ const StatusOfFundsChart = ({
     };
 
     const renderChart = () => {
-        const sortedNums = results.sort((a, b) => (a._budgetaryResources > b._obligations ? b._budgetaryResources - a._budgetaryResources : b._obligations - a._obligations));
-
         // setup x and y scales
         const y = scaleBand()
             .range([0, isMobile ? viewHeight * 2.3 : chartHeightYScale()])
@@ -181,7 +183,9 @@ const StatusOfFundsChart = ({
             .attr('dx', '0em')
             .style("font-size", isMobile ? 36 : fontSizeScreenWidth())
             .style("font-family", 'Source Sans Pro')
-            .style('fill', '#555');
+            .style('fill', '#555')
+            .style('font-size', '1.4rem')
+            .attr("transform", `scale(${textScale} ${textScale})`);
 
         // d3 axis.ticks method does not precisely render tick count so we call a
         // function on each tick to display 3 ticks for 20 results
@@ -224,8 +228,10 @@ const StatusOfFundsChart = ({
             .attr('aria-describedby', (d) => `y axis label-${d}`)
             .style('fill', '#555')
             .style("font-family", 'Source Sans Pro')
+            .style('font-size', '1.4rem')
+            .attr("transform", `scale(${textScale} ${textScale})`)
             .text((d) => truncateTextLabel(d))
-            .call(isLargeScreen ? wrapTextMobile : wrapText, 270);
+            .call(isLargeScreen ? wrapTextMobile : wrapText);
         const tickLabelsY = d3.selectAll(".y-axis-labels");
         tickLabelsY.each(function removeTicks(d) {
             if (!isNaN(d)) {
@@ -336,10 +342,17 @@ const StatusOfFundsChart = ({
     };
 
     useEffect(() => {
-        if (results?.length > 0) {
+        if (sortedNums?.length > 0) {
             renderChart();
         }
-    }, [results, isLargeScreen, isMobile]);
+    }, [sortedNums, textScale]);
+
+    useEffect(() => {
+        if (results?.length > 0) {
+            setSortedNums(results.sort((a, b) => (a._budgetaryResources > b._obligations ? b._budgetaryResources - a._budgetaryResources : b._obligations - a._obligations)));
+        }
+    }, [results]);
+
 
     return (
         <div id="sof_chart" className="status-of-funds__visualization" ref={chartRef} />


### PR DESCRIPTION
**High level description:**

Adjusted the text to makes it appear like the text isn't resizing when the browser is resized.  

**Technical details:**

The chart is a svg so the svg resizes as the browser is resized.  I created a "scale" that is (the initial width svg / the current width of the svg container based on the browser width).  And then applied a transform to the svg text.  The transform scales the text according to the above ratio to counteract any resizing.  This makes it appear like the text isn't resizing when the browser is resized.  

**JIRA Ticket:**
[DEV-8313](https://federal-spending-transparency.atlassian.net/browse/DEV-8313)

**Mockup:**
https://bahdigital.invisionapp.com/share/BSIAHSLA9PE#/screens/296066805

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Code review complete
