### PR TITLE
7759 - removed unneeded alt text from the Top Five components

### DIFF
--- a/src/js/components/recipient/topFive/TopFive.jsx
+++ b/src/js/components/recipient/topFive/TopFive.jsx
@@ -109,7 +109,7 @@ export default class TopFive extends React.Component {
                         <img
                             className="category-table__title-icon"
                             src={`img/state-categories/${this.props.category}.png`}
-                            alt={recipientCategoryTitles[this.props.category]} />
+                            alt="" />
                         <div className="category-table__title-name">
                             {recipientCategoryTitles[this.props.category]}
                         </div>

--- a/src/js/components/state/topFive/TopFive.jsx
+++ b/src/js/components/state/topFive/TopFive.jsx
@@ -49,7 +49,7 @@ const TopFive = (props) => {
                 <img
                     className="category-table__title-icon"
                     src={`img/state-categories/${props.category}.png`}
-                    alt={categoryTitles[props.category]} />
+                    alt="" />
                 <div className="category-table__title-name">
                     {categoryTitles[props.category]}
                 </div>


### PR DESCRIPTION
**High level description:**

Remove unneeded alt text from the images in the Top Five section on both Recipient Profile and State Profile pages.

**Technical details:**

This is from our 508 Tech Debt list. Best practice for alt text says the alt text should not repeat any text that is already on the page, and that if no alt text is needed for an image (if it is only decorative and not essential to content) then leaving the alt attribute with a value of empty string is preferred. 

**JIRA Ticket:**
[DEV-7759](https://federal-spending-transparency.atlassian.net/browse/DEV-7759)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
