### PR TITLE
9147 - merged qat in; several small copy edits in comments from Allie…

### DIFF
--- a/src/js/components/interactiveDataSources/scrollerSections/AwardData.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/AwardData.jsx
@@ -28,10 +28,9 @@ function AwardData() {
                     location information.
                     </p>
                     <p>
-                        File C also contains obligations and outlays tagged by
-                        Disaster{" "}
+                        File C also contains obligations and outlays tagged by{" "}
                         <span className="glossary-term">
-                        Emergency Fund Codes (DEFC)
+                        Disaster Emergency Fund Codes (DEFC)
                         </span>{" "}
                         <GlossaryLink term="disaster-emergency-fund-code-defc" />{" "}
                         to track

--- a/src/js/components/interactiveDataSources/scrollerSections/DataAvailable.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/DataAvailable.jsx
@@ -150,7 +150,7 @@ function DataAvailable() {
                                 </ul>
                                 <p>
                                     While USAspending does receive contract award data from the Department of Defense (DOD) and the
-                                    U.S. Army Corps of Engineers (USACE), there is a 90 delay in the submission of these data to the FPDS source system.
+                                    U.S. Army Corps of Engineers (USACE), there is a 90-day delay in the submission of these data to the FPDS source system.
                                 </p>
                             </>
                         )

--- a/src/js/components/interactiveDataSources/scrollerSections/DataFeatures.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/DataFeatures.jsx
@@ -214,7 +214,7 @@ function DataFeatures() {
                                             to="/download_center/custom_account_data"
                                             target="_blank"
                                             rel="noopener noreferrer">
-                                        Custom Account Data download
+                                        Custom Account Data Download
                                         </Link>{" "}
                                         (using the DEFC filter)
                                     </li>
@@ -283,7 +283,9 @@ function DataFeatures() {
                                         Results from{" "}
                                         <Link
                                             className="scroller-overlay-card__link"
-                                            to="/search">
+                                            to="/search"
+                                            target="_blank"
+                                            rel="noopener noreferrer">
                                             Advanced Search
                                         </Link>{" "}
                                         can be downloaded from the top right of the page
@@ -293,7 +295,9 @@ function DataFeatures() {
                                         column in{" "}
                                         <Link
                                             className="scroller-overlay-card__link"
-                                            to="/search">
+                                            to="/search"
+                                            target="_blank"
+                                            rel="noopener noreferrer">
                                             Advanced Search
                                         </Link>{" "}
                                         results) can be downloaded from the top right of the page

--- a/src/js/components/interactiveDataSources/scrollerSections/DataSubmissionExtraction.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/DataSubmissionExtraction.jsx
@@ -119,15 +119,15 @@ function DataSubmissionExtraction() {
                                 are extracted by USAspending from government sources. For more
                                 information about what is included in these extractions, please
                                 consult the Interface Definition Document (IDD) spreadsheet in
-                                this{" "}
+                                the{" "}
                                 <a
                                     className="scroller-overlay-card__link"
                                     href="https://fiscal.treasury.gov/data-transparency/DAIMS-current.html"
                                     target="_blank"
                                     rel="noopener noreferrer">
-                                    resources page from the Bureau of the Fiscal Service
-                                </a>
-                                .
+                                    USAspending Source and Submission Model
+                                </a>{" "}
+                                page.
                             </p>} />
                 </div>
             </ScrollerOverlay>

--- a/src/js/components/interactiveDataSources/scrollerSections/DataValidation.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/DataValidation.jsx
@@ -151,13 +151,17 @@ function DataValidation() {
                                     awards in the{" "}
                                     <Link
                                         className="scroller-overlay-card__link"
-                                        to="/submission-statistics">
+                                        to="/submission-statistics"
+                                        target="_blank"
+                                        rel="noopener noreferrer">
                                         Agency Submission Statistics page
                                     </Link>.
                                     More information about linked awards is available in the{" "}
                                     <Link
                                         className="scroller-overlay-card__link"
-                                        to="/submission-statistics/data-sources">
+                                        to="/submission-statistics/data-sources"
+                                        target="_blank"
+                                        rel="noopener noreferrer">
                                         Data Sources and Methodology page
                                     </Link>{" "}
                                     for these statistics.

--- a/src/js/components/interactiveDataSources/scrollerSections/Frequency.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/Frequency.jsx
@@ -91,7 +91,7 @@ function Frequency() {
                                     spreadsheets available in the{" "}
                                     <a
                                         className="scroller-overlay-card__link"
-                                        href="https://fiscal.treasury.gov/data-transparency/DAIMS-current.html#fed"
+                                        href="https://fiscal.treasury.gov/data-transparency/resources.html"
                                         target="_blank"
                                         rel="noopener noreferrer">
                                         resources page for the USAspending Source and Submission Model

--- a/src/js/components/interactiveDataSources/sections/AboutSection.jsx
+++ b/src/js/components/interactiveDataSources/sections/AboutSection.jsx
@@ -56,7 +56,7 @@ const AboutSection = () => {
                         rel="noopener noreferrer">
                         API Endpoints
                     </a>
-                    : documentation all JSON objects accessible from API endpoints
+                    : documentation for all JSON objects accessible from API endpoints
                 </li>
                 <li>
                     <a
@@ -98,7 +98,7 @@ const AboutSection = () => {
         </>)
     },
     {
-        title: "How was the DATA Act implemented?",
+        title: "How is the DATA Act implemented?",
         details: (
             <>
                 <p>

--- a/src/js/components/sharedComponents/ReadMore.jsx
+++ b/src/js/components/sharedComponents/ReadMore.jsx
@@ -3,8 +3,6 @@
  * Created by Lizzie Salita 7/24/20
  */
 
-// meaningless change to trigger build again
-
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/js/components/sharedComponents/ReadMore.jsx
+++ b/src/js/components/sharedComponents/ReadMore.jsx
@@ -42,7 +42,7 @@ const ReadMore = ({
                     additionalFunctionality(expanded);
                 }
             }}>{closePrompt}{' '}<span className="usa-button-link__icon"><FontAwesomeIcon className="readMoreUpdated__link-icon" icon={closeIcon} /></span>
-        </button>) : (<button className="read-more-button" onClick={() => setExpanded(false)}>read less</button>);
+        </button>) : (<button className="read-more-button" onClick={() => setExpanded(false)}>Read Less</button>);
     const readMore = openIcon ? (
         <button
             className="readMoreUpdated__button"
@@ -52,7 +52,7 @@ const ReadMore = ({
                     additionalFunctionality();
                 }
             }}>{openPrompt}{' '}<span className="usa-button-link__icon"><FontAwesomeIcon className="readMoreUpdated__link-icon" icon={openIcon} /></span>
-        </button>) : (<button className="read-more-button" onClick={() => setExpanded(true)}>read more</button>);
+        </button>) : (<button className="read-more-button" onClick={() => setExpanded(true)}>Read More</button>);
     if (expanded && children) {
         return (
             <>

--- a/src/js/components/sharedComponents/ReadMore.jsx
+++ b/src/js/components/sharedComponents/ReadMore.jsx
@@ -3,6 +3,8 @@
  * Created by Lizzie Salita 7/24/20
  */
 
+// meaningless change to trigger build again
+
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/tests/components/sharedComponents/ReadMore-test.jsx
+++ b/tests/components/sharedComponents/ReadMore-test.jsx
@@ -15,45 +15,45 @@ describe('ReadMore', () => {
         render(<ReadMore text={mockText} limit={10} />);
         expect(screen.queryByText('Lorem ipsu...')).toBeTruthy();
         expect(screen.queryByText(mockText)).toBeFalsy();
-        expect(screen.queryByText('read more')).toBeTruthy();
+        expect(screen.queryByText('Read More')).toBeTruthy();
     });
     it('should display the full text when the "read more" button is clicked', () => {
         render(<ReadMore text={mockText} limit={10} />);
-        fireEvent.click(screen.getByText('read more'));
+        fireEvent.click(screen.getByText('Read More'));
         expect(screen.queryByText(mockText)).toBeTruthy();
     });
     it('should display the full text and a "read less" button when initially expanded', () => {
         render(<ReadMore text={mockText} limit={10} initiallyExpanded />);
         expect(screen.queryByText('Lorem ipsu...')).toBeFalsy();
         expect(screen.queryByText(mockText)).toBeTruthy();
-        expect(screen.queryByText('read less')).toBeTruthy();
+        expect(screen.queryByText('Read Less')).toBeTruthy();
     });
     it('should truncate the text based on the limit when "read less" is clicked', () => {
         render(<ReadMore text={mockText} limit={10} initiallyExpanded />);
-        fireEvent.click(screen.queryByText('read less'));
+        fireEvent.click(screen.queryByText('Read Less'));
         expect(screen.queryByText('Lorem ipsu...')).toBeTruthy();
         expect(screen.queryByText(mockText)).toBeFalsy();
-        expect(screen.queryByText('read more')).toBeTruthy();
+        expect(screen.queryByText('Read More')).toBeTruthy();
     });
     it('should display the full text with no button if the text does not exceed the character limit', () => {
         render(<ReadMore text="Hello" limit={10} />);
         expect(screen.queryByText('Hello')).toBeTruthy();
-        expect(screen.queryByText('read more')).toBeFalsy();
+        expect(screen.queryByText('Read More')).toBeFalsy();
     });
     it('should display just the "read more" button when children are provided', () => {
         render(<ReadMore>{mockChildren}</ReadMore>);
-        expect(screen.queryByText('read more')).toBeTruthy();
+        expect(screen.queryByText('Read More')).toBeTruthy();
         expect(screen.queryByText('mock children')).toBeFalsy();
     });
     it('should display the children and a "read less" button when "read more" is clicked', () => {
         render(<ReadMore>{mockChildren}</ReadMore>);
-        fireEvent.click(screen.queryByText('read more'));
+        fireEvent.click(screen.queryByText('Read More'));
         expect(screen.queryByText('mock children')).toBeTruthy();
-        expect(screen.queryByText('read less')).toBeTruthy();
+        expect(screen.queryByText('Read Less')).toBeTruthy();
     });
     it('should display the children and a "read less" button when initially expanded', () => {
         render(<ReadMore initiallyExpanded>{mockChildren}</ReadMore>);
         expect(screen.queryByText('mock children')).toBeTruthy();
-        expect(screen.queryByText('read less')).toBeTruthy();
+        expect(screen.queryByText('Read Less')).toBeTruthy();
     });
 });


### PR DESCRIPTION
… on the ticket

**High level description:**

copy edits; in comments on ticket

**Technical details:**

changed the ReadMore component to use title case for 'Read More' and 'Read Less' per instructions from Andrew
https://data-transparency-bfs.slack.com/archives/C0149JM6A82/p1666037083922139

**JIRA Ticket:**
[DEV-9147](https://federal-spending-transparency.atlassian.net/browse/DEV-9147)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
