### PR TITLE
8916 - added title for pagewrapper on homepage

### DIFF
--- a/src/js/components/homepage/Homepage.jsx
+++ b/src/js/components/homepage/Homepage.jsx
@@ -19,7 +19,6 @@ const Homepage = () => (
     <PageWrapper
         pageName="Homepage"
         classNames="usa-da-home-page"
-        title="Government Spending Open Data | USAspending"
         noHeader
         metaTagProps={{ ...homePageMetaTags }}>
         <main id="main-content" className="main-content homepage-content">

--- a/src/js/components/homepage/Homepage.jsx
+++ b/src/js/components/homepage/Homepage.jsx
@@ -19,6 +19,7 @@ const Homepage = () => (
     <PageWrapper
         pageName="Homepage"
         classNames="usa-da-home-page"
+        title="Government Spending Open Data | USAspending"
         noHeader
         metaTagProps={{ ...homePageMetaTags }}>
         <main id="main-content" className="main-content homepage-content">

--- a/src/js/components/sharedComponents/PageWrapper.jsx
+++ b/src/js/components/sharedComponents/PageWrapper.jsx
@@ -44,7 +44,7 @@ PageWrapper.propTypes = {
     classNames: PropTypes.string,
     metaTagProps: PropTypes.object,
     toolBarComponents: PropTypes.arrayOf(PropTypes.element),
-    title: PropTypes.string.isRequired,
+    title: PropTypes.string,
     overLine: PropTypes.string,
     children: PropTypes.element,
     ref: PropTypes.object,


### PR DESCRIPTION
**High level description:**

Add title prop for PageWrapper on homepage

**Technical details:**

Added the prop, got the string from metaTagHelper.js

**JIRA Ticket:**
[DEV-8916](https://federal-spending-transparency.atlassian.net/browse/DEV-8916)

**Mockup:**

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
