### PR TITLE
8822 - changed text size in tooltips at mobile only for spending over…

### DIFF
--- a/src/_scss/pages/account/results/visualizations/time/time.scss
+++ b/src/_scss/pages/account/results/visualizations/time/time.scss
@@ -19,7 +19,11 @@
                 font-weight: $font-light;
                 line-height: rem(30);
                 padding: 0 0 rem(10) 0;
-            }
+                @media(max-width: $tablet-screen) {
+                    font-size: rem(16);
+                    line-height: rem(20);
+                    }
+                }
             .item-label {
                 font-size: $small-font-size;
                 font-weight: $font-normal;


### PR DESCRIPTION
… time chart on federal accounts page

**High level description:**

At mobile sizes the text for the numbers in the tooltips was extending outside the tooltip container

**Technical details:**

Smallified the text

**JIRA Ticket:**
[DEV-8822](https://federal-spending-transparency.atlassian.net/browse/DEV-8822)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
