### PR TITLE
8729 add horiz scroll to search tables mod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3105,6 +3105,14 @@
               "dev": true,
               "requires": {
                 "minimist": "^1.2.6"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.6",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+                  "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+                  "dev": true
+                }
               }
             },
             "yallist": {
@@ -5294,6 +5302,14 @@
               "dev": true,
               "requires": {
                 "minimist": "^1.2.6"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.6",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+                  "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+                  "dev": true
+                }
               }
             },
             "yallist": {
@@ -17619,6 +17635,14 @@
               "dev": true,
               "requires": {
                 "minimist": "^1.2.6"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.6",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+                  "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+                  "dev": true
+                }
               }
             },
             "yallist": {

--- a/src/_scss/lib/ibTable/ibTable.scss
+++ b/src/_scss/lib/ibTable/ibTable.scss
@@ -22,7 +22,6 @@
 
     .ibt-table-header-container {
         position: relative;
-        //overflow: hidden; TODO - dev 8729 check if commenting this out affects other tables
 
         .ibt-header {
             display: block;

--- a/src/_scss/lib/ibTable/ibTable.scss
+++ b/src/_scss/lib/ibTable/ibTable.scss
@@ -1,6 +1,6 @@
 .ibt-table__top-scroller {
     overflow-x: scroll;
-    height: rem(20);
+    height: rem(16);
 
     .ibt-table__scroller {
         height: rem(7);

--- a/src/_scss/lib/ibTable/ibTable.scss
+++ b/src/_scss/lib/ibTable/ibTable.scss
@@ -1,3 +1,12 @@
+.ibt-table__top-scroller {
+    overflow-x: scroll;
+    height: rem(20);
+
+    .ibt-table__scroller {
+        height: rem(7);
+    }
+}
+
 .ibt-table-container {
     position: relative;
     overflow: hidden;
@@ -24,7 +33,7 @@
             overflow: hidden;
             white-space: nowrap;
             will-change: transform;
-            
+
             .ibt-header-row {
                 display: table;
                 position: absolute;

--- a/src/_scss/lib/ibTable/ibTable.scss
+++ b/src/_scss/lib/ibTable/ibTable.scss
@@ -22,7 +22,7 @@
 
     .ibt-table-header-container {
         position: relative;
-        overflow: hidden;
+        //overflow: hidden; TODO - dev 8729 check if commenting this out affects other tables
 
         .ibt-header {
             display: block;

--- a/src/_scss/pages/search/results/table/resultsTable.scss
+++ b/src/_scss/pages/search/results/table/resultsTable.scss
@@ -8,7 +8,6 @@
     @import "./_tableMessages";
     .results-table-content {
         position: relative;
-        //margin-top: rem(15);
         min-height: rem(200);
         @include transition(opacity 0.25s ease-in);
     }

--- a/src/_scss/pages/search/results/table/resultsTable.scss
+++ b/src/_scss/pages/search/results/table/resultsTable.scss
@@ -8,7 +8,7 @@
     @import "./_tableMessages";
     .results-table-content {
         position: relative;
-        margin-top: rem(15);
+        //margin-top: rem(15);
         min-height: rem(200);
         @include transition(opacity 0.25s ease-in);
     }

--- a/src/_scss/pages/search/results/table/resultsTable.scss
+++ b/src/_scss/pages/search/results/table/resultsTable.scss
@@ -8,6 +8,7 @@
     @import "./_tableMessages";
     .results-table-content {
         position: relative;
+        margin-top: rem(2);
         min-height: rem(200);
         @include transition(opacity 0.25s ease-in);
     }

--- a/src/js/components/keyword/table/ResultsTable.jsx
+++ b/src/js/components/keyword/table/ResultsTable.jsx
@@ -138,6 +138,7 @@ export default class ResultsTable extends React.Component {
                     headerCellRender={this.headerCellRender}
                     bodyCellRender={this.bodyCellRender}
                     onReachedBottom={this.props.loadNextPage}
+                    topScroller
                     ref={(table) => {
                         this.tableComponent = table;
                     }} />

--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -198,6 +198,7 @@ export default class ResultsTable extends React.Component {
                     headerCellRender={this.headerCellRender}
                     bodyCellRender={this.bodyCellRender}
                     onReachedBottom={this.props.loadNextPage}
+                    topScroller
                     ref={(table) => {
                         this.tableComponent = table;
                     }} />

--- a/src/js/components/sharedComponents/IBTable/components/Table.jsx
+++ b/src/js/components/sharedComponents/IBTable/components/Table.jsx
@@ -46,7 +46,7 @@ export default class Table extends React.Component {
         this._internalDiv = null;
         this._tableId = `${uniqueId()}`;
 
-        // this._scrolledTable = this._scrolledTable.bind(this);
+        this._scrolledTable = this._scrolledTable.bind(this);
         this._scrolledHeader = this._scrolledHeader.bind(this);
         this._scrolledTableTop = this._scrolledTableTop.bind(this);
         this._scrolledTableBottom = this._scrolledTableBottom.bind(this);
@@ -121,14 +121,14 @@ export default class Table extends React.Component {
         const topBar = document.getElementById("topBar");
         const bottomBar = document.getElementById("bottomBar");
         bottomBar.scrollLeft = topBar.scrollLeft;
-        this._scrolledTable();
+        this._tableWrapper = topBar.scrollLeft;
     }
 
     _scrolledTableBottom() {
         const topBar = document.getElementById("topBar");
         const bottomBar = document.getElementById("bottomBar");
         topBar.scrollLeft = bottomBar.scrollLeft;
-        this._scrolledTable();
+        this._tableWrapper = topBar.scrollLeft;
     }
 
     _scrolledTable() {
@@ -226,33 +226,37 @@ export default class Table extends React.Component {
                         onScroll={this._scrolledTableTop}>
                         <div className="ibt-table__scroller" style={contentStyle} />
                     </div>
-                    <div
-                        className="ibt-table-header-container"
-                        role="presentation"
-                        style={headerStyle}
-                        id="bottomBar"
-                        onScroll={this._scrolledHeader}
-                        ref={(div) => {
-                            this._headerWrapper = div;
-                        }}>
-                        <HeaderRow
-                            tableId={this._tableId}
-                            contentWidth={this.props.contentWidth}
-                            headerHeight={this.props.headerHeight}
-                            columns={this.props.columns}
-                            headerCellRender={this.props.headerCellRender}
-                            ref={(component) => {
-                                this._headerComponent = component;
-                            }} />
+                    <div>
+
+
                     </div>
                     <div
                         className="ibt-table-body-section"
                         role="presentation"
                         style={bodyStyle}
+                        id="bottomBar"
                         onScroll={this._scrolledTableBottom}
                         ref={(div) => {
                             this._tableWrapper = div;
                         }}>
+                        <div
+                            className="ibt-table-header-container"
+                            role="presentation"
+                            style={headerStyle}
+                            onScroll={this._scrolledHeader}
+                            ref={(div) => {
+                                this._headerWrapper = div;
+                            }}>
+                            <HeaderRow
+                                tableId={this._tableId}
+                                contentWidth={this.props.contentWidth}
+                                headerHeight={this.props.headerHeight}
+                                columns={this.props.columns}
+                                headerCellRender={this.props.headerCellRender}
+                                ref={(component) => {
+                                    this._headerComponent = component;
+                                }} />
+                        </div>
                         <div
                             className="ibt-table-content"
                             role="presentation"

--- a/src/js/components/sharedComponents/IBTable/components/Table.jsx
+++ b/src/js/components/sharedComponents/IBTable/components/Table.jsx
@@ -18,7 +18,8 @@ const propTypes = {
     columns: PropTypes.array,
     onReachedBottom: PropTypes.func,
     headerCellRender: PropTypes.func,
-    bodyCellRender: PropTypes.func
+    bodyCellRender: PropTypes.func,
+    topScroller: PropTypes.bool
 };
 
 const defaultProps = {
@@ -28,7 +29,8 @@ const defaultProps = {
     headerHeight: 0,
     rowHeight: 0,
     rowCount: 0,
-    columns: []
+    columns: [],
+    topScroller: false
 };
 
 const scrollbarHeight = 10;
@@ -122,7 +124,6 @@ export default class Table extends React.Component {
         const bottomBar = document.getElementById("bottomBar");
         bottomBar.scrollLeft = topBar.scrollLeft;
         this._tableWrapper = topBar.scrollLeft;
-        // this._scrolledTable();
     }
 
     _scrolledTableBottom() {
@@ -130,7 +131,6 @@ export default class Table extends React.Component {
         const bottomBar = document.getElementById("bottomBar");
         topBar.scrollLeft = bottomBar.scrollLeft;
         this._tableWrapper = bottomBar.scrollLeft;
-        // this._scrolledTable();
     }
 
     _scrolledTable() {
@@ -184,6 +184,11 @@ export default class Table extends React.Component {
             maxWidth: visibleWidth,
             minHeight: visibleHeight + this.props.headerHeight
         };
+        const topScrollerStyle = {
+            minWidth: visibleWidth,
+            maxWidth: visibleWidth,
+            minHeight: this.props.headerHeight
+        };
         const bodyStyle = {
             minWidth: visibleWidth,
             maxWidth: visibleWidth,
@@ -200,10 +205,6 @@ export default class Table extends React.Component {
             height: (this.props.rowCount * this.props.rowHeight)
         };
 
-        // const scrollerStyle = {
-        //     width: this.props.contentWidth
-        // };
-
         let accessibleDescription = `${this.props.columns.length} column`;
         if (this.props.columns.length !== 1) {
             accessibleDescription += 's';
@@ -213,8 +214,8 @@ export default class Table extends React.Component {
             accessibleDescription += 's';
         }
 
-        return (
-            <div>
+        const body = (
+            <>
                 <div
                     className="ibt-table-container"
                     role="grid"
@@ -222,6 +223,68 @@ export default class Table extends React.Component {
                     aria-colcount={this.props.columns.length}
                     aria-label={`This is a table with ${accessibleDescription}. Use your arrow keys to navigate through cells.`}
                     style={style}>
+                    <div
+                        className="ibt-table-header-container"
+                        role="presentation"
+                        style={headerStyle}
+                        onScroll={this._scrolledHeader}
+                        ref={(div) => {
+                            this._headerWrapper = div;
+                        }}>
+                        <HeaderRow
+                            tableId={this._tableId}
+                            contentWidth={this.props.contentWidth}
+                            headerHeight={this.props.headerHeight}
+                            columns={this.props.columns}
+                            headerCellRender={this.props.headerCellRender}
+                            ref={(component) => {
+                                this._headerComponent = component;
+                            }} />
+                    </div>
+                    <div
+                        className="ibt-table-body-section"
+                        role="presentation"
+                        style={bodyStyle}
+                        id="bottomBar"
+                        onScroll={this._scrolledTable}
+                        ref={(div) => {
+                            this._tableWrapper = div;
+                        }}>
+                        <div
+                            className="ibt-table-content"
+                            role="presentation"
+                            style={contentStyle}
+                            ref={(div) => {
+                                this._internalDiv = div;
+                            }}>
+                            <TableBody
+                                tableId={this._tableId}
+                                columns={this.props.columns}
+                                contentWidth={this.props.contentWidth}
+                                bodyWidth={visibleWidth}
+                                bodyHeight={visibleHeight}
+                                rowHeight={this.props.rowHeight}
+                                rowCount={this.props.rowCount}
+                                bodyCellRender={this.props.bodyCellRender}
+                                onReachedBottom={this.props.onReachedBottom}
+                                ref={(component) => {
+                                    this._bodyComponent = component;
+                                }} />
+                        </div>
+                    </div>
+                </div>
+            </>
+        );
+
+        const bodyWithTopScroller = (
+            <>
+                <div
+                    className="ibt-table-container"
+                    role="grid"
+                    aria-rowcount={-1}
+                    aria-colcount={this.props.columns.length}
+                    aria-label={`This is a table with ${accessibleDescription}. Use your arrow keys to navigate through cells.`}
+                    style={topScrollerStyle}>
                     <div
                         className="ibt-table__top-scroller"
                         id="topBar"
@@ -278,6 +341,12 @@ export default class Table extends React.Component {
                         </div>
                     </div>
                 </div>
+            </>
+        );
+
+        return (
+            <div>
+                {this.props.topScroller ? bodyWithTopScroller : body}
             </div>
         );
     }

--- a/src/js/components/sharedComponents/IBTable/components/Table.jsx
+++ b/src/js/components/sharedComponents/IBTable/components/Table.jsx
@@ -49,6 +49,7 @@ export default class Table extends React.Component {
         this._tableId = `${uniqueId()}`;
 
         this._scrolledTable = this._scrolledTable.bind(this);
+        this._scrolledTableWithTopScroller = this._scrolledTableWithTopScroller.bind(this);
         this._scrolledHeader = this._scrolledHeader.bind(this);
         this._scrolledTableTop = this._scrolledTableTop.bind(this);
         this._scrolledTableBottom = this._scrolledTableBottom.bind(this);
@@ -123,24 +124,24 @@ export default class Table extends React.Component {
         const topBar = document.getElementById("topBar");
         const bottomBar = document.getElementById("bottomBar");
         bottomBar.scrollLeft = topBar.scrollLeft;
-        this._tableWrapper = topBar.scrollLeft;
-        // this._scrolledTableWithTopScroller();
+        this._scrolledTableWithTopScroller(topBar.scrollLeft);
     }
 
     _scrolledTableBottom() {
         const topBar = document.getElementById("topBar");
         const bottomBar = document.getElementById("bottomBar");
         topBar.scrollLeft = bottomBar.scrollLeft;
-        this._tableWrapper = bottomBar.scrollLeft;
-        // this._scrolledTableWithTopScroller();
+        this._scrolledTableWithTopScroller(bottomBar.scrollLeft);
     }
 
-    _scrolledTableWithTopScroller() {
+    _scrolledTableWithTopScroller(xScroll) {
         const scrollOperation = {
             operation: () => {
-                // const x = this._tableWrapper.scrollLeft;
+                // this._tableWrapper = calledFromTop ? topBar.scrollLeft : bottomBar.scrollLeft;
+                const x = xScroll;
                 const y = this._tableWrapper.scrollTop;
                 ScrollManager.update({
+                    x,
                     y
                 });
             },

--- a/src/js/components/sharedComponents/IBTable/components/Table.jsx
+++ b/src/js/components/sharedComponents/IBTable/components/Table.jsx
@@ -122,13 +122,15 @@ export default class Table extends React.Component {
         const bottomBar = document.getElementById("bottomBar");
         bottomBar.scrollLeft = topBar.scrollLeft;
         this._tableWrapper = topBar.scrollLeft;
+        // this._scrolledTable();
     }
 
     _scrolledTableBottom() {
         const topBar = document.getElementById("topBar");
         const bottomBar = document.getElementById("bottomBar");
         topBar.scrollLeft = bottomBar.scrollLeft;
-        this._tableWrapper = topBar.scrollLeft;
+        this._tableWrapper = bottomBar.scrollLeft;
+        // this._scrolledTable();
     }
 
     _scrolledTable() {
@@ -225,10 +227,6 @@ export default class Table extends React.Component {
                         id="topBar"
                         onScroll={this._scrolledTableTop}>
                         <div className="ibt-table__scroller" style={contentStyle} />
-                    </div>
-                    <div>
-
-
                     </div>
                     <div
                         className="ibt-table-body-section"

--- a/src/js/components/sharedComponents/IBTable/components/Table.jsx
+++ b/src/js/components/sharedComponents/IBTable/components/Table.jsx
@@ -40,17 +40,12 @@ export default class Table extends React.Component {
         super(props);
 
         this._restorePointerTimer = null;
-
-        this._headerComponent = null;
         this._bodyComponent = null;
-
         this._tableWrapper = null;
         this._internalDiv = null;
         this._tableId = `${uniqueId()}`;
 
         this._scrolledTable = this._scrolledTable.bind(this);
-        this._scrolledTableWithTopScroller = this._scrolledTableWithTopScroller.bind(this);
-        this._scrolledHeader = this._scrolledHeader.bind(this);
         this._scrolledTableTop = this._scrolledTableTop.bind(this);
         this._scrolledTableBottom = this._scrolledTableBottom.bind(this);
     }
@@ -69,105 +64,18 @@ export default class Table extends React.Component {
         }, 300);
     }
 
-    scrollTo(x, y) {
-        const scrollOperation = {
-            operation: () => {
-                if (!this._tableWrapper || !this._headerWrapper) {
-                    return;
-                }
-
-                this._tableWrapper.scrollLeft = x;
-                this._tableWrapper.scrollTop = y;
-                this._headerWrapper.scrollLeft = 0;
-            },
-            type: 'overrideScroll',
-            isSingle: true,
-            args: []
-        };
-
-        RenderQueue.addWrite(scrollOperation);
-    }
-
-    _scrolledHeader() {
-    // The header can only scroll through the use of accessibility hooks.
-    // Because there are two scrolling elements (the transform offset + the scroll offset), we
-    // need to combine them into a single scroll offset.
-        const scrollOperation = {
-            operation: () => {
-                const realX = this._headerWrapper.scrollLeft + this._headerComponent.currentX;
-                const x = realX;
-                const y = this._tableWrapper.scrollTop;
-                ScrollManager.update({
-                    x,
-                    y
-                });
-
-                // Scroll events in the table body will be applied as transforms while native
-                // header scrolls via accessibility hooks, so we need to reset the header scrollLeft
-                // to 0 and apply the full horizontal offset via transforms.
-                // By calling the scrollTo function, we will apply the full horizontal offset to the
-                // table body while simultaneously resetting the header scrollLeft to 0. The table
-                // body's scrollLeft change will trigger the same scroll event that occurs from
-                // native mouse scrolls in the table body (_scrolledTable). _scrolledTable will
-                // synchronize the horizontal offset in the header entirely via transforms.
-                this.scrollTo(x, y);
-            },
-            type: 'scroll',
-            isSingle: true,
-            args: []
-        };
-
-        RenderQueue.addRead(scrollOperation);
-    }
-
     _scrolledTableTop() {
         const topBar = document.getElementById("topBar");
         const bottomBar = document.getElementById("bottomBar");
         bottomBar.scrollLeft = topBar.scrollLeft;
-        this._scrolledTableWithTopScroller(topBar.scrollLeft);
+        this._scrolledTable();
     }
 
     _scrolledTableBottom() {
         const topBar = document.getElementById("topBar");
         const bottomBar = document.getElementById("bottomBar");
         topBar.scrollLeft = bottomBar.scrollLeft;
-        this._scrolledTableWithTopScroller(bottomBar.scrollLeft);
-    }
-
-    _scrolledTableWithTopScroller(xScroll) {
-        const scrollOperation = {
-            operation: () => {
-                // this._tableWrapper = calledFromTop ? topBar.scrollLeft : bottomBar.scrollLeft;
-                const x = xScroll;
-                const y = this._tableWrapper.scrollTop;
-                ScrollManager.update({
-                    x,
-                    y
-                });
-            },
-            type: 'scroll',
-            isSingle: true,
-            args: []
-        };
-
-        const pointerOperation = {
-            operation: () => {
-                if (this._restorePointerTimer) {
-                    window.clearTimeout(this.restorePointer);
-                    this._restorePointerTimer = null;
-                }
-                this._internalDiv.style.pointerEvents = 'none';
-                this._restorePointerTimer = window.setTimeout(() => {
-                    this._internalDiv.style.pointerEvents = 'auto';
-                }, 150);
-            },
-            type: 'pointer',
-            isSingle: true,
-            args: []
-        };
-
-        RenderQueue.addRead(scrollOperation);
-        RenderQueue.addWrite(pointerOperation);
+        this._scrolledTable();
     }
 
     _scrolledTable() {
@@ -263,20 +171,13 @@ export default class Table extends React.Component {
                     <div
                         className="ibt-table-header-container"
                         role="presentation"
-                        style={headerStyle}
-                        onScroll={this._scrolledHeader}
-                        ref={(div) => {
-                            this._headerWrapper = div;
-                        }}>
+                        style={headerStyle}>
                         <HeaderRow
                             tableId={this._tableId}
                             contentWidth={this.props.contentWidth}
                             headerHeight={this.props.headerHeight}
                             columns={this.props.columns}
-                            headerCellRender={this.props.headerCellRender}
-                            ref={(component) => {
-                                this._headerComponent = component;
-                            }} />
+                            headerCellRender={this.props.headerCellRender} />
                     </div>
                     <div
                         className="ibt-table-body-section"
@@ -329,6 +230,17 @@ export default class Table extends React.Component {
                         <div className="ibt-table__scroller" style={contentStyle} />
                     </div>
                     <div
+                        className="ibt-table-header-container"
+                        role="presentation"
+                        style={headerStyle}>
+                        <HeaderRow
+                            tableId={this._tableId}
+                            contentWidth={this.props.contentWidth}
+                            headerHeight={this.props.headerHeight}
+                            columns={this.props.columns}
+                            headerCellRender={this.props.headerCellRender} />
+                    </div>
+                    <div
                         className="ibt-table-body-section"
                         role="presentation"
                         style={bodyStyle}
@@ -337,24 +249,6 @@ export default class Table extends React.Component {
                         ref={(div) => {
                             this._tableWrapper = div;
                         }}>
-                        <div
-                            className="ibt-table-header-container"
-                            role="presentation"
-                            style={headerStyle}
-                            onScroll={this._scrolledHeader}
-                            ref={(div) => {
-                                this._headerWrapper = div;
-                            }}>
-                            <HeaderRow
-                                tableId={this._tableId}
-                                contentWidth={this.props.contentWidth}
-                                headerHeight={this.props.headerHeight}
-                                columns={this.props.columns}
-                                headerCellRender={this.props.headerCellRender}
-                                ref={(component) => {
-                                    this._headerComponent = component;
-                                }} />
-                        </div>
                         <div
                             className="ibt-table-content"
                             role="presentation"

--- a/src/js/components/sharedComponents/IBTable/components/Table.jsx
+++ b/src/js/components/sharedComponents/IBTable/components/Table.jsx
@@ -124,7 +124,7 @@ export default class Table extends React.Component {
         const bottomBar = document.getElementById("bottomBar");
         bottomBar.scrollLeft = topBar.scrollLeft;
         this._tableWrapper = topBar.scrollLeft;
-        this._scrolledTableWithTopScroller();
+        // this._scrolledTableWithTopScroller();
     }
 
     _scrolledTableBottom() {
@@ -132,7 +132,7 @@ export default class Table extends React.Component {
         const bottomBar = document.getElementById("bottomBar");
         topBar.scrollLeft = bottomBar.scrollLeft;
         this._tableWrapper = bottomBar.scrollLeft;
-        this._scrolledTableWithTopScroller();
+        // this._scrolledTableWithTopScroller();
     }
 
     _scrolledTableWithTopScroller() {

--- a/src/js/components/sharedComponents/IBTable/components/Table.jsx
+++ b/src/js/components/sharedComponents/IBTable/components/Table.jsx
@@ -46,8 +46,10 @@ export default class Table extends React.Component {
         this._internalDiv = null;
         this._tableId = `${uniqueId()}`;
 
-        this._scrolledTable = this._scrolledTable.bind(this);
+        // this._scrolledTable = this._scrolledTable.bind(this);
         this._scrolledHeader = this._scrolledHeader.bind(this);
+        this._scrolledTableTop = this._scrolledTableTop.bind(this);
+        this._scrolledTableBottom = this._scrolledTableBottom.bind(this);
     }
 
     reloadTable() {
@@ -113,6 +115,20 @@ export default class Table extends React.Component {
         };
 
         RenderQueue.addRead(scrollOperation);
+    }
+
+    _scrolledTableTop() {
+        const topBar = document.getElementById("topBar");
+        const bottomBar = document.getElementById("bottomBar");
+        bottomBar.scrollLeft = topBar.scrollLeft;
+        this._scrolledTable();
+    }
+
+    _scrolledTableBottom() {
+        const topBar = document.getElementById("topBar");
+        const bottomBar = document.getElementById("bottomBar");
+        topBar.scrollLeft = bottomBar.scrollLeft;
+        this._scrolledTable();
     }
 
     _scrolledTable() {
@@ -182,6 +198,10 @@ export default class Table extends React.Component {
             height: (this.props.rowCount * this.props.rowHeight)
         };
 
+        // const scrollerStyle = {
+        //     width: this.props.contentWidth
+        // };
+
         let accessibleDescription = `${this.props.columns.length} column`;
         if (this.props.columns.length !== 1) {
             accessibleDescription += 's';
@@ -192,59 +212,68 @@ export default class Table extends React.Component {
         }
 
         return (
-            <div
-                className="ibt-table-container"
-                role="grid"
-                aria-rowcount={-1}
-                aria-colcount={this.props.columns.length}
-                aria-label={`This is a table with ${accessibleDescription}. Use your arrow keys to navigate through cells.`}
-                style={style}>
+            <div>
                 <div
-                    className="ibt-table-header-container"
-                    role="presentation"
-                    style={headerStyle}
-                    onScroll={this._scrolledHeader}
-                    ref={(div) => {
-                        this._headerWrapper = div;
-                    }}>
-                    <HeaderRow
-                        tableId={this._tableId}
-                        contentWidth={this.props.contentWidth}
-                        headerHeight={this.props.headerHeight}
-                        columns={this.props.columns}
-                        headerCellRender={this.props.headerCellRender}
-                        ref={(component) => {
-                            this._headerComponent = component;
-                        }} />
-                </div>
-                <div
-                    className="ibt-table-body-section"
-                    role="presentation"
-                    style={bodyStyle}
-                    onScroll={this._scrolledTable}
-                    ref={(div) => {
-                        this._tableWrapper = div;
-                    }}>
+                    className="ibt-table-container"
+                    role="grid"
+                    aria-rowcount={-1}
+                    aria-colcount={this.props.columns.length}
+                    aria-label={`This is a table with ${accessibleDescription}. Use your arrow keys to navigate through cells.`}
+                    style={style}>
                     <div
-                        className="ibt-table-content"
+                        className="ibt-table__top-scroller"
+                        id="topBar"
+                        onScroll={this._scrolledTableTop}>
+                        <div className="ibt-table__scroller" style={contentStyle} />
+                    </div>
+                    <div
+                        className="ibt-table-header-container"
                         role="presentation"
-                        style={contentStyle}
+                        style={headerStyle}
+                        id="bottomBar"
+                        onScroll={this._scrolledHeader}
                         ref={(div) => {
-                            this._internalDiv = div;
+                            this._headerWrapper = div;
                         }}>
-                        <TableBody
+                        <HeaderRow
                             tableId={this._tableId}
-                            columns={this.props.columns}
                             contentWidth={this.props.contentWidth}
-                            bodyWidth={visibleWidth}
-                            bodyHeight={visibleHeight}
-                            rowHeight={this.props.rowHeight}
-                            rowCount={this.props.rowCount}
-                            bodyCellRender={this.props.bodyCellRender}
-                            onReachedBottom={this.props.onReachedBottom}
+                            headerHeight={this.props.headerHeight}
+                            columns={this.props.columns}
+                            headerCellRender={this.props.headerCellRender}
                             ref={(component) => {
-                                this._bodyComponent = component;
+                                this._headerComponent = component;
                             }} />
+                    </div>
+                    <div
+                        className="ibt-table-body-section"
+                        role="presentation"
+                        style={bodyStyle}
+                        onScroll={this._scrolledTableBottom}
+                        ref={(div) => {
+                            this._tableWrapper = div;
+                        }}>
+                        <div
+                            className="ibt-table-content"
+                            role="presentation"
+                            style={contentStyle}
+                            ref={(div) => {
+                                this._internalDiv = div;
+                            }}>
+                            <TableBody
+                                tableId={this._tableId}
+                                columns={this.props.columns}
+                                contentWidth={this.props.contentWidth}
+                                bodyWidth={visibleWidth}
+                                bodyHeight={visibleHeight}
+                                rowHeight={this.props.rowHeight}
+                                rowCount={this.props.rowCount}
+                                bodyCellRender={this.props.bodyCellRender}
+                                onReachedBottom={this.props.onReachedBottom}
+                                ref={(component) => {
+                                    this._bodyComponent = component;
+                                }} />
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/js/components/sharedComponents/IBTable/components/Table.jsx
+++ b/src/js/components/sharedComponents/IBTable/components/Table.jsx
@@ -124,6 +124,7 @@ export default class Table extends React.Component {
         const bottomBar = document.getElementById("bottomBar");
         bottomBar.scrollLeft = topBar.scrollLeft;
         this._tableWrapper = topBar.scrollLeft;
+        this._scrolledTableWithTopScroller();
     }
 
     _scrolledTableBottom() {
@@ -131,6 +132,41 @@ export default class Table extends React.Component {
         const bottomBar = document.getElementById("bottomBar");
         topBar.scrollLeft = bottomBar.scrollLeft;
         this._tableWrapper = bottomBar.scrollLeft;
+        this._scrolledTableWithTopScroller();
+    }
+
+    _scrolledTableWithTopScroller() {
+        const scrollOperation = {
+            operation: () => {
+                // const x = this._tableWrapper.scrollLeft;
+                const y = this._tableWrapper.scrollTop;
+                ScrollManager.update({
+                    y
+                });
+            },
+            type: 'scroll',
+            isSingle: true,
+            args: []
+        };
+
+        const pointerOperation = {
+            operation: () => {
+                if (this._restorePointerTimer) {
+                    window.clearTimeout(this.restorePointer);
+                    this._restorePointerTimer = null;
+                }
+                this._internalDiv.style.pointerEvents = 'none';
+                this._restorePointerTimer = window.setTimeout(() => {
+                    this._internalDiv.style.pointerEvents = 'auto';
+                }, 150);
+            },
+            type: 'pointer',
+            isSingle: true,
+            args: []
+        };
+
+        RenderQueue.addRead(scrollOperation);
+        RenderQueue.addWrite(pointerOperation);
     }
 
     _scrolledTable() {


### PR DESCRIPTION
**High level description:**

Add a top scrollbar to the results table on Advanced Search page

**Technical details:**

Since this is a component that is used in five places, needed to make a prop for the topScroller and also needed to add it to the Keyword Search results table; the table (with three tabs) at the bottom of the Awards page should be unchanged, that table does not get the topScroller; I also removed a couple of functions from this component because they weren't actually ever being called and the code is confusing enough already

**JIRA Ticket:**
[DEV-8729](https://federal-spending-transparency.atlassian.net/browse/DEV-8729)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
