### PR TITLE
Bug/9031 drilldown sidebar back button

### DIFF
--- a/src/_scss/pages/agency/statusOfFunds/_visualizationSection.scss
+++ b/src/_scss/pages/agency/statusOfFunds/_visualizationSection.scss
@@ -192,6 +192,10 @@
 
             .usda-table {
                 margin: rem(20) 0;
+
+                .table-header__label {
+                    max-width: none;
+                }
             }
         }
     }

--- a/src/js/components/agency/statusOfFunds/DrilldownSidebar.jsx
+++ b/src/js/components/agency/statusOfFunds/DrilldownSidebar.jsx
@@ -14,7 +14,7 @@ import DrilldownSidebarLevel from './DrilldownSidebarLevel';
 const propTypes = {
     toggle: PropTypes.bool.isRequired,
     level: PropTypes.number.isRequired,
-    setLevel: PropTypes.func,
+    goBack: PropTypes.func,
     fy: PropTypes.string.isRequired,
     agencyName: PropTypes.string,
     selectedSubcomponent: PropTypes.shape({
@@ -26,12 +26,12 @@ const propTypes = {
 };
 
 const DrilldownSidebar = ({
-    toggle, level, setLevel, fy, agencyName, selectedSubcomponent
+    toggle, level, goBack, fy, agencyName, selectedSubcomponent
 }) => {
     const { agencyBudgetShort, agencyObligatedShort } = useSelector((state) => state.agency.budgetaryResources?.[fy]) || '--';
     const { toptierCode } = useSelector((state) => state.agency.overview) || '--';
     const outlay = useSelector((state) => state.agency.agencyOutlays[toptierCode]) || '--';
-    const goBack = () => setLevel(level - 1);
+
     return (
         <>
             <DrilldownSidebarLevel

--- a/src/js/components/agency/statusOfFunds/StatusOfFunds.jsx
+++ b/src/js/components/agency/statusOfFunds/StatusOfFunds.jsx
@@ -55,6 +55,7 @@ const StatusOfFunds = ({ fy }) => {
         }
         dispatch(resetAgencySubcomponents());
         dispatch(resetFederalAccountsList());
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     // eslint-disable-next-line eqeqeq
@@ -138,6 +139,7 @@ const StatusOfFunds = ({ fy }) => {
         if (Object.keys(subcomponent).length !== 0) {
             fetchFederalAccounts(subcomponent);
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [subcomponent]);
 
     useEffect(() => {
@@ -152,6 +154,7 @@ const StatusOfFunds = ({ fy }) => {
                 fetchFederalAccounts(subcomponent);
             }
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentPage]);
 
     useEffect(() => {
@@ -164,12 +167,14 @@ const StatusOfFunds = ({ fy }) => {
                 changeCurrentPage(1);
             }
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [resetPageChange]);
 
     useEffect(() => {
         if (fy && overview.toptierCode) {
             fetchAgencySubcomponents();
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [fy, overview.toptierCode]);
 
     const onClick = (selectedLevel, data) => {
@@ -222,7 +227,25 @@ const StatusOfFunds = ({ fy }) => {
                             <FontAwesomeIcon icon="arrow-left" />
                             &nbsp;&nbsp;Back
                         </button> : <></>}
-                    { !loading ? <VisualizationSection toggle={toggle} onToggle={onToggle} onKeyToggle={onKeyToggle} fetchFederalAccounts={fetchFederalAccounts} totalItems={totalItems} setTotalItems={setTotalItems} loading={loading} setLoading={setLoading} level={level} setLevel={onClick} selectedSubcomponent={selectedSubcomponent} agencyId={overview.toptierCode} agencyName={overview.name} fy={fy} results={results} /> : <LoadingMessage /> }
+                    { !loading ?
+                        <VisualizationSection
+                            toggle={toggle}
+                            onToggle={onToggle}
+                            onKeyToggle={onKeyToggle}
+                            fetchFederalAccounts={fetchFederalAccounts}
+                            totalItems={totalItems}
+                            setTotalItems={setTotalItems}
+                            loading={loading}
+                            setLoading={setLoading}
+                            level={level}
+                            setLevel={onClick}
+                            selectedSubcomponent={selectedSubcomponent}
+                            agencyId={overview.toptierCode}
+                            agencyName={overview.name}
+                            fy={fy}
+                            results={results} />
+                        :
+                        <LoadingMessage /> }
                     <Pagination
                         currentPage={currentPage}
                         changePage={changeCurrentPage}

--- a/src/js/components/agency/statusOfFunds/VisualizationSection.jsx
+++ b/src/js/components/agency/statusOfFunds/VisualizationSection.jsx
@@ -81,7 +81,7 @@ const VisualizationSection = ({
         [
             {
                 title: 'subComponent',
-                displayName: 'Sub-Component'
+                displayName: levels[level]
             },
             {
                 title: 'outlays',
@@ -93,7 +93,7 @@ const VisualizationSection = ({
         [
             {
                 title: 'subComponent',
-                displayName: 'Sub-Component'
+                displayName: levels[level]
             },
             {
                 title: 'totalBudgetaryResources',
@@ -197,7 +197,17 @@ const VisualizationSection = ({
             {viewType === 'chart' ? (
                 <div
                     className="status-of-funds__visualization-chart">
-                    <StatusOfFundsChart toggle={toggle} fetchFederalAccounts={fetchFederalAccounts} totalItems={totalItems} setTotalItems={setTotalItems} loading={loading} setLoading={setLoading} fy={fy} results={results} level={level} setLevel={setLevel} />
+                    <StatusOfFundsChart
+                        toggle={toggle}
+                        fetchFederalAccounts={fetchFederalAccounts}
+                        totalItems={totalItems}
+                        setTotalItems={setTotalItems}
+                        loading={loading}
+                        setLoading={setLoading}
+                        fy={fy}
+                        results={results}
+                        level={level}
+                        setLevel={setLevel} />
                 </div>
             )
                 :
@@ -207,6 +217,8 @@ const VisualizationSection = ({
                             classNames="award-type-tooltip__table"
                             columns={columns}
                             rows={rows}
+                            // expandable
+                            // divider=""
                             isStacked />
                     </div>
                 )}

--- a/src/js/components/agency/statusOfFunds/VisualizationSection.jsx
+++ b/src/js/components/agency/statusOfFunds/VisualizationSection.jsx
@@ -217,8 +217,6 @@ const VisualizationSection = ({
                             classNames="award-type-tooltip__table"
                             columns={columns}
                             rows={rows}
-                            // expandable
-                            // divider=""
                             isStacked />
                     </div>
                 )}

--- a/src/js/components/agency/statusOfFunds/VisualizationSection.jsx
+++ b/src/js/components/agency/statusOfFunds/VisualizationSection.jsx
@@ -5,7 +5,6 @@
 
 // eslint-disable-next-line no-unused-vars
 import React, { useEffect, useState } from 'react';
-import { throttle } from "lodash";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import PropTypes from 'prop-types';
 import { Table } from 'data-transparency-ui';
@@ -37,7 +36,10 @@ const propTypes = {
         id: PropTypes.string,
         budgetaryResources: PropTypes.string,
         obligations: PropTypes.string
-    })
+    }),
+    isMobile: PropTypes.bool,
+    viewType: PropTypes.string,
+    setViewType: PropTypes.func
 };
 
 const VisualizationSection = ({
@@ -54,29 +56,14 @@ const VisualizationSection = ({
     fy,
     results,
     selectedSubcomponent,
-    fetchFederalAccounts
+    fetchFederalAccounts,
+    isMobile,
+    viewType,
+    setViewType
 }) => {
     const [open, setOpen] = useState(false);
-    const [windowWidth, setWindowWidth] = useState(0);
-    const [isMobile, setIsMobile] = useState(window.innerWidth < tabletScreen);
-    const [viewType, setViewType] = useState(isMobile ? 'table' : 'chart');
-
     const fyString = `FY${fy.slice(2)}`;
     const accordionTitle = (<span>What&nbsp;is&nbsp;this?</span>);
-
-    useEffect(() => {
-        const handleResize = throttle(() => {
-            const newWidth = window.innerWidth;
-            if (windowWidth !== newWidth) {
-                setWindowWidth(newWidth);
-                setIsMobile(newWidth < tabletScreen);
-                setViewType(isMobile ? 'table' : viewType);
-            }
-        }, 50);
-        window.addEventListener('resize', handleResize);
-        return () => window.removeEventListener('resize', handleResize);
-    }, [isMobile, viewType, windowWidth]);
-
     const columns = toggle ?
         [
             {

--- a/src/js/components/agency/statusOfFunds/VisualizationSection.jsx
+++ b/src/js/components/agency/statusOfFunds/VisualizationSection.jsx
@@ -8,7 +8,6 @@ import React, { useEffect, useState } from 'react';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import PropTypes from 'prop-types';
 import { Table } from 'data-transparency-ui';
-import { tabletScreen } from 'dataMapping/shared/mobileBreakpoints';
 import { formatMoneyWithPrecision } from 'helpers/moneyFormatter';
 import { levels } from './StatusOfFunds';
 import StatusOfFundsChart from '../visualizations/StatusOfFundsChart';


### PR DESCRIPTION
**High level description:**

Back button was not reloading data in chart or table

**Technical details:**

Changed the click fn in the button; moved isMobile detection up to StatusOfFunds; removed second back button at < 768px

**JIRA Ticket:**
[DEV-9031](https://federal-spending-transparency.atlassian.net/browse/DEV-9031)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
