### PR TITLE
8340 - HOTFIX-Remove additional Agency V1 links from Award Profile page

### DIFF
--- a/src/js/components/award/idv/activity/ActivityChartTooltip.jsx
+++ b/src/js/components/award/idv/activity/ActivityChartTooltip.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { throttle } from 'lodash';
+// eslint-disable-next-line no-unused-vars
 import { Link } from 'react-router-dom';
 
 import { formatMoney } from 'helpers/moneyFormatter';
@@ -60,20 +61,23 @@ export default class IdvActivityTooltip extends React.Component {
         window.removeEventListener('resize', this.measureWindow);
     }
 
+    // eslint-disable-next-line no-unused-vars
     getLinks(path, id, data, params) {
         if (data === '--' || id === '--') {
             return (<div>{data}</div>);
         }
-        let title;
-        if (this.state.truncated) {
-            title = params;
-        }
+        // let title;
+        // if (this.state.truncated) {
+        //     title = params;
+        // }
         return (
-            <Link
-                title={title}
-                to={`/${path}/${id}`}>
-                {data}
-            </Link>
+            <span>{data}</span>
+            // TODO update after receiving updated endpoint for DEV-8068
+            //  <Link
+            //     title={title}
+            //     to={`/${path}/${id}`}>
+            //     {data}
+            // </Link>
         );
     }
 

--- a/src/js/components/award/idv/referencedAwards/ReferencedAwardsTable.jsx
+++ b/src/js/components/award/idv/referencedAwards/ReferencedAwardsTable.jsx
@@ -64,7 +64,9 @@ export default class ReferencedAwardsTable extends React.Component {
                             data = (<Link to={`/award/${row.internalId}`}>{row[col.name]}</Link>);
                         }
                         if (col.name === 'awardingAgency' && row.awardingAgencyId) {
-                            data = (<Link to={`/agency/${row.awardingAgencyId}`}>{row[col.name]}</Link>);
+                            // TODO update after receiving updated endpoint for DEV-8068
+                            // data = (<Link to={`/agency/${row.awardingAgencyId}`}>{row[col.name]}</Link>);
+                            data = row[col.name];
                         }
                         return (
                             <td

--- a/src/js/dataMapping/award/additionalDetailsContract.js
+++ b/src/js/dataMapping/award/additionalDetailsContract.js
@@ -78,14 +78,16 @@ const additionalDetailsContracts = (awardData) => {
                 }
             },
             'Parent IDV Type': parentAwardDetails.idvType || '',
-            'Parent IDV Agency Name': {
-                type: 'link',
-                data: {
-                    path: parentAwardDetails.agencyId ?
-                        `/agency/${parentAwardDetails.agencyId}` : null,
-                    title: parentAwardDetails.agencyName
-                }
-            },
+            // TODO update after receiving updated endpoint for DEV-8068
+            // 'Parent IDV Agency Name': {
+            //     type: 'link',
+            //     data: {
+            //         path: parentAwardDetails.agencyId ?
+            //             `/agency/${parentAwardDetails.agencyId}` : null,
+            //         title: parentAwardDetails.agencyName
+            //     }
+            // },
+            'Parent IDV Agency Name': parentAwardDetails.agencyName,
             'Parent IDV Sub-Agency Name': parentAwardDetails.subAgencyName,
             'Multiple Or Single Parent Award IDV': parentAwardDetails.multipleOrSingle || ''
         },


### PR DESCRIPTION
**High level description:**

Remove Agency V1 links from Award Profile page in the following cases:
- Additional Info section, Parent Award Details accordion
- For IDV Awards, the IDV Activity Chart Tooltips and the Orders Made Under this IDV table

** See ticket for exact pages where the issue can be reproduced.

**Technical details:**

Commented out links and replaced with text.  Added TODO comments so we can easily go back next week and add agency v2 links once api change is in place.

**JIRA Ticket:**
[DEV-8068](https://federal-spending-transparency.atlassian.net/browse/DEV-8068)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
- [ ] Code review complete
