### PR TITLE
8099 fix data through date to agency profiles, 8422 show for all FYs

### DIFF
--- a/src/js/components/agencyV2/AgencyPage.jsx
+++ b/src/js/components/agencyV2/AgencyPage.jsx
@@ -18,7 +18,6 @@ import { getStickyBreakPointForSidebar } from 'helpers/stickyHeaderHelper';
 import { agencyPageMetaTags } from 'helpers/metaTagHelper';
 import { scrollToY } from 'helpers/scrollToHelper';
 import { getBaseUrl, handleShareOptionClick } from 'helpers/socialShare';
-import { useLatestAccountData } from 'containers/account/WithLatestFy';
 
 import Sidebar from 'components/sharedComponents/sidebar/Sidebar';
 import AgencySection from './AgencySection';
@@ -54,19 +53,10 @@ export const AgencyProfileV2 = ({
     const [activeSection, setActiveSection] = useState('overview');
     const { name } = useSelector((state) => state.agencyV2.overview);
 
-    let dataThroughDate = useLatestAccountData()[0]?.format('M/D/YYYY');
     const dataThroughDates = useSelector((state) => state.agencyV2.dataThroughDates);
-    let overviewDataThroughDate = dataThroughDates?.overviewDataThroughDate || dataThroughDate;
-    let statusDataThroughDate = dataThroughDates?.statusDataThroughDate || dataThroughDate;
-    let awardSpendingDataThroughDate = dataThroughDates?.awardSpendingDataThroughDate;
-
-    // reset/hide if selectedFy is not latestFy
-    if (parseInt(selectedFy, 10) !== latestFy) {
-        dataThroughDate = null;
-        overviewDataThroughDate = null;
-        statusDataThroughDate = null;
-        awardSpendingDataThroughDate = null;
-    }
+    const overviewDataThroughDate = dataThroughDates?.overviewDataThroughDate;
+    const statusDataThroughDate = dataThroughDates?.statusDataThroughDate;
+    const awardSpendingDataThroughDate = dataThroughDates?.awardSpendingDataThroughDate;
 
     const sections = [
         {

--- a/src/js/components/agencyV2/AgencySection.jsx
+++ b/src/js/components/agencyV2/AgencySection.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import moment from 'moment';
 import { LoadingMessage, SectionTitle } from 'data-transparency-ui';
 
 const propTypes = {
@@ -27,7 +28,7 @@ const AgencySection = ({
             dataThroughNote = 'No data available for the selected fiscal year';
         }
         else {
-            dataThroughNote = `Data through ${dataThroughDate}`;
+            dataThroughNote = `Data through ${moment(dataThroughDate).format('M/D/YYYY')}`;
         }
     }
 

--- a/src/js/components/agencyV2/overview/FySummary.jsx
+++ b/src/js/components/agencyV2/overview/FySummary.jsx
@@ -51,7 +51,6 @@ const FySummary = ({
     }, []);
 
     // eslint-disable-next-line eqeqeq
-    // eslint-disable-next-line camelcase
     let overviewDataThroughDate = useLatestAccountData()[1].toArray().filter((i) => i.submission_fiscal_year == fy)[0]?.period_end_date;
     useEffect(() => {
         if (toptierCode) {

--- a/src/js/components/agencyV2/overview/FySummary.jsx
+++ b/src/js/components/agencyV2/overview/FySummary.jsx
@@ -50,7 +50,7 @@ const FySummary = ({
         }
     }, []);
 
-    // eslint-disable-next-line eqeqeq
+    // eslint-disable-next-line eqeqeq, camelcase
     let overviewDataThroughDate = useLatestAccountData()[1].toArray().filter((i) => i.submission_fiscal_year == fy)[0]?.period_end_date;
     useEffect(() => {
         if (toptierCode) {

--- a/src/js/components/agencyV2/overview/FySummary.jsx
+++ b/src/js/components/agencyV2/overview/FySummary.jsx
@@ -51,7 +51,8 @@ const FySummary = ({
     }, []);
 
     // eslint-disable-next-line eqeqeq
-    let overviewDataThroughDate = useLatestAccountData()[1].toArray().filter((i) => i.submission_fiscal_year == fy)[0].period_end_date;
+    // eslint-disable-next-line camelcase
+    let overviewDataThroughDate = useLatestAccountData()[1].toArray().filter((i) => i.submission_fiscal_year == fy)[0]?.period_end_date;
     useEffect(() => {
         if (toptierCode) {
             setIsLoading(true);

--- a/src/js/components/agencyV2/overview/FySummary.jsx
+++ b/src/js/components/agencyV2/overview/FySummary.jsx
@@ -6,12 +6,14 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 import { Carousel, FlexGridRow, FlexGridCol } from 'data-transparency-ui';
 
 import { fetchBudgetaryResources } from 'apis/agencyV2';
 import BaseAgencyBudgetaryResources from 'models/v2/agency/BaseAgencyBudgetaryResources';
 import { setBudgetaryResources, setDataThroughDates } from 'redux/actions/agencyV2/agencyV2Actions';
 import { calculatePercentage, formatMoneyWithUnits } from 'helpers/moneyFormatter';
+import { useLatestAccountData } from 'containers/account/WithLatestFy';
 import TotalObligationsOverTimeContainer from 'containers/agencyV2/visualizations/TotalObligationsOverTimeContainer';
 import ObligationsByAwardTypeContainer from 'containers/agencyV2/visualizations/ObligationsByAwardTypeContainer';
 
@@ -48,6 +50,8 @@ const FySummary = ({
         }
     }, []);
 
+    // eslint-disable-next-line eqeqeq
+    let overviewDataThroughDate = useLatestAccountData()[1].toArray().filter((i) => i.submission_fiscal_year == fy)[0].period_end_date;
     useEffect(() => {
         if (toptierCode) {
             setIsLoading(true);
@@ -65,11 +69,14 @@ const FySummary = ({
                         dataByYear[year.fiscal_year] = fyBudgetaryResources;
                     });
                     dispatch(setBudgetaryResources(dataByYear));
+
                     if (dataByYear[fy].agencyBudget === "--") {
-                        dispatch(setDataThroughDates({
-                            overviewDataThroughDate: 'no data'
-                        }));
+                        overviewDataThroughDate = 'no data';
                     }
+                    dispatch(setDataThroughDates({
+                        overviewDataThroughDate
+                    }));
+
                     setIsLoading(false);
                 })
                 .catch((e) => {
@@ -95,7 +102,7 @@ const FySummary = ({
             dataThroughNote = 'No data available for the selected fiscal year';
         }
         else {
-            dataThroughNote = `Data through ${dataThroughDate}`;
+            dataThroughNote = `Data through ${moment(dataThroughDate).format('M/D/YYYY')}`;
         }
     }
 

--- a/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
+++ b/src/js/components/agencyV2/statusOfFunds/StatusOfFunds.jsx
@@ -20,6 +20,7 @@ import {
 import { fetchSubcomponentsList, fetchFederalAccountsList } from 'apis/agencyV2';
 import { parseRows } from 'helpers/agencyV2/StatusOfFundsVizHelper';
 import { useStateWithPrevious } from 'helpers';
+import { useLatestAccountData } from 'containers/account/WithLatestFy';
 import BaseStatusOfFundsLevel from 'models/v2/agency/BaseStatusOfFundsLevel';
 import Note from 'components/sharedComponents/Note';
 
@@ -55,6 +56,8 @@ const StatusOfFunds = ({ fy }) => {
         dispatch(resetFederalAccountsList());
     }, []);
 
+    // eslint-disable-next-line eqeqeq
+    let statusDataThroughDate = useLatestAccountData()[1].toArray().filter((i) => i.submission_fiscal_year == fy)[0].period_end_date;
     const fetchAgencySubcomponents = () => {
         if (request.current) {
             request.current.cancel();
@@ -77,11 +80,14 @@ const StatusOfFunds = ({ fy }) => {
                 setResults(parsedData);
                 dispatch(setAgencySubcomponents(parsedData));
                 setTotalItems(res.data.page_metadata.total);
+
                 if (parsedData.length === 0) {
-                    dispatch(setDataThroughDates({
-                        statusDataThroughDate: 'no data'
-                    }));
+                    statusDataThroughDate = 'no data';
                 }
+                dispatch(setDataThroughDates({
+                    statusDataThroughDate
+                }));
+
                 setLoading(false);
             }).catch((err) => {
                 setError(true);

--- a/tests/components/agency/overview/FYSummary-test.jsx
+++ b/tests/components/agency/overview/FYSummary-test.jsx
@@ -6,8 +6,11 @@
 import React from 'react';
 import { render, waitFor } from 'test-utils';
 import * as redux from 'react-redux';
+import { List } from "immutable";
 
 import * as helpers from 'apis/agencyV2';
+import * as accountHooks from 'containers/account/WithLatestFy';
+
 import FYSummary from 'components/agencyV2/overview/FySummary';
 import BaseAgencyRecipients from 'models/v2/agency/BaseAgencyRecipients';
 
@@ -42,6 +45,13 @@ beforeEach(() => {
             toptierCode: '010'
         }
     });
+    jest.spyOn(accountHooks, "useLatestAccountData").mockImplementation(() =>
+        [null,
+            new List([{
+                submission_fiscal_year: null,
+                period_end_date: null
+            }])
+        ]);
 });
 
 test('No duplicate API requests', () => {

--- a/webpack/webpack.prod.config.js
+++ b/webpack/webpack.prod.config.js
@@ -18,10 +18,12 @@ module.exports = merge(common, {
     },
     optimization: {
         minimizer: [
-            new TerserPlugin({
-                cache: true,
-                parallel: true
-            }),
+            new TerserPlugin(),
+            // use defaults?
+            // new TerserPlugin({
+            //     cache: true,
+            //     parallel: true
+            // }),
             new OptimizeCssAssetsPlugin({})
         ],
         runtimeChunk: "single",

--- a/webpack/webpack.prod.config.js
+++ b/webpack/webpack.prod.config.js
@@ -18,12 +18,10 @@ module.exports = merge(common, {
     },
     optimization: {
         minimizer: [
-            new TerserPlugin(),
-            // use defaults?
-            // new TerserPlugin({
-            //     cache: true,
-            //     parallel: true
-            // }),
+            new TerserPlugin({
+                cache: true,
+                parallel: true
+            }),
             new OptimizeCssAssetsPlugin({})
         ],
         runtimeChunk: "single",


### PR DESCRIPTION
**High level description:**
corrects date showing momentarily, then changing to "no data available"
also removes check for selected year, so shows appropriate date for all years

**Technical details:**


**JIRA Ticket:**
[DEV-8099](https://federal-spending-transparency.atlassian.net/browse/DEV-8099)
[DEV-8422](https://federal-spending-transparency.atlassian.net/browse/DEV-8422)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [n/a ] Verified mobile/tablet/desktop/monitor responsiveness
- [n/a ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a ] Design review complete `if applicable`
- [n/a ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
