### PR TITLE
Mod 9180 update data source page

### DIFF
--- a/src/js/components/homepageUpdate/HomepageResources/HomepageResources.jsx
+++ b/src/js/components/homepageUpdate/HomepageResources/HomepageResources.jsx
@@ -61,7 +61,7 @@ const cardObjects = [
                 <FontAwesomeIcon icon="sitemap" color="#0081a1" size="lg" />
             </div>
         ),
-        headline: 'Data Model',
+        headline: 'Data Source',
         text: 'Learn how our data is organized',
         buttonText: (
             <>

--- a/src/js/components/interactiveDataSources/InteractiveDataSourcesPage.jsx
+++ b/src/js/components/interactiveDataSources/InteractiveDataSourcesPage.jsx
@@ -1,4 +1,3 @@
-
 import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useQueryParams } from 'helpers/queryParams';
@@ -38,98 +37,98 @@ const InteractiveDataSourcesPage = () => {
             display: 'Introduction',
             showSectionTitle: false,
             scroller: false,
-            component: <IntroSection />
+            component: <IntroSection/>
         },
         {
             name: 'history-section',
             display: 'History of the DATA Act',
             showSectionTitle: false,
             scroller: false,
-            component: <AboutSection />
+            component: <AboutSection/>
         },
         {
             name: 'federal-spending-overview',
             display: 'Federal Spending Overview',
             showSectionTitle: false,
             scroller: true,
-            component: <FederalSpendingOverview />
+            component: <FederalSpendingOverview/>
         },
         {
             name: 'data-available',
             display: 'Data Available on USAspending',
             showSectionTitle: false,
             scroller: true,
-            component: <DataAvailable />
+            component: <DataAvailable/>
         },
         {
             name: 'data-types',
             display: 'USAspending Data Types',
             showSectionTitle: false,
             scroller: true,
-            component: <DataTypes />
+            component: <DataTypes/>
         },
         {
             name: 'data-source-systems',
             display: 'USAspending Source Systems',
             showSectionTitle: false,
             scroller: true,
-            component: <DataSourceSystems />
+            component: <DataSourceSystems/>
         },
         {
             name: 'account-data',
             display: 'USAspending Account Data',
             showSectionTitle: false,
             scroller: true,
-            component: <AccountData />
+            component: <AccountData/>
         },
         {
             name: 'award-data',
             display: 'USAspending Award Data',
             showSectionTitle: false,
             scroller: true,
-            component: <AwardData />
+            component: <AwardData/>
         },
         {
             name: 'additional-data',
             display: 'USAspending Additional Data',
             showSectionTitle: false,
             scroller: true,
-            component: <AdditionalData />
+            component: <AdditionalData/>
         },
         {
             name: 'data-submission-extraction',
             display: 'Data Submission and Extraction',
             showSectionTitle: false,
             scroller: true,
-            component: <DataSubmissionExtraction />
+            component: <DataSubmissionExtraction/>
         },
         {
             name: 'frequency',
             display: 'Frequency of Data Updates',
             showSectionTitle: false,
             scroller: true,
-            component: <Frequency />
+            component: <Frequency/>
         },
         {
             name: 'data-validation',
             display: 'Data Validation',
             showSectionTitle: false,
             scroller: true,
-            component: <DataValidation />
+            component: <DataValidation/>
         },
         {
             name: 'data-access',
             display: 'Features on USAspending',
             showSectionTitle: false,
             scroller: true,
-            component: <DataFeatures />
+            component: <DataFeatures/>
         },
         {
             name: 'data-use-cases',
             display: 'USAspending Use Cases',
             showSectionTitle: false,
             scroller: true,
-            component: <DataUseCases />
+            component: <DataUseCases/>
         }
     ];
     const jumpToSection = (section = '') => {
@@ -171,40 +170,40 @@ const InteractiveDataSourcesPage = () => {
         };
     }, 100), [history, query.section]);
     return (
-            <PageWrapper
-                pageName="Data Sources"
-                classNames="usa-da-interactive-data-sources-page"
-                overLine="resources"
-                metaTagProps={interactiveDataSourcesPageMetaTags}
-                title="Data Sources">
-                <main id="main-content" className="main-content usda__flex-row">
-                    <div className="sidebar usda__flex-col">
-                        <div className="sidebar_content">
-                            <Sidebar
-                                pageName="interactive-data-sources"
-                                fixedStickyBreakpoint={scrollPositionOfSiteHeader}
-                                isGoingToBeSticky
-                                active={activeSection}
-                                jumpToSection={jumpToSection}
-                                detectActiveSection={setActiveSection}
-                                sections={sections.map((section) => ({
-                                    section: section.name,
-                                    label: section.display
-                                }))} />
-                        </div>
+        <PageWrapper
+            pageName="Data Sources"
+            classNames="usa-da-interactive-data-sources-page"
+            overLine="resources"
+            metaTagProps={interactiveDataSourcesPageMetaTags}
+            title="Data Sources">
+            <main id="main-content" className="main-content usda__flex-row">
+                <div className="sidebar usda__flex-col">
+                    <div className="sidebar_content">
+                        <Sidebar
+                            pageName="interactive-data-sources"
+                            fixedStickyBreakpoint={scrollPositionOfSiteHeader}
+                            isGoingToBeSticky
+                            active={activeSection}
+                            jumpToSection={jumpToSection}
+                            detectActiveSection={setActiveSection}
+                            sections={sections.map((section) => ({
+                                section: section.name,
+                                label: section.display
+                            }))}/>
                     </div>
-                    <div className="body usda__flex-col">
-                        {sections.map((section) => (
-                            <InteractiveDataSourcesSection
-                                key={section.name}
-                                section={section}
-                                icon={section.icon}>
-                                {section.component || <ComingSoon />}
-                            </InteractiveDataSourcesSection>
-                        ))}
-                    </div>
-                </main>
-            </PageWrapper>
+                </div>
+                <div className="body usda__flex-col">
+                    {sections.map((section) => (
+                        <InteractiveDataSourcesSection
+                            key={section.name}
+                            section={section}
+                            icon={section.icon}>
+                            {section.component || <ComingSoon/>}
+                        </InteractiveDataSourcesSection>
+                    ))}
+                </div>
+            </main>
+        </PageWrapper>
     );
 };
 export default InteractiveDataSourcesPage;

--- a/src/js/components/interactiveDataSources/InteractiveDataSourcesPage.jsx
+++ b/src/js/components/interactiveDataSources/InteractiveDataSourcesPage.jsx
@@ -24,7 +24,6 @@ import DataSourceSystems from './scrollerSections/DataSourceSystems';
 import AccountData from './scrollerSections/AccountData';
 import AwardData from './scrollerSections/AwardData';
 import AdditionalData from './scrollerSections/AdditionalData';
-import FeatureFlag from "../sharedComponents/FeatureFlag";
 
 require('pages/interactiveDataSources/index.scss');
 
@@ -172,7 +171,6 @@ const InteractiveDataSourcesPage = () => {
         };
     }, 100), [history, query.section]);
     return (
-        <FeatureFlag>
             <PageWrapper
                 pageName="Data Sources"
                 classNames="usa-da-interactive-data-sources-page"
@@ -207,7 +205,6 @@ const InteractiveDataSourcesPage = () => {
                     </div>
                 </main>
             </PageWrapper>
-        </FeatureFlag>
     );
 };
 export default InteractiveDataSourcesPage;

--- a/src/js/components/interactiveDataSources/InteractiveDataSourcesPage.jsx
+++ b/src/js/components/interactiveDataSources/InteractiveDataSourcesPage.jsx
@@ -37,98 +37,98 @@ const InteractiveDataSourcesPage = () => {
             display: 'Introduction',
             showSectionTitle: false,
             scroller: false,
-            component: <IntroSection/>
+            component: <IntroSection />
         },
         {
             name: 'history-section',
             display: 'History of the DATA Act',
             showSectionTitle: false,
             scroller: false,
-            component: <AboutSection/>
+            component: <AboutSection />
         },
         {
             name: 'federal-spending-overview',
             display: 'Federal Spending Overview',
             showSectionTitle: false,
             scroller: true,
-            component: <FederalSpendingOverview/>
+            component: <FederalSpendingOverview />
         },
         {
             name: 'data-available',
             display: 'Data Available on USAspending',
             showSectionTitle: false,
             scroller: true,
-            component: <DataAvailable/>
+            component: <DataAvailable />
         },
         {
             name: 'data-types',
             display: 'USAspending Data Types',
             showSectionTitle: false,
             scroller: true,
-            component: <DataTypes/>
+            component: <DataTypes />
         },
         {
             name: 'data-source-systems',
             display: 'USAspending Source Systems',
             showSectionTitle: false,
             scroller: true,
-            component: <DataSourceSystems/>
+            component: <DataSourceSystems />
         },
         {
             name: 'account-data',
             display: 'USAspending Account Data',
             showSectionTitle: false,
             scroller: true,
-            component: <AccountData/>
+            component: <AccountData />
         },
         {
             name: 'award-data',
             display: 'USAspending Award Data',
             showSectionTitle: false,
             scroller: true,
-            component: <AwardData/>
+            component: <AwardData />
         },
         {
             name: 'additional-data',
             display: 'USAspending Additional Data',
             showSectionTitle: false,
             scroller: true,
-            component: <AdditionalData/>
+            component: <AdditionalData />
         },
         {
             name: 'data-submission-extraction',
             display: 'Data Submission and Extraction',
             showSectionTitle: false,
             scroller: true,
-            component: <DataSubmissionExtraction/>
+            component: <DataSubmissionExtraction />
         },
         {
             name: 'frequency',
             display: 'Frequency of Data Updates',
             showSectionTitle: false,
             scroller: true,
-            component: <Frequency/>
+            component: <Frequency />
         },
         {
             name: 'data-validation',
             display: 'Data Validation',
             showSectionTitle: false,
             scroller: true,
-            component: <DataValidation/>
+            component: <DataValidation />
         },
         {
             name: 'data-access',
             display: 'Features on USAspending',
             showSectionTitle: false,
             scroller: true,
-            component: <DataFeatures/>
+            component: <DataFeatures />
         },
         {
             name: 'data-use-cases',
             display: 'USAspending Use Cases',
             showSectionTitle: false,
             scroller: true,
-            component: <DataUseCases/>
+            component: <DataUseCases />
         }
     ];
     const jumpToSection = (section = '') => {
@@ -189,7 +189,7 @@ const InteractiveDataSourcesPage = () => {
                             sections={sections.map((section) => ({
                                 section: section.name,
                                 label: section.display
-                            }))}/>
+                            }))} />
                     </div>
                 </div>
                 <div className="body usda__flex-col">
@@ -198,7 +198,7 @@ const InteractiveDataSourcesPage = () => {
                             key={section.name}
                             section={section}
                             icon={section.icon}>
-                            {section.component || <ComingSoon/>}
+                            {section.component || <ComingSoon />}
                         </InteractiveDataSourcesSection>
                     ))}
                 </div>

--- a/src/js/dataMapping/navigation/menuOptions.jsx
+++ b/src/js/dataMapping/navigation/menuOptions.jsx
@@ -81,8 +81,8 @@ export const resourceOptions = [
         enabled: true,
         url: '/data-sources',
         callToAction: 'Explore the Data Sources',
-        shouldOpenNewTab: !GlobalConstants.QAT,
-        externalLink: !GlobalConstants.QAT,
+        shouldOpenNewTab: true,
+        externalLink: false,
         isNewTab: true
     },
     {

--- a/src/js/dataMapping/navigation/menuOptions.jsx
+++ b/src/js/dataMapping/navigation/menuOptions.jsx
@@ -72,19 +72,18 @@ export const resourceOptions = [
         url: '/analyst-guide',
         shouldOpenNewTab: false,
         enabled: true,
-        externalLink: false,
-        isNewTab: true
+        externalLink: false
 
     },
     {
-        label: GlobalConstants.QAT ? 'Data Sources' : 'Data Model',
+        label: 'Data Sources',
         type: 'data-sources',
         enabled: true,
-        url: GlobalConstants.QAT ? '/data-sources' : 'https://fiscal.treasury.gov/data-transparency/DAIMS-current.html',
+        url: '/data-sources',
         callToAction: 'Explore the Data Sources',
         shouldOpenNewTab: !GlobalConstants.QAT,
         externalLink: !GlobalConstants.QAT,
-        isNewTab: false
+        isNewTab: true
     },
     {
         label: "Agency Submission Statistics",


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-9180

**High level description:**
Remove code to hide the Data Sources page from upper environments (ie. FeatureFlag component)

Remove code to show “Data Model” instead of “Data Sources” in Staging and Prod, in the main nav under “Resources”

Make sure the “Data Sources” item from AC2 links to the /data-sources page 

remove new badge from analyst guide menu option and make sure new badge is on data sources menu option

**Technical details:**
Added a newTag to data source and removed it from analyst guide 


**JIRA Ticket:**
DEV-9180 https://federal-spending-transparency.atlassian.net/browse/DEV-9180

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
