### PR TITLE
8904 - Temp fix for the tab online on award summary charts

### DIFF
--- a/src/_scss/_dtui-overrides.scss
+++ b/src/_scss/_dtui-overrides.scss
@@ -1,0 +1,5 @@
+.usa-dt-tab-list .usa-dt-tab__wrapper .usa-dt-tab:focus {
+  outline: auto;
+  outline-color: #0071bc;
+  -moz-outline-color: #0071bc;
+}

--- a/src/_scss/all.scss
+++ b/src/_scss/all.scss
@@ -1,5 +1,6 @@
 // Vendor -------------- //
 @import '~data-transparency-ui/dist/data-transparency-ui.css';
+@import 'dtui-overrides';
 @import 'lib/bourbon/bourbon';
 @import 'lib/neat/neat';
 @import 'lib/normalize';


### PR DESCRIPTION
**High level description:**

Temp fix for the tab online on award summary charts

**Technical details:**

I added a new temporary file for dtui overrides.  I figure we'll have future areas where we'll need to override dtui styles.  Instead of mixing these into css for a specific page this could be a good location.  Planning to remove this particular override after we upgrade DTUI to React 17.

**JIRA Ticket:**
[DEV-8904](https://federal-spending-transparency.atlassian.net/browse/DEV-8904)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness

Reviewer(s):
- [ ] Code review complete
