### PR TITLE
Homepage getting started blank image mobile bug fix

### DIFF
--- a/src/_scss/pages/homepageUpdate/homepageUpdate.scss
+++ b/src/_scss/pages/homepageUpdate/homepageUpdate.scss
@@ -11,9 +11,13 @@
       padding-bottom: $global-padding * 12;
       .homepage-background-flair {
           position: absolute;
+          z-index: 0;
           top: 5rem;
           bottom: -50rem;
           width: 125vw;
+          @media (max-width: $medium-screen) {
+            width: 100vw;
+          }
           margin-left: calc(50% - 50vw);
 
           background-color: #f8f8f8;
@@ -44,6 +48,9 @@
         button.feature-carousel-content__arrow {
           width: fit-content;
           z-index: 5;
+        }
+        div.feature-carousel-image {
+          z-index: 3;
         }
         .section-heading-title-wrapper  {
           width: 100%;


### PR DESCRIPTION
**High level description:**

Fixes bug found in testing where image carousel is blank at first in mobile view

**Technical details:**
Background flair was on top of the image hiding it - updated z-indexes on background and image

The following are ALL required for the PR to be merged:

Author:
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Code review complete
