### PR TITLE
Ftr/8962 status of funds chart table toggle

### DIFF
--- a/src/_scss/pages/agency/statusOfFunds/_visualizationSection.scss
+++ b/src/_scss/pages/agency/statusOfFunds/_visualizationSection.scss
@@ -13,9 +13,6 @@
         }
     }
     .status-of-funds__controls {
-        @media(min-width: $large-screen) {
-            margin-right: rem(6);
-        }
         .status-of-funds__controls-desktop-row-one {
             display: flex;
             justify-content: space-between;
@@ -172,7 +169,7 @@
         font-weight: $font-normal;
         color: $color-grayblack;
         @media(min-width: $medium-screen) {
-            margin-top: 0;
+            margin-top: rem(16);
         }
         @media(min-width: $large-screen) {
             margin-left: rem(32);
@@ -191,7 +188,7 @@
     }
     .status-of-funds__visualization-table-container {
         @media(min-width: $large-screen) {
-            margin: 0 rem(6) 0 rem(32);
+            margin-left: rem(32);
 
             .usda-table {
                 margin: rem(20) 0;

--- a/src/js/components/agency/statusOfFunds/VisualizationSection.jsx
+++ b/src/js/components/agency/statusOfFunds/VisualizationSection.jsx
@@ -96,7 +96,7 @@ const VisualizationSection = ({
             },
             {
                 title: 'totalBudgetaryResources',
-                displayName: isMobile ? 'Total Budgetary Resources' : [`${fyString} Total Budgetary`, <br />, 'Resources']
+                displayName: isMobile ? `${fyString} Total Budgetary Resources` : [`${fyString} Total Budgetary`, <br />, 'Resources']
             },
             {
                 title: 'obligations',

--- a/src/js/components/agency/statusOfFunds/VisualizationSection.jsx
+++ b/src/js/components/agency/statusOfFunds/VisualizationSection.jsx
@@ -85,7 +85,8 @@ const VisualizationSection = ({
             },
             {
                 title: 'outlays',
-                displayName: [`${fyString} Outlays`]
+                displayName: [`${fyString} Outlays`],
+                right: true
             }
         ]
         :
@@ -96,11 +97,13 @@ const VisualizationSection = ({
             },
             {
                 title: 'totalBudgetaryResources',
-                displayName: isMobile ? `${fyString} Total Budgetary Resources` : [`${fyString} Total Budgetary`, <br />, 'Resources']
+                displayName: isMobile ? `${fyString} Total Budgetary Resources` : [`${fyString} Total Budgetary`, <br />, 'Resources'],
+                right: true
             },
             {
                 title: 'obligations',
-                displayName: `${fyString} Obligations`
+                displayName: `${fyString} Obligations`,
+                right: true
             }
         ];
 


### PR DESCRIPTION
**High level description:**

These are changes requested by design and qa - removed 6px of margin right on the controls and viz containers  so now they are wider than the pagination controls; added 16px of margin-top to the h6 to make room for a back button when user has drilled down into sub-components; added fy string to budgetary resources column header at mobile

**Technical details:**

see above

**JIRA Ticket:**
[DEV-8962](https://federal-spending-transparency.atlassian.net/browse/DEV-8962)

**Mockup:**
in ticket

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
