### PR TITLE
8511 loans tooltip

### DIFF
--- a/src/_scss/pages/search/filters/keyword/_keywordHover.scss
+++ b/src/_scss/pages/search/filters/keyword/_keywordHover.scss
@@ -24,7 +24,7 @@
 
     color: $color-base;
 
-    z-index: $z-header + 1;
+    z-index: $z-header - 1;
     pointer-events: none;
 
     .icon {

--- a/src/_scss/pages/search/filters/keyword/_keywordHover.scss
+++ b/src/_scss/pages/search/filters/keyword/_keywordHover.scss
@@ -24,7 +24,7 @@
 
     color: $color-base;
 
-    z-index: $z-header - 1;
+    z-index: $z-header + 1;
     pointer-events: none;
 
     .icon {

--- a/src/_scss/pages/search/results/table/_tableTypes.scss
+++ b/src/_scss/pages/search/results/table/_tableTypes.scss
@@ -4,7 +4,6 @@
     display: none;
     @include media($tablet-screen) {
         @include display(flex);
-        overflow: hidden;
     }
 
     .table-type-toggle__wrapper {
@@ -41,7 +40,7 @@
                 border-left: 1px solid $color-gray-light;
                 color: $color-base;
             }
-    
+
             .tab-content {
                 @include display(flex);
                 @include align-items(center);
@@ -52,14 +51,14 @@
                     margin-right: rem(5);
                     white-space: nowrap;
                 }
-    
+
                 .count-badge {
                     @include flex(1 1 auto);
                     background-color: $color-gray-lighter;
                     font-size: rem(12);
                     line-height: rem(16);
                     padding: rem(0) rem(5);
-    
+
                     &.active {
                         background-color: $color-gold;
                     }
@@ -76,7 +75,7 @@
                     }
                   }
             }
-    
+
             &[disabled] {
                 pointer-events: none;
                 color: #1010104d;

--- a/src/_scss/pages/search/results/table/resultsTable.scss
+++ b/src/_scss/pages/search/results/table/resultsTable.scss
@@ -1,13 +1,14 @@
 .search-results-table-section {
     transition: opacity 0.25s ease;
     position: relative;
+    overflow-x: hidden;
     @import "_tableTypes";
     @import "_tableStyle";
     @import "_resultsDropdownPickerWrapper";
     @import "./_tableMessages";
     .results-table-content {
         position: relative;
-        margin-top: rem(15);   
+        margin-top: rem(15);
         min-height: rem(200);
         @include transition(opacity 0.25s ease-in);
     }

--- a/src/js/components/search/table/ResultsTableTabItem.jsx
+++ b/src/js/components/search/table/ResultsTableTabItem.jsx
@@ -25,6 +25,8 @@ export default class ResultsTableTabItem extends React.Component {
     constructor(props) {
         super(props);
 
+        console.log('props', this.props);
+
         this.clickedTab = this.clickedTab.bind(this);
     }
 

--- a/src/js/components/search/table/ResultsTableTabItem.jsx
+++ b/src/js/components/search/table/ResultsTableTabItem.jsx
@@ -25,8 +25,6 @@ export default class ResultsTableTabItem extends React.Component {
     constructor(props) {
         super(props);
 
-        console.log('props', this.props);
-
         this.clickedTab = this.clickedTab.bind(this);
     }
 

--- a/src/js/containers/keyword/table/ResultsTableContainer.jsx
+++ b/src/js/containers/keyword/table/ResultsTableContainer.jsx
@@ -11,7 +11,7 @@ import * as KeywordHelper from 'helpers/keywordHelper';
 import { availableColumns, defaultSort } from 'dataMapping/keyword/resultsTableColumns';
 import { awardTypeGroups } from 'dataMapping/search/awardType';
 import { measureTableHeader } from 'helpers/textMeasurement';
-import tableTabsTooltips from 'dataMapping/shared/tableTabsTooltips';
+import TableTabsTooltips from 'dataMapping/shared/TableTabsTooltips';
 import Analytics from 'helpers/analytics/Analytics';
 
 import ResultsTableSection from 'components/keyword/table/ResultsTableSection';
@@ -41,7 +41,7 @@ const tableTypes = [
     {
         label: 'Loans',
         internal: 'loans',
-        tooltip: tableTabsTooltips('loans')
+        tooltip: TableTabsTooltips('loans')
     },
     {
         label: 'Other',

--- a/src/js/dataMapping/shared/TableTabsTooltips.jsx
+++ b/src/js/dataMapping/shared/TableTabsTooltips.jsx
@@ -25,7 +25,7 @@ const TableTabsTooltips = (type) => {
         <TooltipWrapper
             className="award-section-tt"
             icon="info"
-            tooltipPosition="right"
+            tooltipPosition="left"
             tooltipComponent={<TooltipComponent data={tooltipProps} />} />
     );
 };

--- a/src/js/dataMapping/shared/TableTabsTooltips.jsx
+++ b/src/js/dataMapping/shared/TableTabsTooltips.jsx
@@ -18,16 +18,16 @@ const tooltipContent = () => ({
     }
 });
 
-const tableTabsTooltips = (type) => {
+const TableTabsTooltips = (type) => {
     const tooltipProps = tooltipContent()[type];
     if (!tooltipProps) return null;
     return (
         <TooltipWrapper
             className="award-section-tt"
             icon="info"
-            tooltipPosition="left"
+            tooltipPosition="right"
             tooltipComponent={<TooltipComponent data={tooltipProps} />} />
     );
 };
 
-export default tableTabsTooltips;
+export default TableTabsTooltips;


### PR DESCRIPTION
**High level description:**

On the Keyword Search page, when you hover over the Loans tooltip icon, the tooltip is displayed behind table.  You can only see the arrow pointing to it

**Technical details:**

After trying many things, I found that removing overflow: hidden from the tabs section css and adding overflow-x: hidden to its parent solved it.

**JIRA Ticket:**
[DEV-8511](https://federal-spending-transparency.atlassian.net/browse/DEV-8511)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
