### PR TITLE
8428 - Standardize percentages in award obligation by type tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4205,11 +4205,11 @@
             "dev": true
         },
         "axios": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-            "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
+            "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
             "requires": {
-                "follow-redirects": "^1.14.7"
+                "follow-redirects": "^1.14.8"
             }
         },
         "axobject-query": {
@@ -22318,7 +22318,8 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "5.0.0",
-                    "resolved": "",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
                     "dev": true
                 },
                 "ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "@fortawesome/free-solid-svg-icons": "^5.13.0",
         "@fortawesome/react-fontawesome": "^0.1.4",
         "accounting": "^0.4.1",
-        "axios": "^0.25.0",
+        "axios": "^0.26.0",
         "clean-webpack-plugin": "^0.1.16",
         "commonmark": "^0.27.0",
         "core-js": "^3.0.1",

--- a/src/js/components/agencyV2/visualizations/ObligationsByAwardTypeTooltip.jsx
+++ b/src/js/components/agencyV2/visualizations/ObligationsByAwardTypeTooltip.jsx
@@ -65,7 +65,7 @@ const ObligationsByAwardTypeTooltip = ({
             ),
             (
                 <div className={activeClass}>
-                    {type.value >= 0 ? calculatePercentage(type.value, _awardObligations, '--', 0) : '--'}
+                    {type.value >= 0 ? calculatePercentage(type.value, _awardObligations, '--', 1) : '--'}
                 </div>
             )
         ];

--- a/tests/components/agency/visualizations/ObligationsByAwardTypeTooltip-test.jsx
+++ b/tests/components/agency/visualizations/ObligationsByAwardTypeTooltip-test.jsx
@@ -91,7 +91,7 @@ test('formats the percent of total', () => {
         />,
         { initialState: mockStore }
     );
-    const directPaymentsPercent = screen.queryByText('30%');
+    const directPaymentsPercent = screen.queryByText('30.0%');
     expect(directPaymentsPercent).toBeTruthy();
 });
 


### PR DESCRIPTION
**High level description:**

The percentage figures in the “% of Total” column in the hover state should round to one decimal place.

**Technical details:**

n/a

**JIRA Ticket:**
[DEV-8428](https://federal-spending-transparency.atlassian.net/browse/DEV-8428)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Code review complete
