### PR TITLE
8287 - Add Foresee survey to site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4205,11 +4205,18 @@
             "dev": true
         },
         "axios": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-            "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
+            "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
             "requires": {
-                "follow-redirects": "^1.14.7"
+                "follow-redirects": "^1.14.8"
+            },
+            "dependencies": {
+                "follow-redirects": {
+                    "version": "1.14.8",
+                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+                    "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
+                }
             }
         },
         "axobject-query": {
@@ -8820,7 +8827,8 @@
         "follow-redirects": {
             "version": "1.14.7",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+            "dev": true
         },
         "for-in": {
             "version": "1.0.2",
@@ -22318,7 +22326,8 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "5.0.0",
-                    "resolved": "",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
                     "dev": true
                 },
                 "ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "@fortawesome/free-solid-svg-icons": "^5.13.0",
         "@fortawesome/react-fontawesome": "^0.1.4",
         "accounting": "^0.4.1",
-        "axios": "^0.25.0",
+        "axios": "^0.26.0",
         "clean-webpack-plugin": "^0.1.16",
         "commonmark": "^0.27.0",
         "core-js": "^3.0.1",

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -29,30 +29,55 @@
     <script async src='https://www.google-analytics.com/analytics.js'></script>
     <!-- End Google Analytics -->
     <!-- Start ForeSee Survey -->
-    <script type="text/javascript">
-        // ForeSee Staging Embed Script v2.01
-        // DO NOT MODIFY BELOW THIS LINE *****************************************
-        ;(function (g) {
-            var d = document, am = d.createElement('script'), h = d.head || d.getElementsByTagName("head")[0], fsr = 'fsReady',
-                aex = {
-                    "src": "//gateway.foresee.com/sites/usaspending/staging/gateway.min.js",
-                    "type": "text/javascript",
-                    "async": "true",
-                    "data-vendor": "fs",
-                    "data-role": "gateway"
-                };
-            for (var attr in aex) { am.setAttribute(attr, aex[attr]); } h.appendChild(am); g[fsr] || (g[fsr] = function () { var aT = '__' + fsr + '_stk__'; g[aT] = g[aT] || []; g[aT].push(arguments); });
-        })(window);
-        // DO NOT MODIFY ABOVE THIS LINE *****************************************
+    <% if (IS_PROD) { %>
+        <script type="text/javascript">
+            // ForeSee Production Embed Script v2.01
+            // DO NOT MODIFY BELOW THIS LINE *****************************************
+            ;(function (g) {
+                var d = document, am = d.createElement('script'), h = d.head || d.getElementsByTagName("head")[0], fsr = 'fsReady',
+                    aex = {
+                        "src": "//gateway.foresee.com/sites/usaspending/production/gateway.min.js",
+                        "type": "text/javascript",
+                        "async": "true",
+                        "data-vendor": "fs",
+                        "data-role": "gateway"
+                    };
+                for (var attr in aex) { am.setAttribute(attr, aex[attr]); } h.appendChild(am); g[fsr] || (g[fsr] = function () { var aT = '__' + fsr + '_stk__'; g[aT] = g[aT] || []; g[aT].push(arguments); });
+            })(window);
+            // DO NOT MODIFY ABOVE THIS LINE *****************************************
 
-        // Un-comment out the function below when you are ready to input your variable
-        /*fsReady(function() {
-          FSR.CPPS.set('name','value'); // use single quotes when passing a static-value
-          FSR.CPPS.set('name2',somevariable); // don't use quotes for a dynamic value
-          FSR.CPPS.set('name3',othervariable); // add as many CPPs as you like in this way
-        });*/
-    </script>
+            // Un-comment out the function below when you are ready to input your variable
+            /*fsReady(function() {
+              FSR.CPPS.set('name','value'); // use single quotes when passing a static-value
+              FSR.CPPS.set('name2',somevariable); // don't use quotes for a dynamic value
+              FSR.CPPS.set('name3',othervariable); // add as many CPPs as you like in this way
+            });*/
+        </script>
+    <% } else { %>
+        <script type="text/javascript">
+            // ForeSee Staging Embed Script v2.01
+            // DO NOT MODIFY BELOW THIS LINE *****************************************
+            ;(function (g) {
+                var d = document, am = d.createElement('script'), h = d.head || d.getElementsByTagName("head")[0], fsr = 'fsReady',
+                    aex = {
+                        "src": "//gateway.foresee.com/sites/usaspending/staging/gateway.min.js",
+                        "type": "text/javascript",
+                        "async": "true",
+                        "data-vendor": "fs",
+                        "data-role": "gateway"
+                    };
+                for (var attr in aex) { am.setAttribute(attr, aex[attr]); } h.appendChild(am); g[fsr] || (g[fsr] = function () { var aT = '__' + fsr + '_stk__'; g[aT] = g[aT] || []; g[aT].push(arguments); });
+            })(window);
+            // DO NOT MODIFY ABOVE THIS LINE *****************************************
 
+            // Un-comment out the function below when you are ready to input your variable
+            /*fsReady(function() {
+              FSR.CPPS.set('name','value'); // use single quotes when passing a static-value
+              FSR.CPPS.set('name2',somevariable); // don't use quotes for a dynamic value
+              FSR.CPPS.set('name3',othervariable); // add as many CPPs as you like in this way
+            });*/
+        </script>
+    <% } %>
     <!-- End ForeSee Survey -->
 
     <% if (USE_GTM) { %>

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -28,6 +28,33 @@
     </script>
     <script async src='https://www.google-analytics.com/analytics.js'></script>
     <!-- End Google Analytics -->
+    <!-- Start ForeSee Survey -->
+    <script type="text/javascript">
+        // ForeSee Staging Embed Script v2.01
+        // DO NOT MODIFY BELOW THIS LINE *****************************************
+        ;(function (g) {
+            var d = document, am = d.createElement('script'), h = d.head || d.getElementsByTagName("head")[0], fsr = 'fsReady',
+                aex = {
+                    "src": "//gateway.foresee.com/sites/usaspending/staging/gateway.min.js",
+                    "type": "text/javascript",
+                    "async": "true",
+                    "data-vendor": "fs",
+                    "data-role": "gateway"
+                };
+            for (var attr in aex) { am.setAttribute(attr, aex[attr]); } h.appendChild(am); g[fsr] || (g[fsr] = function () { var aT = '__' + fsr + '_stk__'; g[aT] = g[aT] || []; g[aT].push(arguments); });
+        })(window);
+        // DO NOT MODIFY ABOVE THIS LINE *****************************************
+
+        // Un-comment out the function below when you are ready to input your variable
+        /*fsReady(function() {
+          FSR.CPPS.set('name','value'); // use single quotes when passing a static-value
+          FSR.CPPS.set('name2',somevariable); // don't use quotes for a dynamic value
+          FSR.CPPS.set('name3',othervariable); // add as many CPPs as you like in this way
+        });*/
+    </script>
+
+    <!-- End ForeSee Survey -->
+
     <% if (USE_GTM) { %>
         <!-- Google Tag Manager -->
         <script>(

--- a/src/js/containers/glossary/GlossaryListener.jsx
+++ b/src/js/containers/glossary/GlossaryListener.jsx
@@ -20,12 +20,15 @@ const GlossaryListener = ({
     const queryParams = useQueryParams();
 
     useEffect(() => {
-        if (location.hash) {
-            const urlWithNoHash = location.hash.split("#").length > 1
-                ? location.hash.split("#")[1]
-                : '';
-            history.replace(urlWithNoHash);
+        // The #fscommand=fstest is used to access the Foresee survey admin panel
+        if (!location.hash || location.hash.indexOf('#fscommand=fstest') > -1) {
+            return;
         }
+
+        const urlWithNoHash = location.hash.split("#").length > 1
+            ? location.hash.split("#")[1]
+            : '';
+        history.replace(urlWithNoHash);
     }, [location, history]);
 
     useEffect(() => {

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -101,7 +101,11 @@ module.exports = {
                     process.env.ENV === 'qat' ||
                     process.env.ENV === 'sandbox'
                 ),
-                GTM_ID: process.env.GTM_ID || ''
+                GTM_ID: process.env.GTM_ID || '',
+                IS_PROD: (
+                    process.env.ENV === 'prod'
+                )
+
             }
         }),
         new MiniCssExtractPlugin({


### PR DESCRIPTION
**High level description:**

Add Foresee survey

**Technical details:**

Added survey code snippets for staging (ie. lower environments) and prod to index.ejs.  To set session level options, you can launch the admin panel from usaspending.gov#fscommand=fstest.  The frontend code removes hashes from the URL so updated code to keep hash only for #fscommand=fstest.  This can't be tested locally but the code in the PR is in sandbox.  You'll need to stay on the site for over to 30 seconds and may need to open a few pages for the survey to appear.

**JIRA Ticket:**
[DEV-8287](https://federal-spending-transparency.atlassian.net/browse/DEV-8287)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Code review complete
