### PR TITLE
8515 - added another p to the track card content, to match the MAC

### DIFF
--- a/src/js/containers/homepageUpdate/HomepageCovidContainer.jsx
+++ b/src/js/containers/homepageUpdate/HomepageCovidContainer.jsx
@@ -77,10 +77,14 @@ const HomepageCovidContainer = () => {
         </span>);
     const trackCardHeading = <p>Track <span>COVID-19</span> Spending</p>;
     const trackCardContent = (
-        <p>
-        Our <span>COVID-19</span> profile page helps you track <span>COVID-19</span> spending by who is receiving funding, which agencies have paid out funds, which programs were funded, and more.
-        All <span>COVID-19</span> spending data is available for download on the profile page with one click. You can also read about our datasets and calculations on the <Link to="/disaster/covid-19/data-sources">Data Sources & Methodology page</Link>.
-        </p>);
+        <div>
+            <p>
+            Our <span>COVID-19</span> profile page helps you track <span>COVID-19</span> spending by who is receiving funding, which agencies have paid out funds, which programs were funded, and more.
+            </p>
+            <p>
+            All <span>COVID-19</span> spending data is available for download on the profile page with one click. You can also read about our datasets and calculations on the <Link to="/disaster/covid-19/data-sources">Data Sources & Methodology page</Link>.
+            </p>
+        </div>);
     const trackCardLink = (
         <Link
             to="/disaster/covid-19">


### PR DESCRIPTION
**High level description:**

Responding to QA feedback, need to add a p tag in the content of the second card, to match the MAC

**Technical details:**

Added p tag, now there is a break between the two sentences in that card.

**JIRA Ticket:**
[DEV-8515](https://federal-spending-transparency.atlassian.net/browse/DEV-8515)

**Mockup:**

https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55/screen/621fa593669231a368bf909c

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
