### PR TITLE
8481 - updated the react-checkbox-component package to fix bug; made …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2986,6 +2986,21 @@
         "tar": "^6.1.11"
       },
       "dependencies": {
+        "chownr": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+          "dev": true
+        },
+        "fs-minipass": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+          "dev": true,
+          "requires": {
+            "minipass": "^2.6.0"
+          }
+        },
         "lru-cache": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -3012,11 +3027,37 @@
             }
           }
         },
+        "minipass": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          },
+          "dependencies": {
+            "yallist": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+              "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+              "dev": true
+            }
+          }
+        },
+        "minizlib": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+          "dev": true,
+          "requires": {
+            "minipass": "^2.9.0"
+          }
+        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         },
         "rimraf": {
           "version": "3.0.2",
@@ -3055,6 +3096,23 @@
             "mkdirp": "^0.5.5",
             "safe-buffer": "^5.2.1",
             "yallist": "^3.1.1"
+          },
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.5.6",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+              "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+              "dev": true,
+              "requires": {
+                "minimist": "^1.2.6"
+              }
+            },
+            "yallist": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+              "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+              "dev": true
+            }
           }
         },
         "yallist": {
@@ -5141,6 +5199,33 @@
             "yallist": "^4.0.0"
           }
         },
+        "minizlib": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+          "dev": true,
+          "requires": {
+            "minipass": "^2.9.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.9.0",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "yallist": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+              "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+              "dev": true
+            }
+          }
+        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -5184,6 +5269,48 @@
             "mkdirp": "^0.5.5",
             "safe-buffer": "^5.2.1",
             "yallist": "^3.1.1"
+          },
+          "dependencies": {
+            "chownr": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+              "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+              "dev": true
+            },
+            "fs-minipass": {
+              "version": "1.2.7",
+              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+              "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+              "dev": true,
+              "requires": {
+                "minipass": "^2.6.0"
+              }
+            },
+            "minipass": {
+              "version": "2.9.0",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.6",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+              "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+              "dev": true,
+              "requires": {
+                "minimist": "^1.2.6"
+              }
+            },
+            "yallist": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+              "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+              "dev": true
+            }
           }
         },
         "yallist": {
@@ -13707,7 +13834,8 @@
     "nanoid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.2.tgz",
-      "integrity": "sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA=="
+      "integrity": "sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -13950,6 +14078,14 @@
               "dev": true,
               "requires": {
                 "minimist": "^1.2.6"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.6",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+                  "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+                  "dev": true
+                }
               }
             },
             "yallist": {
@@ -15570,14 +15706,21 @@
       }
     },
     "react-checkbox-tree": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/react-checkbox-tree/-/react-checkbox-tree-1.7.2.tgz",
-      "integrity": "sha512-T0Y3Us2ds5QppOgIM/cSbtdrEBcCGkiz03o2p4elTireAIw0i5k5xPoaTxbjWTFmzgXajUrJzQMlBujEQhOUsQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/react-checkbox-tree/-/react-checkbox-tree-1.5.1.tgz",
+      "integrity": "sha512-fBLMVpd7/YXavzIBz+3OMS5eo2oZLW9PlTY4M1zrJ3TdZRzgILicSzRj6V5VKKm80y8uQXn60skn98pwn3i3Ig==",
       "requires": {
         "classnames": "^2.2.5",
         "lodash": "^4.17.10",
-        "nanoid": "^3.0.0",
+        "nanoid": "^2.0.0",
         "prop-types": "^15.5.8"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "2.1.11",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+          "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+        }
       }
     },
     "react-copy-to-clipboard": {
@@ -17409,11 +17552,52 @@
         "tar": "^6.1.11"
       },
       "dependencies": {
+        "chownr": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+          "dev": true
+        },
+        "fs-minipass": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+          "dev": true,
+          "requires": {
+            "minipass": "^2.6.0"
+          }
+        },
+        "minipass": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          },
+          "dependencies": {
+            "yallist": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+              "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+              "dev": true
+            }
+          }
+        },
+        "minizlib": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+          "dev": true,
+          "requires": {
+            "minipass": "^2.9.0"
+          }
+        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         },
         "safe-buffer": {
           "version": "5.2.1",
@@ -17434,13 +17618,29 @@
             "mkdirp": "^0.5.5",
             "safe-buffer": "^5.2.1",
             "yallist": "^3.1.1"
+          },
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.5.6",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+              "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+              "dev": true,
+              "requires": {
+                "minimist": "^1.2.6"
+              }
+            },
+            "yallist": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+              "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+              "dev": true
+            }
           }
         },
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
         "prop-types": "^15.7.2",
         "react": "^16.13.1",
         "react-aria-modal": "^2.7.0",
-        "react-checkbox-tree": "^1.7.2",
+        "react-checkbox-tree": "1.5.1",
         "react-copy-to-clipboard": "^5.0.1",
         "react-custom-scrollbars": "^4.1.2",
         "react-day-picker": "^7.0.2",

--- a/src/js/components/sharedComponents/CheckboxTree.jsx
+++ b/src/js/components/sharedComponents/CheckboxTree.jsx
@@ -2,6 +2,10 @@
   * CheckboxTree.jsx
   * Created by Jonathan Hill 09/27/2019
   **/
+/**
+ * This component uses react-checkbox-tree and that version MUST be 1.5.1.
+ * Upgrading it causes bugs in the checkbox trees.
+ */
 
 import React, { Component, cloneElement } from 'react';
 import CheckBoxTree from 'react-checkbox-tree';

--- a/src/js/containers/search/filters/naics/NAICSCheckboxTree.jsx
+++ b/src/js/containers/search/filters/naics/NAICSCheckboxTree.jsx
@@ -24,8 +24,7 @@ import {
 } from 'helpers/naicsHelper';
 
 import {
-    getAllDescendants,
-    doesMeetMinimumCharsRequiredForSearch
+    getAllDescendants
 } from 'helpers/checkboxTreeHelper';
 
 import { naicsRequest } from 'helpers/searchHelper';
@@ -205,6 +204,7 @@ export class NAICSCheckboxTree extends React.Component {
 
     onClear = () => {
         if (this.request) this.request.cancel();
+        this.props.setExpandedNaics([], 'SET_SEARCHED_EXPANDED');
         this.props.showNaicsTree();
         this.setState({
             isSearch: false,
@@ -274,13 +274,18 @@ export class NAICSCheckboxTree extends React.Component {
         }
     };
 
+    doesMeetMinimumCharsRequiredForNaicsSearch = (str = '', charMinimum = 2) => (
+        str &&
+        str.length >= charMinimum
+    );
+
     handleTextInputChange = (e) => {
         e.persist();
         const text = e.target.value;
         if (!text) {
             return this.onClear();
         }
-        const shouldTriggerSearch = doesMeetMinimumCharsRequiredForSearch(text);
+        const shouldTriggerSearch = this.doesMeetMinimumCharsRequiredForNaicsSearch(text);
         if (shouldTriggerSearch) {
             return this.setState({
                 searchString: text,

--- a/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
@@ -172,6 +172,7 @@ export class TASCheckboxTree extends React.Component {
 
     onClear = () => {
         if (this.request) this.request.cancel();
+        this.props.setExpandedTas([], 'SET_SEARCHED_EXPANDED');
         this.props.showTasTree();
         this.setState({
             isSearch: false,

--- a/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
@@ -220,6 +220,7 @@ export class PSCCheckboxTreeContainer extends React.Component {
 
     onClear = () => {
         if (this.request) this.request.cancel();
+        this.props.setExpandedPsc([], 'SET_SEARCHED_EXPANDED');
         this.props.showPscTree();
         this.setState({
             isSearch: false,
@@ -361,17 +362,11 @@ export class PSCCheckboxTreeContainer extends React.Component {
         if (!text) {
             return this.onClear();
         }
-        const shouldTriggerSearch = doesMeetMinimumCharsRequiredForSearch(text);
-        if (shouldTriggerSearch) {
-            return this.setState({
-                searchString: text,
-                isSearch: true,
-                isLoading: true
-            }, this.onSearchChange);
-        }
         return this.setState({
-            searchString: text
-        });
+            searchString: text,
+            isSearch: true,
+            isLoading: true
+        }, this.onSearchChange);
     };
 
     render() {

--- a/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
@@ -20,8 +20,7 @@ import {
     getAllDescendants,
     removePlaceholderString,
     getUniqueAncestorPaths,
-    trimCheckedToCommonAncestors,
-    doesMeetMinimumCharsRequiredForSearch
+    trimCheckedToCommonAncestors
 } from 'helpers/checkboxTreeHelper';
 
 import {

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -431,9 +431,6 @@ export const addChildrenAndPossiblyPlaceholder = (children, parent, hide = true)
     }
 
     return children;
-    // return hide
-    //     ? children.map((c) => ({ ...c, className: 'hide' }))
-    //     : children;
 };
 
 /**

--- a/src/js/helpers/checkboxTreeHelper.js
+++ b/src/js/helpers/checkboxTreeHelper.js
@@ -430,9 +430,10 @@ export const addChildrenAndPossiblyPlaceholder = (children, parent, hide = true)
             }));
     }
 
-    return hide
-        ? children.map((c) => ({ ...c, className: 'hide' }))
-        : children;
+    return children;
+    // return hide
+    //     ? children.map((c) => ({ ...c, className: 'hide' }))
+    //     : children;
 };
 
 /**

--- a/tests/containers/search/filters/naics/NAICSCheckboxTree-test.jsx
+++ b/tests/containers/search/filters/naics/NAICSCheckboxTree-test.jsx
@@ -120,15 +120,16 @@ describe('NAICS Search Filter Container', () => {
         });
     });
     describe('handleTextInputChange', () => {
-        it('only calls onSearchChange if search string is greater than or equal to 3 chars', () => {
+        it('only calls onSearchChange if search string is greater than or equal to 2 chars', () => {
             const mockFn = jest.fn();
             const container = shallow(<NAICSCheckboxTree {...defaultProps} nodes={reallyBigTree} />);
             container.instance().onSearchChange = mockFn;
             container.instance().handleTextInputChange({ target: { value: 'a' }, persist: () => {} });
-            container.instance().handleTextInputChange({ target: { value: 'ab' }, persist: () => {} });
             expect(mockFn).not.toHaveBeenCalled();
-            container.instance().handleTextInputChange({ target: { value: 'abc' }, persist: () => {} });
+            container.instance().handleTextInputChange({ target: { value: 'ab' }, persist: () => {} });
             expect(mockFn).toHaveBeenCalledTimes(1);
+            container.instance().handleTextInputChange({ target: { value: 'abc' }, persist: () => {} });
+            expect(mockFn).toHaveBeenCalledTimes(2);
         });
     });
 });

--- a/tests/containers/search/filters/psc/PSCCheckboxTreeContainer-test.jsx
+++ b/tests/containers/search/filters/psc/PSCCheckboxTreeContainer-test.jsx
@@ -61,7 +61,7 @@ describe('PscCheckboxTreeContainer', () => {
             await container.instance().fetchPsc('Service');
             const newNodes = mockFn.mock.calls[0][1];
             expect(newNodes.length).toEqual(23);
-            
+
             newNodes
                 .forEach((secondTier) => {
                     expect(secondTier.children.length).toEqual(1);
@@ -149,12 +149,11 @@ describe('PscCheckboxTreeContainer', () => {
     describe('onCollapse', () => {
         it('updates the props.expanded array', () => {
             const mockFn = jest.fn();
-            const container = shallow(
-                <PSCCheckboxTreeContainer
-                    {...defaultProps}
-                    nodes={treePopulatedToSecondTier}
-                    expanded={['Services', 'B']}
-                    setExpandedPsc={mockFn} />);
+            const container = shallow(<PSCCheckboxTreeContainer
+                {...defaultProps}
+                nodes={treePopulatedToSecondTier}
+                expanded={['Services', 'B']}
+                setExpandedPsc={mockFn} />);
             container.instance().onCollapse(['Services']);
             const newExpanded = mockFn.mock.calls[0][0];
             expect(newExpanded).toEqual(['Services']);
@@ -189,10 +188,9 @@ describe('PscCheckboxTreeContainer', () => {
     });
     describe('componentDidMount', () => {
         it('does not replace nodes if they are already there', async () => {
-            const container = shallow(
-                <PSCCheckboxTreeContainer
-                    {...defaultProps}
-                    nodes={[1, 2]} />);
+            const container = shallow(<PSCCheckboxTreeContainer
+                {...defaultProps}
+                nodes={[1, 2]} />);
             const mockFn = jest.fn();
             container.instance().fetchPsc = mockFn;
             await container.instance().componentDidMount();
@@ -207,25 +205,24 @@ describe('PscCheckboxTreeContainer', () => {
                 { label: 'Product', value: 'Product', count: 1 },
                 { label: 'Service', value: 'Service', count: 7 }
             ];
-            const container = shallow(
-                <PSCCheckboxTreeContainer
-                    {...defaultProps}
-                    setPscCounts={mockSetCounts}
-                    setExpandedPsc={mockExpandPsc}
-                    uncheckedFromHash={[
-                        ['Product', '10', '1000']
-                    ]}
-                    checkedFromHash={[
-                        ['Product', '10'],
-                        ['Service', 'B', 'B5', 'B516'],
-                        ['Service', 'B', 'B5', 'B513'],
-                        ['Service', 'B', 'B5', 'B502'],
-                        ['Service', 'B', 'B5', 'B502'],
-                        ['Service', 'B', 'B5', 'B503'],
-                        ['Service', 'B', 'B5', 'B504'],
-                        ['Service', 'B', 'B5', 'B505']
-                    ]}
-                    countsFromHash={countsFromHash} />);
+            const container = shallow(<PSCCheckboxTreeContainer
+                {...defaultProps}
+                setPscCounts={mockSetCounts}
+                setExpandedPsc={mockExpandPsc}
+                uncheckedFromHash={[
+                    ['Product', '10', '1000']
+                ]}
+                checkedFromHash={[
+                    ['Product', '10'],
+                    ['Service', 'B', 'B5', 'B516'],
+                    ['Service', 'B', 'B5', 'B513'],
+                    ['Service', 'B', 'B5', 'B502'],
+                    ['Service', 'B', 'B5', 'B502'],
+                    ['Service', 'B', 'B5', 'B503'],
+                    ['Service', 'B', 'B5', 'B504'],
+                    ['Service', 'B', 'B5', 'B505']
+                ]}
+                countsFromHash={countsFromHash} />);
             container.instance().fetchPsc = mockFetchPsc;
             container.instance().setCheckedStateFromUrlHash = mockCheckPsc;
             await container.instance().componentDidMount();
@@ -265,13 +262,12 @@ describe('PscCheckboxTreeContainer', () => {
             const checked = ['AC2']; // mock data here has seven children even though in reality it has 8.
             // const mockSetUncheckedPsc = jest.fn();
             const mockSetCheckedPsc = jest.fn();
-            const container = shallow(
-                <PSCCheckboxTreeContainer
-                    {...defaultProps}
-                    setCheckedPsc={mockSetCheckedPsc}
-                    nodes={reallyBigTree}
-                    uncheckedFromHash={unchecked}
-                    checkedFromHash={checked} />);
+            const container = shallow(<PSCCheckboxTreeContainer
+                {...defaultProps}
+                setCheckedPsc={mockSetCheckedPsc}
+                nodes={reallyBigTree}
+                uncheckedFromHash={unchecked}
+                checkedFromHash={checked} />);
             await container.instance().setCheckedStateFromUrlHash(checked);
             const nodeFromChecked = getPscNodeFromTree(reallyBigTree, 'AC2');
             const checkedNodes = getAllDescendants(nodeFromChecked)
@@ -280,15 +276,16 @@ describe('PscCheckboxTreeContainer', () => {
         });
     });
     describe('handleTextInputChange', () => {
-        it('only calls onSearchChange if search string is greater than or equal to 3 chars', () => {
+        it('calls onSearchChange if search string is one or more chars', () => {
             const mockFn = jest.fn();
             const container = shallow(<PSCCheckboxTreeContainer {...defaultProps} nodes={reallyBigTree} />);
             container.instance().onSearchChange = mockFn;
             container.instance().handleTextInputChange({ target: { value: 'a' }, persist: () => {} });
-            container.instance().handleTextInputChange({ target: { value: 'ab' }, persist: () => {} });
-            expect(mockFn).not.toHaveBeenCalled();
-            container.instance().handleTextInputChange({ target: { value: 'abc' }, persist: () => {} });
             expect(mockFn).toHaveBeenCalledTimes(1);
+            container.instance().handleTextInputChange({ target: { value: 'ab' }, persist: () => {} });
+            expect(mockFn).toHaveBeenCalledTimes(2);
+            container.instance().handleTextInputChange({ target: { value: 'abc' }, persist: () => {} });
+            expect(mockFn).toHaveBeenCalledTimes(3);
         });
     });
 });

--- a/tests/helpers/checkboxTreeHelper-test.js
+++ b/tests/helpers/checkboxTreeHelper-test.js
@@ -224,7 +224,7 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
             const grandPlaceHolderExists = childFromSearch
                 .children
                 .some((grand) => grand.isPlaceHolder);
-            
+
             const greatGrandNotOverwritten = childFromSearch
                 .children
                 .find((grand) => grand.value === '111120')
@@ -539,7 +539,7 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
                 .children[0]
                 .children
                 .map((grand) => grand.value);
-    
+
             const [newCounts, newUnchecked] = incrementCountAndUpdateUnchecked(
                 allGrandchildrenOf1111,
                 allGrandchildrenOf1111.filter((grand) => grand !== '111110'),
@@ -550,7 +550,7 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
                 getImmediateAncestorNaicsCode,
                 getHighestAncestorNaicsCode
             );
-    
+
             expect(newCounts[0].count).toEqual(8);
             expect(newUnchecked.length).toEqual(0);
         });
@@ -647,7 +647,7 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
                 children: getPscNodeFromTree(pscMockData.reallyBigTree, 'AC2').children
             };
             const nodeWithMixedChildren = getPscNodeFromTree(pscMockData.reallyBigTree, 'AC');
-            
+
             expect(areChildrenPartial(nodeWithMixedChildren.count, nodeWithMixedChildren.children)).toEqual(true);
             expect(areChildrenPartial(fullyPopulatedNode.count, fullyPopulatedNode.children)).toEqual(false);
         });
@@ -741,34 +741,28 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
                     ['Research and Development', 'AA', 'AA9', 'AA91']
                 ]
             );
-            expect(result).toEqual(
-                [
-                    'Products',
-                    'Service',
-                    'Research and Development',
-                    'Products/10',
-                    'Service/B',
-                    'Research and Development/AA',
-                    'Service/B/B5',
-                    'Research and Development/AA/AA9'
-                ]
-            );
+            expect(result).toEqual([
+                'Products',
+                'Service',
+                'Research and Development',
+                'Products/10',
+                'Service/B',
+                'Research and Development/AA',
+                'Service/B/B5',
+                'Research and Development/AA/AA9'
+            ]);
         });
         it('if the path has only one item, return it', () => {
-            const result = getUniqueAncestorPaths(
-                [
-                    ['Products'],
-                    ['Research and Development'],
-                    ['Service']
-                ]
-            );
-            expect(result).toEqual(
-                [
-                    'Products',
-                    'Research and Development',
-                    'Service'
-                ]
-            );
+            const result = getUniqueAncestorPaths([
+                ['Products'],
+                ['Research and Development'],
+                ['Service']
+            ]);
+            expect(result).toEqual([
+                'Products',
+                'Research and Development',
+                'Service'
+            ]);
         });
     });
     describe('getAncestryPathOfNodes', () => {
@@ -895,18 +889,4 @@ describe('checkboxTree Helpers (using NAICS data)', () => {
         expect(mockTrue).toEqual(true);
     });
 });
-
-const initialPscTreeOnExpand = cleanPscData(pscMockData.topTierResponse.results);
-const searchResultWithPartialData = cleanPscData(pscMockData.partialSearchResults.results);
-
-test.each([
-    [initialPscTreeOnExpand, searchResultWithPartialData, ['Service', 'G', 'G0'], 1]
-])(
-    'partial search results under a grand child only are given placeholders and hidden (mock tree before search: %p), (search result: %p)',
-    (initialTree, searchResult, pathToChildren, hiddenNodesLength) => {
-        const result = addSearchResultsToTree(initialTree, searchResult, getPscNodeFromTree);
-        const children = pathToChildren.reduce((acc, id) => acc.find((node) => node.value === id).children, result);
-        expect(children.filter((c) => c.className === 'hide').length).toEqual(hiddenNodesLength);
-    }
-);
 


### PR DESCRIPTION
…change so that children are shown in search results in tas; changed psc to start search on one char; changed naics to start search on two char; added call to clear searchExpanded array in onClear in all three sections

**High level description:**

This branch will address the bug described in 8481 and 8771, in the TAS, NAICS, and PSC filter section on the Advanced Search page.

**Technical details:**

The main problem is solved with reverting react-checkbox-tree to v1.5.1.
Other problems addressed are: making TAS return children in search results; making NAICS begin search with two chars, since it has many items with two char titles; and making PSC begin search on one char bc it has many items with one char titles

**JIRA Ticket:**
[DEV-8481](https://federal-spending-transparency.atlassian.net/browse/DEV-8481)
[DEV-8771](https://federal-spending-transparency.atlassian.net/browse/DEV-8771)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
