### PR TITLE
9160 - changed copy in the external link modal

### DIFF
--- a/src/js/components/sharedComponents/RedirectModal.jsx
+++ b/src/js/components/sharedComponents/RedirectModal.jsx
@@ -21,7 +21,7 @@ export default class RedirectModal extends React.Component {
             <Modal
                 mounted={this.props.mounted}
                 onExit={this.props.hideModal}
-                titleText="You're leaving a Bureau of the Fiscal Service website."
+                titleText="You're leaving a Federal Government website."
                 dialogClass="usa-dt-modal"
                 verticallyCenter
                 escapeExits>
@@ -43,11 +43,11 @@ export default class RedirectModal extends React.Component {
                                 </i>
                             </div>
                             <div className="usa-dt-modal__title-text">
-                                You&apos;re leaving a Bureau of the Fiscal Service website.
+                                You&apos;re leaving a Federal Government website.
                             </div>
                         </div>
                         <div className="usa-dt-modal__explanation">
-                            You&apos;re going to a website that is not managed or controlled by the Bureau of the Fiscal Service.
+                            You&apos;re going to a website that is not managed or controlled by the Federal Government.
                             <br /> Its privacy policies may differ from ours.
                         </div>
                         <div className="usa-dt-modal__directions">


### PR DESCRIPTION
**High level description:**

Small copy change to the text in the external link modal

**Technical details:**

I copied the new text from the ticket then pasted it over the old text in the code.

**JIRA Ticket:**
[DEV-9160](https://federal-spending-transparency.atlassian.net/browse/DEV-9160)

**Mockup:**
n/a, but there's a picture attached to the ticket

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
