### PR TITLE
8903 - Add Award Amount chart tabs on mobile

### DIFF
--- a/src/_scss/pages/award/_awardAgencyRecipient.scss
+++ b/src/_scss/pages/award/_awardAgencyRecipient.scss
@@ -6,6 +6,7 @@
     p {
         margin: rem(8) 0;
     }
+
     .award-amounts__content h4 {
         margin-top: rem(20);
         font-weight: $font-normal;

--- a/src/_scss/pages/award/shared/awardAmountsSection/_index.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_index.scss
@@ -90,6 +90,10 @@
     padding-top: rem(16);
   }
 
+  .usa-dt-tab-list:not(.tabless-tabs) .usa-dt-tab-list__border-post-filler {
+    border-bottom: 2px solid #d6d7d9 !important;
+  }
+
     @import "./charts";
     @import "./dataTable";
 }

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsSection.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsSection.jsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { Tabs } from "data-transparency-ui";
 
 import { determineSpendingScenarioByAwardType } from 'helpers/awardAmountHelper';
 import { getToolTipBySectionAndAwardType } from 'dataMapping/award/tooltips';
-import ResultsTableTabs from 'components/search/table/ResultsTableTabs';
 
 import AwardSection from '../AwardSection';
 import AwardSectionHeader from '../AwardSectionHeader';
@@ -51,11 +51,10 @@ const AwardAmountsSection = ({
                 <AwardSectionHeader title="$ Award Amounts" tooltip={tooltip} />
                 <div className="award-amounts__content">
                     <div style={{ display: showInfrastructureTabs() ? `block` : `none`, paddingBottom: showInfrastructureTabs() ? '20px' : '' }}>
-                        <ResultsTableTabs
-                            types={tabTypes}
+                        <Tabs
                             active={active}
                             switchTab={switchTab}
-                            hideCounts />
+                            types={tabTypes} />
                     </div>
                     <AwardAmountsChart
                         awardOverview={awardOverview}

--- a/src/js/containers/award/idv/IdvAwardAmountsSectionContainer.jsx
+++ b/src/js/containers/award/idv/IdvAwardAmountsSectionContainer.jsx
@@ -18,8 +18,6 @@ import * as awardActions from 'redux/actions/award/awardActions';
 import BaseAwardAmounts from 'models/v2/award/BaseAwardAmounts';
 
 import AggregatedAwardAmounts from 'components/award/idv/amounts/AggregatedAwardAmountsSection';
-import ResultsTableTabs from 'components/search/table/ResultsTableTabs';
-import ResultsTablePicker from 'components/search/table/ResultsTablePicker';
 import { awardAmountsInfo } from 'components/award/shared/InfoTooltipContent';
 import withDefCodes from 'containers/covid19/WithDefCodes';
 import AggregatedAwardAmountsTableWrapper
@@ -172,10 +170,6 @@ export class IdvAmountsContainer extends React.Component {
                         active={this.state.active}
                         switchTab={this.switchTab}
                         tabsClassName={tabsClassName} />
-                    {/*<ResultsTablePicker*/}
-                    {/*    types={tabTypes}*/}
-                    {/*    active={this.state.active}*/}
-                    {/*    switchTab={this.switchTab} />*/}
                 </div>
                 {this.state.active === 'awards' && (
                     <AggregatedAwardAmounts

--- a/src/js/containers/award/idv/IdvAwardAmountsSectionContainer.jsx
+++ b/src/js/containers/award/idv/IdvAwardAmountsSectionContainer.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { isCancel } from 'axios';
-import { TooltipWrapper } from 'data-transparency-ui';
+import { TooltipWrapper, Tabs } from 'data-transparency-ui';
 import { flowRight } from 'lodash';
 
 import * as IdvHelper from 'helpers/idvHelper';
@@ -167,16 +167,15 @@ export class IdvAmountsContainer extends React.Component {
                 </div>
                 <hr />
                 <div className="award-viz__tabs">
-                    <ResultsTableTabs
+                    <Tabs
                         types={tabTypes}
                         active={this.state.active}
                         switchTab={this.switchTab}
-                        tabsClassName={tabsClassName}
-                        hideCounts />
-                    <ResultsTablePicker
-                        types={tabTypes}
-                        active={this.state.active}
-                        switchTab={this.switchTab} />
+                        tabsClassName={tabsClassName} />
+                    {/*<ResultsTablePicker*/}
+                    {/*    types={tabTypes}*/}
+                    {/*    active={this.state.active}*/}
+                    {/*    switchTab={this.switchTab} />*/}
                 </div>
                 {this.state.active === 'awards' && (
                     <AggregatedAwardAmounts


### PR DESCRIPTION
**High level description:**

Add Award Amount chart tabs on mobile.  this affects idv and non-idv awards with infrastructure spending

**Technical details:**

Switched both idv and non-idv awards to use the Tabs common component from DTUI 

**JIRA Ticket:**
[DEV-8903](https://federal-spending-transparency.atlassian.net/browse/DEV-8903)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Code review complete
