### PR TITLE
8243 - Show tooltip for total time obligation chart on tab

### DIFF
--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/AgencyBudgetLine.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/AgencyBudgetLine.jsx
@@ -82,6 +82,8 @@ const AgencyBudgetLine = ({
         <g
             onMouseEnter={() => { setHoveredRectangle(true); toggleTooltipVisibility(true); }}
             onMouseLeave={() => { setHoveredRectangle(false); toggleTooltipVisibility(false); }}
+            onFocus={() => { setHoveredRectangle(true); toggleTooltipVisibility(true); }}
+            onBlur={() => { setHoveredRectangle(false); toggleTooltipVisibility(false); }}
             className="bar-chart__item">
             <line
                 tabIndex="0"

--- a/src/js/components/agencyV2/visualizations/totalObligationsOverTime/TotalObligationsOverTimeVisualization.jsx
+++ b/src/js/components/agencyV2/visualizations/totalObligationsOverTime/TotalObligationsOverTimeVisualization.jsx
@@ -62,7 +62,6 @@ const TotalObligationsOverTimeVisualization = ({
     useEffect(() => {
         // start of the domain is October 1st of the prior selected fiscal year midnight local time
         const start = new Date(parseInt(fy, 10) - 1, 9, 1);
-        console.log(start);
         // end of the domain is September 30th midnight local time
         const end = new Date(`${fy}`, 8, 30);
         setXDomain([getMilliseconds(start), getMilliseconds(end)]);


### PR DESCRIPTION
**High level description:**

Users should be able to view the tooltip for the total time over obligations chart by the keyboard

**Technical details:**

Added onfocus and onblur event listeners/handlers to show the tooltip on tab.

**JIRA Ticket:**
[DEV-8234](https://federal-spending-transparency.atlassian.net/browse/DEV-8234)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Code review complete
