### PR TITLE
8480 - Added UEI warning banner to recipient profile page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4205,11 +4205,18 @@
             "dev": true
         },
         "axios": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-            "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
+            "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
             "requires": {
-                "follow-redirects": "^1.14.7"
+                "follow-redirects": "^1.14.8"
+            },
+            "dependencies": {
+                "follow-redirects": {
+                    "version": "1.14.8",
+                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+                    "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
+                }
             }
         },
         "axobject-query": {
@@ -8820,7 +8827,8 @@
         "follow-redirects": {
             "version": "1.14.7",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+            "dev": true
         },
         "for-in": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "@fortawesome/free-solid-svg-icons": "^5.13.0",
         "@fortawesome/react-fontawesome": "^0.1.4",
         "accounting": "^0.4.1",
-        "axios": "^0.25.0",
+        "axios": "^0.26.0",
         "clean-webpack-plugin": "^0.1.16",
         "commonmark": "^0.27.0",
         "core-js": "^3.0.1",

--- a/src/_scss/pages/recipient/_recipientInfoBanner.scss
+++ b/src/_scss/pages/recipient/_recipientInfoBanner.scss
@@ -2,26 +2,8 @@
 
 .info-banner {
   @include usa-alert-warning;
-  @include display(flex);
   border-top: solid 5px $color-gold;
-  text-align: left;
   .info-banner__exclamation-triangle {
-    @include flex(0 0 auto);
     color: $color-gold;
-  }
-  .info-banner__content {
-    @include flex (1 1 auto);
-    info-banner__title-text {
-      margin: 0 0 rem(6);
-      font-weight: $font-semibold;
-      font-size: rem(18);
-      line-height: rem(22);
-    }
-    p {
-      margin: 0;
-      a {
-        font-weight: $font-semibold;
-      }
-    }
   }
 }

--- a/src/_scss/pages/recipient/_recipientInfoBanner.scss
+++ b/src/_scss/pages/recipient/_recipientInfoBanner.scss
@@ -1,3 +1,5 @@
+@import '../../layouts/default/header/warning';
+
 .info-banner {
   @include usa-alert-warning;
   @include display(flex);

--- a/src/_scss/pages/recipient/_recipientInfoBanner.scss
+++ b/src/_scss/pages/recipient/_recipientInfoBanner.scss
@@ -3,14 +3,11 @@
 .info-banner {
   @include usa-alert-warning;
   @include display(flex);
-  border: solid 1px $color-gold;
+  border-top: solid 5px $color-gold;
   text-align: left;
-  padding: rem(18) rem(10);
-  .modal-disclaimer__icon {
+  .info-banner__exclamation-triangle {
     @include flex(0 0 auto);
     color: $color-gold;
-    font-size: rem(26);
-    margin-right: rem(10);
   }
   .info-banner__content {
     @include flex (1 1 auto);

--- a/src/_scss/pages/recipient/_recipientInfoBanner.scss
+++ b/src/_scss/pages/recipient/_recipientInfoBanner.scss
@@ -1,0 +1,28 @@
+.info-banner {
+  @include usa-alert-warning;
+  @include display(flex);
+  border: solid 1px $color-gold;
+  text-align: left;
+  padding: rem(18) rem(10);
+  .modal-disclaimer__icon {
+    @include flex(0 0 auto);
+    color: $color-gold;
+    font-size: rem(26);
+    margin-right: rem(10);
+  }
+  .info-banner__content {
+    @include flex (1 1 auto);
+    info-banner__title-text {
+      margin: 0 0 rem(6);
+      font-weight: $font-semibold;
+      font-size: rem(18);
+      line-height: rem(22);
+    }
+    p {
+      margin: 0;
+      a {
+        font-weight: $font-semibold;
+      }
+    }
+  }
+}

--- a/src/_scss/pages/recipient/recipientPage.scss
+++ b/src/_scss/pages/recipient/recipientPage.scss
@@ -6,6 +6,10 @@
 	$color-gray-border: #D8D8D8;
 	$color-blue-background: #F5FBFC;
 
+	.info-banner-container {
+		@import "./_recipientInfoBanner";
+	}
+
 	.usda-page-header .usda-page-header__container .usda-page-header__toolbar {
 		@media(max-width: $medium-screen) {
 			border-bottom: rem(1) solid $color-gray-lighter;

--- a/src/js/components/recipient/RecipientInfoBanner.jsx
+++ b/src/js/components/recipient/RecipientInfoBanner.jsx
@@ -1,19 +1,19 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Cookies from "js-cookie";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import InfoBanner from "../sharedComponents/header/InfoBanner";
-import PropTypes from "prop-types";
 
-const propTypes = {
-    closeBanner: PropTypes.func
-};
+const RecipientInfoBanner = () => {
+    const [showInfoBanner, setShowInfoBanner] = useState(false);
 
-const RecipientInfoBanner = (props) => {
-    const [showBanner, setShowBanner] = useState(true);
+    const cookie = 'usaspending-recipient-uei-warning';
 
-    const cookie = 'recipient-uei-warning';
-
-    Cookies.set(cookie, 'showUEIBanner');
+    useEffect(() => {
+        if (!Cookies.get(cookie) || Cookies.get(cookie) === 'show') {
+            setShowInfoBanner(true);
+            Cookies.set(cookie, 'show', { expires: 730 });
+        }
+    });
 
     const title = 'NOTICE';
     const content = (
@@ -30,11 +30,10 @@ const RecipientInfoBanner = (props) => {
     const closeBanner = () => {
         // set a cookie to hide the banner in the future if banner is closed
         Cookies.set(cookie, 'hide', { expires: 7 });
-        setShowBanner(false);
+        setShowInfoBanner(false);
     };
 
-    return <>{showBanner && <InfoBanner {...props} title={title} content={content} icon={icon} closeBanner={closeBanner} />}</>;
+    return <>{showInfoBanner && <InfoBanner closeBanner={closeBanner} title={title} content={content} icon={icon} />}</>;
 };
 
-RecipientInfoBanner.propTypes = propTypes;
 export default RecipientInfoBanner;

--- a/src/js/components/recipient/RecipientInfoBanner.jsx
+++ b/src/js/components/recipient/RecipientInfoBanner.jsx
@@ -11,7 +11,7 @@ const RecipientInfoBanner = (props) => {
         </p>
     );
     const icon = (
-        <span className="modal-disclaimer__icon">
+        <span className="info-banner__exclamation-triangle">
             <FontAwesomeIcon size="lg" icon="exclamation-triangle" />
         </span>
     );

--- a/src/js/components/recipient/RecipientInfoBanner.jsx
+++ b/src/js/components/recipient/RecipientInfoBanner.jsx
@@ -11,7 +11,7 @@ const RecipientInfoBanner = () => {
     useEffect(() => {
         if (!Cookies.get(cookie) || Cookies.get(cookie) === 'show') {
             setShowInfoBanner(true);
-            Cookies.set(cookie, 'show', { expires: 730 });
+            Cookies.set(cookie, 'show', { expires: 7 });
         }
     });
 

--- a/src/js/components/recipient/RecipientInfoBanner.jsx
+++ b/src/js/components/recipient/RecipientInfoBanner.jsx
@@ -1,13 +1,24 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Cookies from "js-cookie";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import InfoBanner from "../sharedComponents/header/InfoBanner";
+import PropTypes from "prop-types";
+
+const propTypes = {
+    closeBanner: PropTypes.func
+};
 
 const RecipientInfoBanner = (props) => {
+    const [showBanner, setShowBanner] = useState(true);
+
+    const cookie = 'recipient-uei-warning';
+
+    Cookies.set(cookie, 'showUEIBanner');
+
     const title = 'NOTICE';
     const content = (
         <p>
-            URLs to Recipient Profile pages are being updated as part of a site-wide change based on the new Unique Entity Identifier (UEI) data element. Please update any saved links to avoid service disruption.
+            URLs to Recipient Profile pages are being updated as part of a site-wide change based on the new Unique Entity Identifier (UEI) data element. <strong>Please update any saved links to avoid service disruption</strong>.
         </p>
     );
     const icon = (
@@ -16,15 +27,14 @@ const RecipientInfoBanner = (props) => {
         </span>
     );
 
-    const closeBanner = (bannerType) => {
+    const closeBanner = () => {
         // set a cookie to hide the banner in the future if banner is closed
         Cookies.set(cookie, 'hide', { expires: 7 });
-        this.setState({
-            [bannerType]: false
-        });
+        setShowBanner(false);
     };
 
-    return <InfoBanner {...props} title={title} content={content} icon={icon} closeBanner={closeBanner} />;
+    return <>{showBanner && <InfoBanner {...props} title={title} content={content} icon={icon} closeBanner={closeBanner} />}</>;
 };
 
+RecipientInfoBanner.propTypes = propTypes;
 export default RecipientInfoBanner;

--- a/src/js/components/recipient/RecipientInfoBanner.jsx
+++ b/src/js/components/recipient/RecipientInfoBanner.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Cookies from "js-cookie";
+import InfoBanner from "../sharedComponents/header/InfoBanner";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+
+const RecipientInfoBanner = (props) => {
+    const title = 'NOTICE';
+    const content = (
+        <p>
+            URLs to Recipient Profile pages are being updated as part of a site-wide change based on the new Unique Entity Identifier (UEI) data element. Please update any saved links to avoid service disruption.
+        </p>
+    );
+    const icon = (
+        <span className="info-banner__info-circle">
+            <FontAwesomeIcon size="lg" icon="exclamation-triangle" />
+        </span>
+    );
+
+    // const closeBanner = (bannerType) => {
+    //     // set a cookie to hide the banner in the future if banner is closed
+    //     Cookies.set(cookie, 'hide', { expires: 7 });
+    //     this.setState({
+    //         [bannerType]: false
+    //     });
+    // }
+
+    return (
+        <InfoBanner {...props} title={title} content={content} icon={icon} />
+    );
+};
+
+export default RecipientInfoBanner;

--- a/src/js/components/recipient/RecipientInfoBanner.jsx
+++ b/src/js/components/recipient/RecipientInfoBanner.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Cookies from "js-cookie";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import InfoBanner from "../sharedComponents/header/InfoBanner";
-import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
 const RecipientInfoBanner = (props) => {
     const title = 'NOTICE';
@@ -11,22 +11,20 @@ const RecipientInfoBanner = (props) => {
         </p>
     );
     const icon = (
-        <span className="info-banner__info-circle">
+        <span className="modal-disclaimer__icon">
             <FontAwesomeIcon size="lg" icon="exclamation-triangle" />
         </span>
     );
 
-    // const closeBanner = (bannerType) => {
-    //     // set a cookie to hide the banner in the future if banner is closed
-    //     Cookies.set(cookie, 'hide', { expires: 7 });
-    //     this.setState({
-    //         [bannerType]: false
-    //     });
-    // }
+    const closeBanner = (bannerType) => {
+        // set a cookie to hide the banner in the future if banner is closed
+        Cookies.set(cookie, 'hide', { expires: 7 });
+        this.setState({
+            [bannerType]: false
+        });
+    };
 
-    return (
-        <InfoBanner {...props} title={title} content={content} icon={icon} />
-    );
+    return <InfoBanner {...props} title={title} content={content} icon={icon} closeBanner={closeBanner} />;
 };
 
 export default RecipientInfoBanner;

--- a/src/js/components/recipient/RecipientPage.jsx
+++ b/src/js/components/recipient/RecipientPage.jsx
@@ -19,6 +19,7 @@ import PageWrapper from 'components/sharedComponents/PageWrapper';
 import Error from 'components/sharedComponents/Error';
 
 import RecipientContent from './RecipientContent';
+import RecipientInfoBanner from "./RecipientInfoBanner";
 
 const propTypes = {
     loading: PropTypes.bool,
@@ -85,19 +86,24 @@ export const RecipientPage = ({
                     onShareOptionClick={handleShare}
                     url={getBaseUrl(slug)} />
             ]}>
-            <main id="main-content" className="main-content">
-                <LoadingWrapper isLoading={loading}>
-                    {content}
-                    <ChildRecipientModalContainer
-                        mounted={isChildModalVisible}
-                        hideModal={hideChildRecipientModal}
-                        recipient={recipient} />
-                    <AlternateNamesRecipientModalContainer
-                        mounted={isAlternateModalVisible}
-                        hideModal={hideAlternateModal}
-                        recipient={recipient} />
-                </LoadingWrapper>
-            </main>
+            <>
+                <div className="info-banner-container">
+                    <RecipientInfoBanner />
+                </div>
+                <main id="main-content" className="main-content">
+                    <LoadingWrapper isLoading={loading}>
+                        {content}
+                        <ChildRecipientModalContainer
+                            mounted={isChildModalVisible}
+                            hideModal={hideChildRecipientModal}
+                            recipient={recipient} />
+                        <AlternateNamesRecipientModalContainer
+                            mounted={isAlternateModalVisible}
+                            hideModal={hideAlternateModal}
+                            recipient={recipient} />
+                    </LoadingWrapper>
+                </main>
+            </>
         </PageWrapper>
     );
 };

--- a/src/js/components/sharedComponents/header/Header.jsx
+++ b/src/js/components/sharedComponents/header/Header.jsx
@@ -8,7 +8,7 @@ import { isIe } from "helpers/browser";
 import GlossaryContainer from 'containers/glossary/GlossaryContainer';
 import GlobalModalContainer from 'containers/globalModal/GlobalModalContainer';
 import Analytics from 'helpers/analytics/Analytics';
-import InfoBanner from './InfoBanner';
+import UEIInfoBanner from './UEIInfoBanner';
 import NavBar from './NavBar';
 
 const clickedHeaderLink = (route) => {
@@ -80,7 +80,7 @@ export default class Header extends React.Component {
 
     render() {
         let infoBanner = (
-            <InfoBanner
+            <UEIInfoBanner
                 triggerModal={this.openBannerModal}
                 closeBanner={this.closeBanner} />
         );

--- a/src/js/components/sharedComponents/header/Header.jsx
+++ b/src/js/components/sharedComponents/header/Header.jsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Cookies from 'js-cookie';
 import { Link } from 'react-router-dom';
-import { isBefore, startOfToday } from 'date-fns';
-import { isIe } from "helpers/browser";
 
 import GlossaryContainer from 'containers/glossary/GlossaryContainer';
 import GlobalModalContainer from 'containers/globalModal/GlobalModalContainer';
@@ -18,39 +15,14 @@ const clickedHeaderLink = (route) => {
     });
 };
 
-let cookie = 'usaspending_covid_release';
-
-Cookies.set(cookie, 'showUEIBanner');
-
-if (isIe() && isBefore(startOfToday(), new Date(2022, 1, 18))) {
-    cookie = 'usaspending_end_of_IE';
-    Cookies.set(cookie, 'showIEBanner');
-}
-
 export default class Header extends React.Component {
     constructor(props) {
         super(props);
 
-        this.state = {
-            showInfoBanner: false
-        };
         // bind functions
         this.skippedNav = this.skippedNav.bind(this);
-        this.closeBanner = this.closeBanner.bind(this);
-        this.openBannerModal = this.openBannerModal.bind(this);
     }
 
-    componentDidMount() {
-        this.setShowInfoBanner();
-    }
-
-    setShowInfoBanner() {
-        if (Cookies.get(cookie) === 'showIEBanner' || Cookies.get(cookie) === 'showUEIBanner') {
-            this.setState({
-                showInfoBanner: true
-            });
-        }
-    }
     skippedNav(e) {
         // don't update the URL due to potential React Router conflicts
         e.preventDefault();
@@ -64,29 +36,12 @@ export default class Header extends React.Component {
             mainFocus.focus();
         }
     }
-    closeBanner(bannerType) {
-        // set a cookie to hide the banner in the future if banner is closed
-        Cookies.set(cookie, 'hide', { expires: 7 });
-        this.setState({
-            [bannerType]: false
-        });
-    }
-
-    openBannerModal(e) {
-        e.preventDefault();
-        this.props.showModal(null, 'uei');
-    }
-
 
     render() {
-        let infoBanner = (
-            <UEIInfoBanner
-                triggerModal={this.openBannerModal}
-                closeBanner={this.closeBanner} />
+        const infoBanner = (
+            <UEIInfoBanner showModal={this.props.showModal} />
         );
-        if (!this.state.showInfoBanner) {
-            infoBanner = null;
-        }
+
         return (
             <div className="site-header">
                 <a

--- a/src/js/components/sharedComponents/header/InfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/InfoBanner.jsx
@@ -5,7 +5,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 const propTypes = {
     closeBanner: PropTypes.func,
-    triggerModal: PropTypes.func,
     title: PropTypes.string,
     content: PropTypes.string,
     icon: PropTypes.string

--- a/src/js/components/sharedComponents/header/InfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/InfoBanner.jsx
@@ -2,73 +2,41 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { isBefore, startOfToday } from "date-fns";
-import { isIe } from "helpers/browser";
-import ExternalLink from 'components/sharedComponents/ExternalLink';
 
 const propTypes = {
     closeBanner: PropTypes.func,
-    triggerModal: PropTypes.func
+    triggerModal: PropTypes.func,
+    title: PropTypes.string,
+    content: PropTypes.string,
+    icon: PropTypes.string
 };
 
-export default class InfoBanner extends React.Component {
-    constructor(props) {
-        super(props);
-        this.bannerClosed = this.bannerClosed.bind(this);
-    }
+const InfoBanner = (props) => {
+    const bannerClosed = () => {
+        props.closeBanner('showInfoBanner');
+    };
 
-    bannerClosed() {
-        this.props.closeBanner('showInfoBanner');
-    }
-
-    render() {
-        let title = 'New on USAspending: Unique Entity Identifiers';
-        let content = (
-            <p>
-                Beginning in March, UEIs will be added to USAspending displays alongside DUNS numbers.
-                <a onClick={this.props.triggerModal} onKeyDown={this.props.triggerModal} role="button" tabIndex={0}> Learn more and find out what changes you’ll see on the site.</a>
-            </p>
-        );
-
-        // reminder that month is 0-indexed
-        if (isIe() && isBefore(startOfToday(), new Date(2022, 1, 18))) {
-            title = 'USAspending Ending Support for Internet Explorer';
-            content = (
-                <p>
-                    Support for Internet Explorer will end on Friday, 2/18/2022. Please use one of the following browsers to continue to access USAspending.gov:
-                    <ExternalLink url="https://support.microsoft.com/en-us/microsoft-edge/make-the-switch-from-internet-explorer-to-microsoft-edge-a6f7173e-e84a-36a3-9728-3df20ade9b3c">{' '}Microsoft Edge</ExternalLink>
-                    ,
-                    <ExternalLink url="https://support.google.com/chrome/answer/95417?hl=en&co=GENIE.Platform%3DDesktop">{' '}Google Chrome</ExternalLink>
-                    ,
-                    <ExternalLink url="https://www.mozilla.org/en-US/firefox/new/">{' '}Mozilla Firefox</ExternalLink>
-                    , Apple Safari.
-                </p>
-            );
-        }
-
-        return (
-            <div className="info-banner">
-                <div className="info-banner__content">
-                    <span className="info-banner__info-circle">
-                        <FontAwesomeIcon size="lg" icon="info-circle" />
-                    </span>
-                    <>
-                        <div className="info-banner__alert-text">
-                            <p className="info-banner__title-text">{title}</p>
-                            {content}
-                        </div>
-                        <button
-                            className="info-banner__close-button"
-                            title="Dismiss message"
-                            aria-label="Dismiss message"
-                            onClick={this.bannerClosed}>
-                            <FontAwesomeIcon size="lg" alt="Dismiss message" icon="times" />
-                        </button>
-                    </>
-                </div>
+    return (
+        <div className="info-banner">
+            <div className="info-banner__content">
+                {props.icon}
+                <>
+                    <div className="info-banner__alert-text">
+                        <p className="info-banner__title-text">{props.title}</p>
+                        {props.content}
+                    </div>
+                    <button
+                        className="info-banner__close-button"
+                        title="Dismiss message"
+                        aria-label="Dismiss message"
+                        onClick={bannerClosed}>
+                        <FontAwesomeIcon size="lg" alt="Dismiss message" icon="times" />
+                    </button>
+                </>
             </div>
-        );
-    }
-}
+        </div>
+    );
+};
 
 InfoBanner.propTypes = propTypes;
+export default InfoBanner;

--- a/src/js/components/sharedComponents/header/UEIInfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/UEIInfoBanner.jsx
@@ -1,20 +1,41 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from "prop-types";
-import InfoBanner from "./InfoBanner";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Cookies from "js-cookie";
-import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import InfoBanner from "./InfoBanner";
 
 const propTypes = {
-    closeBanner: PropTypes.func,
-    triggerModal: PropTypes.func,
+    showModal: PropTypes.func
 };
 
 const UEIInfoBanner = (props) => {
+    const [showInfoBanner, setShowInfoBanner] = useState(false);
+    const cookie = 'usaspending-uei-notification';
+
+    useEffect(() => {
+        if (!Cookies.get(cookie) || Cookies.get(cookie) === 'show') {
+            setShowInfoBanner(true);
+            Cookies.set(cookie, 'show', { expires: 730 });
+        }
+    }, []);
+
+    const closeBanner = () => {
+        // set a cookie to hide the banner in the future if banner is closed
+        console.log('here');
+        Cookies.set(cookie, 'hide', { expires: 730 });
+        setShowInfoBanner(false);
+    };
+
+    const openBannerModal = (e) => {
+        e.preventDefault();
+        props.showModal(null, 'uei');
+    };
+
     const title = 'New on USAspending: Unique Entity Identifiers';
     const content = (
         <p>
             Beginning in March, UEIs will be added to USAspending displays alongside DUNS numbers.
-            <a onClick={props.triggerModal} onKeyDown={props.triggerModal} role="button" tabIndex={0}> Learn more and find out what changes you’ll see on the site.</a>
+            <a onClick={openBannerModal} onKeyDown={openBannerModal} role="button" tabIndex={0}> Learn more and find out what changes you’ll see on the site.</a>
         </p>
     );
     const icon = (
@@ -24,7 +45,7 @@ const UEIInfoBanner = (props) => {
     );
 
     return (
-        <InfoBanner {...props} title={title} content={content} icon={icon} />
+        <>{showInfoBanner && <InfoBanner closeBanner={closeBanner} title={title} content={content} icon={icon} />} </>
     );
 };
 

--- a/src/js/components/sharedComponents/header/UEIInfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/UEIInfoBanner.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from "prop-types";
+import InfoBanner from "./InfoBanner";
+import Cookies from "js-cookie";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+
+const propTypes = {
+    closeBanner: PropTypes.func,
+    triggerModal: PropTypes.func,
+};
+
+const UEIInfoBanner = (props) => {
+    const title = 'New on USAspending: Unique Entity Identifiers';
+    const content = (
+        <p>
+            Beginning in March, UEIs will be added to USAspending displays alongside DUNS numbers.
+            <a onClick={props.triggerModal} onKeyDown={props.triggerModal} role="button" tabIndex={0}> Learn more and find out what changes you’ll see on the site.</a>
+        </p>
+    );
+    const icon = (
+        <span className="info-banner__info-circle">
+            <FontAwesomeIcon size="lg" icon="info-circle" />
+        </span>
+    );
+
+    return (
+        <InfoBanner {...props} title={title} content={content} icon={icon} />
+    );
+};
+
+UEIInfoBanner.propTypes = propTypes;
+export default UEIInfoBanner;

--- a/src/js/components/sharedComponents/header/UEIInfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/UEIInfoBanner.jsx
@@ -15,13 +15,13 @@ const UEIInfoBanner = (props) => {
     useEffect(() => {
         if (!Cookies.get(cookie) || Cookies.get(cookie) === 'show') {
             setShowInfoBanner(true);
-            Cookies.set(cookie, 'show', { expires: 730 });
+            Cookies.set(cookie, 'show', { expires: 7 });
         }
     }, []);
 
     const closeBanner = () => {
         // set a cookie to hide the banner in the future if banner is closed
-        Cookies.set(cookie, 'hide', { expires: 730 });
+        Cookies.set(cookie, 'hide', { expires: 7 });
         setShowInfoBanner(false);
     };
 

--- a/src/js/components/sharedComponents/header/UEIInfoBanner.jsx
+++ b/src/js/components/sharedComponents/header/UEIInfoBanner.jsx
@@ -21,7 +21,6 @@ const UEIInfoBanner = (props) => {
 
     const closeBanner = () => {
         // set a cookie to hide the banner in the future if banner is closed
-        console.log('here');
         Cookies.set(cookie, 'hide', { expires: 730 });
         setShowInfoBanner(false);
     };

--- a/src/js/dataMapping/stickyHeader/stickyHeader.js
+++ b/src/js/dataMapping/stickyHeader/stickyHeader.js
@@ -1,3 +1,2 @@
 export const stickyHeaderHeight = 66;
 export const globalBannerHeight = 90;
-export const globalCovidBannerCookie = 'usaspending_covid_release';


### PR DESCRIPTION
**High level description:**

The calculation of the recipient_hash will be check for UEI, then DUNS, then Recipient Name. Due to this change certain links to Recipient Profile pages that depend on the hashes might be broken so we need to add a warning banner to those pages alerting users to update any saved links. 

**Technical details:**

Refactored the InfoBanner component to be reuseable.  Created separate components for the site wide UEI banner and this recipient profile to include the infobanner component.  Fixed the close button to not show the banner even after refreshing the page.  Removed reference to the IE unsuported banner.

**JIRA Ticket:**
[DEV-8480](https://federal-spending-transparency.atlassian.net/browse/DEV-8480)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Code review complete
