### PR TITLE
7613 static break for wrapping

### DIFF
--- a/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
@@ -5,7 +5,8 @@
         @extend %column-less-table__row;
         flex-wrap: wrap;
         border-bottom: 0;
-        white-space: nowrap;
+        // white-space: nowrap;
+        padding-left: 2.3rem;
         &:nth-of-type(1) {
             border-radius: rem(5) rem(5) 0 0;
         }
@@ -14,8 +15,8 @@
             border-bottom: solid rem(1) $border-light-gray;
         }
 
-        .indent {
-            padding-left: 1.5rem;
+        .hanging {
+            text-indent: -1.5rem;
 
             @media (max-width: $tablet-screen) {
                 flex-basis: 100%;

--- a/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
@@ -5,7 +5,6 @@
         @extend %column-less-table__row;
         flex-wrap: wrap;
         border-bottom: 0;
-        // white-space: nowrap;
         padding-left: 2.3rem;
         &:nth-of-type(1) {
             border-radius: rem(5) rem(5) 0 0;

--- a/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
@@ -16,6 +16,10 @@
 
         .indent {
             padding-left: 1.5rem;
+
+            @media (max-width: $tablet-screen) {
+                flex-basis: 100%;
+            }
         }
     }
 

--- a/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
@@ -19,6 +19,7 @@
             text-indent: -1.5rem;
 
             @media (max-width: $tablet-screen) {
+                padding-bottom: 4px;
                 flex-basis: 100%;
             }
         }

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
@@ -97,11 +97,11 @@ const AwardAmountsTable = ({
                         ? null
                         :
                         <div key={uniqueId(title)} className="award-amounts__data-content">
-                            <div>
+                            <div className="hanging">
                                 <span className={`award-amounts__data-icon ${(title === 'Outlayed Amount' || title === 'Combined Outlayed Amounts') ? '' : awardTableClassMap[title]}`} />
                                 {title}
                             </div>
-                            <span className="indent">{amountMapByCategoryTitle[title]}</span>
+                            <span>{amountMapByCategoryTitle[title]}</span>
                         </div>
                 ))
             }


### PR DESCRIPTION
**High level description:**

ticket AC clarified

**Technical details:**
update to break on port width, not dynamic

**JIRA Ticket:**
[DEV-7613](https://federal-spending-transparency.atlassian.net/browse/DEV-7613)

**Mockup:**
in ticket comments

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [n/a ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [n/a ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [n/a ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
