### PR TITLE
8287 - Disable Foresee survey in QAT

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -29,55 +29,55 @@
     <script async src='https://www.google-analytics.com/analytics.js'></script>
     <!-- End Google Analytics -->
     <!-- Start ForeSee Survey -->
-    <% if (IS_PROD) { %>
-        <script type="text/javascript">
-            // ForeSee Production Embed Script v2.01
-            // DO NOT MODIFY BELOW THIS LINE *****************************************
-            ;(function (g) {
-                var d = document, am = d.createElement('script'), h = d.head || d.getElementsByTagName("head")[0], fsr = 'fsReady',
-                    aex = {
-                        "src": "//gateway.foresee.com/sites/usaspending/production/gateway.min.js",
-                        "type": "text/javascript",
-                        "async": "true",
-                        "data-vendor": "fs",
-                        "data-role": "gateway"
-                    };
-                for (var attr in aex) { am.setAttribute(attr, aex[attr]); } h.appendChild(am); g[fsr] || (g[fsr] = function () { var aT = '__' + fsr + '_stk__'; g[aT] = g[aT] || []; g[aT].push(arguments); });
-            })(window);
-            // DO NOT MODIFY ABOVE THIS LINE *****************************************
+<!--    <% if (IS_PROD) { %>-->
+<!--        <script type="text/javascript">-->
+<!--            // ForeSee Production Embed Script v2.01-->
+<!--            // DO NOT MODIFY BELOW THIS LINE *****************************************-->
+<!--            ;(function (g) {-->
+<!--                var d = document, am = d.createElement('script'), h = d.head || d.getElementsByTagName("head")[0], fsr = 'fsReady',-->
+<!--                    aex = {-->
+<!--                        "src": "//gateway.foresee.com/sites/usaspending/production/gateway.min.js",-->
+<!--                        "type": "text/javascript",-->
+<!--                        "async": "true",-->
+<!--                        "data-vendor": "fs",-->
+<!--                        "data-role": "gateway"-->
+<!--                    };-->
+<!--                for (var attr in aex) { am.setAttribute(attr, aex[attr]); } h.appendChild(am); g[fsr] || (g[fsr] = function () { var aT = '__' + fsr + '_stk__'; g[aT] = g[aT] || []; g[aT].push(arguments); });-->
+<!--            })(window);-->
+<!--            // DO NOT MODIFY ABOVE THIS LINE *****************************************-->
 
-            // Un-comment out the function below when you are ready to input your variable
-            /*fsReady(function() {
-              FSR.CPPS.set('name','value'); // use single quotes when passing a static-value
-              FSR.CPPS.set('name2',somevariable); // don't use quotes for a dynamic value
-              FSR.CPPS.set('name3',othervariable); // add as many CPPs as you like in this way
-            });*/
-        </script>
-    <% } else { %>
-        <script type="text/javascript">
-            // ForeSee Staging Embed Script v2.01
-            // DO NOT MODIFY BELOW THIS LINE *****************************************
-            ;(function (g) {
-                var d = document, am = d.createElement('script'), h = d.head || d.getElementsByTagName("head")[0], fsr = 'fsReady',
-                    aex = {
-                        "src": "//gateway.foresee.com/sites/usaspending/staging/gateway.min.js",
-                        "type": "text/javascript",
-                        "async": "true",
-                        "data-vendor": "fs",
-                        "data-role": "gateway"
-                    };
-                for (var attr in aex) { am.setAttribute(attr, aex[attr]); } h.appendChild(am); g[fsr] || (g[fsr] = function () { var aT = '__' + fsr + '_stk__'; g[aT] = g[aT] || []; g[aT].push(arguments); });
-            })(window);
-            // DO NOT MODIFY ABOVE THIS LINE *****************************************
+<!--            // Un-comment out the function below when you are ready to input your variable-->
+<!--            /*fsReady(function() {-->
+<!--              FSR.CPPS.set('name','value'); // use single quotes when passing a static-value-->
+<!--              FSR.CPPS.set('name2',somevariable); // don't use quotes for a dynamic value-->
+<!--              FSR.CPPS.set('name3',othervariable); // add as many CPPs as you like in this way-->
+<!--            });*/-->
+<!--        </script>-->
+<!--    <% } else { %>-->
+<!--        <script type="text/javascript">-->
+<!--            // ForeSee Staging Embed Script v2.01-->
+<!--            // DO NOT MODIFY BELOW THIS LINE *****************************************-->
+<!--            ;(function (g) {-->
+<!--                var d = document, am = d.createElement('script'), h = d.head || d.getElementsByTagName("head")[0], fsr = 'fsReady',-->
+<!--                    aex = {-->
+<!--                        "src": "//gateway.foresee.com/sites/usaspending/staging/gateway.min.js",-->
+<!--                        "type": "text/javascript",-->
+<!--                        "async": "true",-->
+<!--                        "data-vendor": "fs",-->
+<!--                        "data-role": "gateway"-->
+<!--                    };-->
+<!--                for (var attr in aex) { am.setAttribute(attr, aex[attr]); } h.appendChild(am); g[fsr] || (g[fsr] = function () { var aT = '__' + fsr + '_stk__'; g[aT] = g[aT] || []; g[aT].push(arguments); });-->
+<!--            })(window);-->
+<!--            // DO NOT MODIFY ABOVE THIS LINE *****************************************-->
 
-            // Un-comment out the function below when you are ready to input your variable
-            /*fsReady(function() {
-              FSR.CPPS.set('name','value'); // use single quotes when passing a static-value
-              FSR.CPPS.set('name2',somevariable); // don't use quotes for a dynamic value
-              FSR.CPPS.set('name3',othervariable); // add as many CPPs as you like in this way
-            });*/
-        </script>
-    <% } %>
+<!--            // Un-comment out the function below when you are ready to input your variable-->
+<!--            /*fsReady(function() {-->
+<!--              FSR.CPPS.set('name','value'); // use single quotes when passing a static-value-->
+<!--              FSR.CPPS.set('name2',somevariable); // don't use quotes for a dynamic value-->
+<!--              FSR.CPPS.set('name3',othervariable); // add as many CPPs as you like in this way-->
+<!--            });*/-->
+<!--        </script>-->
+<!--    <% } %>-->
     <!-- End ForeSee Survey -->
 
     <% if (USE_GTM) { %>


### PR DESCRIPTION
**High level description:**
Disabling the Foresee Survey in QAT.  The survey is currently blocking ops from testing with the dynamic renderer.  Foresee can disable certain user agents but the turn around time isn't immediate.  Once Foresee disables the correct user agent for the dynamic renderer we can re-enable the survey.

**JIRA Ticket:**
[DEV-8287](https://federal-spending-transparency.atlassian.net/browse/DEV-8287)


Author:
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
- [ ] Code review complete
