### PR TITLE
8366 - Added the analyst guide to the nav bar

### DIFF
--- a/src/js/dataMapping/navigation/menuOptions.jsx
+++ b/src/js/dataMapping/navigation/menuOptions.jsx
@@ -68,6 +68,16 @@ export const resourceOptions = [
         externalLink: false
     },
     {
+        label: 'Analyst Guide',
+        type: 'analyst-guide',
+        url: '/analyst-guide',
+        shouldOpenNewTab: false,
+        enabled: GlobalConstants.SHOW_ANALYSTGUIDE,
+        externalLink: false,
+        isNewTab: true
+
+    },
+    {
         label: 'Data Model',
         enabled: true,
         url: 'https://fiscal.treasury.gov/data-transparency/DAIMS-current.html',


### PR DESCRIPTION
**High level description:**

This ticket adds the Analyst Guide to the nav bar for environments where it's enabled.  If the analyst guide isn't not enabled in the environment (ie. prod and staging), the nav bar items shows as coming soon.

**Technical details:**

code is pretty self explanatory

**JIRA Ticket:**
[DEV-8366](https://federal-spending-transparency.atlassian.net/browse/DEV-8366)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
- [ ] Code review complete
