### PR TITLE
8519:  Updated typography styles global styles to match homepage updates

### DIFF
--- a/src/_scss/core/_variables.scss
+++ b/src/_scss/core/_variables.scss
@@ -1,16 +1,30 @@
 // Typography
 $em-base:             10px;
+
 $base-font-size:      rem(16px);
 $small-font-size:     rem(14px);
 $smallest-font-size:  rem(11px);
 $lead-font-size:      rem(20px);
 $title-font-size:     rem(52px);
-$h1-font-size:        rem(59px);
-$h2-font-size:        rem(47px);
-$h3-font-size:        rem(38px);
-$h4-font-size:        rem(30px);
-$h5-font-size:        rem(24px);
+$h1-font-size:        rem(56px);
+$h2-font-size:        rem(40px);
+$h3-font-size:        rem(32px);
+$h4-font-size:        rem(28px);
+$h5-font-size:        rem(20px);
 $h6-font-size:        rem(19px);
+
+
+//$base-font-size:      rem(16px);
+//$small-font-size:     rem(14px);
+//$smallest-font-size:  rem(11px);
+//$lead-font-size:      rem(20px);
+//$title-font-size:     rem(52px);
+//$h1-font-size:        rem(59px);
+//$h2-font-size:        rem(47px);
+//$h3-font-size:        rem(38px);
+//$h4-font-size:        rem(30px);
+//$h5-font-size:        rem(24px);
+//$h6-font-size:        rem(19px);
 $base-line-height:    1.5;
 $heading-line-height: 1.2;
 $lead-line-height:    1.7;

--- a/src/_scss/core/_variables.scss
+++ b/src/_scss/core/_variables.scss
@@ -13,18 +13,6 @@ $h4-font-size:        rem(28px);
 $h5-font-size:        rem(20px);
 $h6-font-size:        rem(19px);
 
-
-//$base-font-size:      rem(16px);
-//$small-font-size:     rem(14px);
-//$smallest-font-size:  rem(11px);
-//$lead-font-size:      rem(20px);
-//$title-font-size:     rem(52px);
-//$h1-font-size:        rem(59px);
-//$h2-font-size:        rem(47px);
-//$h3-font-size:        rem(38px);
-//$h4-font-size:        rem(30px);
-//$h5-font-size:        rem(24px);
-//$h6-font-size:        rem(19px);
 $base-line-height:    1.5;
 $heading-line-height: 1.2;
 $lead-line-height:    1.7;


### PR DESCRIPTION
**High level description:**

Updated typography styles global styles to match homepage updates

**Technical details:**

I made some simple changes in _variables.scss.  It looks like each page is overriding h1 - h5 for the specific page so changing these values global didn't change anything from what I can tell.  However, while working on the homepage we should reference these variables for typography from _variables.scss.  Also see the ticket for a list of variables defined across files.  I scheduled a frontend meeting for the team to discuss how we could consolidate these files moving forward.

**JIRA Ticket:**
[DEV-8519](https://federal-spending-transparency.atlassian.net/browse/DEV-8519)

**Mockup:**
https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55/screen/621fa649d1b184a0f2a2d1f0

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
- [ ] Code review complete
