### PR TITLE
Bumped up axios version to 0.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4122,18 +4122,11 @@
             "dev": true
         },
         "axios": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.22.0.tgz",
-            "integrity": "sha512-Z0U3uhqQeg1oNcihswf4ZD57O3NrR1+ZXhxaROaWpDmsDTx7T2HNBV2ulBtie2hwJptu8UvgnJoK+BIqdzh/1w==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+            "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
             "requires": {
-                "follow-redirects": "^1.14.4"
-            },
-            "dependencies": {
-                "follow-redirects": {
-                    "version": "1.14.7",
-                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-                    "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
-                }
+                "follow-redirects": "^1.14.7"
             }
         },
         "axobject-query": {
@@ -8701,8 +8694,7 @@
         "follow-redirects": {
             "version": "1.14.7",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
-            "dev": true
+            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
         },
         "for-in": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "@fortawesome/free-solid-svg-icons": "^5.13.0",
         "@fortawesome/react-fontawesome": "^0.1.4",
         "accounting": "^0.4.1",
-        "axios": "^0.22.0",
+        "axios": "^0.25.0",
         "clean-webpack-plugin": "^0.1.16",
         "commonmark": "^0.27.0",
         "core-js": "^3.0.1",

--- a/tests/helpers/apiRequest-test.js
+++ b/tests/helpers/apiRequest-test.js
@@ -7,9 +7,10 @@ import { apiRequest } from 'helpers/apiRequest';
 import { encodedAwardId, decodedAwardId } from "../mockData";
 
 describe('API Request', () => {
-    const mockRequest = apiRequest();
+    const mockURL = `v2/awards/count/test/`;
+    const mockRequest = apiRequest({ url: mockURL });
     it('should return all properties', () => {
-        const newRequest = apiRequest();
+        const newRequest = apiRequest({ url: mockURL });
         expect(newRequest).toHaveProperty('promise');
         expect(newRequest).toHaveProperty('execute');
         expect(newRequest).toHaveProperty('cancel');
@@ -20,12 +21,12 @@ describe('API Request', () => {
     });
     describe('Headers method', () => {
         it('should return default headers', () => {
-            const newRequest = apiRequest();
+            const newRequest = apiRequest({ url: mockURL });
             const headers = newRequest.headers();
             expect(headers).toEqual(mockRequest.headers());
         });
         it('should add additional headers', () => {
-            const newRequest = apiRequest();
+            const newRequest = apiRequest({ url: mockURL });
             const additionalHeaders = newRequest.headers({
                 "content-type": "application/json"
             });
@@ -35,20 +36,20 @@ describe('API Request', () => {
     });
     describe('Params method', () => {
         it('should return default params', () => {
-            const newRequest = apiRequest();
+            const newRequest = apiRequest({ url: mockURL });
             const params = newRequest.params();
             expect(params).toHaveProperty('baseURL');
             expect(params).toHaveProperty('cancelToken');
             expect(params).toHaveProperty('headers');
         });
         it('should add additional params', () => {
-            const newRequest = apiRequest();
+            const newRequest = apiRequest({ url: mockURL });
             const params = newRequest.params({ method: 'post' });
             expect(params).toHaveProperty('method');
         });
         it('should decode any award ids in a POST request', () => {
             const urlWithEncodedAwardId = `v2/awards/count/test/${encodedAwardId}`;
-            const newRequest = apiRequest();
+            const newRequest = apiRequest({ url: mockURL });
             let params = newRequest.params({ method: 'post', data: { award_id: encodedAwardId } });
             expect(params).toHaveProperty('method');
             expect(params.data.award_id).toEqual(decodedAwardId);


### PR DESCRIPTION
**High level description:**

Bumped up axios version from 0.22 to 0.25

**Technical details:**

This is in response to the vulnerability detected by dependabot.  See the following PR with comments.
[Technical details for the knowledge of other developers.](https://github.com/fedspendingtransparency/usaspending-website/pull/2880)

Please note, I had to add the url param to unit tests to account for additional error checking in axios - Adding error handling when missing url ([see axios version 0.25 changelog](https://github.com/axios/axios/blob/v0.25.0/CHANGELOG.md) )

Reviewer(s):
- [ ] Code review complete
