### PR TITLE
8429 - moved donut up slightly; moved labels down slightly; added a l…

### DIFF
--- a/src/_scss/pages/agency/visualizations/_obligationsByAwardType.scss
+++ b/src/_scss/pages/agency/visualizations/_obligationsByAwardType.scss
@@ -35,9 +35,8 @@
 
     .obligations-by-award-type__chart {
         text.obligations-by-award-type__label {
-            font-size: 1.2rem;
-            fill: $color-gray;
-            font-weight: $font-semibold;
+            font-size: rem(14);
+            color: $color-base;
         }
         .obligations-by-award-type__donut {
             @include media($medium-screen) {

--- a/src/js/components/agency/visualizations/ObligationsByAwardType.jsx
+++ b/src/js/components/agency/visualizations/ObligationsByAwardType.jsx
@@ -64,7 +64,7 @@ export default function ObligationsByAwardType({
             .attr('width', chartWidth)
             .append('g')
             // y value moves everything toward top of container, to make room for labels at bottom
-            .attr('transform', `translate(${chartWidth / 2}, ${(chartHeight / 2) - 24})`);
+            .attr('transform', `translate(${chartWidth / 2}, ${(chartHeight / 2) - 30})`);
 
         const pie = d3.pie()
             .value((d) => d.value)
@@ -183,14 +183,14 @@ export default function ObligationsByAwardType({
             .attr('tabIndex', 0);
 
         // labels
-        const labelPos = (i, yOffset = 0) => {
+        const labelPos = (i) => {
             if (i === 0) {
                 // Financial Assistance
                 // positions were changed with ticket 8429, now below chart
-                return [labelRadius - 192, ((chartHeight / 2)) + 4];
+                return [labelRadius - 188, ((chartHeight / 2)) + 28];
             }
             // Contracts
-            return [labelRadius - 192, ((chartHeight / 2)) - yOffset - 12];
+            return [labelRadius - 188, ((chartHeight / 2)) + 4];
         };
 
         const outerLabels = outer.map((d) => d.label.join(""));
@@ -200,7 +200,7 @@ export default function ObligationsByAwardType({
             // circle
             svg.append('circle')
                 .attr('cx', labelRadius - 200)
-                .attr('cy', (chartHeight / 2))
+                .attr('cy', (chartHeight / 2) + 24)
                 .attr('r', 4)
                 .style("fill", outer[0].color)
                 // adding hover with ticket 8429
@@ -255,7 +255,7 @@ export default function ObligationsByAwardType({
             // circle
             svg.append('circle')
                 .attr('cx', labelRadius - 200)
-                .attr('cy', (chartHeight / 2) - 15)
+                .attr('cy', (chartHeight / 2))
                 .attr('r', 4)
                 .style("fill", outer[1].color)
                 // adding hover with ticket 8429


### PR DESCRIPTION
…ittle more space btw circle and label; made font match labels on other charts

**High level description:**

Changes based on Jessica's latest comment in the ticket.

**Technical details:**

In commit message

**JIRA Ticket:**
[DEV-8429](https://federal-spending-transparency.atlassian.net/browse/DEV-8429)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
