### PR TITLE
dev-8331 add negative obligations status of funds

### DIFF
--- a/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
+++ b/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
@@ -31,35 +31,6 @@ const propTypes = {
     fy: PropTypes.string
 };
 
-const mockChartData = {
-    page_metadata: {
-        page: 1,
-        total: 1,
-        limit: 2,
-        next: 2,
-        previous: null,
-        hasNext: true,
-        hasPrevious: false
-    },
-    results: [
-        {
-            name: "Bureau Oceanic",
-            _budgetaryResources: 900000000,
-            _obligations: 590000
-        },
-        {
-            name: "National Oceanic and Atmospheric Administration",
-            _budgetaryResources: 900000000,
-            _obligations: -490000
-        },
-        {
-            name: "Bureau of the Census",
-            _budgetaryResources: 400000000,
-            _obligations: -10000000
-        }
-    ]
-};
-
 export const levels = ['Sub-Component', 'Federal Account'];
 
 const StatusOfFunds = ({ fy }) => {
@@ -229,7 +200,7 @@ const StatusOfFunds = ({ fy }) => {
                             <FontAwesomeIcon icon="arrow-left" />
                             &nbsp;&nbsp;Back
                         </button> : <></>}
-                    { !loading ? <VisualizationSection fetchFederalAccounts={fetchFederalAccounts} totalItems={totalItems} setTotalItems={setTotalItems} loading={loading} setLoading={setLoading} level={level} setLevel={onClick} selectedSubcomponent={selectedSubcomponent} agencyId={overview.toptierCode} agencyName={overview.name} fy={fy} results={mockChartData.results} /> : <LoadingMessage /> }
+                    { !loading ? <VisualizationSection fetchFederalAccounts={fetchFederalAccounts} totalItems={totalItems} setTotalItems={setTotalItems} loading={loading} setLoading={setLoading} level={level} setLevel={onClick} selectedSubcomponent={selectedSubcomponent} agencyId={overview.toptierCode} agencyName={overview.name} fy={fy} results={results} /> : <LoadingMessage /> }
                     <Pagination
                         currentPage={currentPage}
                         changePage={changeCurrentPage}

--- a/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
+++ b/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
@@ -31,6 +31,35 @@ const propTypes = {
     fy: PropTypes.string
 };
 
+const mockChartData = {
+    page_metadata: {
+        page: 1,
+        total: 1,
+        limit: 2,
+        next: 2,
+        previous: null,
+        hasNext: true,
+        hasPrevious: false
+    },
+    results: [
+        {
+            name: "Bureau Oceanic",
+            _budgetaryResources: 900000000,
+            _obligations: 590000
+        },
+        {
+            name: "National Oceanic and Atmospheric Administration",
+            _budgetaryResources: 900000000,
+            _obligations: -490000
+        },
+        {
+            name: "Bureau of the Census",
+            _budgetaryResources: 400000000,
+            _obligations: -10000000
+        }
+    ]
+};
+
 export const levels = ['Sub-Component', 'Federal Account'];
 
 const StatusOfFunds = ({ fy }) => {
@@ -200,7 +229,7 @@ const StatusOfFunds = ({ fy }) => {
                             <FontAwesomeIcon icon="arrow-left" />
                             &nbsp;&nbsp;Back
                         </button> : <></>}
-                    { !loading ? <VisualizationSection fetchFederalAccounts={fetchFederalAccounts} totalItems={totalItems} setTotalItems={setTotalItems} loading={loading} setLoading={setLoading} level={level} setLevel={onClick} selectedSubcomponent={selectedSubcomponent} agencyId={overview.toptierCode} agencyName={overview.name} fy={fy} results={results} /> : <LoadingMessage /> }
+                    { !loading ? <VisualizationSection fetchFederalAccounts={fetchFederalAccounts} totalItems={totalItems} setTotalItems={setTotalItems} loading={loading} setLoading={setLoading} level={level} setLevel={onClick} selectedSubcomponent={selectedSubcomponent} agencyId={overview.toptierCode} agencyName={overview.name} fy={fy} results={mockChartData.results} /> : <LoadingMessage /> }
                     <Pagination
                         currentPage={currentPage}
                         changePage={changeCurrentPage}

--- a/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
@@ -12,30 +12,6 @@ const propTypes = {
     setLevel: PropTypes.func
 };
 
-const mockChartData = {
-    page_metadata: {
-        page: 1,
-        total: 1,
-        limit: 2,
-        next: 2,
-        previous: null,
-        hasNext: true,
-        hasPrevious: false
-    },
-    results: [
-        {
-            name: "National Oceanic and Atmospheric Administration",
-            _budgetaryResources: 900000000,
-            _obligations: -490000
-        },
-        {
-            name: "Bureau of the Census",
-            _budgetaryResources: 400000000,
-            _obligations: -10000000
-        }
-    ]
-};
-
 const StatusOfFundsChart = ({
     results, fy, setLevel, level
 }) => {
@@ -186,19 +162,19 @@ const StatusOfFundsChart = ({
         const tickMobileXAxis = isLargeScreen ? 'translate(-130,0)' : 'translate(90, 0)';
         const tickMobileYAxis = isLargeScreen ? 'translate(-150,16)' : 'translate(60, 0)';
         // scale to x and y data points
-        if (mockChartData.results[0]._obligations <= 0) {
-            x.domain([mockChartData.results[mockChartData.results.length - 1]._obligations, 0]);
+        if (sortedNums[0]._obligations <= 0) {
+            x.domain([sortedNums[sortedNums.length - 1]._obligations, 0]);
         }
         else {
-            x.domain([0, Math.max(mockChartData.results[0]._budgetaryResources, mockChartData.results[0]._obligations)]);
+            x.domain([0, Math.max(sortedNums[0]._budgetaryResources, sortedNums[0]._obligations)]);
         }
         // extract sorted agency names
-        for (let i = 0; i < mockChartData.results.length; i++) {
+        for (let i = 0; i < sortedNums.length; i++) {
             // resultNames = resultNames.concat(sortedNums[i].name.split(',')[0]);
-            resultNames = resultNames.concat(mockChartData.results[i].name);
+            resultNames = resultNames.concat(sortedNums[i].name);
         }
-        if (mockChartData.results.length < 10) {
-            for (let i = mockChartData.results.length; i < 10; i++) {
+        if (sortedNums.length < 10) {
+            for (let i = sortedNums.length; i < 10; i++) {
                 resultNames.push(i);
             }
         }
@@ -278,7 +254,7 @@ const StatusOfFundsChart = ({
         const barGroups = svg.append('g')
             .attr('class', 'parent-g')
             .selectAll('.bar-group')
-            .data(mockChartData.results)
+            .data(sortedNums)
             .enter()
             .append('g')
             .attr('class', 'bar-group')
@@ -379,7 +355,7 @@ const StatusOfFundsChart = ({
     useEffect(() => {
         if (results?.length > 0) {
             setSortedNums(results.sort((a, b) => (a._budgetaryResources > b._obligations ? b._budgetaryResources - a._budgetaryResources : b._obligations - a._obligations)));
-            if (mockChartData.results[0]._obligations <= 0) {
+            if (results[0]._obligations <= 0) {
                 setIsNegative(true);
             }
         }

--- a/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
@@ -143,9 +143,9 @@ const StatusOfFundsChart = ({
 
         const drawNegativeObligations = (data) => {
             if (!isLargeScreen) {
-                return (chartWidth + 100) - (x(data._obligations) + 11);
+                return (chartWidth + 100) - ((x(0) - x(data._obligations)) + 11);
             }
-            return (chartWidth + 350) - (x(data._obligations) + 11);
+            return (chartWidth + 350) - ((x(0) - x(data._obligations)) + 11);
         };
 
         // append the svg object to the div
@@ -162,8 +162,8 @@ const StatusOfFundsChart = ({
         const tickMobileXAxis = isLargeScreen ? 'translate(-130,0)' : 'translate(90, 0)';
         const tickMobileYAxis = isLargeScreen ? 'translate(-150,16)' : 'translate(60, 0)';
         // scale to x and y data points
-        if (sortedNums[0]._obligations <= 0) {
-            x.domain([sortedNums[sortedNums.length - 1]._obligations, 0]);
+        if (sortedNums[sortedNums.length - 1]._obligations <= 0) {
+            x.domain([sortedNums[sortedNums.length - 1]._obligations, sortedNums[0]._obligations]);
         }
         else {
             x.domain([0, Math.max(sortedNums[0]._budgetaryResources, sortedNums[0]._obligations)]);
@@ -282,7 +282,7 @@ const StatusOfFundsChart = ({
         // append total obligations bars
         barGroups.append("rect")
             .attr('transform', tickMobileXAxis)
-            .attr("x", isNegative ? (d) => x(d._obligations) - 8 : -8)
+            .attr("x", isNegative ? x(0) - 8 : -8)
             .attr("y", (d) => (isLargeScreen ? y(d.name) + 80 : y(d.name) + 40))
             .attr("width", isNegative ? (d) => drawNegativeObligations(d) : (d) => x(d._obligations) + 11)
             .attr("height", y.bandwidth() - 36)
@@ -349,9 +349,9 @@ const StatusOfFundsChart = ({
                 .attr('transform', tickMobileXAxis)
                 .style("stroke", "#aeb0b5")
                 .style("stroke-width", 3)
-                .attr("x1", isLargeScreen ? chartWidth + 330 : chartWidth + 81)
+                .attr("x1", x(0))
                 .attr("y1", 0)
-                .attr("x2", isLargeScreen ? chartWidth + 330 : chartWidth + 81)
+                .attr("x2", x(0))
                 .attr("y2", chartHeight + 4);
         }
     };
@@ -365,7 +365,8 @@ const StatusOfFundsChart = ({
     useEffect(() => {
         if (results?.length > 0) {
             setSortedNums(results.sort((a, b) => (a._budgetaryResources > b._obligations ? b._budgetaryResources - a._budgetaryResources : b._obligations - a._obligations)));
-            if (results[0]._obligations <= 0) {
+            if (results[results.length - 1]._obligations <= 0) {
+                setSortedNums(results.sort((a, b) => (a.obligations > b._obligations ? b._budgetaryResources - a._budgetaryResources : b._obligations - a._obligations)));
                 setIsNegative(true);
             }
         }

--- a/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
@@ -344,6 +344,16 @@ const StatusOfFundsChart = ({
             .attr('class', 'y-axis-labels')
             .style('fill', '#555')
             .attr("alignment-baseline", "middle");
+        if (isNegative) {
+            svg.append('line')
+                .attr('transform', tickMobileXAxis)
+                .style("stroke", "#aeb0b5")
+                .style("stroke-width", 3)
+                .attr("x1", isLargeScreen ? chartWidth + 330 : chartWidth + 81)
+                .attr("y1", 0)
+                .attr("x2", isLargeScreen ? chartWidth + 330 : chartWidth + 81)
+                .attr("y2", chartHeight + 4);
+        }
     };
 
     useEffect(() => {

--- a/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agencyV2/visualizations/StatusOfFundsChart.jsx
@@ -142,10 +142,10 @@ const StatusOfFundsChart = ({
             .range([0, isLargeScreen ? chartWidth + 330 : chartWidth + 80]);
 
         const drawNegativeObligations = (data) => {
-            if (!isLargeScreen) {
-                return (chartWidth + 100) - ((x(0) - x(data._obligations)) + 11);
+            if (data._obligations <= 0) {
+                return (Math.abs(x(0) - x(data._obligations))) + 7;
             }
-            return (chartWidth + 350) - ((x(0) - x(data._obligations)) + 11);
+            return (Math.abs(x(0) - x(data._obligations))) + 2;
         };
 
         // append the svg object to the div
@@ -163,7 +163,7 @@ const StatusOfFundsChart = ({
         const tickMobileYAxis = isLargeScreen ? 'translate(-150,16)' : 'translate(60, 0)';
         // scale to x and y data points
         if (sortedNums[sortedNums.length - 1]._obligations <= 0) {
-            x.domain([sortedNums[sortedNums.length - 1]._obligations, sortedNums[0]._obligations]);
+            x.domain(d3.extent(sortedNums, (d) => d._obligations));
         }
         else {
             x.domain([0, Math.max(sortedNums[0]._budgetaryResources, sortedNums[0]._obligations)]);
@@ -216,6 +216,7 @@ const StatusOfFundsChart = ({
             }
             if (isLargeScreen) {
                 if (i === 2) d3.select(this).attr('dx', '-1em');
+                if (i === 0 && isNegative) d3.select(this).attr('dx', '0.8em');
             }
             if (i === 4) d3.select(this).attr('dx', '-1em');
         });
@@ -227,7 +228,15 @@ const StatusOfFundsChart = ({
             .style("stroke-width", 3)
             .attr("x1", -10)
             .attr("y1", 0)
-            .attr("x2", isLargeScreen ? chartWidth + 330 : chartWidth + 81)
+            .attr("x2", () => {
+                if (sortedNums[0]._obligations <= 0) {
+                    return x(0);
+                }
+                if (!isNegative) {
+                    return isLargeScreen ? chartWidth + 330 : chartWidth + 81;
+                }
+                return x(sortedNums[0]._obligations);
+            })
             .attr("y2", 0);
         // append y axis (names)
         svg.append('g')
@@ -282,7 +291,15 @@ const StatusOfFundsChart = ({
         // append total obligations bars
         barGroups.append("rect")
             .attr('transform', tickMobileXAxis)
-            .attr("x", isNegative ? x(0) - 8 : -8)
+            .attr("x", (d) => {
+                if (d._obligations <= 0) {
+                    return x(Math.min(0, d._obligations)) - 8;
+                }
+                if (!isNegative) {
+                    return x(0) - 8;
+                }
+                return x(0);
+            })
             .attr("y", (d) => (isLargeScreen ? y(d.name) + 80 : y(d.name) + 40))
             .attr("width", isNegative ? (d) => drawNegativeObligations(d) : (d) => x(d._obligations) + 11)
             .attr("height", y.bandwidth() - 36)
@@ -352,7 +369,7 @@ const StatusOfFundsChart = ({
                 .attr("x1", x(0))
                 .attr("y1", 0)
                 .attr("x2", x(0))
-                .attr("y2", chartHeight + 4);
+                .attr("y2", isLargeScreen ? chartHeight + 500 : chartHeight + 4);
         }
     };
 

--- a/tests/components/agency/visualizations/StatusOfFundsChart-test.jsx
+++ b/tests/components/agency/visualizations/StatusOfFundsChart-test.jsx
@@ -87,7 +87,7 @@ const mockChartDataNegative = {
         {
             name: "National Oceanic and Atmospheric Administration",
             total_budgetary_resources: 9100000000,
-            total_obligations: -6000000000
+            total_obligations: 6000000000
         },
         {
             name: "Bureau of the Census",
@@ -141,6 +141,13 @@ describe('StatusOfFundsChart', () => {
         // set timeout to wait for expect() to pass after call to render
         setTimeout(() => {
             expect(screen.getByText('-$2.5B').toBeInTheDocument());
+        }, 1000);
+    });
+    it('should display $0 axis when positive and negative values are present', () => {
+        render(<StatusOfFundsChart results={mockChartDataNegative.results} fy={fy} level={0} />);
+        // set timeout to wait for expect() to pass after call to render
+        setTimeout(() => {
+            expect(screen.getByText('$0').toBeInTheDocument());
         }, 1000);
     });
     it("should make an API call on level change", () => {

--- a/tests/components/agency/visualizations/StatusOfFundsChart-test.jsx
+++ b/tests/components/agency/visualizations/StatusOfFundsChart-test.jsx
@@ -73,6 +73,34 @@ const mockChartData = {
         }
     ]
 };
+const mockChartDataNegative = {
+    page_metadata: {
+        page: 1,
+        total: 1,
+        limit: 2,
+        next: 2,
+        previous: null,
+        hasNext: true,
+        hasPrevious: false
+    },
+    results: [
+        {
+            name: "National Oceanic and Atmospheric Administration",
+            total_budgetary_resources: 9100000000,
+            total_obligations: -6000000000
+        },
+        {
+            name: "Bureau of the Census",
+            total_budgetary_resources: 4400000000,
+            total_obligations: -2500000000
+        },
+        {
+            name: "U.S. Patent and Trademark Office",
+            total_budgetary_resources: 4200000000,
+            total_obligations: -2700000000
+        }
+    ]
+};
 const fy = '2021';
 const toptierCode = '012';
 const name = 'Department of Agriculture';
@@ -106,6 +134,13 @@ describe('StatusOfFundsChart', () => {
         // set timeout to wait for expect() to pass after call to render
         setTimeout(() => {
             expect(screen.getByText(`${name} by Sub-Component for FY 2021`).toBeInTheDocument());
+        }, 1000);
+    });
+    it('should display negative formatted amount used for max x axis value', () => {
+        render(<StatusOfFundsChart results={mockChartDataNegative.results} fy={fy} level={0} />);
+        // set timeout to wait for expect() to pass after call to render
+        setTimeout(() => {
+            expect(screen.getByText('-$2.5B').toBeInTheDocument());
         }, 1000);
     });
     it("should make an API call on level change", () => {


### PR DESCRIPTION
**High level description:**

As a user, I can see negative values on the Status of Funds chart as well as on the drilldown on the left. Example: Advanced search “Categories” tab horizontal bar chart

**Technical details:**
Note: Currently there are no known cases of negative values to test so I created a mock data object to test negative treatment. The mock data object should be created in StatusOfFunds.jsx and passed as a prop to VisualizationSection `results={mockChartData.results}`.

~ Text and axis overlap issue in mobile is known and being worked on by design

```
const mockChartData = {
    page_metadata: {
        page: 1,
        total: 1,
        limit: 2,
        next: 2,
        previous: null,
        hasNext: true,
        hasPrevious: false
    },
    results: [
        {
            name: "National Oceanic and Atmospheric Administration",
            _budgetaryResources: 9100000000,
            _obligations: 6000000000
        },
        {
            name: "Bureau of the Census",
            _budgetaryResources: 4400000000,
            _obligations: 2500000000
        },
        {
            name: "U.S. Patent and Trademark Office",
            _budgetaryResources: 4200000000,
            _obligations: -2700000000
        },
        {
            name: "Economic Development Administration",
            _budgetaryResources: 4150000000,
            _obligations: -1300000000
        },
        {
            name: "National Telecommunications and Information Administration",
            _budgetaryResources: 2100000000,
            _obligations: 50000000
        },
        {
            name: "National Institute of Standards and Technology",
            _budgetaryResources: 1900000000,
            _obligations: -1560000000
        },
        {
            name: "International Trade Administration",
            _budgetaryResources: 1010000000,
            _obligations: 960000000
        },
        {
            name: "Departmental Management",
            _budgetaryResources: 100500000,
            _obligations: -905000000
        },
        {
            name: "Bureau of Industry and Security",
            _budgetaryResources: 10500000,
            _obligations: -9050000
        },
        {
            name: "Bureau of Economic Analysis",
            _budgetaryResources: 5000000,
            _obligations: -4000000
        }
    ]
};
```


**JIRA Ticket:**
[DEV-8331](https://federal-spending-transparency.atlassian.net/browse/DEV-8331)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)

Reviewer(s):
- [x] Design review complete `if applicable`
- [ ] Code review complete
