### PR TITLE
8282 - added slugs to IDV and FinancialAssistance data objects

### DIFF
--- a/src/js/GlobalConstants.js
+++ b/src/js/GlobalConstants.js
@@ -11,8 +11,7 @@ const filesServerUrlByEnv = {
 };
 
 const globalConstants = {
-    // API: process.env.USASPENDING_API,
-    API: 'https://qat-api.usaspending.gov/api/',
+    API: process.env.USASPENDING_API,
     LOCAL: false,
     PERF_LOG: false,
     MAPBOX_TOKEN: process.env.MAPBOX_TOKEN,

--- a/src/js/GlobalConstants.js
+++ b/src/js/GlobalConstants.js
@@ -11,7 +11,8 @@ const filesServerUrlByEnv = {
 };
 
 const globalConstants = {
-    API: process.env.USASPENDING_API,
+    // API: process.env.USASPENDING_API,
+    API: 'https://qat-api.usaspending.gov/api/',
     LOCAL: false,
     PERF_LOG: false,
     MAPBOX_TOKEN: process.env.MAPBOX_TOKEN,

--- a/src/js/models/v2/award/BaseFinancialAssistance.js
+++ b/src/js/models/v2/award/BaseFinancialAssistance.js
@@ -97,7 +97,8 @@ BaseFinancialAssistance.populate = function populate(data) {
             toptierAbbr: data.awarding_agency.toptier_agency.abbreviation || '',
             subtierName: data.awarding_agency.subtier_agency.name,
             subtierAbbr: data.awarding_agency.subtier_agency.abbreviation || '',
-            officeName: data.awarding_agency.office_agency_name
+            officeName: data.awarding_agency.office_agency_name,
+            agencySlug: data.awarding_agency.toptier_agency.slug
         };
         const awardingAgency = Object.create(CoreAwardAgency);
         awardingAgency.populateCore(awardingAgencyData);
@@ -115,7 +116,8 @@ BaseFinancialAssistance.populate = function populate(data) {
             toptierAbbr: data.funding_agency.toptier_agency.abbreviation || '',
             subtierName: data.funding_agency.subtier_agency.name,
             subtierAbbr: data.funding_agency.subtier_agency.abbreviation || '',
-            officeName: data.funding_agency.office_agency_name
+            officeName: data.funding_agency.office_agency_name,
+            agencySlug: data.funding_agency.toptier_agency.slug
         };
         const fundingAgency = Object.create(CoreAwardAgency);
         fundingAgency.populateCore(fundingAgencyData);

--- a/src/js/models/v2/award/BaseIdv.js
+++ b/src/js/models/v2/award/BaseIdv.js
@@ -93,7 +93,8 @@ BaseIdv.populate = function populate(data) {
             toptierAbbr: data.funding_agency.toptier_agency.abbreviation || '',
             subtierName: data.funding_agency.subtier_agency.name,
             subtierAbbr: data.funding_agency.subtier_agency.abbreviation || '',
-            officeName: data.funding_agency.office_agency_name
+            officeName: data.funding_agency.office_agency_name,
+            agencySlug: data.funding_agency.toptier_agency.slug
         };
         fundingAgency.populateCore(fundingAgencyData);
     }
@@ -108,7 +109,8 @@ BaseIdv.populate = function populate(data) {
             toptierAbbr: data.awarding_agency.toptier_agency.abbreviation || '',
             subtierName: data.awarding_agency.subtier_agency.name,
             subtierAbbr: data.awarding_agency.subtier_agency.abbreviation || '',
-            officeName: data.awarding_agency.office_agency_name
+            officeName: data.awarding_agency.office_agency_name,
+            agencySlug: data.awarding_agency.toptier_agency.slug
         };
         awardingAgency.populateCore(awardingAgencyData);
     }


### PR DESCRIPTION
**High level description:**

This ticket was returned because for non-Contract Awards (e.g. IDVs, Grants, Direct Payments, Loans, and Other) the agency link at the top of the page was returning 404 due to 'undefined' being in the url and the Awarding Agency and Funding Agency links in the Agency Details accordion in the Additional Information section were showing the agency names with no hyperlinks.

**Technical details:**

Added the slugs to the IDV and FinancialAssistance data objects.

**JIRA Ticket:**
[DEV-8282](https://federal-spending-transparency.atlassian.net/browse/DEV-8282)

**Mockup:**

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
