### PR TITLE
Ftr/9082 stay in touch banner

### DIFF
--- a/src/_scss/layouts/default/footer/_stayInTouch.scss
+++ b/src/_scss/layouts/default/footer/_stayInTouch.scss
@@ -4,6 +4,9 @@
   @media (min-width: $tablet-screen) {
     padding: $global-padding * 3 $global-padding * 4;
   }
+  @media (min-width: 1600px) {
+    padding: $global-padding * 3 0;
+  }
 
   .stay-in-touch__container-row {
     max-width: 1600px;
@@ -20,10 +23,15 @@
       @media (min-width: $medium-screen) {
         width: rem(250);
       }
+      @media (min-width: $large-screen) {
+        margin-right: $global-margin * 3;
+      }
+      @media (min-width: 1400px) {
+        margin-right: $global-margin * 8;
+      }
       @media (min-width: 1600px) {
         padding: 0;
-        width: unset;
-        margin-right: $global-margin * 4;
+        margin-right: $global-margin * 18;
       }
       .stay-in-touch__title-row {
         flex-flow: row nowrap;

--- a/src/_scss/pages/about/_sidebar.scss
+++ b/src/_scss/pages/about/_sidebar.scss
@@ -9,6 +9,7 @@
     &.float-sidebar {
         position: fixed;
         top: rem(96);
+        z-index: 1;
     }
 
     background-color: $color-white;

--- a/src/_scss/pages/covid19/_sidebar.scss
+++ b/src/_scss/pages/covid19/_sidebar.scss
@@ -10,14 +10,15 @@
 
     .sidebar__content {
         position: relative;
-        
+        z-index: 1;
+
         .covid19-sidebar-reference {
             display: none;
             &.float-sidebar {
                 display: block;
             }
         }
-    
+
         .covid19-sidebar-content {
             height: 654px;
             overflow-y: scroll;
@@ -44,10 +45,10 @@
             ul {
                 @include unstyled-list;
                 padding: rem(30) rem(20);
-    
+
                 li {
                     margin-bottom: rem(24);
-    
+
                     &:last-child {
                         margin-bottom: rem(0);
                     }
@@ -55,16 +56,16 @@
                         border-bottom: 5px solid $color-primary;
                     }
                 }
-    
+
                 a.sidebar-link {
                     color: $color-base;
                     font-size: rem(19);
                     line-height: rem(20);
-    
+
                     text-decoration: none;
                     border-bottom: 5px solid transparent;
                     @include transition(all 0.15s ease-in-out);
-    
+
                     &.active {
                         font-weight: $font-bold;
                         border-bottom: 5px solid $color-primary;


### PR DESCRIPTION
**High level description:**

Feedback from testers and design; needed to make sure the sidebar on About page and Covid page was on top of the footer, like in Prod; needed to change the spacing between the three elements in the section at large screen sizes

**Technical details:**

Added z-index 1 to the sidebars; added media queries and margin for the spacing

**JIRA Ticket:**
[DEV-9082](https://federal-spending-transparency.atlassian.net/browse/DEV-9082)

**Mockup:**
in tkt; but what design asked for at large screen sizes does not match the mock

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
