### PR TITLE
9163 - made data sources page sidebar sticky

### DIFF
--- a/src/_scss/pages/interactiveDataSources/_sidebar.scss
+++ b/src/_scss/pages/interactiveDataSources/_sidebar.scss
@@ -8,55 +8,55 @@
         margin: rem(20);
     }
 
-    .interactive-data-sources-sidebar-reference {
-        display: none;
-        &.float-sidebar {
-            display: block;
-        }
-    }
+    .sidebar_content {
+        position: sticky;
+        top: rem(86);
+        // todo - remove this when the sidebar component has its reference div removed
+        margin-top: -20px;
 
-    .interactive-data-sources-sidebar-content {
-        background-color: $color-white;
-        box-shadow: $container-shadow;
-        border-top: 1px solid $color-gray-border;
-        border-right: 1px solid $color-gray-border;
-        border-bottom: 1px solid $color-gray-border;
-        border-radius: rem(5);
-        padding: rem(30);
-        &.float-sidebar {
-            position: fixed;
-            top: rem(96);
-        }
-        ul {
-            @include unstyled-list;
-            li {
-                border-bottom: solid rem(1) $color-gray-lighter;
-                a.sidebar-link {
-                    display: block;
-                    padding: rem(10);
-                    border-left: solid rem(5) transparent;
-                    @include transition(all 0.15s ease-in-out);
-                    color: $color-base;
-                    font-size: rem(19);
-                    line-height: rem(20);
-                    text-decoration: none;
-                    font-weight: $font-semibold;
-                    &:hover {
-                        background-color: $color-gray-lightest;
+        .interactive-data-sources-sidebar-content {
+            background-color: $color-white;
+            box-shadow: $container-shadow;
+            border-top: 1px solid $color-gray-border;
+            border-right: 1px solid $color-gray-border;
+            border-bottom: 1px solid $color-gray-border;
+            border-radius: rem(5);
+            padding: rem(30);
+            ul {
+                @include unstyled-list;
+
+                li {
+                    border-bottom: solid rem(1) $color-gray-lighter;
+
+                    a.sidebar-link {
+                        display: block;
+                        padding: rem(10);
+                        border-left: solid rem(5) transparent;
+                        @include transition(all 0.15s ease-in-out);
+                        color: $color-base;
+                        font-size: rem(19);
+                        line-height: rem(20);
                         text-decoration: none;
+                        font-weight: $font-semibold;
+
+                        &:hover {
+                            background-color: $color-gray-lightest;
+                            text-decoration: none;
+                        }
+
+                        &.active {
+                            border-left: 5px solid $color-primary;
+                        }
+
+                        .sidebar-link__overline {
+                            font-weight: normal;
+                            text-transform: uppercase;
+                            font-size: rem(12);
+                            letter-spacing: 0.3px;
+                        }
                     }
 
-                    &.active {
-                        border-left: 5px solid $color-primary;
-                    }
-                    .sidebar-link__overline {
-                        font-weight: normal;
-                        text-transform: uppercase;
-                        font-size: rem(12);
-                        letter-spacing: 0.3px;
-                    }
                 }
-                
             }
         }
     }

--- a/src/js/components/interactiveDataSources/InteractiveDataSourcesPage.jsx
+++ b/src/js/components/interactiveDataSources/InteractiveDataSourcesPage.jsx
@@ -181,17 +181,19 @@ const InteractiveDataSourcesPage = () => {
                 title="Data Sources">
                 <main id="main-content" className="main-content usda__flex-row">
                     <div className="sidebar usda__flex-col">
-                        <Sidebar
-                            pageName="interactive-data-sources"
-                            fixedStickyBreakpoint={scrollPositionOfSiteHeader}
-                            isGoingToBeSticky
-                            active={activeSection}
-                            jumpToSection={jumpToSection}
-                            detectActiveSection={setActiveSection}
-                            sections={sections.map((section) => ({
-                                section: section.name,
-                                label: section.display
-                            }))} />
+                        <div className="sidebar_content">
+                            <Sidebar
+                                pageName="interactive-data-sources"
+                                fixedStickyBreakpoint={scrollPositionOfSiteHeader}
+                                isGoingToBeSticky
+                                active={activeSection}
+                                jumpToSection={jumpToSection}
+                                detectActiveSection={setActiveSection}
+                                sections={sections.map((section) => ({
+                                    section: section.name,
+                                    label: section.display
+                                }))} />
+                        </div>
                     </div>
                     <div className="body usda__flex-col">
                         {sections.map((section) => (


### PR DESCRIPTION
**High level description:**

The sidebar was overlapping the footer and the text in the Stay in Touch banner was over the sidebar content.

**Technical details:**

I used examples from work done in branch 8498 (never merged in) to make the sidebar for this page sticky, so it no longer overlaps the footer or Stay in Touch banner.
To make this change to the Sidebar component would require making changes to every instance of the Sidebar in the site.

**JIRA Ticket:**
[DEV-9163](https://federal-spending-transparency.atlassian.net/browse/DEV-9163)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
