### PR TITLE
8583 - added new component for intro section in Award Spending section

### DIFF
--- a/src/_scss/pages/agencyV2/statusOfFunds/_introSection.scss
+++ b/src/_scss/pages/agencyV2/statusOfFunds/_introSection.scss
@@ -1,4 +1,4 @@
-@import 'mixins/profilePage';
+@import "all";
 
 .status-of-funds__intro-wrapper {
     padding-bottom: 4rem;

--- a/src/js/components/agencyV2/awardSpending/AwardSpendingIntro.jsx
+++ b/src/js/components/agencyV2/awardSpending/AwardSpendingIntro.jsx
@@ -1,0 +1,28 @@
+/**
+ * AwardSpendingIntro.jsx
+ * Created by Brian Petway 11/04/21
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import GlossaryLink from '../../sharedComponents/GlossaryLink';
+
+require('pages/agencyV2/statusOfFunds/_introSection.scss');
+
+const propTypes = {
+    name: PropTypes.string.isRequired
+};
+
+const AwardSpendingIntro = ({ name }) => (
+    <div className="status-of-funds__intro-wrapper">
+        <div className="status-of-funds__intro-section-title">
+            How much is {name} spending on contracts and financial assistance?
+        </div>
+        <div className="status-of-funds__intro-section-text" data-testid="introCopy" >
+            Federal agencies use some portion of their <span className="status-of-funds__glossary-term">budgetary resources</span> <GlossaryLink term="budgetary-resources" /> for awards to recipients in the form of contracts and financial assistance. Each award consists of a roll-up of individual <span className="status-of-funds__glossary-term">transactions</span> <GlossaryLink term="transaction" />, including transactions that obligate money. In this section, we show which sub-agencies of {name} have issued awards through different types of contracts or financial assistance and how much each sub-agency has obligated (promised to spend).
+        </div>
+    </div>
+);
+
+AwardSpendingIntro.propTypes = propTypes;
+export default AwardSpendingIntro;

--- a/src/js/components/agencyV2/awardSpending/AwardSpendingSubagency.jsx
+++ b/src/js/components/agencyV2/awardSpending/AwardSpendingSubagency.jsx
@@ -12,6 +12,7 @@ import SubAgencySummaryContainer from 'containers/agencyV2/awardSpending/SubAgen
 import SubagencyTableContainer from 'containers/agencyV2/awardSpending/SubagencyTableContainer';
 import { useStateWithPrevious } from 'helpers';
 import Note from 'components/sharedComponents/Note';
+import AwardSpendingIntro from "./AwardSpendingIntro";
 
 const propTypes = {
     fy: PropTypes.string
@@ -70,8 +71,9 @@ const initialActiveTabState = {
 };
 
 const AwardSpendingSubagency = ({ fy }) => {
-    const { subagencyCount } = useSelector((state) => state.agencyV2);
+    const { overview, subagencyCount } = useSelector((state) => state.agencyV2);
     const [prevActiveTab, activeTab, setActiveTab] = useStateWithPrevious(initialActiveTabState);
+
 
     const moreOptionsTabsRef = useRef(null);
 
@@ -89,6 +91,7 @@ const AwardSpendingSubagency = ({ fy }) => {
 
     return (
         <div className="body__content">
+            <AwardSpendingIntro name={overview.name} />
             <div ref={moreOptionsTabsRef}>
                 <Tabs active={activeTab.internal} types={awardTabs} switchTab={changeActiveTab} />
             </div>


### PR DESCRIPTION
**High level description:**

Adding new copy to the Award Spending section of the Agency Profile page.

**Technical details:**

Made a new component for an intro to the Award Spending section, used the intro section of Status of Funds as a template since the AC specifies that this section should use the same css as that section. 
For some reason I started getting errors related to the css import in the _introSection.scss, it suddenly couldn't find those variables. I tried importing only '_variables.scss' but that didn't work so I imported 'all' and that solved it. If there is a better way to do it, I'm open to that.

**JIRA Ticket:**
[DEV-8583](https://federal-spending-transparency.atlassian.net/browse/DEV-8583)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Internet Explorer, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
