### PR TITLE
dev-8052 bug fix prevent enter keypress at subcomponent level

### DIFF
--- a/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
@@ -291,6 +291,7 @@ const StatusOfFundsChart = ({
         if (level === 1) {
             svg.selectAll(".y-axis-labels").attr("aria-label", (d) => `Link to ${d}`); // Add aria label for screenreaders to detect links
             svg.selectAll(".bar-group").on('click', null);
+            svg.selectAll(".bar-group").on('keypress', null);
             for (let i = 0; i < sortedNums.length; i++) {
                 resultIds = resultIds.concat(sortedNums[i].id);
             }


### PR DESCRIPTION
**High level description:**
Testing fix - we should not be able to drilldown further at the subcomponent level. There was already a line to nullify the onclick handler so added another line to nullify on keypress


**JIRA Ticket:**
[DEV-8052](https://federal-spending-transparency.atlassian.net/browse/DEV-8052)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Code review complete
