### PR TITLE
8250 - added defcodes Z and 1 to the useDefCodes return obj; added th…

### DIFF
--- a/src/js/components/bulkDownload/DEFCheckboxTreeDownload.jsx
+++ b/src/js/components/bulkDownload/DEFCheckboxTreeDownload.jsx
@@ -22,6 +22,16 @@ const covidParentNode = {
     children: []
 };
 
+const infrastructureParentNode = {
+    label: "Infrastructure Spending",
+    value: "INFRA",
+    className: "def-checkbox-label--covid",
+    expandDisabled: true,
+    isSearchable: false,
+    showNodeIcon: false,
+    children: []
+};
+
 const parseCovidCodes = (codes) => codes
     .filter((code) => code.disaster === 'covid_19')
     .reduce((acc, covidCode) => ({
@@ -38,6 +48,23 @@ const parseCovidCodes = (codes) => codes
                 return 0;
             })
     }), covidParentNode);
+
+const extractInfraCodes = (codes) => codes
+    .filter((code) => code.code === '1' || code.code === 'Z')
+    .reduce((acc, infraCode) => ({
+        ...acc,
+        children: acc.children.concat([{
+            label: infraCode.title,
+            subLabel: infraCode.public_law,
+            value: infraCode.code,
+            expandDisabled: true
+        }])
+            .sort((a, b) => {
+                if (a.value < b.value) return 1;
+                if (a.value > b.value) return -1;
+                return 0;
+            })
+    }), infrastructureParentNode);
 
 const DEFCheckboxTreeDownload = ({
     type,
@@ -74,6 +101,22 @@ const DEFCheckboxTreeDownload = ({
                 expanded={expanded}
                 isDisabled={isDisabled}
                 data={[parseCovidCodes(validDefCodes)]}
+                isError={(errorMsg !== '')}
+                errorMessage={errorMsg}
+                isLoading={isLoading}
+                searchText=""
+                noResults={false}
+                labelComponent={<DEFCheckboxTreeLabel />}
+                onUncheck={stageFilter}
+                onCheck={stageFilter}
+                onCollapse={onCollapse}
+                onExpand={onExpand} />
+            <CheckboxTree
+                className="def-checkbox-tree"
+                checked={defCodes}
+                expanded={expanded}
+                isDisabled={isDisabled}
+                data={[extractInfraCodes(validDefCodes)]}
                 isError={(errorMsg !== '')}
                 errorMessage={errorMsg}
                 isLoading={isLoading}

--- a/src/js/containers/covid19/WithDefCodes.jsx
+++ b/src/js/containers/covid19/WithDefCodes.jsx
@@ -23,7 +23,7 @@ export const useDefCodes = () => {
             request.current = fetchDEFCodes();
             request.current.promise
                 .then(({ data: { codes } }) => {
-                    dispatch(setDEFCodes(codes.filter((c) => c.disaster === 'covid_19')));
+                    dispatch(setDEFCodes(codes.filter((c) => c.disaster === 'covid_19' || c.code === '1' || c.code === 'Z')));
                     setLoading(false);
                     request.current = null;
                 })


### PR DESCRIPTION
…e Infrastructure dropdown to the Custom aAccounts Download section

**High level description:**

Add dropdown for Infrasctructure def codes to the defcodes section of the page

**Technical details:**

Added defcodes Z and 1 to the return obj of useDefCodes, then made a new CheckboxTree below the one for Covid-19 defcodes on the Custom Accounts Download page

**JIRA Ticket:**
[DEV-8250](https://federal-spending-transparency.atlassian.net/browse/DEV-8250)

**Mockup:**
attached to ticket

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
