### PR TITLE
Bug/8863 set aside filter

### DIFF
--- a/src/js/dataMapping/search/contractFields.js
+++ b/src/js/dataMapping/search/contractFields.js
@@ -30,6 +30,7 @@ export const setAsideDefinitions = {
     'BI': 'Buy Indian',
     'HS2Civ': 'Combination HUBZone and 8(a)',
     'EDWOSB': 'Economically-Disadvantaged Women-Owned Small Business',
+    'EDWOSBSS': 'Economically Disadvantaged Women Owned Small Business Sole Source',
     'ESB': 'Emerging Small Business Set-Aside',
     'HMP': 'HBCU or MI Set-Aside - Partial',
     'HMT': 'HBCU or MI Set-Aside - Total',
@@ -47,7 +48,8 @@ export const setAsideDefinitions = {
     'VSBCiv': 'Very Small Business Set-Aside',
     'VSA': 'Veteran Set-Aside',
     'VSS': 'Veteran Sole Source',
-    'WOSB': 'Women-Owned Small Business'
+    'WOSB': 'Women-Owned Small Business',
+    'WOSBSS': 'Women Owned Small Business Sole Source'
 };
 
 export const extentCompetedDefinitions = {

--- a/src/js/dataMapping/search/contractFields.js
+++ b/src/js/dataMapping/search/contractFields.js
@@ -27,7 +27,7 @@ export const setAsideDefinitions = {
     '8AN': '8(a) Sole Source',
     'HS3': '8(a) with HUBZone Preference',
     '8A': '8A Competed',
-    'BICiv': 'Buy Indian',
+    'BI': 'Buy Indian',
     'HS2Civ': 'Combination HUBZone and 8(a)',
     'EDWOSB': 'Economically-Disadvantaged Women-Owned Small Business',
     'ESB': 'Emerging Small Business Set-Aside',


### PR DESCRIPTION
**High level description:**

Need to add two new Set Asides and update the code for one

**Technical details:**

Changed the code for 'Buy Indian' and added two new Set Asides and their codes. These now appear in the Search page Filter Section for Set Asides.
There is no code for 'Buy American Act' so that was not added.

**JIRA Ticket:**
[DEV-8863](https://federal-spending-transparency.atlassian.net/browse/DEV-8863)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
