### PR TITLE
Mod/9158 data sources touchups

### DIFF
--- a/src/_scss/pages/interactiveDataSources/_aboutSection.scss
+++ b/src/_scss/pages/interactiveDataSources/_aboutSection.scss
@@ -30,7 +30,7 @@
     }
 
     .interactives-guide-cardText {
-        margin-top: 0px;
+        margin-top: 20px;
         a {
             color: white;
             &:visited {
@@ -63,16 +63,19 @@
         border-bottom: 2px solid black;
     }
 
-    .interactives-guide__cardLine {
-        @media (max-width: $medium-screen) {
-            margin: 2px 16px 20px;
-            width: 100%;
-        }
-        width: 38%;
-        margin: 5px 0px 10px;
-        border-bottom: 3px solid $color-primary;
-    }
+    .interactives-guide__heading-container {
+        display: inline-block;
 
+        .interactives-guide__heading {
+            border-bottom: 3px solid $color-primary;
+            line-height: 1.5 !important;
+            width: 84%;
+            @media (min-width: 408px) {
+                line-height: 1.75 !important;
+                width: unset;
+            }
+        }
+    }
 
     .interactives-guide__background-green {
         background: linear-gradient(to bottom, $color-white 25%, $color-vis-green-darkest 25%);

--- a/src/js/components/interactiveDataSources/lottieAnimation/LottieAnimation.jsx
+++ b/src/js/components/interactiveDataSources/lottieAnimation/LottieAnimation.jsx
@@ -226,7 +226,7 @@ class LottieAnimation extends React.Component {
 LottieAnimation.propTypes = {
     src: PropTypes.string,
     autoplay: PropTypes.bool,
-    loop: PropTypes.bool,
+    loop: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
     fps: PropTypes.number,
     isScrollerBackdrop: PropTypes.bool,
     direction: PropTypes.string,

--- a/src/js/components/interactiveDataSources/scrollerSections/AccountData.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/AccountData.jsx
@@ -83,7 +83,7 @@ function AccountData() {
                 </div>
                 <div className="bottom-animation">
                     <LottieAnimation
-                        loop
+                        loop={1}
                         ref={ref2}
                         src="/img/interactive-data-sources/5_DS_ACCOUNT_BG.json"
                         role="presentation" />

--- a/src/js/components/interactiveDataSources/scrollerSections/AdditionalData.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/AdditionalData.jsx
@@ -63,7 +63,7 @@ function AdditionalData() {
                 </div>
                 <div className="bottom-animation">
                     <LottieAnimation
-                        loop
+                        loop={1}
                         ref={ref2}
                         src="/img/interactive-data-sources/5_DS_ADDITIONAL_BG.json"
                         role="presentation" />

--- a/src/js/components/interactiveDataSources/scrollerSections/AwardData.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/AwardData.jsx
@@ -276,7 +276,7 @@ function AwardData() {
                 </div>
                 <div className="bottom-animation">
                     <LottieAnimation
-                        loop
+                        loop={1}
                         ref={ref2}
                         src="/img/interactive-data-sources/5_DS_AWARD_BG.json"
                         role="presentation" />

--- a/src/js/components/interactiveDataSources/scrollerSections/DataAvailable.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/DataAvailable.jsx
@@ -29,7 +29,7 @@ function DataAvailable() {
                 </div>
                 <div className="bottom-animation">
                     <LottieAnimation
-                        loop
+                        loop={1}
                         ref={ref2}
                         src="/img/interactive-data-sources/2_DA_BG.json"
                         role="presentation" />
@@ -39,14 +39,14 @@ function DataAvailable() {
             <div name="animation-loop1" className="position position--center">
                 <div className="top-animation">
                     <LottieAnimation
-                        loop
+                        loop={1}
                         ref={ref3}
                         src="/img/interactive-data-sources/2_DA.json"
                         role="presentation" />
                 </div>
                 <div className="bottom-animation">
                     <LottieAnimation
-                        loop
+                        loop={1}
                         ref={ref4}
                         src="/img/interactive-data-sources/2_DA_BG.json"
                         role="presentation" />
@@ -56,14 +56,14 @@ function DataAvailable() {
             <div name="animation-loop2" className="position position--center">
                 <div className="top-animation">
                     <LottieAnimation
-                        loop
+                        loop={1}
                         ref={ref5}
                         src="/img/interactive-data-sources/2_DA.json"
                         role="presentation" />
                 </div>
                 <div className="bottom-animation">
                     <LottieAnimation
-                        loop
+                        loop={1}
                         ref={ref6}
                         src="/img/interactive-data-sources/2_DA_BG.json"
                         role="presentation" />

--- a/src/js/components/interactiveDataSources/scrollerSections/DataFeatures.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/DataFeatures.jsx
@@ -14,7 +14,7 @@ function DataFeatures() {
             {/* SCROLLER BACKDROPS */}
             <div name="animation-loop" className="position position--center">
                 <LottieAnimation
-                    loop
+                    loop={1}
                     ref={ref1}
                     src="/img/interactive-data-sources/9_DA.json"
                     role="presentation" />

--- a/src/js/components/interactiveDataSources/scrollerSections/DataSourceSystems.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/DataSourceSystems.jsx
@@ -23,14 +23,14 @@ function DataSourceSystems() {
                 </div>
                 <div className="top-animation">
                     <LottieAnimation
-                        loop
+                        loop={1}
                         ref={ref2}
                         src="/img/interactive-data-sources/4_DSS_TYPES.json"
                         role="presentation" />
                 </div>
                 <div className="bottom-animation">
                     <LottieAnimation
-                        loop
+                        loop={1}
                         ref={ref3}
                         src="/img/interactive-data-sources/4_DSS_BG.json"
                         role="presentation" />

--- a/src/js/components/interactiveDataSources/scrollerSections/DataSubmissionExtraction.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/DataSubmissionExtraction.jsx
@@ -21,7 +21,7 @@ function DataSubmissionExtraction() {
                 </div>
                 <div className="bottom-animation">
                     <LottieAnimation
-                        loop
+                        loop={1}
                         ref={ref2}
                         src="/img/interactive-data-sources/6_DSE_BG.json"
                         role="presentation" />

--- a/src/js/components/interactiveDataSources/scrollerSections/DataTypes.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/DataTypes.jsx
@@ -22,14 +22,14 @@ function DataTypes() {
                 </div>
                 <div className="top-animation">
                     <LottieAnimation
-                        loop
+                        loop={1}
                         ref={ref2}
                         src="/img/interactive-data-sources/3_DT_GIRL.json"
                         role="presentation" />
                 </div>
                 <div className="bottom-animation">
                     <LottieAnimation
-                        loop
+                        loop={1}
                         ref={ref3}
                         src="/img/interactive-data-sources/3_DT_BG.json"
                         role="presentation" />

--- a/src/js/components/interactiveDataSources/scrollerSections/DataUseCases.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/DataUseCases.jsx
@@ -12,7 +12,7 @@ function DataUseCases() {
             {/* SCROLLER BACKDROPS */}
             <div name="animation-loop" className="position position--center">
                 <LottieAnimation
-                    loop
+                    loop={1}
                     ref={ref1}
                     src="/img/interactive-data-sources/10_UUC.json"
                     role="presentation" />

--- a/src/js/components/interactiveDataSources/scrollerSections/DataValidation.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/DataValidation.jsx
@@ -13,7 +13,7 @@ function DataValidation() {
             {/* SCROLLER BACKDROPS */}
             <div name="animation-loop" className="position position--center">
                 <LottieAnimation
-                    loop
+                    loop={1}
                     ref={ref1}
                     src="/img/interactive-data-sources/8_DVBS.json"
                     role="presentation" />

--- a/src/js/components/interactiveDataSources/scrollerSections/FederalSpendingOverview.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/FederalSpendingOverview.jsx
@@ -72,7 +72,7 @@ function FederalSpendingOverview() {
                 </div>
                 <div className="bottom-animation">
                     <LottieAnimation
-                        loop
+                        loop={1}
                         ref={ref2}
                         src="/img/interactive-data-sources/1_FSO.json"
                         role="presentation" />

--- a/src/js/components/interactiveDataSources/scrollerSections/Frequency.jsx
+++ b/src/js/components/interactiveDataSources/scrollerSections/Frequency.jsx
@@ -23,7 +23,7 @@ function Frequency() {
                 </div>
                 <div className="bottom-animation">
                     <LottieAnimation
-                        loop
+                        loop={1}
                         ref={ref2}
                         src="/img/interactive-data-sources/7_FDU.json"
                         role="presentation" />

--- a/src/js/components/interactiveDataSources/sections/AboutSection.jsx
+++ b/src/js/components/interactiveDataSources/sections/AboutSection.jsx
@@ -112,10 +112,9 @@ const AboutSection = () => {
     }];
     const dataModelCardContent = {
         heading: (
-            <>
-                <h4>USAspending Data Model</h4>
-                <div role="separator" className="interactives-guide__cardLine" />
-            </>
+            <div className="interactives-guide__heading-container">
+                <h4 className="interactives-guide__heading">USAspending Data Model</h4>
+            </div>
         ),
         content: (
             <>

--- a/src/js/components/interactiveDataSources/sections/IntroSection.jsx
+++ b/src/js/components/interactiveDataSources/sections/IntroSection.jsx
@@ -24,7 +24,7 @@ const IntroSection = () => (
         <div className="interactive-data-sources-intro-animation">
             <LottieAnimation
                 autoplay
-                loop
+                loop={1}
                 src="/img/interactive-data-sources/intro-animation.json"
                 role="presentation" />
         </div>


### PR DESCRIPTION
**High level description:**

The blue underline of the text 'USAspending Data Model' in the intro was off at mobile; the animations loops needed to stop after some amount of time, to comply with a11y guidelines

**Technical details:**

ended up changing the way that border is drawn and using border-bottom on the text; set all the loops to repeat only once

**JIRA Ticket:**
[DEV-9158](https://federal-spending-transparency.atlassian.net/browse/DEV-9158)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
