### PR TITLE
8809 - added names to the top five tables when no slug is present

### DIFF
--- a/src/js/components/recipient/topFive/TopFiveRow.jsx
+++ b/src/js/components/recipient/topFive/TopFiveRow.jsx
@@ -29,7 +29,7 @@ export default class TopFiveRow extends React.Component {
                 title={this.props.data.name}>
                 {this.props.data._slug ?
                     this.props.data.linkedName
-                    : ''}
+                    : this.props.data.name}
             </td>
         );
     }


### PR DESCRIPTION
**High level description:**

On Recipients page, in the top 5 tables, the names were not showing.

**Technical details:**

Added the data for .name to show when there is no slug present

**JIRA Ticket:**
[DEV-8809](https://federal-spending-transparency.atlassian.net/browse/DEV-8809)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
