### PR TITLE
8429 - added logic to get rid of highlighting any row in the tooltip …

### DIFF
--- a/src/js/components/agency/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agency/visualizations/ObligationsByAwardType.jsx
@@ -47,6 +47,7 @@ export default function ObligationsByAwardType({
     const [chartWidth, setChartWidth] = useState(0);
     const [activeType, setActiveType] = useState(null);
     const [categoryHover, setCategoryHover] = useState(null);
+    const [labelTooltip, setLabelTooltip] = useState(false);
     const chartRef = useRef();
 
     const renderChart = () => {
@@ -207,13 +208,21 @@ export default function ObligationsByAwardType({
                 .on('mouseover', () => {
                     // store the award type of the section the user is hovering over
                     setActiveType('Direct Payments');
+                    setLabelTooltip(true);
                 })
-                .on('mouseout', () => setActiveType(null))
+                .on('mouseout', () => {
+                    setActiveType(null);
+                    setLabelTooltip(false);
+                })
                 .on('focus', () => {
                     // store the award type of the section the user is hovering over
                     setActiveType('Direct Payments');
+                    setLabelTooltip(true);
                 })
-                .on('blur', () => setActiveType(null));
+                .on('blur', () => {
+                    setActiveType(null);
+                    setLabelTooltip(false);
+                });
             // text
             svg.append('text')
                 .attr('transform', (d, i) => `translate(${labelPos(0, i * 12)})`)
@@ -224,13 +233,21 @@ export default function ObligationsByAwardType({
                 .on('mouseover', () => {
                     // store the award type of the section the user is hovering over
                     setActiveType('Direct Payments');
+                    setLabelTooltip(true);
                 })
-                .on('mouseout', () => setActiveType(null))
+                .on('mouseout', () => {
+                    setActiveType(null);
+                    setLabelTooltip(false);
+                })
                 .on('focus', () => {
                     // store the award type of the section the user is hovering over
                     setActiveType('Direct Payments');
+                    setLabelTooltip(true);
                 })
-                .on('blur', () => setActiveType(null));
+                .on('blur', () => {
+                    setActiveType(null);
+                    setLabelTooltip(false);
+                });
         }
 
         // Contracts legend
@@ -246,13 +263,21 @@ export default function ObligationsByAwardType({
                 .on('mouseover', () => {
                     // store the award type of the section the user is hovering over
                     setActiveType('Contracts');
+                    setLabelTooltip(true);
                 })
-                .on('mouseout', () => setActiveType(null))
+                .on('mouseout', () => {
+                    setActiveType(null);
+                    setLabelTooltip(false);
+                })
                 .on('focus', () => {
                     // store the award type of the section the user is hovering over
                     setActiveType('Contracts');
+                    setLabelTooltip(true);
                 })
-                .on('blur', () => setActiveType(null));
+                .on('blur', () => {
+                    setActiveType(null);
+                    setLabelTooltip(false);
+                });
             // text
             svg.append('text')
                 .attr('transform', (d, i) => `translate(${labelPos(1, i * 12)})`)
@@ -263,13 +288,21 @@ export default function ObligationsByAwardType({
                 .on('mouseover', () => {
                     // store the award type of the section the user is hovering over
                     setActiveType('Contracts');
+                    setLabelTooltip(true);
                 })
-                .on('mouseout', () => setActiveType(null))
+                .on('mouseout', () => {
+                    setActiveType(null);
+                    setLabelTooltip(false);
+                })
                 .on('focus', () => {
                     // store the award type of the section the user is hovering over
                     setActiveType('Contracts');
+                    setLabelTooltip(true);
                 })
-                .on('blur', () => setActiveType(null));
+                .on('blur', () => {
+                    setActiveType(null);
+                    setLabelTooltip(false);
+                });
         }
     };
 
@@ -299,7 +332,8 @@ export default function ObligationsByAwardType({
                     fiscalYear={fiscalYear}
                     activeType={activeType}
                     categoryType={getActiveCategoryType(activeType, categoryMapping)}
-                    isCategoryHover={categoryHover?.length > 0} />)}
+                    isCategoryHover={categoryHover?.length > 0}
+                    labelTooltip={labelTooltip} />)}
             controlledProps={{
                 isControlled: true,
                 isVisible: activeType && !isMobile,

--- a/src/js/components/agency/visualizations/ObligationsByAwardTypeTooltip.jsx
+++ b/src/js/components/agency/visualizations/ObligationsByAwardTypeTooltip.jsx
@@ -36,7 +36,7 @@ const columns = [
 
 
 const ObligationsByAwardTypeTooltip = ({
-    awardTypes, fiscalYear, activeType, categoryType, isCategoryHover
+    awardTypes, fiscalYear, activeType, categoryType, isCategoryHover, labelTooltip
 }) => {
     const { _awardObligations } = useSelector((state) => state.agency);
     const awardTypesByCategory = awardTypes.filter((item) => item.type === categoryType);
@@ -48,7 +48,10 @@ const ObligationsByAwardTypeTooltip = ({
     };
 
     const rows = awardTypesByCategory.map((type) => {
-        const activeClass = `award-type-tooltip__table-data${!isCategoryHover && type.label === activeType ? ' award-type-tooltip__table-data_active' : ''}`;
+        let activeClass = `award-type-tooltip__table-data${!isCategoryHover && type.label === activeType ? ' award-type-tooltip__table-data_active' : ''}`;
+        if (labelTooltip) {
+            activeClass = '';
+        }
         return [
             (
                 <div className={activeClass}>


### PR DESCRIPTION
…when it is called from a label

**High level description:**

QAT found issue with AC4, need to get rid of bold text in any row when the tooltip is called from a label

**Technical details:**

Added new state var as prop for the tooltip component, use it as bool to get rid of the css making a row bold

**JIRA Ticket:**
[DEV-8429](https://federal-spending-transparency.atlassian.net/browse/DEV-8429)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
