### PR TITLE
9074 - added numerator2 to the loans with covid data object being sen…

### DIFF
--- a/src/js/components/award/shared/awardAmounts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsChart.jsx
@@ -714,7 +714,7 @@ const AwardAmountsChart = ({
                 }
             };
 
-            const propsWithoutFileCAndOutlays = {
+            const hasOutlaysOrHasInfrastructureProps = {
                 numerator: {
                     labelPosition: 'bottom',
                     labelSortOrder: 1,
@@ -789,11 +789,24 @@ const AwardAmountsChart = ({
                                 tooltipData: getTooltipPropsByAwardTypeAndSpendingCategory('loan', 'fileCOutlay', awardAmounts)
                             }]
                         }]
+                    },
+                    numerator2: {
+                        labelSortOrder: 0,
+                        labelPosition: 'top',
+                        className: `${awardType}-outlayed`,
+                        rawValue: getAwardOutlayRawValue(awardAmounts, awardType, fileCType),
+                        value: getAwardOutlayValue(awardAmounts, awardType, fileCType),
+                        color: getAwardColor(outlayColor, infrastructureOutlayColor, fileCType),
+                        lineOffset: lineOffsetsBySpendingCategory.potential,
+                        text: 'Outlayed Amount'
                     }
                 }
                 : propsWithoutFileC;
-            if ((hasOutlays || hasInfrastructure) && !showFilecCovid) {
-                return <HorizontalSingleStackedBarViz {...propsWithoutFileCAndOutlays} />;
+            if (showFilecCovid) {
+                return <HorizontalSingleStackedBarViz {...props} />;
+            }
+            else if (hasOutlays || hasInfrastructure) {
+                return <HorizontalSingleStackedBarViz {...hasOutlaysOrHasInfrastructureProps} />;
             }
             return <RectanglePercentViz {...props} />;
         }

--- a/src/js/components/award/shared/awardAmounts/HorizontalSingleStackedBarViz.jsx
+++ b/src/js/components/award/shared/awardAmounts/HorizontalSingleStackedBarViz.jsx
@@ -258,14 +258,14 @@ const HorizontalSingleStackedBarViz = ({
                 }
                 // current label
                 chartSvg.append("foreignObject")
-                    .attr('width', x(propsArr[1]) - 10)
+                    .attr('width', x(propsArr[0]) - x(propsArr[1]) <= 270 ? x(propsArr[1]) - 10 : x(propsArr[0]) - x(propsArr[1]) - 10)
                     .attr('height', 70)
-                    .attr('x', 0)
+                    .attr('x', x(propsArr[0]) - x(propsArr[1]) <= 270 ? 0 : x(propsArr[1]) + 10)
                     .attr('y', 230)
                     .html(`<div className="award-amounts-viz-label__desc-text"><strong>${currentAmountValue}</strong><br />${currentAmountLabel}</div>`)
                     .select('div')
-                    .style('float', 'right')
-                    .style('text-align', 'right')
+                    .style('float', x(propsArr[0]) - x(propsArr[1]) <= 270 ? 'right' : 'left')
+                    .style('text-align', x(propsArr[0]) - x(propsArr[1]) <= 270 ? 'right' : 'left')
                     .style('background-color', 'white')
                     .select('strong')
                     .style('font-size', '20px');
@@ -437,7 +437,7 @@ const HorizontalSingleStackedBarViz = ({
         else {
             renderBarChartLoans();
         }
-    }, [windowWidth, propsArr]);
+    }, [windowWidth, propsArr, numerator.className, potentialAmountValue, potentialAmountLabel, outlayedAmountValue, obligatedAmountColor, outlayedAmountColor, isNffZero, obligatedAmountValue, obligatedAmountLabel, currentAmountValue, currentAmountLabel, outlayedAmountLabel]);
 
     useEffect(() => {
         const handleResize = throttle(() => {

--- a/src/js/components/award/shared/awardAmounts/HorizontalSingleStackedBarViz.jsx
+++ b/src/js/components/award/shared/awardAmounts/HorizontalSingleStackedBarViz.jsx
@@ -437,7 +437,8 @@ const HorizontalSingleStackedBarViz = ({
         else {
             renderBarChartLoans();
         }
-    }, [windowWidth, propsArr, numerator.className, potentialAmountValue, potentialAmountLabel, outlayedAmountValue, obligatedAmountColor, outlayedAmountColor, isNffZero, obligatedAmountValue, obligatedAmountLabel, currentAmountValue, currentAmountLabel, outlayedAmountLabel]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [windowWidth, propsArr]);
 
     useEffect(() => {
         const handleResize = throttle(() => {


### PR DESCRIPTION
…t to the horizontal bar chart; changed d3 in that chart to make the new label more dynamic and responsive; changed an inaccurate var name

**High level description:**

Make the Loan Awards with Covid spending use the horizontal bar chart

**Technical details:**

in commit message, title of pr
Here are two loans that have covid spending and outlays that I used for testing
ASST_NON_1750409101_7300
ASST_NON_7925788702_7300

**JIRA Ticket:**
[DEV-9074](https://federal-spending-transparency.atlassian.net/browse/DEV-9074)

**Mockup:**
in ticket

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
