### PR TITLE
9080 - added Flex Col to the card row to make it 100% width; removed …

### DIFF
--- a/src/_scss/pages/homepage/_homepageResources.scss
+++ b/src/_scss/pages/homepage/_homepageResources.scss
@@ -36,9 +36,6 @@
     }
 
     .homepage-resources__card-row {
-      width: 100%;
-      padding: 0;
-      margin: 0;
       .homepage-resources__card-col:last-child {
         margin-bottom: 0;
       }
@@ -49,7 +46,6 @@
       }
 
       .homepage-resources__card-col {
-        padding: 0;
         margin-bottom: $global-margin * 6;
         @media (min-width: $medium-screen) {
           margin-bottom: 0;

--- a/src/js/components/homepageUpdate/HomepageResources/HomepageResources.jsx
+++ b/src/js/components/homepageUpdate/HomepageResources/HomepageResources.jsx
@@ -93,28 +93,30 @@ const HomepageResources = () => (
                 </FlexGridRow>
                 <FlexGridRow className="homepage-resources__headline">Find answers to your data questions</FlexGridRow>
             </FlexGridCol>
-            <FlexGridRow className="homepage-resources__card-row grid-content" hasGutter gutterSize="lg">
-                {cardObjects.map((card, index) => (
-                    <FlexGridCol
-                        className="homepage-resources__card-col"
-                        key={index}
-                        mobile={12}
-                        tablet={6}
-                        desktop={3}>
-                        <CardContainer>
-                            {card.icon}
-                            <CardBody
-                                headline={card.headline}
-                                text={card.text}>
-                                <CardButton
-                                    variant="text"
-                                    text={card.buttonText}
-                                    link={card.buttonLink} />
-                            </CardBody>
-                        </CardContainer>
-                    </FlexGridCol>
-                ))}
-            </FlexGridRow>
+            <FlexGridCol width={12}>
+                <FlexGridRow className="homepage-resources__card-row" hasGutter gutterSize="lg">
+                    {cardObjects.map((card, index) => (
+                        <FlexGridCol
+                            className="homepage-resources__card-col"
+                            key={index}
+                            mobile={12}
+                            tablet={6}
+                            desktop={3}>
+                            <CardContainer>
+                                {card.icon}
+                                <CardBody
+                                    headline={card.headline}
+                                    text={card.text}>
+                                    <CardButton
+                                        variant="text"
+                                        text={card.buttonText}
+                                        link={card.buttonLink} />
+                                </CardBody>
+                            </CardContainer>
+                        </FlexGridCol>
+                    ))}
+                </FlexGridRow>
+            </FlexGridCol>
         </FlexGridRow>
     </section>
 );


### PR DESCRIPTION
…old css that attempted that

**High level description:**

In testing they saw that the resources cards did not line up exactly with the Ready to Get Started cards; this was bc the card row in Resources was not adding the gutters for some reason and also was not the full 100% width even with width: 100% in it's class; adding a FlexGridCol above that row solved these issues

**Technical details:**

Added FlexGridCol above the card row; removed the old css that was applied there and no longer needed

**JIRA Ticket:**
[DEV-9080](https://federal-spending-transparency.atlassian.net/browse/DEV-9080)

**Mockup:**
in tkt

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
