### PR TITLE
8289 add uei column to recipients table

### DIFF
--- a/src/js/components/recipientLanding/RecipientLandingSearchBar.jsx
+++ b/src/js/components/recipientLanding/RecipientLandingSearchBar.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import GlobalConstants from 'GlobalConstants';
 
 import { Search, Close } from 'components/sharedComponents/icons/Icons';
 
@@ -76,7 +77,7 @@ export default class RecipientLandingSearchBar extends React.Component {
                         name="recipient"
                         value={this.state.recipient}
                         onChange={this.onChange}
-                        placeholder="Search by Recipient Name or DUNS" />
+                        placeholder="Search by Recipient Name, UEI, or DUNS" />
                     <button
                         aria-label="Search"
                         className="search-section__button"

--- a/src/js/components/recipientLanding/RecipientLandingSearchBar.jsx
+++ b/src/js/components/recipientLanding/RecipientLandingSearchBar.jsx
@@ -5,7 +5,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import GlobalConstants from 'GlobalConstants';
 
 import { Search, Close } from 'components/sharedComponents/icons/Icons';
 

--- a/src/js/components/recipientLanding/RecipientLandingSearchBar.jsx
+++ b/src/js/components/recipientLanding/RecipientLandingSearchBar.jsx
@@ -77,7 +77,7 @@ export default class RecipientLandingSearchBar extends React.Component {
                         name="recipient"
                         value={this.state.recipient}
                         onChange={this.onChange}
-                        placeholder="Recipient Name, UEI, or DUNS" />
+                        placeholder="Search by Recipient Name, UEI, or DUNS" />
                     <button
                         aria-label="Search"
                         className="search-section__button"

--- a/src/js/components/recipientLanding/RecipientLandingSearchBar.jsx
+++ b/src/js/components/recipientLanding/RecipientLandingSearchBar.jsx
@@ -77,7 +77,7 @@ export default class RecipientLandingSearchBar extends React.Component {
                         name="recipient"
                         value={this.state.recipient}
                         onChange={this.onChange}
-                        placeholder="Search by Recipient Name, UEI, or DUNS" />
+                        placeholder="Recipient Name, UEI, or DUNS" />
                     <button
                         aria-label="Search"
                         className="search-section__button"

--- a/src/js/components/recipientLanding/table/RecipientLandingTable.jsx
+++ b/src/js/components/recipientLanding/table/RecipientLandingTable.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import GlobalConstants from 'GlobalConstants';
 
 import StateLandingTableSorter from 'components/stateLanding/table/StateLandingTableSorter';
 import RecipientLinkCell from './RecipientLinkCell';
@@ -32,6 +33,9 @@ const RecipientLandingTable = (props) => {
                 type={row.recipientLevel}
                 name={row.name}
                 searchString={props.searchString} />
+            <td className="recipient-list__body-cell recipient-list__body-cell_left">
+                {row.uei}
+            </td>
             <td className="recipient-list__body-cell recipient-list__body-cell_left">
                 {row.duns}
             </td>
@@ -84,7 +88,21 @@ const RecipientLandingTable = (props) => {
                             <div className="header-cell ">
                                 <div className="header-cell__text">
                                     <div className="header-cell__title header-cell__title_cap">
-                                        Duns
+                                        UEI
+                                    </div>
+                                </div>
+                                <StateLandingTableSorter
+                                    field="duns"
+                                    label="duns"
+                                    active={{ field: props.order.field, direction: props.order.direction }}
+                                    setSort={props.setSort} />
+                            </div>
+                        </th>
+                        <th className="recipient-list__head-cell">
+                            <div className="header-cell ">
+                                <div className="header-cell__text">
+                                    <div className="header-cell__title header-cell__title_cap">
+                                        {GlobalConstants.DUNS_LABEL}DUNS
                                     </div>
                                 </div>
                                 <StateLandingTableSorter

--- a/src/js/components/recipientLanding/table/RecipientLandingTable.jsx
+++ b/src/js/components/recipientLanding/table/RecipientLandingTable.jsx
@@ -92,8 +92,8 @@ const RecipientLandingTable = (props) => {
                                     </div>
                                 </div>
                                 <StateLandingTableSorter
-                                    field="duns"
-                                    label="duns"
+                                    field="uei"
+                                    label="uei"
                                     active={{ field: props.order.field, direction: props.order.direction }}
                                     setSort={props.setSort} />
                             </div>

--- a/src/js/models/v2/recipient/BaseRecipientLandingRow.js
+++ b/src/js/models/v2/recipient/BaseRecipientLandingRow.js
@@ -11,6 +11,7 @@ const BaseRecipientLandingRow = {
         this.recipientLevel = data.recipient_level || '';
         this.name = data.name || 'Not provided in source system';
         this.duns = data.duns || 'DUNS not provided';
+        this.uei = data.uei || 'UEI not provided';
         this.id = data.id || '';
         this._amount = data.amount || 0;
     },


### PR DESCRIPTION
**High level description:**

Add column for UEI to the table on the Recipients landing page.

**Technical details:**

Added the column, following the pattern for the DUNS column. Backend changes were required, so for testing you need to use the QAT endpoints. Also added the new var for the DUNS label in that table.

**JIRA Ticket:**
[DEV-8289](https://federal-spending-transparency.atlassian.net/browse/DEV-8289)

**Mockup:**
link to mock in the ticket is bad, but it should look like the DUNS column right next to it

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
