### PR TITLE
7769 - made changes to the properties for the new badge used in the s…

### DIFF
--- a/src/js/components/search/SearchSidebar.jsx
+++ b/src/js/components/search/SearchSidebar.jsx
@@ -125,7 +125,7 @@ const staticFilters = {
         null,
         null,
         null,
-        NewBadge,
+        null,
         null,
         null,
         null,

--- a/src/js/components/search/SearchSidebar.jsx
+++ b/src/js/components/search/SearchSidebar.jsx
@@ -25,7 +25,7 @@ import PSCCheckboxTreeContainer from 'containers/search/filters/psc/PSCCheckboxT
 import PricingTypeContainer from 'containers/search/filters/PricingTypeContainer';
 import SetAsideContainer from 'containers/search/filters/SetAsideContainer';
 import ExtentCompetedContainer from 'containers/search/filters/ExtentCompetedContainer';
-import DEFCheckboxTree, { NewBadge } from 'containers/search/filters/def/DEFCheckboxTree';
+import DEFCheckboxTree from 'containers/search/filters/def/DEFCheckboxTree';
 
 import {
     KeyWordTooltip,

--- a/src/js/components/sharedComponents/filterSidebar/FilterExpandButton.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterExpandButton.jsx
@@ -43,9 +43,8 @@ const FilterExpandButton = (props) => {
             {props.accessory && (
                 <div
                     className="filter-toggle__accessory"
-                    tabIndex="0"
-                    id="accessory-view"
-                    role="toolbar">
+                    tabIndex="-1"
+                    id="accessory-view">
                     <props.accessory />
                 </div>
             )}


### PR DESCRIPTION
…earch filters to improve accessibility; also removed the new badge from the DEFC filter section, for ticket 8707

**High level description:**

This pr is for both 7769 and 8707. 7769 makes changes to the new badge to improve accessibility, and 8707 removed the new badge from the DEFC filter on the Advanced Search page.

**Technical details:**

Changed the properties on the badge, removed the badge.

**JIRA Ticket:**
[DEV-7769](https://federal-spending-transparency.atlassian.net/browse/DEV-7769)
[DEV-8707](https://federal-spending-transparency.atlassian.net/browse/DEV-8707)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
