### PR TITLE
Fix homepage 404

### DIFF
--- a/scripts/buildRedirectConfig.js
+++ b/scripts/buildRedirectConfig.js
@@ -6,6 +6,7 @@ import agencyIdsToSlugs from '../src/js/dataMapping/agencyV2/agencyIdsToSlugs';
 
 const legacyRedirects = {
     "^/Pages/Default.aspx/": "/",
+    "^/index.html/": "/",
     "^/Pages/AdvancedSearch.aspx/": "/search",
     "^/DownloadCenter/Pages/DataDownload.aspx/": "/download_center/custom_award_data",
     "^/DownloadCenter/Pages/dataarchives.aspx/": "/download_center/award_data_archive",


### PR DESCRIPTION
**High level description:**
https://www.usaspending.gov/index.html is returning a 404.  Added a server redirect to fix this.
https://data-transparency-bfs.slack.com/archives/C0155EL4AU9/p1647358127740889 

**JIRA Ticket:**
n/a


Reviewer(s):
- [ ] Code review complete
