### PR TITLE
8931 - added logic to detect if an idv is unlinked

### DIFF
--- a/src/js/containers/award/AwardContainer.jsx
+++ b/src/js/containers/award/AwardContainer.jsx
@@ -139,7 +139,7 @@ export class AwardContainer extends React.Component {
 
         this.countRequest.promise
             .then((results) => {
-                const countDataBool = results.data.federal_accounts === 0;
+                const countDataBool = (results.data.federal_accounts === 0 || results.data.count === 0);
 
                 this.setState({
                     unlinked: countDataBool


### PR DESCRIPTION
**High level description:**

QAT found that the msg was not showing in the Federal Account section if the award is IDV and unlinked.

**Technical details:**

Added a check for the data.count property if the award is idv.
The additional urls to check different types of awards are in a comment from Allie.

**JIRA Ticket:**
[DEV-8931](https://federal-spending-transparency.atlassian.net/browse/DEV-8931)

**Mockup:**
in ticket

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
