### PR TITLE
DEV-8484 keyword shake

### DIFF
--- a/src/_scss/pages/search/_filterExpand.scss
+++ b/src/_scss/pages/search/_filterExpand.scss
@@ -3,6 +3,12 @@
     @include display(flex);
     @include align-items(center);
 
+    .tooltip-spacer {
+        @media(max-width:424px) {
+            width: 375px !important;
+        }
+    }
+
     .filter-toggle__button {
         @include button-unstyled;
         @include display(flex);


### PR DESCRIPTION
**High level description:**

The word keyword shakes on the tooltip on mobile
**Technical details:**

There seemed to be conflicting widths being applied in css for screen size <424 px. Forced a single rule to be applied and it fixed the problem.

**JIRA Ticket:**
[DEV-8484](https://federal-spending-transparency.atlassian.net/browse/DEV-8484)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
