### PR TITLE
8562 uei column in recipient child table

### DIFF
--- a/src/_scss/pages/modals/recipient/_table.scss
+++ b/src/_scss/pages/modals/recipient/_table.scss
@@ -6,7 +6,6 @@
         .recipients-list__head-cell {
             background-color: $color-white;
             border: none;
-            vertical-align: top;
 
             @import "pages/stateLanding/_header";
             @import "pages/stateLanding/_sorter";

--- a/src/js/components/recipient/modal/table/ChildRecipientModalTable.jsx
+++ b/src/js/components/recipient/modal/table/ChildRecipientModalTable.jsx
@@ -29,6 +29,9 @@ export default class ChildRecipientModalTable extends React.Component {
                     <Link to={`/recipient/${child.id}/latest`} onClick={this.props.hideModal}>{child.name}</Link>
                 </td>
                 <td className="recipients-list__body-cell">
+                    {child.uei}
+                </td>
+                <td className="recipients-list__body-cell">
                     {child.duns}
                 </td>
                 <td className="recipients-list__body-cell">
@@ -64,6 +67,20 @@ export default class ChildRecipientModalTable extends React.Component {
                                 <Sorter
                                     field="name"
                                     label="recipient name"
+                                    active={{ field: this.props.sortField, direction: this.props.sortDirection }}
+                                    setSort={this.props.updateSort} />
+                            </div>
+                        </th>
+                        <th className="recipients-list__head-cell">
+                            <div className="header-cell">
+                                <div className="header-cell__text">
+                                    <div className="header-cell__title">
+                                        UEI
+                                    </div>
+                                </div>
+                                <Sorter
+                                    field="uei"
+                                    label="UEI"
                                     active={{ field: this.props.sortField, direction: this.props.sortDirection }}
                                     setSort={this.props.updateSort} />
                             </div>

--- a/src/js/components/recipient/modal/table/ChildRecipientModalTable.jsx
+++ b/src/js/components/recipient/modal/table/ChildRecipientModalTable.jsx
@@ -25,7 +25,7 @@ export default class ChildRecipientModalTable extends React.Component {
         const body = this.props.childRecipients.map((child) => (
             <tr
                 className="recipients-list__body-row"
-                key={child.duns}>
+                key={child.uei}>
                 <td className="recipients-list__body-cell">
                     <Link to={`/recipient/${child.id}/latest`} onClick={this.props.hideModal}>{child.name}</Link>
                 </td>

--- a/src/js/models/v2/recipient/BaseChildRecipient.js
+++ b/src/js/models/v2/recipient/BaseChildRecipient.js
@@ -10,6 +10,7 @@ const BaseChildRecipient = {
         this.id = data.recipient_id || null;
         this.name = data.name || 'Name not provided';
         this.duns = data.duns || 'DUNS not provided';
+        this.uei = data.uei || 'UEI not provided';
         this._amount = parseFloat(data.amount) || 0;
         this.stateProvince = data.state_province || '--';
     },


### PR DESCRIPTION
**High level description**

This is a follow up ticket to correct a problem with the headers, found by QA.
At smaller desktop screen sizes the headers were not aligned with each other.
There was also a problem with sorting but that seems to be caused by having many rows with 'UEI not provided' or 'DUNS not provided' and is no longer happening.

**Technical details:**

Removed vertical-align: top from the table css.
I also changed the key in the table to use uei instead of duns, since duns will go away soon.

**JIRA Ticket:**
[DEV-8562](https://federal-spending-transparency.atlassian.net/browse/DEV-8562)

**Mockup:**

n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
