### PR TITLE
8647 - Add downloadable CJ csv

### DIFF
--- a/src/js/components/agencyLanding/AgencyLandingContent.jsx
+++ b/src/js/components/agencyLanding/AgencyLandingContent.jsx
@@ -28,7 +28,8 @@ export default class AgencyLandingContent extends React.Component {
                         Find an Agency Profile.
                     </h2>
                     <div className="landing-page__description">
-                        Featuring information on each agency&rsquo;s total obligations, along with obligation breakdowns by Object Class and Federal Accounts, our Agency Profiles help you understand how each agency spends its funding.
+                        <p>Featuring information on each agency&rsquo;s total obligations, along with obligation breakdowns by Object Class and Federal Accounts, our Agency Profiles help you understand how each agency spends its funding.</p>
+                        <p>P.L. 117-103 requires the posting of a list of agencies that have submitted Congressional Justifications and the dates that those were submitted to Congress. <a href="https://usaspending.gov/data/cj_list.csv" target="_blank" rel="noopener noreferrer">Click here</a> to download a machine-readable version of this list. Note that this list contains agencies that do not currently submit data to USAspending.gov and therefore do not appear elsewhere on the website.</p>
                     </div>
                 </div>
                 <LandingSearchBar

--- a/src/js/components/agencyLanding/AgencyLandingContent.jsx
+++ b/src/js/components/agencyLanding/AgencyLandingContent.jsx
@@ -29,7 +29,7 @@ export default class AgencyLandingContent extends React.Component {
                     </h2>
                     <div className="landing-page__description">
                         <p>Featuring information on each agency&rsquo;s total obligations, along with obligation breakdowns by Object Class and Federal Accounts, our Agency Profiles help you understand how each agency spends its funding.</p>
-                        <p>P.L. 117-103 requires the posting of a list of agencies that have submitted Congressional Justifications and the dates that those were submitted to Congress. <a href="https://usaspending.gov/data/cj_list.csv" target="_blank" rel="noopener noreferrer">Click here</a> to download a machine-readable version of this list. Note that this list contains agencies that do not currently submit data to USAspending.gov and therefore do not appear elsewhere on the website.</p>
+                        <p>P.L. 117-103 requires the posting of a list of agencies that have submitted Congressional Justifications and the dates that those were submitted to Congress. <a href="/data/cj_list.csv" download="cj_list.csv">Click here</a> to download a machine-readable version of this list. Note that this list contains agencies that do not currently submit data to USAspending.gov and therefore do not appear elsewhere on the website.</p>
                     </div>
                 </div>
                 <LandingSearchBar


### PR DESCRIPTION
**High level description:**

On the agency landing page, add new text and downloadable csv with CJ info

**Technical details:**

The downloadable file is located in Cloudfront, not locally so the link won't actually work until we're in QAT

**JIRA Ticket:**
[DEV-8647](https://federal-spending-transparency.atlassian.net/browse/DEV-8647)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge

Reviewer(s):
- [ ] Code review complete
