### PR TITLE
9027 - added logic for the heading in the table to change when we are…

### DIFF
--- a/src/_scss/pages/agency/statusOfFunds/_visualizationSection.scss
+++ b/src/_scss/pages/agency/statusOfFunds/_visualizationSection.scss
@@ -192,6 +192,10 @@
 
             .usda-table {
                 margin: rem(20) 0;
+
+                .table-header__label {
+                    max-width: none;
+                }
             }
         }
     }

--- a/src/js/components/agency/statusOfFunds/StatusOfFunds.jsx
+++ b/src/js/components/agency/statusOfFunds/StatusOfFunds.jsx
@@ -55,6 +55,7 @@ const StatusOfFunds = ({ fy }) => {
         }
         dispatch(resetAgencySubcomponents());
         dispatch(resetFederalAccountsList());
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     // eslint-disable-next-line eqeqeq
@@ -138,6 +139,7 @@ const StatusOfFunds = ({ fy }) => {
         if (Object.keys(subcomponent).length !== 0) {
             fetchFederalAccounts(subcomponent);
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [subcomponent]);
 
     useEffect(() => {
@@ -152,6 +154,7 @@ const StatusOfFunds = ({ fy }) => {
                 fetchFederalAccounts(subcomponent);
             }
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentPage]);
 
     useEffect(() => {
@@ -164,12 +167,14 @@ const StatusOfFunds = ({ fy }) => {
                 changeCurrentPage(1);
             }
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [resetPageChange]);
 
     useEffect(() => {
         if (fy && overview.toptierCode) {
             fetchAgencySubcomponents();
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [fy, overview.toptierCode]);
 
     const onClick = (selectedLevel, data) => {
@@ -222,7 +227,25 @@ const StatusOfFunds = ({ fy }) => {
                             <FontAwesomeIcon icon="arrow-left" />
                             &nbsp;&nbsp;Back
                         </button> : <></>}
-                    { !loading ? <VisualizationSection toggle={toggle} onToggle={onToggle} onKeyToggle={onKeyToggle} fetchFederalAccounts={fetchFederalAccounts} totalItems={totalItems} setTotalItems={setTotalItems} loading={loading} setLoading={setLoading} level={level} setLevel={onClick} selectedSubcomponent={selectedSubcomponent} agencyId={overview.toptierCode} agencyName={overview.name} fy={fy} results={results} /> : <LoadingMessage /> }
+                    { !loading ?
+                        <VisualizationSection
+                            toggle={toggle}
+                            onToggle={onToggle}
+                            onKeyToggle={onKeyToggle}
+                            fetchFederalAccounts={fetchFederalAccounts}
+                            totalItems={totalItems}
+                            setTotalItems={setTotalItems}
+                            loading={loading}
+                            setLoading={setLoading}
+                            level={level}
+                            setLevel={onClick}
+                            selectedSubcomponent={selectedSubcomponent}
+                            agencyId={overview.toptierCode}
+                            agencyName={overview.name}
+                            fy={fy}
+                            results={results} />
+                        :
+                        <LoadingMessage /> }
                     <Pagination
                         currentPage={currentPage}
                         changePage={changeCurrentPage}

--- a/src/js/components/agency/statusOfFunds/VisualizationSection.jsx
+++ b/src/js/components/agency/statusOfFunds/VisualizationSection.jsx
@@ -81,7 +81,7 @@ const VisualizationSection = ({
         [
             {
                 title: 'subComponent',
-                displayName: 'Sub-Component'
+                displayName: levels[level]
             },
             {
                 title: 'outlays',
@@ -93,7 +93,7 @@ const VisualizationSection = ({
         [
             {
                 title: 'subComponent',
-                displayName: 'Sub-Component'
+                displayName: levels[level]
             },
             {
                 title: 'totalBudgetaryResources',
@@ -197,7 +197,17 @@ const VisualizationSection = ({
             {viewType === 'chart' ? (
                 <div
                     className="status-of-funds__visualization-chart">
-                    <StatusOfFundsChart toggle={toggle} fetchFederalAccounts={fetchFederalAccounts} totalItems={totalItems} setTotalItems={setTotalItems} loading={loading} setLoading={setLoading} fy={fy} results={results} level={level} setLevel={setLevel} />
+                    <StatusOfFundsChart
+                        toggle={toggle}
+                        fetchFederalAccounts={fetchFederalAccounts}
+                        totalItems={totalItems}
+                        setTotalItems={setTotalItems}
+                        loading={loading}
+                        setLoading={setLoading}
+                        fy={fy}
+                        results={results}
+                        level={level}
+                        setLevel={setLevel} />
                 </div>
             )
                 :
@@ -207,6 +217,8 @@ const VisualizationSection = ({
                             classNames="award-type-tooltip__table"
                             columns={columns}
                             rows={rows}
+                            // expandable
+                            // divider=""
                             isStacked />
                     </div>
                 )}

--- a/src/js/components/agency/statusOfFunds/VisualizationSection.jsx
+++ b/src/js/components/agency/statusOfFunds/VisualizationSection.jsx
@@ -217,8 +217,6 @@ const VisualizationSection = ({
                             classNames="award-type-tooltip__table"
                             columns={columns}
                             rows={rows}
-                            // expandable
-                            // divider=""
                             isStacked />
                     </div>
                 )}


### PR DESCRIPTION
… in the second level of data; and changed the layout for the table headers to no max width so the line breaks will be observed

**High level description:**

two small changes to appearance of table headers when user is on second level data

**Technical details:**

Used the levels[level] pattern that was already in VisualizationSection.jsx to change the text; got rid of max-width: 100% to correct the line break problem in Total Budgetary Resources heading

**JIRA Ticket:**
[DEV-9027](https://federal-spending-transparency.atlassian.net/browse/DEV-9027)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
