### PR TITLE
8562 - added padding top to header cell with longer title, to align w…

### DIFF
--- a/src/_scss/pages/stateLanding/_header.scss
+++ b/src/_scss/pages/stateLanding/_header.scss
@@ -21,6 +21,10 @@
         &.header-cell__title_right {
             text-align: right;
         }
+
+    }
+    .header-cell__longer-title {
+        padding-top: rem(18);
     }
     .header-cell__subtitle {
         text-align: right;

--- a/src/js/components/recipient/modal/table/ChildRecipientModalTable.jsx
+++ b/src/js/components/recipient/modal/table/ChildRecipientModalTable.jsx
@@ -117,7 +117,7 @@ export default class ChildRecipientModalTable extends React.Component {
                         <th className="recipients-list__head-cell">
                             <div className="header-cell header-cell_right">
                                 <div className="header-cell__text">
-                                    <div className="header-cell__title header-cell__title_right">
+                                    <div className="header-cell__title header-cell__title_right header-cell__longer-title">
                                     Transaction Amount
                                         <div className="header-cell__subtitle">
                                             {timePeriod}


### PR DESCRIPTION
…ith other headers

**High level description:**

This was returned by QA, asking to make the 'Transaction History' header align with the others, before wrapping.

**Technical details:**

Added a new class only for the 'Transaction History' header, pushing it down a little. Now at very wide screens, with no wrapping, everything is on one line, and as the screen gets smaller and wrapping happens, the 'Transaction History' text is now aligned with the next longest header, 'Legacy DUNS'.

**JIRA Ticket:**
[DEV-8562](https://federal-spending-transparency.atlassian.net/browse/DEV-8562)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
