### PR TITLE
8730 - Added infrastructure spending to idv awards summary chart

### DIFF
--- a/src/_scss/pages/award/shared/awardAmountsSection/_index.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_index.scss
@@ -3,6 +3,9 @@
     $border-light-gray: #d5d6d8;
     .award-amounts__content {
       @import '../../../search/results/table/tableMessages';
+      .usa-dt-tab__wrapper.tabless-tab:not(.active), .usa-dt-tab-list__border-post-filler {
+        border-bottom: unset;
+      }
       .results-table-message-container {
         position: relative;
         background-color: rgb(246, 246, 246);

--- a/src/js/components/award/contract/ContractContent.jsx
+++ b/src/js/components/award/contract/ContractContent.jsx
@@ -71,7 +71,7 @@ const ContractContent = ({
     });
     return (
         <AwardPageWrapper
-            defCodes={overview.defCodes}
+            allDefCodes={overview.defCodes}
             glossaryLink={glossaryLink}
             overviewType={overview.type}
             identifier={overview.piid}

--- a/src/js/components/award/financialAssistance/FinancialAssistanceContent.jsx
+++ b/src/js/components/award/financialAssistance/FinancialAssistanceContent.jsx
@@ -79,7 +79,7 @@ const FinancialAssistanceContent = ({
 
     return (
         <AwardPageWrapper
-            defCodes={overview.defCodes}
+            allDefCodes={overview.defCodes}
             identifier={identifier}
             idLabel={idLabel}
             awardType={overview.category}

--- a/src/js/components/award/idv/IdvContent.jsx
+++ b/src/js/components/award/idv/IdvContent.jsx
@@ -51,7 +51,7 @@ const IdvContent = ({
     return (
         <AwardPageWrapper
             awardType="idv"
-            defCodes={getAllNetPositiveIdvFileCDefCodes(overview, details)}
+            allDefCodes={getAllNetPositiveIdvFileCDefCodes(overview, details)}
             title={overview.title}
             lastModifiedDateLong={overview.dates.lastModifiedDateLong}
             glossaryLink={glossaryLink}

--- a/src/js/components/award/idv/amounts/AggregatedAwardAmountsSection.jsx
+++ b/src/js/components/award/idv/amounts/AggregatedAwardAmountsSection.jsx
@@ -77,7 +77,6 @@ export default class AggregatedAwardAmounts extends React.Component {
 
         const { awardAmounts } = this.props;
         const spendingScenario = determineSpendingScenarioByAwardType("idv", awardAmounts);
-        console.log('awardAmount', awardAmounts);
 
         return (
             <div className="award-amounts__content">

--- a/src/js/components/award/idv/amounts/AggregatedAwardAmountsSection.jsx
+++ b/src/js/components/award/idv/amounts/AggregatedAwardAmountsSection.jsx
@@ -77,15 +77,18 @@ export default class AggregatedAwardAmounts extends React.Component {
 
         const { awardAmounts } = this.props;
         const spendingScenario = determineSpendingScenarioByAwardType("idv", awardAmounts);
+        console.log('awardAmount', awardAmounts);
 
         return (
             <div className="award-amounts__content">
                 <AwardsBanner
                     jumpToReferencedAwardsTable={this.jumpToReferencedAwardsTable} />
-                <Tabs tablessStyle
-                    active={this.state.active}
-                    switchTab={this.switchTab}
-                    types={tabConfig} />
+                <div style={{ display: awardAmounts._fileCOutlayInfrastructure > 0 || awardAmounts._fileCObligatedInfrastructure > 0  ? `block` : `none` }}>
+                    <Tabs tablessStyle
+                        active={this.state.active}
+                        switchTab={this.switchTab}
+                        types={tabConfig} />
+                </div>
                 <AwardAmountsChart
                     showCaresActViz={this.props.showFileC}
                     awardOverview={awardAmounts}

--- a/src/js/components/award/idv/amounts/AggregatedAwardAmountsSection.jsx
+++ b/src/js/components/award/idv/amounts/AggregatedAwardAmountsSection.jsx
@@ -16,7 +16,6 @@ import { AWARD_AGGREGATED_AMOUNTS_PROPS } from '../../../../propTypes';
 import AwardAmountsTable from '../../shared/awardAmounts/AwardAmountsTable';
 import AwardAmountsChart from '../../shared/awardAmounts/AwardAmountsChart';
 import JumpToSectionButton from '../../shared/awardAmounts/JumpToSectionButton';
-import {tabTooltips} from "../../../aboutTheData/componentMapping/tooltipContentMapping";
 
 const propTypes = {
     awardAmounts: AWARD_AGGREGATED_AMOUNTS_PROPS,
@@ -30,11 +29,22 @@ const propTypes = {
 export default class AggregatedAwardAmounts extends React.Component {
     constructor(props) {
         super(props);
+        this.state = {
+            active: "overall"
+        };
+
         this.jumpToReferencedAwardsTable = this.jumpToReferencedAwardsTable.bind(this);
+        this.switchTab = this.switchTab.bind(this);
     }
 
     jumpToReferencedAwardsTable() {
         this.props.jumpToSection('referenced-awards');
+    }
+
+    switchTab(tab) {
+        this.setState({
+            active: tab
+        });
     }
 
     render() {
@@ -55,11 +65,14 @@ export default class AggregatedAwardAmounts extends React.Component {
 
         const { awardAmounts } = this.props;
         const spendingScenario = determineSpendingScenarioByAwardType("idv", awardAmounts);
+
         return (
             <div className="award-amounts__content">
                 <AwardsBanner
                     jumpToReferencedAwardsTable={this.jumpToReferencedAwardsTable} />
                 <Tabs tablessStyle
+                    active={this.state.active}
+                    switchTab={this.switchTab}
                     types={[
                         {
                             internal: 'overall',
@@ -74,7 +87,9 @@ export default class AggregatedAwardAmounts extends React.Component {
                     showCaresActViz={this.props.showFileC}
                     awardOverview={awardAmounts}
                     awardType="idv"
-                    spendingScenario={spendingScenario} />
+                    spendingScenario={spendingScenario}
+                    infrastructureSpending={this.state.active}
+                />
                 <AwardAmountsTable
                     awardAmountType="idv_aggregated"
                     showFileC={this.props.showFileC}

--- a/src/js/components/award/idv/amounts/AggregatedAwardAmountsSection.jsx
+++ b/src/js/components/award/idv/amounts/AggregatedAwardAmountsSection.jsx
@@ -25,17 +25,29 @@ const propTypes = {
     jumpToSection: PropTypes.func
 };
 
+const tabConfig = [
+    {
+        internal: 'overall',
+        label: "Overall Spending"
+    },
+    {
+        internal: 'infrastructure',
+        label: "Infrastructure"
+    }
+];
 
 export default class AggregatedAwardAmounts extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            active: "overall"
+            active: tabConfig[0].internal
         };
 
         this.jumpToReferencedAwardsTable = this.jumpToReferencedAwardsTable.bind(this);
         this.switchTab = this.switchTab.bind(this);
     }
+
+
 
     jumpToReferencedAwardsTable() {
         this.props.jumpToSection('referenced-awards');
@@ -73,16 +85,7 @@ export default class AggregatedAwardAmounts extends React.Component {
                 <Tabs tablessStyle
                     active={this.state.active}
                     switchTab={this.switchTab}
-                    types={[
-                        {
-                            internal: 'overall',
-                            label: "Overall Spending"
-                        },
-                        {
-                            internal: 'infrastructure',
-                            label: "Infrastructure"
-                        }
-                    ]} />
+                    types={tabConfig} />
                 <AwardAmountsChart
                     showCaresActViz={this.props.showFileC}
                     awardOverview={awardAmounts}

--- a/src/js/components/award/idv/amounts/AggregatedAwardAmountsSection.jsx
+++ b/src/js/components/award/idv/amounts/AggregatedAwardAmountsSection.jsx
@@ -5,6 +5,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Tabs } from "data-transparency-ui";
+
 import { formatNumber } from 'helpers/moneyFormatter';
 
 import { determineSpendingScenarioByAwardType } from 'helpers/awardAmountHelper';
@@ -14,6 +16,7 @@ import { AWARD_AGGREGATED_AMOUNTS_PROPS } from '../../../../propTypes';
 import AwardAmountsTable from '../../shared/awardAmounts/AwardAmountsTable';
 import AwardAmountsChart from '../../shared/awardAmounts/AwardAmountsChart';
 import JumpToSectionButton from '../../shared/awardAmounts/JumpToSectionButton';
+import {tabTooltips} from "../../../aboutTheData/componentMapping/tooltipContentMapping";
 
 const propTypes = {
     awardAmounts: AWARD_AGGREGATED_AMOUNTS_PROPS,
@@ -56,6 +59,17 @@ export default class AggregatedAwardAmounts extends React.Component {
             <div className="award-amounts__content">
                 <AwardsBanner
                     jumpToReferencedAwardsTable={this.jumpToReferencedAwardsTable} />
+                <Tabs tablessStyle
+                    types={[
+                        {
+                            internal: 'overall',
+                            label: "Overall Spending"
+                        },
+                        {
+                            internal: 'infrastructure',
+                            label: "Infrastructure"
+                        }
+                    ]} />
                 <AwardAmountsChart
                     showCaresActViz={this.props.showFileC}
                     awardOverview={awardAmounts}

--- a/src/js/components/award/shared/AwardPageWrapper.jsx
+++ b/src/js/components/award/shared/AwardPageWrapper.jsx
@@ -3,12 +3,12 @@ import { TooltipWrapper } from 'data-transparency-ui';
 import { Link } from 'react-router-dom';
 
 import { awardTypeCodes } from 'dataMapping/search/awardType';
+import { useDefCodes } from 'containers/covid19/WithDefCodes';
 
 import { Glossary } from '../../sharedComponents/icons/Icons';
 import { AWARD_PAGE_WRAPPER_PROPS } from '../../../propTypes/index';
 import AwardStatus from './AwardStatus';
 import { CovidFlagTooltip } from '../shared/InfoTooltipContent';
-import { useDefCodes } from 'containers/covid19/WithDefCodes';
 
 const AwardPageWrapper = ({
     allDefCodes,
@@ -29,7 +29,7 @@ const AwardPageWrapper = ({
     const [covidDefCodes, setCovidDefCodes] = useState(null);
 
     useEffect(() => {
-        if(!areDefCodesLoading) {
+        if (!areDefCodesLoading) {
             setCovidDefCodes(defCodes.filter((c) => c.disaster === 'covid_19' && allDefCodes.indexOf(c.code) > -1).map((code) => code.code));
         }
     }, [areDefCodesLoading]);

--- a/src/js/components/award/shared/AwardPageWrapper.jsx
+++ b/src/js/components/award/shared/AwardPageWrapper.jsx
@@ -32,7 +32,7 @@ const AwardPageWrapper = ({
         if (!areDefCodesLoading) {
             setCovidDefCodes(defCodes.filter((c) => c.disaster === 'covid_19' && allDefCodes.indexOf(c.code) > -1).map((code) => code.code));
         }
-    }, [areDefCodesLoading]);
+    }, [areDefCodesLoading, allDefCodes]);
 
     return (
         <div className={`award award-${awardType}`}>

--- a/src/js/components/award/shared/AwardPageWrapper.jsx
+++ b/src/js/components/award/shared/AwardPageWrapper.jsx
@@ -11,7 +11,6 @@ import { CovidFlagTooltip } from '../shared/InfoTooltipContent';
 import { useDefCodes } from 'containers/covid19/WithDefCodes';
 
 const AwardPageWrapper = ({
-    // defCodes from api are already filtered down to covid codes only.
     allDefCodes,
     awardType,
     title,

--- a/src/js/components/award/shared/AwardPageWrapper.jsx
+++ b/src/js/components/award/shared/AwardPageWrapper.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { TooltipWrapper } from 'data-transparency-ui';
 import { Link } from 'react-router-dom';
 
@@ -8,10 +8,11 @@ import { Glossary } from '../../sharedComponents/icons/Icons';
 import { AWARD_PAGE_WRAPPER_PROPS } from '../../../propTypes/index';
 import AwardStatus from './AwardStatus';
 import { CovidFlagTooltip } from '../shared/InfoTooltipContent';
+import { useDefCodes } from 'containers/covid19/WithDefCodes';
 
 const AwardPageWrapper = ({
     // defCodes from api are already filtered down to covid codes only.
-    defCodes,
+    allDefCodes,
     awardType,
     title,
     glossaryLink,
@@ -24,6 +25,16 @@ const AwardPageWrapper = ({
     const glossaryTitleText = awardTypeCodes[overviewType] ?
         `View glossary definition of ${awardTypeCodes[overviewType]}` :
         'View glossary definition';
+
+    const [, areDefCodesLoading, defCodes] = useDefCodes();
+    const [covidDefCodes, setCovidDefCodes] = useState(null);
+
+    useEffect(() => {
+        if(!areDefCodesLoading) {
+            setCovidDefCodes(defCodes.filter((c) => c.disaster === 'covid_19' && allDefCodes.indexOf(c.code) > -1).map((code) => code.code));
+        }
+    }, [areDefCodesLoading]);
+
     return (
         <div className={`award award-${awardType}`}>
             <div className="award__heading">
@@ -43,8 +54,8 @@ const AwardPageWrapper = ({
                     awardType={awardType}
                     dates={dates} />
             </div>
-            {defCodes.length > 0 &&
-            <TooltipWrapper className="award-summary__covid-19-flag" tooltipComponent={<CovidFlagTooltip codes={defCodes} />}>
+            {covidDefCodes && covidDefCodes.length > 0 &&
+            <TooltipWrapper className="award-summary__covid-19-flag" tooltipComponent={<CovidFlagTooltip codes={covidDefCodes} />}>
                 <span className="covid-spending-flag">
                                 Includes COVID-19 Spending
                 </span>

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsChart.jsx
@@ -48,11 +48,8 @@ const getAwardColor = (overallColor, infrastructureColor, infrastructure) => {
 };
 
 const getAwardOutlayRawValue = (data, awardType, infrastructure) => {
-    // _fileCOutlayByType[infrastructure]
-    // combinedOutlayAbbreviated
-    // totalOutlayAbbreviated
     if (infrastructure) {
-        return 990;
+        return data._fileCOutlayInfrastructure;
     }
 
     return awardType === "idv" ? data._combinedOutlay : data._totalOutlay;
@@ -60,17 +57,15 @@ const getAwardOutlayRawValue = (data, awardType, infrastructure) => {
 
 const getAwardOutlayValue = (data, awardType, infrastructure) => {
     if (infrastructure) {
-        return '$990';
+        return data.infrastructureOutlayAbbreviated;
     }
 
     return awardType === 'idv' ? data.combinedOutlayAbbreviated : data.totalOutlayAbbreviated;
 }
 
 const getAwardObligatedRawValue = (data, awardType, infrastructure) => {
-    // _fileCObligatedByType[infrastructure]
-    // totalObligationAbbreviated
     if (infrastructure) {
-        return 12047.3;
+        return data._fileCOutlayInfrastructure;
     }
 
     return data._totalObligation;
@@ -78,7 +73,7 @@ const getAwardObligatedRawValue = (data, awardType, infrastructure) => {
 
 const getAwardObligatedValue = (data, awardType, infrastructure) => {
     if (infrastructure) {
-        return '$1,205';
+        return data.infrastructureObligationAbbreviated;
     }
 
     return data.totalObligationAbbreviated;
@@ -501,12 +496,10 @@ const AwardAmountsChart = ({
    infrastructureSpending
 }) => {
 
-    console.log(infrastructureSpending);
     const [infrastructure, setInfrastructure] = useState(infrastructureSpending === "infrastructure");
 
     useEffect(() => {
         setInfrastructure(infrastructureSpending === "infrastructure");
-        console.log(infrastructureSpending)
     }, [infrastructureSpending]);
 
     const renderChartBySpendingScenario = (
@@ -547,7 +540,6 @@ const AwardAmountsChart = ({
 
     const renderChartByAwardType = (awardAmounts = awardOverview, type = awardType, scenario = spendingScenario) => {
         const isNormal = scenario === 'normal';
-        console.log(awardAmounts)
         if (asstAwardTypesWithSimilarAwardAmountData.includes(type) && isNormal) {
             const isNffZero = awardAmounts._nonFederalFunding === 0;
             const showFileC = awardAmounts._fileCObligated > 0;

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsChart.jsx
@@ -52,7 +52,7 @@ const getAwardOutlayRawValue = (data, awardType, infrastructure) => {
     // combinedOutlayAbbreviated
     // totalOutlayAbbreviated
     if (infrastructure) {
-        return 11111;
+        return 990;
     }
 
     return awardType === "idv" ? data._combinedOutlay : data._totalOutlay;
@@ -60,7 +60,7 @@ const getAwardOutlayRawValue = (data, awardType, infrastructure) => {
 
 const getAwardOutlayValue = (data, awardType, infrastructure) => {
     if (infrastructure) {
-        return 11111;
+        return '$990';
     }
 
     return awardType === 'idv' ? data.combinedOutlayAbbreviated : data.totalOutlayAbbreviated;
@@ -70,7 +70,7 @@ const getAwardObligatedRawValue = (data, awardType, infrastructure) => {
     // _fileCObligatedByType[infrastructure]
     // totalObligationAbbreviated
     if (infrastructure) {
-        return 111110;
+        return 12047.3;
     }
 
     return data._totalObligation;
@@ -78,7 +78,7 @@ const getAwardObligatedRawValue = (data, awardType, infrastructure) => {
 
 const getAwardObligatedValue = (data, awardType, infrastructure) => {
     if (infrastructure) {
-        return 111110;
+        return '$1,205';
     }
 
     return data.totalObligationAbbreviated;

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsChart.jsx
@@ -488,6 +488,7 @@ const AwardAmountsChart = ({
 
     const renderChartByAwardType = (awardAmounts = awardOverview, type = awardType, scenario = spendingScenario) => {
         const isNormal = scenario === 'normal';
+        console.log(awardAmounts)
         if (asstAwardTypesWithSimilarAwardAmountData.includes(type) && isNormal) {
             const isNffZero = awardAmounts._nonFederalFunding === 0;
             const showFileC = awardAmounts._fileCObligated > 0;

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsChart.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import {
@@ -10,6 +10,7 @@ import {
     nonFederalFundingColor,
     subsidyColor,
     faceValueColor,
+
     // Offsets per DEV-5242:
     lineOffsetsBySpendingCategory
 } from 'dataMapping/award/awardAmountsSection';
@@ -28,7 +29,23 @@ const propTypes = {
 };
 
 // Only for Contract and IDV Awards
-const buildNormalProps = (awardType, data, hasFileC, hasOutlays) => {
+
+const getAwardTypeText = (awardType, amountType, infrastructure) => {
+    const preText = infrastructure ? "Infrastructure" : "Combined";
+    return awardType === "idv" ? `${preText} ${amountType} Amounts` : `${amountType} Amount`;
+};
+
+const getAwardAmount = (awardType, amountType, infrastructure) => {
+    const preText = infrastructure ? "Infrastructure" : "Combined";
+    return awardType === "idv" ? `${preText} ${amountType} Amounts` : `${amountType} Amount`;
+};
+
+const getAwardColor = (awardType, amountType, infrastructure) => {
+    const preText = infrastructure ? "Infrastructure" : "Combined";
+    return awardType === "idv" ? `${preText} ${amountType} Amounts` : `${amountType} Amount`;
+};
+
+const buildNormalProps = (awardType, data, hasFileC, hasOutlays, infrastructure) => {
     const chartProps = {
         denominator: {
             labelSortOrder: 3,
@@ -95,14 +112,12 @@ const buildNormalProps = (awardType, data, hasFileC, hasOutlays) => {
             rawValue: awardType === 'idv'
                 ? data._combinedOutlay
                 : data._totalOutlay,
-            value: awardType === 'idv'
+            value: infrastructure ? '1111' : awardType === 'idv'
                 ? data.combinedOutlayAbbreviated
                 : data.totalOutlayAbbreviated,
             color: outlayColor,
             lineOffset: lineOffsetsBySpendingCategory.potential,
-            text: awardType === 'idv'
-                ? "Combined Outlayed Amounts"
-                : "Outlayed Amount"
+            text: getAwardTypeText(awardType, "Outlayed", infrastructure)
         },
         numerator: {
             labelSortOrder: 2,
@@ -124,9 +139,7 @@ const buildNormalProps = (awardType, data, hasFileC, hasOutlays) => {
                     rawValue: data._totalObligation,
                     denominatorValue: data._baseExercisedOptions,
                     value: data.totalObligationAbbreviated,
-                    text: awardType === 'idv'
-                        ? "Combined Obligated Amounts"
-                        : "Obligated Amount",
+                    text: getAwardTypeText(awardType, "Obligated", infrastructure),
                     color: obligatedColor,
                     lineOffset: lineOffsetsBySpendingCategory.obligationProcurement
                 }
@@ -450,6 +463,9 @@ const AwardAmountsChart = ({
     awardOverview,
     spendingScenario
 }) => {
+
+    const [infrastructure, setInfrastructure] = useState(true);
+
     const renderChartBySpendingScenario = (
         scenario = spendingScenario,
         type = awardType,
@@ -471,7 +487,7 @@ const AwardAmountsChart = ({
             case "normal":
                 if (hasOutlays) {
                     return (
-                        <HorizontalSingleStackedBarViz {...buildNormalProps(type, awardAmounts, hasFileC, hasOutlays)} />
+                        <HorizontalSingleStackedBarViz {...buildNormalProps(type, awardAmounts, hasFileC, hasOutlays, infrastructure)} />
                     );
                 }
                 return (

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsSection.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsSection.jsx
@@ -43,12 +43,14 @@ const AwardAmountsSection = ({
         setActive(tab);
     }
 
+    console.log('awardAmount', awardOverview);
+
     return (
         <AwardSection type="column" className="award-viz award-amounts">
             <div className="award__col__content">
                 <AwardSectionHeader title="$ Award Amounts" tooltip={tooltip} />
                 <div className="award-amounts__content">
-                    <div style={{ display: awardOverview._fileCObligatedByType?.infrastructure === 11111 ? `block` : `none` }}>
+                    <div style={{ display: awardOverview._fileCOutlayInfrastructure > 0 || awardOverview._fileCObligatedInfrastructure > 0  ? `block` : `none` }}>
                         <ResultsTableTabs
                             types={tabTypes}
                             active={active}

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsSection.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsSection.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 import { determineSpendingScenarioByAwardType } from 'helpers/awardAmountHelper';
 import { getToolTipBySectionAndAwardType } from 'dataMapping/award/tooltips';
+import ResultsTableTabs from 'components/search/table/ResultsTableTabs';
+
 import AwardSection from '../AwardSection';
 import AwardSectionHeader from '../AwardSectionHeader';
 import AwardAmountsChart from './AwardAmountsChart';
@@ -15,6 +17,19 @@ const propTypes = {
     awardOverview: AWARD_OVERVIEW_AWARD_AMOUNTS_SECTION_PROPS,
     jumpToTransactionHistoryTable: PropTypes.func
 };
+
+const tabTypes = [
+    {
+        enabled: true,
+        internal: 'overall',
+        label: 'Overall Spending'
+    },
+    {
+        enabled: true,
+        internal: 'infrastructure',
+        label: 'Infrastructure Spending'
+    }
+];
 
 const AwardAmountsSection = ({
     awardOverview,
@@ -29,6 +44,10 @@ const AwardAmountsSection = ({
             <div className="award__col__content">
                 <AwardSectionHeader title="$ Award Amounts" tooltip={tooltip} />
                 <div className="award-amounts__content">
+                    <ResultsTableTabs
+                        types={tabTypes}
+                        active={true}
+                        hideCounts />
                     <AwardAmountsChart
                         awardOverview={awardOverview}
                         awardType={awardType}

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsSection.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsSection.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { determineSpendingScenarioByAwardType } from 'helpers/awardAmountHelper';
@@ -20,17 +20,16 @@ const propTypes = {
 
 const tabTypes = [
     {
-        enabled: true,
         internal: 'overall',
         label: 'Overall Spending'
     },
     {
-        enabled: true,
         internal: 'infrastructure',
         label: 'Infrastructure Spending'
     }
 ];
 
+// how do know if there's covid spending an
 const AwardAmountsSection = ({
     awardOverview,
     awardType,
@@ -38,20 +37,30 @@ const AwardAmountsSection = ({
 }) => {
     const spendingScenario = determineSpendingScenarioByAwardType(awardType, awardOverview);
     const tooltip = getToolTipBySectionAndAwardType('awardAmounts', awardType);
+    const [active, setActive] = useState(tabTypes[0].internal)
+
+    const switchTab = (tab) => {
+        setActive(tab);
+    }
 
     return (
         <AwardSection type="column" className="award-viz award-amounts">
             <div className="award__col__content">
                 <AwardSectionHeader title="$ Award Amounts" tooltip={tooltip} />
                 <div className="award-amounts__content">
-                    <ResultsTableTabs
-                        types={tabTypes}
-                        active={true}
-                        hideCounts />
+                    <div style={{ display: awardOverview._fileCObligatedByType?.infrastructure === 11111 ? `block` : `none` }}>
+                        <ResultsTableTabs
+                            types={tabTypes}
+                            active={active}
+                            switchTab={switchTab}
+                            hideCounts />
+                    </div>
                     <AwardAmountsChart
                         awardOverview={awardOverview}
                         awardType={awardType}
-                        spendingScenario={spendingScenario} />
+                        spendingScenario={spendingScenario}
+                        infrastructureSpending={active}
+                    />
                     <AwardAmountsTable
                         showFileC={(
                             (

--- a/src/js/components/award/shared/awardAmounts/HorizontalSingleStackedBarViz.jsx
+++ b/src/js/components/award/shared/awardAmounts/HorizontalSingleStackedBarViz.jsx
@@ -58,12 +58,16 @@ const HorizontalSingleStackedBarViz = ({
 
     const currentAmountValue = numerator.value;
     const currentAmountLabel = numerator.text;
+    const currentAmountColor = numerator.color;
     const outlayedAmountValue = numerator2.value;
     const outlayedAmountLabel = numerator2.text;
+    const outlayedAmountColor = numerator2.color;
     const obligatedAmountValue = numerator.children[0].value;
     const obligatedAmountLabel = numerator.children[0].text;
+    const obligatedAmountColor = numerator.children[0].color;
     const potentialAmountValue = denominator.value;
     const potentialAmountLabel = denominator.text;
+    const potentialAmountColor = denominator.color;
     const isNffZero = numerator.className === 'asst-non-federal-funding' && numerator.value === '$0';
 
     useEffect(() => {
@@ -88,7 +92,7 @@ const HorizontalSingleStackedBarViz = ({
                 .attr("y", height / 2.5)
                 .attr("width", x(propsArr[0]))
                 .attr("height", '50')
-                .attr("fill", "#dce4ee");
+                .attr("fill", potentialAmountColor);
             // grants, direct payments, other
             if (numerator.className === "asst-non-federal-funding") {
                 // obligated rect
@@ -97,14 +101,14 @@ const HorizontalSingleStackedBarViz = ({
                     .attr("y", (height / 2.5) + 5)
                     .attr("width", x(propsArr[2]))
                     .attr("height", '40')
-                    .attr("fill", "#4773aa");
+                    .attr("fill", obligatedAmountColor);
                 // outlayed rect
                 chartSvg.append("rect")
                     .attr("x", 0)
                     .attr("y", (height / 2.5) + 10)
                     .attr("width", x(propsArr[3]))
                     .attr("height", '30')
-                    .attr("fill", "#0b2e5a");
+                    .attr("fill", outlayedAmountColor);
                 if (!isNffZero) {
                     // nff rect
                     chartSvg.append("rect")
@@ -135,7 +139,7 @@ const HorizontalSingleStackedBarViz = ({
                     .attr("x2", x(propsArr[0]) - 2)
                     .attr("y2", height - 50)
                     .style("stroke-width", 4)
-                    .style("stroke", "#dce4ee")
+                    .style("stroke", potentialAmountColor)
                     .style("fill", "none");
                 // outlay line
                 chartSvg.append("line")
@@ -144,7 +148,7 @@ const HorizontalSingleStackedBarViz = ({
                     .attr("x2", x(propsArr[3]) - 2)
                     .attr("y2", (height / 2.5) + 35)
                     .style("stroke-width", 4)
-                    .style("stroke", "#0b2e5a")
+                    .style("stroke", outlayedAmountColor)
                     .style("fill", "none");
                 // obligated line
                 chartSvg.append("line")
@@ -153,7 +157,7 @@ const HorizontalSingleStackedBarViz = ({
                     .attr("x2", x(propsArr[2]) - 2)
                     .attr("y2", (height / 2.5) + 45)
                     .style("stroke-width", 4)
-                    .style("stroke", "#4773aa")
+                    .style("stroke", obligatedAmountColor)
                     .style("fill", "none");
                 if (!isNffZero) {
                     // current line
@@ -193,14 +197,14 @@ const HorizontalSingleStackedBarViz = ({
                     .attr("y", (height / 2.5) + 10)
                     .attr("width", x(propsArr[2]))
                     .attr("height", '30')
-                    .attr("fill", "#4773aa");
+                    .attr("fill", obligatedAmountColor);
                 // outlayed rect
                 chartSvg.append("rect")
                     .attr("x", 0)
                     .attr("y", (height / 2.5) + 15)
                     .attr("width", x(propsArr[3]))
                     .attr("height", '20')
-                    .attr("fill", "#0b2e5a");
+                    .attr("fill", outlayedAmountColor);
                 // potential line
                 chartSvg.append("line")
                     .attr("x1", x(propsArr[0]) - 2)
@@ -208,7 +212,7 @@ const HorizontalSingleStackedBarViz = ({
                     .attr("x2", x(propsArr[0]) - 2)
                     .attr("y2", height - 50)
                     .style("stroke-width", 4)
-                    .style("stroke", "#dce4ee")
+                    .style("stroke", potentialAmountColor)
                     .style("fill", "none");
                 // current line
                 chartSvg.append("line")
@@ -226,7 +230,7 @@ const HorizontalSingleStackedBarViz = ({
                     .attr("x2", x(propsArr[3]) - 2)
                     .attr("y2", (height / 2.5) + 35)
                     .style("stroke-width", 4)
-                    .style("stroke", "#0b2e5a")
+                    .style("stroke", outlayedAmountColor)
                     .style("fill", "none");
                 // obligated line
                 chartSvg.append("line")
@@ -235,7 +239,7 @@ const HorizontalSingleStackedBarViz = ({
                     .attr("x2", x(propsArr[2]) - 2)
                     .attr("y2", (height / 2.5) + 40)
                     .style("stroke-width", 4)
-                    .style("stroke", "#4773aa")
+                    .style("stroke", obligatedAmountColor)
                     .style("fill", "none");
                 // current label
                 chartSvg.append("foreignObject")
@@ -323,7 +327,7 @@ const HorizontalSingleStackedBarViz = ({
                 .attr("y", (height / 2.5) + 10)
                 .attr("width", x(propsArr[2]) < 8 ? 8 + x(propsArr[2]) : x(propsArr[2]))
                 .attr("height", '30')
-                .attr("fill", "#0b2e5a");
+                .attr("fill", outlayedAmountColor);
             // face value line
             chartSvg.append("line")
                 .attr("x1", x(propsArr[0]) - 2)
@@ -349,7 +353,7 @@ const HorizontalSingleStackedBarViz = ({
                 .attr("x2", (x(propsArr[2]) - 2) < 8 ? 8 + (x(propsArr[2]) - 2) : (x(propsArr[2]) - 2))
                 .attr("y2", (height / 2.5) + 40)
                 .style("stroke-width", 4)
-                .style("stroke", "#0b2e5a")
+                .style("stroke", "red")
                 .style("fill", "none");
             // subsidy label
             chartSvg.append("foreignObject")

--- a/src/js/containers/award/AwardContainer.jsx
+++ b/src/js/containers/award/AwardContainer.jsx
@@ -132,6 +132,7 @@ export class AwardContainer extends React.Component {
     }
 
     parseAward(data) {
+        console.log(this.props.defCodes)
         this.setState({
             noAward: false
         });
@@ -199,7 +200,7 @@ export class AwardContainer extends React.Component {
                 award={this.props.award}
                 isLoading={this.state.inFlight}
                 noAward={this.state.noAward}
-                defCodes={this.props.defCodes?.map((defc) => defc.code)} />
+                defCodes={this.props.defCodes} />
         );
     }
 }

--- a/src/js/containers/award/AwardContainer.jsx
+++ b/src/js/containers/award/AwardContainer.jsx
@@ -132,7 +132,6 @@ export class AwardContainer extends React.Component {
     }
 
     parseAward(data) {
-        console.log(this.props.defCodes)
         this.setState({
             noAward: false
         });

--- a/src/js/containers/award/idv/IdvAwardAmountsSectionContainer.jsx
+++ b/src/js/containers/award/idv/IdvAwardAmountsSectionContainer.jsx
@@ -154,7 +154,7 @@ export class IdvAmountsContainer extends React.Component {
         return (
             <div className="award__col award-viz award-amounts">
                 <div className="award-viz__heading">
-                    <h3 className="award-viz__title">$ Award Amounts</h3>
+                    <h3 className="award-viz__title">***$ Award Amounts</h3>
                     <TooltipWrapper
                         className="award-section-tt"
                         icon="info"

--- a/src/js/containers/award/idv/IdvAwardAmountsSectionContainer.jsx
+++ b/src/js/containers/award/idv/IdvAwardAmountsSectionContainer.jsx
@@ -154,7 +154,7 @@ export class IdvAmountsContainer extends React.Component {
         return (
             <div className="award__col award-viz award-amounts">
                 <div className="award-viz__heading">
-                    <h3 className="award-viz__title">***$ Award Amounts</h3>
+                    <h3 className="award-viz__title">$ Award Amounts</h3>
                     <TooltipWrapper
                         className="award-section-tt"
                         icon="info"

--- a/src/js/dataMapping/award/awardAmountsSection.js
+++ b/src/js/dataMapping/award/awardAmountsSection.js
@@ -145,6 +145,10 @@ export const potentialColor = '#dce4ee';
 export const subsidyColor = '#8c6e86';
 export const faceValueColor = '#ded5db';
 export const nonFederalFundingColor = '#47AAA7';
+export const infrastructureOutlayColor = "#2d6878";
+export const infrastructureObligatedColor = '#afcdd5';
+export const infrastructureCurrentColor = '#8ba6c9';
+export const infrastructurePotentialColor = '#dce4ee';
 
 // Offsets per DEV-5242:
 // 3px padding between outermost bar and first nested bar

--- a/src/js/models/v2/award/BaseAwardAmounts.js
+++ b/src/js/models/v2/award/BaseAwardAmounts.js
@@ -6,11 +6,13 @@
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 
 const getCovid19Totals = (arr, defCodes = []) => {
-    console.log(arr.filter((obj) => defCodes.filter((d) => d?.disaster === "covid_19")?.map((defc) => defc.code).includes(obj?.code)).reduce((acc, obj) => acc + obj?.amount || 0, 0));
     return arr.filter((obj) => defCodes.filter((d) => d?.disaster === "covid_19")?.map((defc) => defc.code).includes(obj?.code)).reduce((acc, obj) => acc + obj?.amount || 0, 0)
 }
 
-const getInfrastructureTotals = (arr, defCodes = []) => arr.filter((obj) => defCodes.filter((d) => d?.disaster === null)?.map((defc) => defc.code).includes(obj?.code)).reduce((acc, obj) => acc + obj?.amount || 0, 0);
+const getInfrastructureTotals = (arr, defCodes = []) => {
+    // return arr.filter((obj) => obj?.code === 'Z' || obj?.code === '1')?.reduce((acc, obj) => acc + obj?.amount || 0, 0);
+    return 11111;
+}
 
 const BaseAwardAmounts = {
     populateBase(data) {

--- a/src/js/models/v2/award/BaseAwardAmounts.js
+++ b/src/js/models/v2/award/BaseAwardAmounts.js
@@ -5,11 +5,12 @@
 
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 
-const getCovid19Totals = (arr, defCodes = []) => arr
-    .filter((obj) => defCodes.filter((d) => d?.disaster === "covid_19").includes(obj?.code))
-    .reduce((acc, obj) => acc + obj?.amount || 0, 0);
+const getCovid19Totals = (arr, defCodes = []) => {
+    console.log(arr.filter((obj) => defCodes.filter((d) => d?.disaster === "covid_19")?.map((defc) => defc.code).includes(obj?.code)).reduce((acc, obj) => acc + obj?.amount || 0, 0));
+    return arr.filter((obj) => defCodes.filter((d) => d?.disaster === "covid_19")?.map((defc) => defc.code).includes(obj?.code)).reduce((acc, obj) => acc + obj?.amount || 0, 0)
+}
 
-const getInfrastructureTotals = (arr, defCodes = []) => arr.filter((obj) => defCodes.filter((d) => d.disaster === null).includes(obj?.code)).reduce((acc, obj) => acc + obj?.amount || 0, 0);
+const getInfrastructureTotals = (arr, defCodes = []) => arr.filter((obj) => defCodes.filter((d) => d?.disaster === null)?.map((defc) => defc.code).includes(obj?.code)).reduce((acc, obj) => acc + obj?.amount || 0, 0);
 
 const BaseAwardAmounts = {
     populateBase(data) {

--- a/src/js/models/v2/award/BaseAwardAmounts.js
+++ b/src/js/models/v2/award/BaseAwardAmounts.js
@@ -6,8 +6,10 @@
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 
 const getCovid19Totals = (arr, defCodes = []) => arr
-    .filter((obj) => defCodes.includes(obj?.code))
+    .filter((obj) => defCodes.filter((d) => d?.disaster === "covid_19").includes(obj?.code))
     .reduce((acc, obj) => acc + obj?.amount || 0, 0);
+
+const getInfrastructureTotals = (arr, defCodes = []) => arr.filter((obj) => defCodes.filter((d) => d.disaster === null).includes(obj?.code)).reduce((acc, obj) => acc + obj?.amount || 0, 0);
 
 const BaseAwardAmounts = {
     populateBase(data) {
@@ -45,6 +47,20 @@ const BaseAwardAmounts = {
                 .concat(data.grandchild_account_obligations_by_defc),
             defCodes
         );
+        this._fileCOutlayByType = {
+            infrastructure: getInfrastructureTotals(data.child_account_outlays_by_defc
+                .concat(data.grandchild_account_outlays_by_defc), defCodes),
+            covid: getCovid19Totals(
+                data.child_account_outlays_by_defc
+                .concat(data.grandchild_account_outlays_by_defc), defCodes)
+        }
+        this._fileCObligatedByType = {
+            infrastructure: getInfrastructureTotals(data.child_account_obligations_by_defc
+                .concat(data.grandchild_account_obligationss_by_defc), defCodes),
+            covid: getCovid19Totals(
+                data.child_account_outlays_by_defc
+                    .concat(data.grandchild_account_outlays_by_defc), defCodes)
+        }
     },
     populateIdv(data, defCodes) {
         this._totalObligation = data._totalObligation;
@@ -55,6 +71,16 @@ const BaseAwardAmounts = {
         this._baseAndAllOptions = data._baseAndAllOptions;
         this._fileCOutlay = getCovid19Totals(data.fileC.outlays, defCodes);
         this._fileCObligated = getCovid19Totals(data.fileC.obligations, defCodes);
+        this._fileCOutlayByType = {
+            infrastructure: getInfrastructureTotals(data.fileC.outlays, defCodes),
+            covid: getCovid19Totals(
+                data.fileC.outlays, defCodes)
+        };
+        this._fileCObligatedByType = {
+            infrastructure: getInfrastructureTotals(data.fileC.obligations, defCodes),
+            covid: getCovid19Totals(
+                data.fileC.obligations, defCodes)
+        };
     },
     populateLoan(data, defCodes) {
         this._subsidy = data._subsidy;
@@ -62,6 +88,16 @@ const BaseAwardAmounts = {
         this._totalOutlay = data._totalOutlay;
         this._fileCOutlay = getCovid19Totals(data.fileC.outlays, defCodes);
         this._fileCObligated = getCovid19Totals(data.fileC.obligations, defCodes);
+        this._fileCOutlayByType = {
+            infrastructure: getInfrastructureTotals(data.fileC.outlays, defCodes),
+            covid: getCovid19Totals(
+                data.fileC.outlays, defCodes)
+        };
+        this._fileCObligatedByType = {
+            infrastructure: getInfrastructureTotals(data.fileC.obligations, defCodes),
+            covid: getCovid19Totals(
+                data.fileC.obligations, defCodes)
+        };
     },
     populateAsst(data, defCodes) {
         this._totalObligation = data._totalObligation;
@@ -70,6 +106,16 @@ const BaseAwardAmounts = {
         this._nonFederalFunding = data._nonFederalFunding;
         this._fileCOutlay = getCovid19Totals(data.fileC.outlays, defCodes);
         this._fileCObligated = getCovid19Totals(data.fileC.obligations, defCodes);
+        this._fileCOutlayByType = {
+            infrastructure: getInfrastructureTotals(data.fileC.outlays, defCodes),
+            covid: getCovid19Totals(
+                data.fileC.outlays, defCodes)
+        };
+        this._fileCObligatedByType = {
+            infrastructure: getInfrastructureTotals(data.fileC.obligations, defCodes),
+            covid: getCovid19Totals(
+                data.fileC.obligations, defCodes)
+        };
     },
     populateContract(data, defCodes) {
         this._totalObligation = data._totalObligation;
@@ -78,6 +124,16 @@ const BaseAwardAmounts = {
         this._baseAndAllOptions = data._baseAndAllOptions;
         this._fileCOutlay = getCovid19Totals(data.fileC.outlays, defCodes);
         this._fileCObligated = getCovid19Totals(data.fileC.obligations, defCodes);
+        this._fileCOutlayByType = {
+            infrastructure: getInfrastructureTotals(data.fileC.outlays, defCodes),
+            covid: getCovid19Totals(
+                data.fileC.outlays, defCodes)
+        };
+        this._fileCObligatedByType = {
+            infrastructure: getInfrastructureTotals(data.fileC.obligations, defCodes),
+            covid: getCovid19Totals(
+                data.fileC.obligations, defCodes)
+        };
     },
     populate(data, awardAmountType, defCodes) {
         this.populateBase(data, awardAmountType);

--- a/src/js/models/v2/award/BaseAwardAmounts.js
+++ b/src/js/models/v2/award/BaseAwardAmounts.js
@@ -6,12 +6,12 @@
 import * as MoneyFormatter from 'helpers/moneyFormatter';
 
 const getCovid19Totals = (arr, defCodes = []) => {
+    console.log('defc - in based award amounts needs to be fixed', defCodes);
     return arr.filter((obj) => defCodes.filter((d) => d?.disaster === "covid_19")?.map((defc) => defc.code).includes(obj?.code)).reduce((acc, obj) => acc + obj?.amount || 0, 0)
 }
 
-const getInfrastructureTotals = (arr, defCodes = []) => {
-    // return arr.filter((obj) => obj?.code === 'Z' || obj?.code === '1')?.reduce((acc, obj) => acc + obj?.amount || 0, 0);
-    return 11111;
+const getInfrastructureTotals = (arr) => {
+    return arr.filter((d) => d?.code === "Z" || d?.code === "Q")?.reduce((acc, obj) => acc + obj?.amount || 0, 0);
 }
 
 const BaseAwardAmounts = {
@@ -50,20 +50,10 @@ const BaseAwardAmounts = {
                 .concat(data.grandchild_account_obligations_by_defc),
             defCodes
         );
-        this._fileCOutlayByType = {
-            infrastructure: getInfrastructureTotals(data.child_account_outlays_by_defc
-                .concat(data.grandchild_account_outlays_by_defc), defCodes),
-            covid: getCovid19Totals(
-                data.child_account_outlays_by_defc
-                .concat(data.grandchild_account_outlays_by_defc), defCodes)
-        }
-        this._fileCObligatedByType = {
-            infrastructure: getInfrastructureTotals(data.child_account_obligations_by_defc
-                .concat(data.grandchild_account_obligationss_by_defc), defCodes),
-            covid: getCovid19Totals(
-                data.child_account_outlays_by_defc
-                    .concat(data.grandchild_account_outlays_by_defc), defCodes)
-        }
+        this._fileCOutlayInfrastructure = getInfrastructureTotals(data.child_account_outlays_by_defc
+            .concat(data.grandchild_account_outlays_by_defc));
+        this._fileCObligatedInfrastructure = getInfrastructureTotals(data.child_account_obligations_by_defc
+            .concat(data.grandchild_account_obligations_by_defc));
     },
     populateIdv(data, defCodes) {
         this._totalObligation = data._totalObligation;
@@ -74,16 +64,8 @@ const BaseAwardAmounts = {
         this._baseAndAllOptions = data._baseAndAllOptions;
         this._fileCOutlay = getCovid19Totals(data.fileC.outlays, defCodes);
         this._fileCObligated = getCovid19Totals(data.fileC.obligations, defCodes);
-        this._fileCOutlayByType = {
-            infrastructure: getInfrastructureTotals(data.fileC.outlays, defCodes),
-            covid: getCovid19Totals(
-                data.fileC.outlays, defCodes)
-        };
-        this._fileCObligatedByType = {
-            infrastructure: getInfrastructureTotals(data.fileC.obligations, defCodes),
-            covid: getCovid19Totals(
-                data.fileC.obligations, defCodes)
-        };
+        this._fileCOutlayInfrastructure = getInfrastructureTotals(data.fileC.outlays);
+        this._fileCObligatedInfrastructure = getInfrastructureTotals(data.fileC.obligations);
     },
     populateLoan(data, defCodes) {
         this._subsidy = data._subsidy;
@@ -91,16 +73,8 @@ const BaseAwardAmounts = {
         this._totalOutlay = data._totalOutlay;
         this._fileCOutlay = getCovid19Totals(data.fileC.outlays, defCodes);
         this._fileCObligated = getCovid19Totals(data.fileC.obligations, defCodes);
-        this._fileCOutlayByType = {
-            infrastructure: getInfrastructureTotals(data.fileC.outlays, defCodes),
-            covid: getCovid19Totals(
-                data.fileC.outlays, defCodes)
-        };
-        this._fileCObligatedByType = {
-            infrastructure: getInfrastructureTotals(data.fileC.obligations, defCodes),
-            covid: getCovid19Totals(
-                data.fileC.obligations, defCodes)
-        };
+        this._fileCOutlayInfrastructure = getInfrastructureTotals(data.fileC.outlays);
+        this._fileCObligatedInfrastructure = getInfrastructureTotals(data.fileC.obligations);
     },
     populateAsst(data, defCodes) {
         this._totalObligation = data._totalObligation;
@@ -109,16 +83,8 @@ const BaseAwardAmounts = {
         this._nonFederalFunding = data._nonFederalFunding;
         this._fileCOutlay = getCovid19Totals(data.fileC.outlays, defCodes);
         this._fileCObligated = getCovid19Totals(data.fileC.obligations, defCodes);
-        this._fileCOutlayByType = {
-            infrastructure: getInfrastructureTotals(data.fileC.outlays, defCodes),
-            covid: getCovid19Totals(
-                data.fileC.outlays, defCodes)
-        };
-        this._fileCObligatedByType = {
-            infrastructure: getInfrastructureTotals(data.fileC.obligations, defCodes),
-            covid: getCovid19Totals(
-                data.fileC.obligations, defCodes)
-        };
+        this._fileCOutlayInfrastructure = getInfrastructureTotals(data.fileC.outlays);
+        this._fileCObligatedInfrastructure = getInfrastructureTotals(data.fileC.obligations);
     },
     populateContract(data, defCodes) {
         this._totalObligation = data._totalObligation;
@@ -127,16 +93,8 @@ const BaseAwardAmounts = {
         this._baseAndAllOptions = data._baseAndAllOptions;
         this._fileCOutlay = getCovid19Totals(data.fileC.outlays, defCodes);
         this._fileCObligated = getCovid19Totals(data.fileC.obligations, defCodes);
-        this._fileCOutlayByType = {
-            infrastructure: getInfrastructureTotals(data.fileC.outlays, defCodes),
-            covid: getCovid19Totals(
-                data.fileC.outlays, defCodes)
-        };
-        this._fileCObligatedByType = {
-            infrastructure: getInfrastructureTotals(data.fileC.obligations, defCodes),
-            covid: getCovid19Totals(
-                data.fileC.obligations, defCodes)
-        };
+        this._fileCOutlayInfrastructure = getInfrastructureTotals(data.fileC.outlays);
+        this._fileCObligatedInfrastructure = getInfrastructureTotals(data.fileC.obligations);
     },
     populate(data, awardAmountType, defCodes) {
         this.populateBase(data, awardAmountType);
@@ -221,6 +179,32 @@ const BaseAwardAmounts = {
             return `(${Math.abs(MoneyFormatter.formatMoney(this._totalObligation))})`;
         }
         return MoneyFormatter.formatMoney(this._totalObligation);
+    },
+    get infrastructureOutlayAbbreviated() {
+        if (Math.abs(this._fileCOutlayInfrastructure) >= MoneyFormatter.unitValues.MILLION) {
+            const units = MoneyFormatter.calculateUnitForSingleValue(this._fileCOutlayInfrastructure);
+            if (this._fileCOutlayInfrastructure < 0) {
+                return `(${MoneyFormatter.formatMoneyWithPrecision(Math.abs(this._fileCOutlayInfrastructure) / units.unit, 1)} ${units.longLabel.charAt(0).toUpperCase() + units.longLabel.slice(1)})`;
+            }
+            return `${MoneyFormatter.formatMoneyWithPrecision(this._fileCOutlayInfrastructure / units.unit, 1)} ${units.longLabel.charAt(0).toUpperCase() + units.longLabel.slice(1)}`;
+        }
+        else if (this._fileCOutlayInfrastructure < 0) {
+            return `(${Math.abs(MoneyFormatter.formatMoney(this._fileCOutlayInfrastructure))})`;
+        }
+        return MoneyFormatter.formatMoney(this._fileCOutlayInfrastructure);
+    },
+    get infrastructureObligationAbbreviated() {
+        if (Math.abs(this._fileCObligatedInfrastructure) >= MoneyFormatter.unitValues.MILLION) {
+            const units = MoneyFormatter.calculateUnitForSingleValue(this._fileCObligatedInfrastructure);
+            if (this._fileCObligatedInfrastructure < 0) {
+                return `(${MoneyFormatter.formatMoneyWithPrecision(Math.abs(this._fileCObligatedInfrastructure) / units.unit, 1)} ${units.longLabel.charAt(0).toUpperCase() + units.longLabel.slice(1)})`;
+            }
+            return `${MoneyFormatter.formatMoneyWithPrecision(this._fileCObligatedInfrastructure / units.unit, 1)} ${units.longLabel.charAt(0).toUpperCase() + units.longLabel.slice(1)}`;
+        }
+        else if (this._fileCObligatedInfrastructure < 0) {
+            return `(${Math.abs(MoneyFormatter.formatMoney(this._fileCObligatedInfrastructure))})`;
+        }
+        return MoneyFormatter.formatMoney(this._fileCObligatedInfrastructure);
     },
     get baseExercisedOptionsFormatted() {
         return MoneyFormatter.formatMoneyWithPrecision(this._baseExercisedOptions, 2);


### PR DESCRIPTION
**High level description:**

Added infrastructure spending to idv awards summary chart

**Technical details:**

Added tab to toggle between overall and infrastructure spending.  Updated the award amount chart data, labels and colors for infrastructure.  There is an issue with the data from the end point - https://api.usaspending.gov/api/v2/awards/CONT_IDV_12475620D0001_12C2

Cannot filter by defc.code === "1".  Currently investigating

**JIRA Ticket:**
[DEV-8730](https://federal-spending-transparency.atlassian.net/browse/DEV-8730)

**Mockup:**
https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55/screen/628d3656bc382fbafbb27c1d

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Code review complete
