### PR TITLE
Hotfix/8548 - Remove infrastructure defc from COVID DS&M

### DIFF
--- a/src/js/components/covid19/DataSourcesAndMethodologiesPage.jsx
+++ b/src/js/components/covid19/DataSourcesAndMethodologiesPage.jsx
@@ -74,6 +74,7 @@ require('pages/data-sources/index.scss');
 const getDefCValues = (errorMsg, isLoading, codes) => {
     if (isLoading) return "Loading...";
     if (errorMsg) return "There was an error fetching DEFC values";
+
     return (
         <span>
             {codes
@@ -125,6 +126,11 @@ export default () => {
     const dataDisclaimerBannerRef = useRef(null);
     const [dataDisclaimerBanner, setDataDisclaimerBanner] = useState(Cookies.get('usaspending_data_disclaimer'));
     const [isBannerSticky, , , setBannerStickyOnScroll] = useDynamicStickyClass(dataDisclaimerBannerRef, getStickyBreakPointForCovidBanner(Cookies.get('usaspending_covid_homepage')));
+    const [covidDefCodes, setCovidDefCodes] = useState();
+
+    useEffect(() => {
+        setCovidDefCodes(defCodes.filter((c) => c.disaster === 'covid_19'));
+    }, [defCodes]);
 
     useEffect(() => {
         window.addEventListener('scroll', setBannerStickyOnScroll);
@@ -451,7 +457,7 @@ export default () => {
                                             If it is after FY20, repeat this process for each FY after FY20 until you have reached the current FY (one file per FY)
                                                 </li>
                                                 <li>
-                                            Filter for rows with DEFC values {getDefCValues(errorMsg, isLoading, defCodes)} in the downloaded file
+                                            Filter for rows with DEFC values {getDefCValues(errorMsg, isLoading, covidDefCodes)} in the downloaded file
                                                 </li>
                                             </ol>
                                         </div>
@@ -466,7 +472,7 @@ export default () => {
                                                 <ExternalLink
                                                     url="https://www.whitehouse.gov/wp-content/uploads/2020/04/Implementation-Guidance-for-Supplemental-Funding-Provided-in-Response.pdf">
                                             Memorandum M-20-21
-                                                </ExternalLink>, <strong>COVID-19 supplemental appropriations are identified by a Disaster Emergency Fund Code (DEFC)</strong>. The COVID-19 Spending profile page download is pre-filtered to include only spending data associated with COVID-19 DEFC values. If you use the <Link to="/download_center/custom_account_data">Custom Account Data</Link> page to download Broker File C data, be sure to filter for rows with DEFC values {getDefCValues(errorMsg, isLoading, defCodes)} in the downloaded file.
+                                                </ExternalLink>, <strong>COVID-19 supplemental appropriations are identified by a Disaster Emergency Fund Code (DEFC)</strong>. The COVID-19 Spending profile page download is pre-filtered to include only spending data associated with COVID-19 DEFC values. If you use the <Link to="/download_center/custom_account_data">Custom Account Data</Link> page to download Broker File C data, be sure to filter for rows with DEFC values {getDefCValues(errorMsg, isLoading, covidDefCodes)} in the downloaded file.
                                             </p>
                                             <p>
                                         Note that the <strong>National Interest Action (NIA)</strong> code is also used to track COVID-19 spending. However, it only applies to procurement actions (i.e., contracts) and is not necessarily tied to COVID-19 supplemental appropriations. Thus, awards with the COVID-19 NIA value may not have a COVID-19 DEFC value, and vice versa.
@@ -475,7 +481,7 @@ export default () => {
                                         The relevant codes for COVID-19 response funding and their associated legislation are as follows:
                                             </p>
                                             <ul>
-                                                {renderDefCodes(errorMsg, isLoading, defCodes)}
+                                                {renderDefCodes(errorMsg, isLoading, covidDefCodes)}
                                             </ul>
                                         </div>
                                     </div>


### PR DESCRIPTION
**High level description:**

Remove infrastructure defc from COVID DS&M

**Technical details:**

The useDefCode custom hook now returns all defcs including both COVID and Infrastructure.  When using useDefCode on 
covid pages we need to filter for the covid disaster code.

**JIRA Ticket:**
[DEV-8548](https://federal-spending-transparency.atlassian.net/browse/DEV-8548)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [n/a] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [n/a] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [n/a] Verified mobile/tablet/desktop/monitor responsiveness
- [n/a] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [n/a] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [n/a] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [n/a] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [n/a] Design review complete `if applicable`
- [n/a] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
