### PR TITLE
8883 - Add Google analytics tracking events to the Data Dives page

### DIFF
--- a/src/js/components/dataDives/EquityCovidSpendingPage.jsx
+++ b/src/js/components/dataDives/EquityCovidSpendingPage.jsx
@@ -6,6 +6,8 @@
 import React from 'react';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { getBaseUrl, handleShareOptionClick } from 'helpers/socialShare';
+import Analytics from 'helpers/analytics/Analytics';
+
 import { ShareIcon } from 'data-transparency-ui';
 import { Link } from "react-router-dom";
 import PageWrapper from "../sharedComponents/PageWrapper";
@@ -17,6 +19,23 @@ import EquitySpotlightCards from "./equity/EquitySpotlightCards";
 require('pages/equityCovidSpendingPage/equityCovidSpendingPage.scss');
 
 const EquityCovidSpendingPage = () => {
+
+    const analyticsEvent = (action, label) => {
+        Analytics.event({
+            category: 'Data Dives: Equity Covid Spending Page',
+            action,
+            label
+        });
+    };
+
+    const spotlightClickHandler = () => {
+        analyticsEvent('Spotlight on The Opportunity Project', 'Spotlight on The Opportunity Project');
+    };
+
+    const covidClickHandler = () => {
+        analyticsEvent('Spotlight on COVID Profile', 'Spotlight on COVID Profile');
+    };
+
     const HeadingContentObject = {
         heading: 'Equity in COVID-19 Spending',
         intro: 'We worked with teams from various schools and advocacy groups across the country to create tools for analyzing USAspending data and other federal open datasets to understand how the $4.5 trillion in federal COVID-19 spending has been shared across communities most vulnerable to the impacts of the pandemic.',
@@ -47,7 +66,8 @@ const EquityCovidSpendingPage = () => {
         ),
         spotlightCardLink: (
             <Link
-                to="/disaster/covid-19/the-opportunity-project">
+                to="/disaster/covid-19/the-opportunity-project"
+                onClick={spotlightClickHandler}>
                 Learn More
             </Link>
         ),
@@ -65,7 +85,8 @@ const EquityCovidSpendingPage = () => {
         ),
         trackCardLink: (
             <Link
-                to="/disaster/covid-19?publicLaw=all">
+                to="/disaster/covid-19?publicLaw=all"
+                onClick={covidClickHandler}>
                 Explore Now
             </Link>
         )
@@ -79,6 +100,7 @@ const EquityCovidSpendingPage = () => {
 
     const handleShare = (optionName) => {
         handleShareOptionClick(optionName, slug, emailArgs);
+        analyticsEvent('Share Page', slug);
     };
 
     return (

--- a/src/js/components/dataDives/EquityCovidSpendingPage.jsx
+++ b/src/js/components/dataDives/EquityCovidSpendingPage.jsx
@@ -20,11 +20,10 @@ require('pages/equityCovidSpendingPage/equityCovidSpendingPage.scss');
 
 const EquityCovidSpendingPage = () => {
 
-    const analyticsEvent = (action, label) => {
+    const analyticsEvent = (action) => {
         Analytics.event({
             category: 'Data Dives: Equity Covid Spending Page',
-            action,
-            label
+            action
         });
     };
 
@@ -100,7 +99,7 @@ const EquityCovidSpendingPage = () => {
 
     const handleShare = (optionName) => {
         handleShareOptionClick(optionName, slug, emailArgs);
-        analyticsEvent('Share Page', slug);
+        analyticsEvent('Share Page');
     };
 
     return (

--- a/src/js/components/dataDives/EquityCovidSpendingPage.jsx
+++ b/src/js/components/dataDives/EquityCovidSpendingPage.jsx
@@ -19,7 +19,6 @@ import EquitySpotlightCards from "./equity/EquitySpotlightCards";
 require('pages/equityCovidSpendingPage/equityCovidSpendingPage.scss');
 
 const EquityCovidSpendingPage = () => {
-
     const analyticsEvent = (action) => {
         Analytics.event({
             category: 'Data Dives: Equity Covid Spending Page',

--- a/src/js/components/dataDives/sections/MainCards.jsx
+++ b/src/js/components/dataDives/sections/MainCards.jsx
@@ -7,6 +7,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { largeScreen } from 'dataMapping/shared/mobileBreakpoints';
 import ExternalLink from 'components/sharedComponents/ExternalLink';
+import Analytics from 'helpers/analytics/Analytics';
+
 import { FlexGridRow, FlexGridCol } from 'data-transparency-ui';
 import ReadMore from '../../sharedComponents/ReadMore';
 import EquityMainCard from '../../sharedComponents/EquityMainCard';
@@ -28,6 +30,14 @@ const MainCards = ({ contentObject }) => {
         }
     };
 
+    const analyticsEvent = (item) => {
+        Analytics.event({
+            category: 'Data Dives: Equity Covid Spending Page Main Card',
+            action: `Clicked ${item} See Project Button`,
+            label: 'item'
+        });
+    };
+
     const bowieImg = <img className="main-cards__svg" role="presentation" src="../../../../img/top-bowie-state-combined-image.svg" alt="" />;
     const kansasImg = <img className="main-cards__svg" role="presentation" src="../../../../img/top-university-kansas-combined-image.svg" alt="" />;
     const morehouseImg = <img className="main-cards__svg" role="presentation" src="../../../../img/top-morehouse-combined-image.svg" alt="" />;
@@ -39,10 +49,10 @@ const MainCards = ({ contentObject }) => {
     const momHdg = <h2>The Mom Project</h2>;
 
 
-    const bowieBtn = (<ExternalLink url={contentObject.bowieLink}>See Project&nbsp;&nbsp;</ExternalLink>);
-    const kansasBtn = (<ExternalLink url={contentObject.kansasLink}>See Project&nbsp;&nbsp;</ExternalLink>);
-    const morehouseBtn = (<ExternalLink url={contentObject.morehouseLink}>See Project&nbsp;&nbsp;</ExternalLink>);
-    const momBtn = (<ExternalLink url={contentObject.momLink}>See Project&nbsp;&nbsp;</ExternalLink>);
+    const bowieBtn = (<ExternalLink url={contentObject.bowieLink} onClick={() => analyticsEvent(bowieHdg)}>See Project&nbsp;&nbsp;</ExternalLink>);
+    const kansasBtn = (<ExternalLink url={contentObject.kansasLink} onClick={() => analyticsEvent(kansasHdg)}>See Project&nbsp;&nbsp;</ExternalLink>);
+    const morehouseBtn = (<ExternalLink url={contentObject.morehouseLink} onClick={() => analyticsEvent(morehouseHdg)}>See Project&nbsp;&nbsp;</ExternalLink>);
+    const momBtn = (<ExternalLink url={contentObject.momLink} onClick={() => analyticsEvent(momHdg)}>See Project&nbsp;&nbsp;</ExternalLink>);
 
     const {
         bowieText, kansasText, momText, morehouseText

--- a/src/js/components/dataDives/sections/MainCards.jsx
+++ b/src/js/components/dataDives/sections/MainCards.jsx
@@ -33,8 +33,7 @@ const MainCards = ({ contentObject }) => {
     const analyticsEvent = (item) => {
         Analytics.event({
             category: 'Data Dives: Equity Covid Spending Page Main Card',
-            action: `Clicked ${item} See Project Button`,
-            label: 'item'
+            action: `Clicked ${item} See Project Button`
         });
     };
 


### PR DESCRIPTION
**High level description:**

Add Google analytics tracking events to the Data Dives page

**Technical details:**

Historically these have been tested in an environment instead of locally.  Melissa is going to work with Andrew Ly to get these tested.  Please verify the code looks correct.

**JIRA Ticket:**
[DEV-8883](https://federal-spending-transparency.atlassian.net/browse/DEV-8883)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
- [ ] Code review complete
