### PR TITLE
8335 uei banner and modal

### DIFF
--- a/src/_scss/layouts/default/header/_warning.scss
+++ b/src/_scss/layouts/default/header/_warning.scss
@@ -49,6 +49,10 @@
                     padding-left: rem(2);
                 }
             }
+            a {
+                text-decoration: none;
+                cursor: pointer;
+            }
         }
         .info-banner__description-external-link {
           color: $color-link;

--- a/src/_scss/pages/modals/covid19/_covid19.scss
+++ b/src/_scss/pages/modals/covid19/_covid19.scss
@@ -11,6 +11,10 @@
     }
     .usa-dt-modal.covid-modal {
         width: 100%;
+        @media screen and (max-width: 500px) {
+            max-width: 38rem;
+            max-height: 98rem;
+        }
         .usa-dt-modal__header {
             background: $color-disaster-covid-19;
             &.covid-header {
@@ -110,6 +114,8 @@
         }
     }
 }
+
+
 
 @include media($tablet-screen) {
     .usa-dt-modal.covid-modal {

--- a/src/_scss/pages/modals/covid19/_covid19.scss
+++ b/src/_scss/pages/modals/covid19/_covid19.scss
@@ -2,8 +2,12 @@
     .uei-modal-header {
         background: #205493 !important;
         h1 {
-            padding-left: rem(48) !important;
+            padding-left: rem(24) !important;
         }
+    }
+    .uei-modal-body {
+        text-align: left !important;
+        padding: 2rem 1.5rem 5rem rem(24) !important;
     }
     .usa-dt-modal.covid-modal {
         width: 100%;

--- a/src/_scss/pages/modals/covid19/_covid19.scss
+++ b/src/_scss/pages/modals/covid19/_covid19.scss
@@ -1,4 +1,10 @@
 @include media($small-screen) {
+    .uei-modal-header {
+        background: #205493 !important;
+        h1 {
+            padding-left: rem(48) !important;
+        }
+    }
     .usa-dt-modal.covid-modal {
         width: 100%;
         .usa-dt-modal__header {

--- a/src/js/components/sharedComponents/header/Header.jsx
+++ b/src/js/components/sharedComponents/header/Header.jsx
@@ -19,6 +19,9 @@ const clickedHeaderLink = (route) => {
 };
 
 let cookie = 'usaspending_covid_release';
+
+Cookies.set(cookie, 'showUEIBanner');
+
 if (isIe() && isBefore(startOfToday(), new Date(2022, 1, 18))) {
     cookie = 'usaspending_end_of_IE';
     Cookies.set(cookie, 'showIEBanner');
@@ -42,7 +45,7 @@ export default class Header extends React.Component {
     }
 
     setShowInfoBanner() {
-        if (Cookies.get(cookie) === 'showIEBanner') {
+        if (Cookies.get(cookie) === 'showIEBanner' || Cookies.get(cookie) === 'showUEIBanner') {
             this.setState({
                 showInfoBanner: true
             });
@@ -71,7 +74,7 @@ export default class Header extends React.Component {
 
     openBannerModal(e) {
         e.preventDefault();
-        this.props.showModal(null, 'covid');
+        this.props.showModal(null, 'uei');
     }
 
 

--- a/src/js/components/sharedComponents/header/InfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/InfoBanner.jsx
@@ -26,7 +26,7 @@ export default class InfoBanner extends React.Component {
         let content = (
             <p>
                 Beginning in March, UEIs will be added to USAspending displays alongside DUNS numbers.
-                <a onClick={this.props.triggerModal}> Learn more and find out what changes you’ll see on the site.</a>
+                <a onClick={this.props.triggerModal} onKeyDown={this.props.triggerModal} role="button" tabIndex={0}> Learn more and find out what changes you’ll see on the site.</a>
             </p>
         );
 

--- a/src/js/components/sharedComponents/header/InfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/InfoBanner.jsx
@@ -26,7 +26,7 @@ export default class InfoBanner extends React.Component {
         let content = (
             <p>
                 Beginning in March, UEIs will be added to USAspending displays alongside DUNS numbers.
-                <button onClick={this.props.triggerModal}> Learn more and find out what changes you’ll see on the site.</button>
+                <a onClick={this.props.triggerModal}> Learn more and find out what changes you’ll see on the site.</a>
             </p>
         );
 

--- a/src/js/components/sharedComponents/header/InfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/InfoBanner.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { isBefore, startOfToday } from "date-fns";
@@ -23,14 +22,15 @@ export default class InfoBanner extends React.Component {
     }
 
     render() {
-        let title = 'New to USAspending: COVID-19 Spending Data';
+        let title = 'Coming to USAspending: Unique Entity Identifiers';
         let content = (
             <p>
-            USAspending now has spending data from federal agencies related to the Coronavirus Aid, Relief, and Economic Security (CARES) Act and other COVID-19 appropriations.
-                <button onClick={this.props.triggerModal}> Learn more</button> about the new data and features, or <Link to="/disaster/covid-19">visit the profile page</Link> to explore and download the data today!
+            In April 2022, we will add a new Unique Entity Identifier (UEI) alongside DUNS numbers for awardees and recipients.
+                <button onClick={this.props.triggerModal}> Learn more about the transition and what changes you&apos;ll find on the site.</button>
             </p>
         );
 
+        // reminder that month is 0-indexed
         if (isIe() && isBefore(startOfToday(), new Date(2022, 1, 18))) {
             title = 'USAspending Ending Support for Internet Explorer';
             content = (

--- a/src/js/components/sharedComponents/header/InfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/InfoBanner.jsx
@@ -22,11 +22,11 @@ export default class InfoBanner extends React.Component {
     }
 
     render() {
-        let title = 'Coming to USAspending: Unique Entity Identifiers';
+        let title = 'New on USAspending: Unique Entity Identifiers';
         let content = (
             <p>
-            In April 2022, we will add a new Unique Entity Identifier (UEI) alongside DUNS numbers for awardees and recipients.
-                <button onClick={this.props.triggerModal}> Learn more about the transition and what changes you&apos;ll find on the site.</button>
+                Beginning in March, UEIs will be added to USAspending displays alongside DUNS numbers.
+                <button onClick={this.props.triggerModal}> Learn more and find out what changes you’ll see on the site.</button>
             </p>
         );
 

--- a/src/js/containers/globalModal/GlobalModalContainer.jsx
+++ b/src/js/containers/globalModal/GlobalModalContainer.jsx
@@ -13,6 +13,7 @@ import InterimDataDisclaimerModal from 'components/covid19/InterimDataDisclaimer
 import CovidModalContainer from 'containers/covid19/CovidModalContainer';
 
 import { globalModalProps } from '../../propTypes';
+import UEIModalContainer from "../homepage/UEIModalContainer";
 
 const propTypes = {
     globalModal: globalModalProps,
@@ -39,6 +40,13 @@ export class GlobalModalContainer extends React.Component {
         if (this.props.globalModal.modal === "covid-data-disclaimer") {
             return (
                 <InterimDataDisclaimerModal
+                    mounted={this.props.globalModal.display}
+                    hideModal={this.props.hideModal} />
+            );
+        }
+        if (this.props.globalModal.modal === "uei") {
+            return (
+                <UEIModalContainer
                     mounted={this.props.globalModal.display}
                     hideModal={this.props.hideModal} />
             );

--- a/src/js/containers/homepage/UEIModalContainer.jsx
+++ b/src/js/containers/homepage/UEIModalContainer.jsx
@@ -41,8 +41,8 @@ const CovidModalContainer = ({
             verticallyCenter
             escapeExits>
             <div className="usa-dt-modal covid-modal">
-                <div className="usa-dt-modal__header covid-header uei-modal-header">
-                    <h1>Coming to USAspending: Unique Entity Identifiers</h1>
+                <div className="usa-dt-modal__header uei-modal-header">
+                    <h1 className="usa-dt-modal__title">Coming to USAspending: Unique Entity Identifiers</h1>
                     <button
                         className="usa-dt-modal__close-button"
                         onClick={hideModal}
@@ -51,33 +51,31 @@ const CovidModalContainer = ({
                         <FontAwesomeIcon icon="times" size="10x" />
                     </button>
                 </div>
-                <div className="usa-dt-modal__body interim-data-modal">
+                <div className="usa-dt-modal__body uei-modal-body">
                     <p>
                         By April 2022, the federal government will transition from DUNS numbers to the new Unique Entity Identifier (UEI) as the official identifier for doing business with the U.S. government.
                     </p>
                     <p className="covid-modal-bold">
                         What does this transition mean for users of USAspending?
                     </p>
-                    <div>
-                        <ul>
-                            <li className="covid-modal-li">
-                                UEIs have been added to DUNS endpoints
-                            </li>
-                            <li className="covid-modal-li">
-                                Download files that currently list DUNS numbers now also include UEIs
-                            </li>
-                            <li className="covid-modal-li">
-                                You will start seeing UEI numbers alongside DUNS numbers in some instances on the following pages:
-                                <ul>
-                                    <li>Recipient Profiles</li>
-                                    <li>Award Profile pages</li>
-                                </ul>
-                            </li>
-                            <li>
-                                You will be able to find federal awards using UEI or DUNS number via <Link onClick={handleGoToKeywordSearch} to="/keyword_search">Keyword Search</Link> or the &apos;Recipient&apos; filter on <Link onClick={handleGoToAdvancedSearch} to="/search">Advanced Search</Link>
-                            </li>
-                        </ul>
-                    </div>
+                    <ul>
+                        <li>
+                            UEIs have been added to DUNS endpoints
+                        </li>
+                        <li>
+                            Download files that currently list DUNS numbers now also include UEIs
+                        </li>
+                        <li>
+                            You will start seeing UEI numbers alongside DUNS numbers in some instances on the following pages:
+                            <ul>
+                                <li>Recipient Profiles</li>
+                                <li>Award Profile pages</li>
+                            </ul>
+                        </li>
+                        <li>
+                            You will be able to find federal awards using UEI or DUNS number via <Link onClick={handleGoToKeywordSearch} to="/keyword_search">Keyword Search</Link> or the &apos;Recipient&apos; filter on <Link onClick={handleGoToAdvancedSearch} to="/search">Advanced Search</Link>
+                        </li>
+                    </ul>
                     <p className="covid-modal-bold">
                         What is a UEI?
                     </p>

--- a/src/js/containers/homepage/UEIModalContainer.jsx
+++ b/src/js/containers/homepage/UEIModalContainer.jsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { useHistory, Link } from 'react-router-dom';
+import Modal from 'react-aria-modal';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { clearAllFilters } from 'redux/actions/search/searchFilterActions';
+import { applyStagedFilters, resetAppliedFilters, setAppliedFilterCompletion } from 'redux/actions/search/appliedFilterActions';
+
+const CovidModalContainer = ({
+    mounted,
+    hideModal,
+    clearFilters,
+    resetFilters,
+}) => {
+    const history = useHistory();
+
+    const handleGoToAdvancedSearch = (e) => {
+        e.preventDefault();
+        hideModal();
+        clearFilters();
+        resetFilters();
+        history.push('/search');
+    };
+
+    const handleGoToKeywordSearch = (e) => {
+        e.preventDefault();
+        hideModal();
+        clearFilters();
+        resetFilters();
+        history.push('/keyword_search');
+    };
+
+    return (
+        <Modal
+            mounted={mounted}
+            onExit={hideModal}
+            titleText="New to USAspending: COVID-19 Response Data"
+            dialogClass="usa-dt-modal"
+            verticallyCenter
+            escapeExits>
+            <div className="usa-dt-modal covid-modal">
+                <div className="usa-dt-modal__header covid-header uei-modal-header">
+                    <h1>Coming to USAspending: Unique Entity Identifiers</h1>
+                    <button
+                        className="usa-dt-modal__close-button"
+                        onClick={hideModal}
+                        title="Close"
+                        aria-label="Close">
+                        <FontAwesomeIcon icon="times" size="10x" />
+                    </button>
+                </div>
+                <div className="usa-dt-modal__body interim-data-modal">
+                    <p>
+                        By April 2022, the federal government will transition from DUNS numbers to the new Unique Entity Identifier (UEI) as the official identifier for doing business with the U.S. government.
+                    </p>
+                    <p className="covid-modal-bold">
+                        What does this transition mean for users of USAspending?
+                    </p>
+                    <div>
+                        <ul>
+                            <li className="covid-modal-li">
+                                UEIs have been added to DUNS endpoints
+                            </li>
+                            <li className="covid-modal-li">
+                                Download files that currently list DUNS numbers now also include UEIs
+                            </li>
+                            <li className="covid-modal-li">
+                                You will start seeing UEI numbers alongside DUNS numbers in some instances on the following pages:
+                                <ul>
+                                    <li>Recipient Profiles</li>
+                                    <li>Award Profile pages</li>
+                                </ul>
+                            </li>
+                            <li>
+                                You will be able to find federal awards using UEI or DUNS number via <Link onClick={handleGoToKeywordSearch} to="/keyword_search">Keyword Search</Link> or the &apos;Recipient&apos; filter on <Link onClick={handleGoToAdvancedSearch} to="/search">Advanced Search</Link>
+                            </li>
+                        </ul>
+                    </div>
+                    <p className="covid-modal-bold">
+                        What is a UEI?
+                    </p>
+                    <p>
+                        The UEI for an awardee or recipient is an alphanumeric code created in the System for Award Management (SAM.gov) that is used to uniquely identify specific commercial, nonprofit, or business entities registered to do business with the federal government.
+                    </p>
+                    <p>
+                        <a href="mailto:join-usaspending@lists.fiscal.treasury.gov?subject=Yes!%20I'd%20like%20to%20receive%20updates.">Sign up</a> to receive email notifications of future updates, new features, and more!
+                    </p>
+                </div>
+            </div>
+        </Modal>
+    );
+};
+
+CovidModalContainer.propTypes = {
+    mounted: PropTypes.bool,
+    hideModal: PropTypes.func,
+    stageDefCodesForAdvancedSearch: PropTypes.func,
+    clearFilters: PropTypes.func,
+    resetFilters: PropTypes.func,
+    setAppliedFilters: PropTypes.func,
+    history: PropTypes.object
+};
+
+const mapDispatchToProps = (dispatch) => ({
+    resetFilters: () => dispatch(resetAppliedFilters()),
+    clearFilters: () => dispatch(clearAllFilters()),
+    stageDefCodesForAdvancedSearch: (filters) => dispatch(applyStagedFilters(filters)),
+    setAppliedFilters: (areApplied) => dispatch(setAppliedFilterCompletion(areApplied))
+});
+
+export default connect(null, mapDispatchToProps)(CovidModalContainer);

--- a/src/js/containers/homepage/UEIModalContainer.jsx
+++ b/src/js/containers/homepage/UEIModalContainer.jsx
@@ -12,7 +12,7 @@ const CovidModalContainer = ({
     mounted,
     hideModal,
     clearFilters,
-    resetFilters,
+    resetFilters
 }) => {
     const history = useHistory();
 

--- a/src/js/containers/homepage/UEIModalContainer.jsx
+++ b/src/js/containers/homepage/UEIModalContainer.jsx
@@ -36,13 +36,13 @@ const CovidModalContainer = ({
         <Modal
             mounted={mounted}
             onExit={hideModal}
-            titleText="New to USAspending: COVID-19 Response Data"
+            titleText="ueimodal"
             dialogClass="usa-dt-modal"
             verticallyCenter
             escapeExits>
             <div className="usa-dt-modal covid-modal">
                 <div className="usa-dt-modal__header uei-modal-header">
-                    <h1 className="usa-dt-modal__title">Coming to USAspending: Unique Entity Identifiers</h1>
+                    <h1 className="usa-dt-modal__title">New on USAspending: Unique Entity Identifiers</h1>
                     <button
                         className="usa-dt-modal__close-button"
                         onClick={hideModal}
@@ -53,34 +53,39 @@ const CovidModalContainer = ({
                 </div>
                 <div className="usa-dt-modal__body uei-modal-body">
                     <p>
-                        By April 2022, the federal government will transition from DUNS numbers to the new Unique Entity Identifier (UEI) as the official identifier for doing business with the U.S. government.
+                        In April 2022, the federal government will transition from DUNS numbers to the new Unique Entity Identifier (UEI) as the official identifier for doing business with the U.S. government. To prepare for this change, we’re adding UEIs to USAspending.
                     </p>
                     <p className="covid-modal-bold">
                         What does this transition mean for users of USAspending?
                     </p>
                     <ul>
                         <li>
-                            UEIs have been added to DUNS endpoints
+                            UEIs have been added to recipient endpoints
                         </li>
                         <li>
                             Download files that currently list DUNS numbers now also include UEIs
                         </li>
                         <li>
-                            You will start seeing UEI numbers alongside DUNS numbers in some instances on the following pages:
+                            You will start seeing UEIs alongside DUNS numbers on the following pages:
                             <ul>
                                 <li>Recipient Profiles</li>
-                                <li>Award Profile pages</li>
+                                <li>Award Profiles</li>
+                                <li>Advanced Search</li>
+                                <li>Keyword Search</li>
                             </ul>
                         </li>
                         <li>
-                            You will be able to find federal awards using UEI or DUNS number via <Link onClick={handleGoToKeywordSearch} to="/keyword_search">Keyword Search</Link> or the &apos;Recipient&apos; filter on <Link onClick={handleGoToAdvancedSearch} to="/search">Advanced Search</Link>
+                            You will be able to find federal awards using UEI or DUNS numbers via <Link onClick={handleGoToKeywordSearch} to="/keyword_search">Keyword Search</Link> or by using the &apos;Keyword&apos; or &apos;Recipient&apos; filters on <Link onClick={handleGoToAdvancedSearch} to="/search">Advanced Search</Link>
+                        </li>
+                        <li>
+                            URLs to recipient profile pages will become associated with UEIs rather than DUNS — <span className="covid-modal-bold">please update any saved links to these pages to avoid service disruption</span>
                         </li>
                     </ul>
                     <p className="covid-modal-bold">
                         What is a UEI?
                     </p>
                     <p>
-                        The UEI for an awardee or recipient is an alphanumeric code created in the System for Award Management (SAM.gov) that is used to uniquely identify specific commercial, nonprofit, or business entities registered to do business with the federal government.
+                        The UEI for an awardee or recipient is an alphanumeric code created in the System for Award Management (SAM) that is used to uniquely identify specific commercial, nonprofit, or business entities registered to do business with the federal government.
                     </p>
                     <p>
                         <a href="mailto:join-usaspending@lists.fiscal.treasury.gov?subject=Yes!%20I'd%20like%20to%20receive%20updates.">Sign up</a> to receive email notifications of future updates, new features, and more!


### PR DESCRIPTION
**High level description:**

Add a banner and modal to announce the upcoming addition of UEI, to replace DUNS.

**Technical details:**

Used InfoBanner.jsx for banner, changed the text and did not set an expiration date in the code since that wasn't specified in the ticket. Made a new Modal component, based on the CovidModalContainer. Reused some css from that component and added some '!important' css to make the new component match the mocks.
The latest copy is attached to the ticket.

**JIRA Ticket:**
[DEV-8335](https://federal-spending-transparency.atlassian.net/browse/DEV-8335)

**Mockup:**
link in ticket

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
