### PR TITLE
DEV-8576 Update custom account data file type naming

### DIFF
--- a/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
+++ b/src/js/dataMapping/bulkDownload/bulkDownloadOptions.js
@@ -202,19 +202,19 @@ export const accountDownloadOptions = {
     submissionTypes: [
         {
             name: 'accountBalances',
-            label: 'Account Balances',
+            label: 'Account Balances (File A)',
             apiName: 'account_balances',
             file: 'File A'
         },
         {
             name: 'accountBreakdown',
-            label: 'Account Breakdown by Program Activity & Object Class',
+            label: 'Account Breakdown by Program Activity & Object Class (File B)',
             apiName: 'object_class_program_activity',
             file: 'File B'
         },
         {
             name: 'accountBreakdownByAward',
-            label: 'Account Breakdown by Award*',
+            label: 'Account Breakdown by Award* (File C)',
             apiName: 'award_financial',
             file: 'File C'
         }


### PR DESCRIPTION
**High level description:**

In Custom Account Data download, add the parentheticals for file name after the business names in the “file type” filter, as well as in the “Your selected options are…” section.

**JIRA Ticket:**
[DEV-8576](https://federal-spending-transparency.atlassian.net/browse/DEV-8576)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Code review complete
