### PR TITLE
dev-8319 remove federal account hyperlinks from status of funds chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4130,9 +4130,9 @@
             },
             "dependencies": {
                 "follow-redirects": {
-                    "version": "1.14.4",
-                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-                    "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
+                    "version": "1.14.7",
+                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+                    "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
                 }
             }
         },
@@ -8699,9 +8699,9 @@
             }
         },
         "follow-redirects": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-            "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+            "version": "1.14.7",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
             "dev": true
         },
         "for-in": {

--- a/src/_scss/pages/agencyV2/statusOfFunds/_visualizationSection.scss
+++ b/src/_scss/pages/agencyV2/statusOfFunds/_visualizationSection.scss
@@ -31,10 +31,7 @@
         .parent-g > * { transition: opacity 150ms ease-in-out 100ms; }
         .parent-g:hover > * { opacity: 0.4; }
         .parent-g > *:hover { cursor: pointer; opacity: 1; transition-delay: 0ms, 0ms; rect#hlines { filter: drop-shadow(0px 8px 16px rgba(0, 0, 0, 0.1)); fill-opacity: 1; stroke: 1px }}
-        text#tick-labels-links:hover{
-            text-decoration: underline;
-            cursor: pointer;
-        }
+
         text.y-axis-labels {
             font-size: rem(20);
             @media(max-width: 1499px) {

--- a/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
@@ -29,7 +29,6 @@ const StatusOfFundsChart = ({
     const chartHeight = viewHeight - margins.top - margins.bottom;
     const chartWidth = viewWidth - margins.left - margins.right;
     let resultNames = [];
-    let resultIds = [];
 
     const [textScale, setTextScale] = useState(viewWidth / viewWidth);
 
@@ -289,22 +288,8 @@ const StatusOfFundsChart = ({
         svg.selectAll(".y-axis-labels").append("svg:title")
             .text((d) => d);
         if (level === 1) {
-            svg.selectAll(".y-axis-labels").attr("aria-label", (d) => `Link to ${d}`); // Add aria label for screenreaders to detect links
             svg.selectAll(".bar-group").on('click', null);
             svg.selectAll(".bar-group").on('keypress', null);
-            for (let i = 0; i < sortedNums.length; i++) {
-                resultIds = resultIds.concat(sortedNums[i].id);
-            }
-            svg.selectAll(".y-axis-labels").style('fill', '#0071bc');
-            svg.selectAll(".y-axis-labels").attr('id', 'tick-labels-links');
-            svg.selectAll(".y-axis-labels").on("click", (d, i) => {
-                window.open(`/federal_account/${resultIds[i]}`);
-            });
-            svg.selectAll(".y-axis-labels").on("keypress", (d, i) => { // tab through and enter/space functionality
-                if (d3.event.keyCode === 13 || d3.event.keyCode === 32) {
-                    window.open(`/federal_account/${resultIds[i]}`);
-                }
-            });
         }
         // horizontal border above legend
         svg.append('line')


### PR DESCRIPTION
**High level description:**

Due to data reasons, we’d like to remove the hyperlinks on the graphic on the Status of Funds graphic on the Agency V2 issue. 

**Technical details:**

Undo updates made in [dev-8053](https://github.com/fedspendingtransparency/usaspending-website/pull/2863/commits/079c7c51b77702bb3060bc09684700af2fa98bdd) 

**JIRA Ticket:**
[DEV-8319](https://federal-spending-transparency.atlassian.net/browse/DEV-8319)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Code review complete
