### PR TITLE
8318 - In Agency v2 award spending table, added office code to office name

### DIFF
--- a/src/js/dataMapping/agency/tableColumns.js
+++ b/src/js/dataMapping/agency/tableColumns.js
@@ -85,7 +85,7 @@ export const accountColumns = {
 export const subagencyColumns = [
     {
         title: 'name',
-        displayName: 'Agency Name'
+        displayName: 'Sub-Agency Name'
     },
     {
         title: 'totalObligations',

--- a/src/js/helpers/agencyV2/AwardSpendingSubagencyHelper.js
+++ b/src/js/helpers/agencyV2/AwardSpendingSubagencyHelper.js
@@ -1,4 +1,5 @@
 import BaseSubagencySpendingRow from 'models/v2/agency/BaseSubagencySpendingRow';
+import BaseSubagencySpendingRowChildren from 'models/v2/agency/BaseSubagencySpendingRowChildren';
 
 // eslint-disable-next-line import/prefer-default-export
 export const parseRows = (data) => {
@@ -25,12 +26,12 @@ export const parseRows = (data) => {
     // parse row and row's children
     const parsedData = dataAndTotalObligation.map((item) => {
         const subagencyTotalsRow = Object.create(BaseSubagencySpendingRow);
-        subagencyTotalsRow.populate(item);
+        subagencyTotalsRow.populateCore(item);
 
         let rowChildren = [];
         if (item.children && item.children.length > 0) {
             rowChildren = item.children.map((childItem) => {
-                const subagencyTotalsRowChild = Object.create(BaseSubagencySpendingRow);
+                const subagencyTotalsRowChild = Object.create(BaseSubagencySpendingRowChildren);
                 subagencyTotalsRowChild.populate(childItem);
                 return subagencyTotalsRowChild;
             });

--- a/src/js/models/v2/agency/BaseSubagencySpendingRow.js
+++ b/src/js/models/v2/agency/BaseSubagencySpendingRow.js
@@ -1,7 +1,7 @@
 import { formatMoney, formatNumber } from 'helpers/moneyFormatter';
 
 const BaseSubagencySpendingRow = {
-    populate(data) {
+    populateCore(data) {
         this.name = data?.name || '--';
         // eslint-disable-next-line camelcase
         this._newAwardCount = data?.new_award_count || 0;

--- a/src/js/models/v2/agency/BaseSubagencySpendingRowChildren.js
+++ b/src/js/models/v2/agency/BaseSubagencySpendingRowChildren.js
@@ -1,0 +1,10 @@
+import BaseSubagencySpendingRow from './BaseSubagencySpendingRow';
+
+const BaseSubagencySpendingRowChildren = Object.create(BaseSubagencySpendingRow);
+
+BaseSubagencySpendingRowChildren.populate = function populate(data) {
+    this.populateCore(data);
+    this.name = `${data?.name} (${data?.code})`;
+};
+
+export default BaseSubagencySpendingRowChildren;

--- a/src/js/redux/reducers/agencyV2/agencyV2Reducer.js
+++ b/src/js/redux/reducers/agencyV2/agencyV2Reducer.js
@@ -16,7 +16,7 @@ const subagencyCount = Object.create(BaseAgencySubagencyCount);
 subagencyCount.populate();
 
 const spendingBySubagencyTotals = Object.create(BaseSubagencySpendingRow);
-spendingBySubagencyTotals.populate();
+spendingBySubagencyTotals.populateCore();
 
 const agencySubcomponentsList = Object.create(BaseAgencySubcomponentsList);
 agencySubcomponentsList.populate();

--- a/tests/helpers/agencyV2/visualizations/ObligationsByAwardTypeHelper-test.js
+++ b/tests/helpers/agencyV2/visualizations/ObligationsByAwardTypeHelper-test.js
@@ -1,5 +1,5 @@
 /**
- * ObligationsByAwardTypeHelper.js
+ * ObligationsByAwardTypeHelper-test.js
  * Created by Andrea Blackwell 12/15/2021
  */
 

--- a/tests/models/agency/BaseSubagencySpendingRow-test.js
+++ b/tests/models/agency/BaseSubagencySpendingRow-test.js
@@ -25,7 +25,7 @@ export const mockAwardSpendingRow = {
 
 
 const awardSpendingRow = Object.create(BaseSubagencySpendingRow);
-awardSpendingRow.populate(mockAwardSpendingRow);
+awardSpendingRow.populateCore(mockAwardSpendingRow);
 
 describe('BaseSubagencySpendingRow', () => {
     it('should store the name', () => {


### PR DESCRIPTION
**High level description:**

In the Agency V2 award spending table, added office code to the office name so the office name is formatted “Office Name (Office Code)”

**Technical details:**

Added new model for subagency row children (ie. for offices) since the office codes were added to the data.  Changed the office name to “Office Name (Office Code)”. Also Jessica asked the frontend to change the table column "Agency Name" to Sub-Agency Name" (see [DEV-8293](https://federal-spending-transparency.atlassian.net/browse/DEV-8293)) so I did that too.

Please note to review, please use the staging API in GlobalConstants to get the correct data
```
const globalConstants = {
    API: 'https://staging-api.usaspending.gov/api/',
```

**JIRA Ticket:**
[DEV-8318](https://federal-spending-transparency.atlassian.net/browse/DEV-8318)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
- [ ] Code review complete
