### PR TITLE
DEV-8853 hide training banner

### DIFF
--- a/src/js/containers/Footer.jsx
+++ b/src/js/containers/Footer.jsx
@@ -53,7 +53,7 @@ const Footer = ({
                 filters={filters} />
             <BulkDownloadBottomBarContainer />
             <Subscribe pageName={pageName} />
-            <Training pageName={pageName} />
+            {/* <Training pageName={pageName} />*/}
             <footer
                 className="footer-outer-wrap"
                 role="contentinfo"

--- a/src/js/containers/Footer.jsx
+++ b/src/js/containers/Footer.jsx
@@ -21,7 +21,7 @@ import BulkDownloadBottomBarContainer from
 import FloatingGlossaryButton from 'components/sharedComponents/FloatingGlossaryButton';
 import FooterExternalLink from 'components/sharedComponents/FooterExternalLink';
 import Subscribe from '../components/sharedComponents/Subscribe';
-import Training from '../components/sharedComponents/Training';
+// import Training from '../components/sharedComponents/Training';
 
 const propTypes = {
     pageName: PropTypes.string.isRequired,


### PR DESCRIPTION
**High level description:**

Hiding training banner until updates made
 
**Technical details:**

Commented out banner

**JIRA Ticket:**
[DEV-8853](https://federal-spending-transparency.atlassian.net/browse/DEV-8853)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
