### PR TITLE
[DEV-8499] Increase download limit message back to 500k

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4205,11 +4205,18 @@
             "dev": true
         },
         "axios": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-            "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
+            "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
             "requires": {
-                "follow-redirects": "^1.14.7"
+                "follow-redirects": "^1.14.8"
+            },
+            "dependencies": {
+                "follow-redirects": {
+                    "version": "1.14.8",
+                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+                    "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
+                }
             }
         },
         "axobject-query": {
@@ -8820,7 +8827,8 @@
         "follow-redirects": {
             "version": "1.14.7",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+            "dev": true
         },
         "for-in": {
             "version": "1.0.2",
@@ -22318,7 +22326,8 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "5.0.0",
-                    "resolved": "",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
                     "dev": true
                 },
                 "ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "@fortawesome/free-solid-svg-icons": "^5.13.0",
         "@fortawesome/react-fontawesome": "^0.1.4",
         "accounting": "^0.4.1",
-        "axios": "^0.25.0",
+        "axios": "^0.26.0",
         "clean-webpack-plugin": "^0.1.16",
         "commonmark": "^0.27.0",
         "core-js": "^3.0.1",

--- a/src/js/components/search/header/NoDownloadHover.jsx
+++ b/src/js/components/search/header/NoDownloadHover.jsx
@@ -10,7 +10,7 @@ import { TooltipComponent } from 'data-transparency-ui';
 const NoDownloadHover = () => (
     <TooltipComponent title="Advanced Search Download">
         <div className="message">
-            Our Advanced Search limits downloads to 250,000 records.
+            Our Advanced Search limits downloads to 500,000 records.
             Narrow your search using additional filters, or grab larger files from
             our <Link to="/download_center/award_data_archive">Award Data Archive</Link>.
         </div>


### PR DESCRIPTION
**High level description:**

Download limit is getting increased back to 500k. As a result, the frontend message should match the current limit.

**JIRA Ticket:**
[DEV-8499](https://federal-spending-transparency.atlassian.net/browse/DEV-8499)

Reviewer(s):
- [ ] [API #3371](https://github.com/fedspendingtransparency/usaspending-api/pull/3371) merged concurrently `if applicable`
- [ ] Code review complete
