### PR TITLE
9131 - changed the line-clamp to 4, from 992 to 1200; had to also get…

### DIFF
--- a/src/_scss/pages/homepage/_wordOfTheDay.scss
+++ b/src/_scss/pages/homepage/_wordOfTheDay.scss
@@ -59,6 +59,13 @@
         display: -webkit-box;
         -webkit-line-clamp: 5;
         -webkit-box-orient: vertical;
+        @media(min-width: $medium-screen) {
+          -webkit-line-clamp: 4;
+          overflow: hidden;
+        }
+        @media(min-width: $large-screen) {
+          -webkit-line-clamp: 5;
+        }
       }
     }
   }
@@ -74,6 +81,9 @@
   .card__button {
     margin-top: rem(32);
     justify-content: flex-start;
+    @media(min-width: $medium-screen) {
+      margin-top: 0;
+    }
   }
 
   .word-of-the-day__button {


### PR DESCRIPTION
… rid of margin-top for the button at >992

**High level description:**

Card heights were different btw 992 and 1200-ish

**Technical details:**

changed the line-clamp to 4, from 992 to 1200; had to also get rid of margin-top for the button at >992

**JIRA Ticket:**
[DEV-9131](https://federal-spending-transparency.atlassian.net/browse/DEV-9131)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
