### PR TITLE
8616 - added names without links to top 5 when no slug is available

### DIFF
--- a/src/js/components/state/topFive/TopFiveRow.jsx
+++ b/src/js/components/state/topFive/TopFiveRow.jsx
@@ -24,7 +24,7 @@ const TopFiveRow = (props) => {
                 title={props.data.name}>
                 {props.data._slug ?
                     props.data.linkedName
-                    : ''}
+                    : props.data.name}
             </td>
             <td
                 className="category-table__table-cell category-table__table-cell_centered"


### PR DESCRIPTION
**High level description:**

The names were not showing in the top five tables for states

**Technical details:**

Needed to make the same change that we made for Recipients top five tables last week, add the name without link if no slug is available for the name

**JIRA Ticket:**
[DEV-8816](https://federal-spending-transparency.atlassian.net/browse/DEV-8816)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
