### PR TITLE
Hotfix 8832 covid award tag staging

### DIFF
--- a/src/js/components/award/contract/ContractContent.jsx
+++ b/src/js/components/award/contract/ContractContent.jsx
@@ -71,7 +71,7 @@ const ContractContent = ({
     });
     return (
         <AwardPageWrapper
-            defCodes={overview.defCodes}
+            allDefCodes={overview.defCodes}
             glossaryLink={glossaryLink}
             overviewType={overview.type}
             identifier={overview.piid}

--- a/src/js/components/award/financialAssistance/FinancialAssistanceContent.jsx
+++ b/src/js/components/award/financialAssistance/FinancialAssistanceContent.jsx
@@ -79,7 +79,7 @@ const FinancialAssistanceContent = ({
 
     return (
         <AwardPageWrapper
-            defCodes={overview.defCodes}
+            allDefCodes={overview.defCodes}
             identifier={identifier}
             idLabel={idLabel}
             awardType={overview.category}

--- a/src/js/components/award/idv/IdvContent.jsx
+++ b/src/js/components/award/idv/IdvContent.jsx
@@ -51,7 +51,7 @@ const IdvContent = ({
     return (
         <AwardPageWrapper
             awardType="idv"
-            defCodes={getAllNetPositiveIdvFileCDefCodes(overview, details)}
+            allDefCodes={getAllNetPositiveIdvFileCDefCodes(overview, details)}
             title={overview.title}
             lastModifiedDateLong={overview.dates.lastModifiedDateLong}
             glossaryLink={glossaryLink}

--- a/src/js/components/award/shared/AwardPageWrapper.jsx
+++ b/src/js/components/award/shared/AwardPageWrapper.jsx
@@ -3,12 +3,12 @@ import { TooltipWrapper } from 'data-transparency-ui';
 import { Link } from 'react-router-dom';
 
 import { awardTypeCodes } from 'dataMapping/search/awardType';
+import { useDefCodes } from 'containers/covid19/WithDefCodes';
 
 import { Glossary } from '../../sharedComponents/icons/Icons';
 import { AWARD_PAGE_WRAPPER_PROPS } from '../../../propTypes/index';
 import AwardStatus from './AwardStatus';
 import { CovidFlagTooltip } from '../shared/InfoTooltipContent';
-import { useDefCodes } from 'containers/covid19/WithDefCodes';
 
 const AwardPageWrapper = ({
     allDefCodes,
@@ -29,7 +29,7 @@ const AwardPageWrapper = ({
     const [covidDefCodes, setCovidDefCodes] = useState(null);
 
     useEffect(() => {
-        if(!areDefCodesLoading) {
+        if (!areDefCodesLoading) {
             setCovidDefCodes(defCodes.filter((c) => c.disaster === 'covid_19' && allDefCodes.indexOf(c.code) > -1).map((code) => code.code));
         }
     }, [areDefCodesLoading]);

--- a/src/js/components/award/shared/AwardPageWrapper.jsx
+++ b/src/js/components/award/shared/AwardPageWrapper.jsx
@@ -11,7 +11,6 @@ import { CovidFlagTooltip } from '../shared/InfoTooltipContent';
 import { useDefCodes } from 'containers/covid19/WithDefCodes';
 
 const AwardPageWrapper = ({
-    // defCodes from api are already filtered down to covid codes only.
     allDefCodes,
     awardType,
     title,

--- a/src/js/components/award/shared/AwardPageWrapper.jsx
+++ b/src/js/components/award/shared/AwardPageWrapper.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { TooltipWrapper } from 'data-transparency-ui';
 import { Link } from 'react-router-dom';
 
@@ -8,10 +8,11 @@ import { Glossary } from '../../sharedComponents/icons/Icons';
 import { AWARD_PAGE_WRAPPER_PROPS } from '../../../propTypes/index';
 import AwardStatus from './AwardStatus';
 import { CovidFlagTooltip } from '../shared/InfoTooltipContent';
+import { useDefCodes } from 'containers/covid19/WithDefCodes';
 
 const AwardPageWrapper = ({
     // defCodes from api are already filtered down to covid codes only.
-    defCodes,
+    allDefCodes,
     awardType,
     title,
     glossaryLink,
@@ -24,6 +25,16 @@ const AwardPageWrapper = ({
     const glossaryTitleText = awardTypeCodes[overviewType] ?
         `View glossary definition of ${awardTypeCodes[overviewType]}` :
         'View glossary definition';
+
+    const [, areDefCodesLoading, defCodes] = useDefCodes();
+    const [covidDefCodes, setCovidDefCodes] = useState(null);
+
+    useEffect(() => {
+        if(!areDefCodesLoading) {
+            setCovidDefCodes(defCodes.filter((c) => c.disaster === 'covid_19' && allDefCodes.indexOf(c.code) > -1).map((code) => code.code));
+        }
+    }, [areDefCodesLoading]);
+
     return (
         <div className={`award award-${awardType}`}>
             <div className="award__heading">
@@ -43,8 +54,8 @@ const AwardPageWrapper = ({
                     awardType={awardType}
                     dates={dates} />
             </div>
-            {defCodes.length > 0 &&
-            <TooltipWrapper className="award-summary__covid-19-flag" tooltipComponent={<CovidFlagTooltip codes={defCodes} />}>
+            {covidDefCodes && covidDefCodes.length > 0 &&
+            <TooltipWrapper className="award-summary__covid-19-flag" tooltipComponent={<CovidFlagTooltip codes={covidDefCodes} />}>
                 <span className="covid-spending-flag">
                                 Includes COVID-19 Spending
                 </span>


### PR DESCRIPTION
***High level description:***

Filter defcode based on covid_19 disaster group

***Technical details:***

Get covid disaster codes from redux and filter award codes to only show COVID codes

**JIRA Ticket:**
[DEV-8832](https://federal-spending-transparency.atlassian.net/browse/DEV-8832)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
