### PR TITLE
8243 - Fixed the agency v2 donut chart tab functionality

### DIFF
--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -159,7 +159,8 @@ export default function ObligationsByAwardType({
             })
             .on('blur', () => setActiveType(null))
             .attr('aria-label', (d) => `${d.data.label}: ${d3.format("($,.2f")(d.value)}`)
-            .attr('role', 'listitem');
+            .attr('role', 'listitem')
+            .attr('tabIndex', 0);
 
 
         // labels
@@ -217,10 +218,7 @@ export default function ObligationsByAwardType({
         }
     };
 
-    useEffect(() => {
-        renderChart();
-    },
-    []);
+    renderChart();
 
     useEffect(() => {
         const rect = chartRef.current.parentElement.getBoundingClientRect();

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -49,198 +49,187 @@ export default function ObligationsByAwardType({
     const [categoryHover, setCategoryHover] = useState(null);
     const chartRef = useRef();
 
+    const renderChart = () => {
+        const labelRadius = Math.min(chartHeight, chartWidth) / 2;
+        const outerRadius = labelRadius * 0.7;
+        const outerStrokeWidth = 3;
+        const innerRadius = outerRadius - (outerStrokeWidth * 2);
+
+        // clear & append the svg object to the div
+        d3.select('#obl_chart').selectAll('*').remove();
+        const svg = d3.select('#obl_chart')
+            .append('svg')
+            .attr('height', chartHeight)
+            .attr('width', chartWidth)
+            .append('g')
+            .attr('transform', `translate(${chartWidth / 2}, ${chartHeight / 2})`);
+
+        const pie = d3.pie()
+            .value((d) => d.value)
+            .sortValues(null)(inner);
+
+        // rotate chart so midpoints are 127deg off vertical
+        const rotationAxis = 357;
+        const rotation = rotationAxis - ((pie[0].endAngle / Math.PI) * 90); // rad => deg
+        const chart = svg
+            .append('g')
+            .attr('transform', `rotate (${rotation})`)
+            .attr('class', 'obligations-by-award-type__donut')
+            .attr('role', 'list');
+
+        // outer ring..
+        chart.selectAll()
+            .data(pie)
+            .enter()
+            .append('path')
+            .attr('d', d3.arc()
+                .outerRadius(outerRadius)
+                .innerRadius(outerRadius - outerStrokeWidth))
+            .attr('fill', (d, i) => {
+                const activeCategory = getCategoryNameByAwardType(activeType, categoryMapping);
+                const currentCategory = getCategoryNameByAwardType(inner[i].label, categoryMapping);
+                const currentCategoryId = getOuterCategoryId(currentCategory, outer);
+
+                // Use the faded color when another section is hovered over
+                if (activeType && !isMobile && activeCategory !== currentCategory) {
+                    return outer[currentCategoryId].fadedColor;
+                }
+                return outer[currentCategoryId].color;
+            })
+            .style('cursor', 'pointer')
+            .on('mouseenter', (d) => {
+                // store the award type of the section the user is hovering over
+                setActiveType(d.data.label);
+                setCategoryHover(mapToFullCategoryName(d.data.type));
+            })
+            .on('mouseleave', () => {
+                setActiveType(null);
+                setCategoryHover(null);
+            })
+            .attr('aria-label', (d) => `${d.data.label}: ${d3.format("($,.2f")(d.value)}`)
+            .attr('role', 'listitem');
+
+        // white ring
+        chart.selectAll()
+            .data(pie)
+            .enter()
+            .append('path')
+            .attr('d', d3.arc()
+                .outerRadius(outerRadius - outerStrokeWidth)
+                .innerRadius(innerRadius)
+            )
+            .attr('fill', 'white')
+            .style('cursor', 'pointer')
+            .on('mouseenter', (d) => {
+                // store the award type of the section the user is hovering over
+                setActiveType(d.data.label);
+            })
+            .on('mouseleave', () => {
+                setActiveType(null);
+            })
+            .attr('role', 'listitem');
+
+
+        // inner ring
+        chart.selectAll()
+            .data(pie)
+            .enter()
+            .append('path')
+            .attr('d', d3.arc()
+                .outerRadius(innerRadius)
+                .innerRadius(innerRadius / 2)
+            )
+            .attr('fill', (d, i) => {
+                if (categoryHover && categoryHover === mapToFullCategoryName(d.data.type) && !isMobile) {
+                    return inner[i].color;
+                }
+
+                // Use the faded color when another section is hovered over
+                return ((activeType && activeType !== inner[i].label) && !isMobile) ? inner[i].fadedColor : inner[i].color;
+            })
+            .style('cursor', 'pointer')
+            .on('mouseover', (d) => {
+                // store the award type of the section the user is hovering over
+                setActiveType(d.data.label);
+            })
+            .on('mouseout', () => setActiveType(null))
+            .on('focus', (d) => {
+                // store the award type of the section the user is hovering over
+                setActiveType(d.data.label);
+            })
+            .on('blur', () => setActiveType(null))
+            .attr('aria-label', (d) => `${d.data.label}: ${d3.format("($,.2f")(d.value)}`)
+            .attr('role', 'listitem');
+
+
+        // labels
+        const labelPos = (i, yOffset = 0) => {
+            if (i === 0) {
+                // Financial Assistance, bottom right
+                return [labelRadius - 62, ((chartHeight / 2) - 25) + yOffset];
+            }
+            // Contracts, top left
+            return [-(labelRadius) + 18, -(chartHeight / 2) + 29 + yOffset];
+        };
+
+        const outerLabels = outer.map((d) => d.label);
+
+        // Financial Assistance legend
+        if (outer[0].value > 0) {
+            // circle
+            svg.selectAll()
+                .data(pie)
+                .enter()
+                .append('circle')
+                .attr('cx', labelRadius - 70)
+                .attr('cy', (chartHeight / 2) - 29)
+                .attr('r', 4)
+                .style("fill", outer[0].color);
+            // text
+            svg.selectAll()
+                .data(outerLabels[0])
+                .enter()
+                .append('text')
+                .attr('transform', (d, i) => `translate(${labelPos(0, i * 12)})`)
+                .attr('class', 'obligations-by-award-type__label')
+                .text((d) => d);
+        }
+
+        // Contracts legend
+        if (outer[1].value > 0) {
+            // circle
+            svg.selectAll()
+                .data(pie)
+                .enter()
+                .append('circle')
+                .attr('cx', -labelRadius + 10)
+                .attr('cy', -(chartHeight / 2) + 25)
+                .attr('r', 4)
+                .style("fill", outer[1].color);
+            // text
+            svg.selectAll()
+                .data(outerLabels[1])
+                .enter()
+                .append('text')
+                .attr('transform', (d, i) => `translate(${labelPos(1, i * 12)})`)
+                .attr('class', 'obligations-by-award-type__label')
+                .text((d) => d);
+        }
+    };
+
+    useEffect(() => {
+        renderChart();
+    },
+    []);
+
     useEffect(() => {
         const rect = chartRef.current.parentElement.getBoundingClientRect();
         if (rect.height !== chartHeight || rect.width !== chartWidth) {
             setChartHeight(rect.height);
             setChartWidth(rect.width);
+            renderChart();
         }
     }, [windowWidth]);
-
-    const labelRadius = Math.min(chartHeight, chartWidth) / 2;
-    const outerRadius = labelRadius * 0.7;
-    const outerStrokeWidth = 3;
-    const innerRadius = outerRadius - (outerStrokeWidth * 2);
-
-    // clear & append the svg object to the div
-    d3.select('#obl_chart').selectAll('*').remove();
-    const svg = d3.select('#obl_chart')
-        .append('svg')
-        .attr('height', chartHeight)
-        .attr('width', chartWidth)
-        .append('g')
-        .attr('transform', `translate(${chartWidth / 2}, ${chartHeight / 2})`);
-
-    const pie = d3.pie()
-        .value((d) => d.value)
-        .sortValues(null)(inner);
-
-    // rotate chart so midpoints are 127deg off vertical
-    const rotationAxis = 357;
-    const rotation = rotationAxis - ((pie[0].endAngle / Math.PI) * 90); // rad => deg
-    const chart = svg
-        .append('g')
-        .attr('transform', `rotate (${rotation})`)
-        .attr('class', 'obligations-by-award-type__donut')
-        .attr('role', 'list');
-
-    // invisible outer ring to force tooltip to close when mousing out of the donut
-    chart.selectAll()
-        .data(pie)
-        .enter()
-        .append('path')
-        .attr('d', d3.arc()
-            .outerRadius(outerRadius + 75)
-            .innerRadius(outerRadius + 1))
-        .attr('fill', 'white')
-        .style('cursor', 'default')
-        .on('mouseenter', null)
-        .on('mouseenter', () => {
-            // store the award type of the section the user is hovering over
-            setActiveType(null);
-        })
-        .on('mouseleave', () => {
-            setActiveType(null);
-        });
-
-    // outer ring.
-    chart.selectAll()
-        .data(pie)
-        .enter()
-        .append('path')
-        .attr('d', d3.arc()
-            .outerRadius(outerRadius)
-            .innerRadius(outerRadius - outerStrokeWidth))
-        .attr('fill', (d, i) => {
-            const activeCategory = getCategoryNameByAwardType(activeType, categoryMapping);
-            const currentCategory = getCategoryNameByAwardType(inner[i].label, categoryMapping);
-            const currentCategoryId = getOuterCategoryId(currentCategory, outer);
-
-            // Use the faded color when another section is hovered over
-            if (activeType && !isMobile && activeCategory !== currentCategory) {
-                return outer[currentCategoryId].fadedColor;
-            }
-            return outer[currentCategoryId].color;
-        })
-        .style('cursor', 'pointer')
-        .on('mouseenter', (d) => {
-            // store the award type of the section the user is hovering over
-            setActiveType(d.data.label);
-            setCategoryHover(mapToFullCategoryName(d.data.type));
-        })
-        .on('mouseleave', () => {
-            setActiveType(null);
-            setCategoryHover(null);
-        })
-        .attr('aria-label', (d) => `${d.data.label}: ${d3.format("($,.2f")(d.value)}`)
-        .attr('role', 'listitem');
-
-    // white ring
-    chart.selectAll()
-        .data(pie)
-        .enter()
-        .append('path')
-        .attr('d', d3.arc()
-            .outerRadius(outerRadius - outerStrokeWidth)
-            .innerRadius(innerRadius)
-        )
-        .attr('fill', 'white')
-        .style('cursor', 'pointer')
-        .on('mouseenter', (d) => {
-            // store the award type of the section the user is hovering over
-            setActiveType(d.data.label);
-        })
-        .on('mouseleave', () => {
-            setActiveType(null);
-        })
-        .attr('role', 'listitem');
-
-
-    // inner ring
-    chart.selectAll()
-        .data(pie)
-        .enter()
-        .append('path')
-        .attr('d', d3.arc()
-            .outerRadius(innerRadius)
-            .innerRadius(innerRadius / 2)
-        )
-        .attr('fill', (d, i) => {
-            if (categoryHover && categoryHover === mapToFullCategoryName(d.data.type) && !isMobile) {
-                return inner[i].color;
-            }
-
-            // Use the faded color when another section is hovered over
-            return ((activeType && activeType !== inner[i].label) && !isMobile) ? inner[i].fadedColor : inner[i].color;
-        })
-        .style('cursor', 'pointer')
-        .on('mouseenter', (d) => {
-            // store the award type of the section the user is hovering over
-            setActiveType(d.data.label);
-        })
-        .on('mouseleave', () => setActiveType(null))
-        .attr('aria-label', (d) => `${d.data.label}: ${d3.format("($,.2f")(d.value)}`)
-        .attr('role', 'listitem')
-        .attr('tabindex', 0)
-        .on('focus', (d) => {
-            // store the award type of the section the user is hovering over
-            setActiveType(d.data.label);
-        });
-
-
-    // labels
-    const labelPos = (i, yOffset = 0) => {
-        if (i === 0) {
-            // Financial Assistance, bottom right
-            return [labelRadius - 62, ((chartHeight / 2) - 25) + yOffset];
-        }
-        // Contracts, top left
-        return [-(labelRadius) + 18, -(chartHeight / 2) + 29 + yOffset];
-    };
-
-    const outerLabels = outer.map((d) => d.label);
-
-    // Financial Assistance legend
-    if (outer[0].value > 0) {
-        // circle
-        svg.selectAll()
-            .data(pie)
-            .enter()
-            .append('circle')
-            .attr('cx', labelRadius - 70)
-            .attr('cy', (chartHeight / 2) - 29)
-            .attr('r', 4)
-            .style("fill", outer[0].color);
-        // text
-        svg.selectAll()
-            .data(outerLabels[0])
-            .enter()
-            .append('text')
-            .attr('transform', (d, i) => `translate(${labelPos(0, i * 12)})`)
-            .attr('class', 'obligations-by-award-type__label')
-            .text((d) => d);
-    }
-
-    // Contracts legend
-    if (outer[1].value > 0) {
-        // circle
-        svg.selectAll()
-            .data(pie)
-            .enter()
-            .append('circle')
-            .attr('cx', -labelRadius + 10)
-            .attr('cy', -(chartHeight / 2) + 25)
-            .attr('r', 4)
-            .style("fill", outer[1].color);
-        // text
-        svg.selectAll()
-            .data(outerLabels[1])
-            .enter()
-            .append('text')
-            .attr('transform', (d, i) => `translate(${labelPos(1, i * 12)})`)
-            .attr('class', 'obligations-by-award-type__label')
-            .text((d) => d);
-    }
 
     return (
         <TooltipWrapper

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -77,7 +77,26 @@ export default function ObligationsByAwardType({
             .attr('class', 'obligations-by-award-type__donut')
             .attr('role', 'list');
 
-        // outer ring..
+        // invisible outer ring to force tooltip to close when mousing out of the donut
+        chart.selectAll()
+            .data(pie)
+            .enter()
+            .append('path')
+            .attr('d', d3.arc()
+                .outerRadius(outerRadius + 75)
+                .innerRadius(outerRadius + 1))
+            .attr('fill', 'white')
+            .style('cursor', 'default')
+            .on('mouseenter', null)
+            .on('mouseenter', () => {
+                // store the award type of the section the user is hovering over
+                setActiveType(null);
+            })
+            .on('mouseleave', () => {
+                setActiveType(null);
+            });
+
+        // outer ring.
         chart.selectAll()
             .data(pie)
             .enter()
@@ -159,8 +178,7 @@ export default function ObligationsByAwardType({
             })
             .on('blur', () => setActiveType(null))
             .attr('aria-label', (d) => `${d.data.label}: ${d3.format("($,.2f")(d.value)}`)
-            .attr('role', 'listitem')
-            .attr('tabIndex', 0);
+            .attr('role', 'listitem');
 
 
         // labels
@@ -218,14 +236,17 @@ export default function ObligationsByAwardType({
         }
     };
 
-    renderChart();
+    useEffect(() => {
+        if (chartWidth && chartHeight) {
+            renderChart();
+        }
+    }, [chartWidth, chartHeight]);
 
     useEffect(() => {
         const rect = chartRef.current.parentElement.getBoundingClientRect();
         if (rect.height !== chartHeight || rect.width !== chartWidth) {
             setChartHeight(rect.height);
             setChartWidth(rect.width);
-            renderChart();
         }
     }, [windowWidth]);
 

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardType.jsx
@@ -178,7 +178,8 @@ export default function ObligationsByAwardType({
             })
             .on('blur', () => setActiveType(null))
             .attr('aria-label', (d) => `${d.data.label}: ${d3.format("($,.2f")(d.value)}`)
-            .attr('role', 'listitem');
+            .attr('role', 'listitem')
+            .attr('tabIndex', 0);
 
 
         // labels

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/TotalObligationsOverTimeVisualization.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/TotalObligationsOverTimeVisualization.jsx
@@ -62,6 +62,7 @@ const TotalObligationsOverTimeVisualization = ({
     useEffect(() => {
         // start of the domain is October 1st of the prior selected fiscal year midnight local time
         const start = new Date(parseInt(fy, 10) - 1, 9, 1);
+        console.log(start);
         // end of the domain is September 30th midnight local time
         const end = new Date(`${fy}`, 8, 30);
         setXDomain([getMilliseconds(start), getMilliseconds(end)]);


### PR DESCRIPTION
**High level description:**
Enabled tabbing through each individual arc of the donut chart.  Showing the tooltip on tab into an arc / hide the tooltip on tab out.

**Technical details:**

Added on focus and on blur listeners and event handlers to enable tabbing through the arcs in the donut chart.  However, Every time you mouseover and keypress into the chart, the 'activeType' state is getting updated so the chart tries to re-render.  When you mouseout activeType is cleared and react tries to flush the updates while react is already in a render cycle. So we get this error in the console - Warning: unstable_flushDiscreteUpdates: Cannot flush updates when React is already rendering. I fixed this by putting the d3 code in a function and only re-render the chart after chart height and chart width states have changed.

Technical details for the knowledge of other developers.

**JIRA Ticket:**
[DEV-8243](https://federal-spending-transparency.atlassian.net/browse/DEV-8243)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
applicable`

Reviewer(s):
- [ ] Code review complete
