### PR TITLE
Removed the second resources tab that was accidentally committed

### DIFF
--- a/src/js/components/sharedComponents/header/NavBar.jsx
+++ b/src/js/components/sharedComponents/header/NavBar.jsx
@@ -194,14 +194,6 @@ export default class NavBar extends React.Component {
                                     label="Resources"
                                     items={resourceOptions} />
                             </li>
-                            <li
-                                className="full-menu__item"
-                                role="menuitem">
-                                <Dropdown
-                                    title="Resources"
-                                    label="Resources"
-                                    items={resourceOptions} />
-                            </li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
https://data-transparency-bfs.slack.com/archives/CE5P5AWE8/p1653409627992429

Was testing out the nav bar and accidentally merged this into QAT