### PR TITLE
8438 total obl chart overlap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22318,7 +22318,8 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "5.0.0",
-                    "resolved": "",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
                     "dev": true
                 },
                 "ansi-styles": {

--- a/src/_scss/pages/agencyV2/visualizations/_totalObligationsOverTime.scss
+++ b/src/_scss/pages/agencyV2/visualizations/_totalObligationsOverTime.scss
@@ -132,7 +132,6 @@
             width: 100%;
             @include display(flex);
             @include align-items(flex-end);
-            padding: 0 10%;
             @include media($medium-screen) {
                 padding: 0 rem(2.5);
             }


### PR DESCRIPTION
**High level description:**

This chart was off center and spilling over into the next chart in the carousel, at tablet and mobile sizes only.

**Technical details:**

I removed the padding that was causing it. I didn't see any spots where this adversely affected any tooltips, but please check for any.

**JIRA Ticket:**
[DEV-8438](https://federal-spending-transparency.atlassian.net/browse/DEV-8438)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
