### PR TITLE
9178 - made homepage ready for Prod; changed route; removed FeatureFl…

### DIFF
--- a/src/js/GlobalConstants.js
+++ b/src/js/GlobalConstants.js
@@ -20,11 +20,8 @@ const globalConstants = {
     PROD: process.env.ENV === 'prod',
     FILES_SERVER_BASE_URL: filesServerUrlByEnv[process.env.ENV],
     ARP_RELEASED: process.env.ENV !== 'prod',
-    DUNS_LABEL: 'Legacy ', // 'Legacy ' later...
-    SHOW_HOMEPAGE_UPDATE: true,
+    DUNS_LABEL: 'Legacy ',
     REQUEST_VERSION: '2020-06-01'
-
-
 };
 
 module.exports = globalConstants;

--- a/src/js/components/homepageUpdate/HomepageResources/HomepageResources.jsx
+++ b/src/js/components/homepageUpdate/HomepageResources/HomepageResources.jsx
@@ -89,8 +89,7 @@ const cardObjects = [
                 <FontAwesomeIcon icon="arrow-right" />
             </>
         ),
-        // todo - change this path when the url changes to /homepage
-        buttonLink: '/homepage_update/?glossary&',
+        buttonLink: '/?glossary&',
         action: () => Analytics.event({
             category: 'Homepage',
             action: 'Link',

--- a/src/js/components/homepageUpdate/HomepageUpdate.jsx
+++ b/src/js/components/homepageUpdate/HomepageUpdate.jsx
@@ -13,27 +13,25 @@ import HomepageExploreToggle from "./HomepageExploreToggle/HomepageExploreToggle
 import HomepageResources from "./HomepageResources/HomepageResources";
 import ReadyToGetStarted from "./ReadyToGetStarted/ReadyToGetStarted";
 import HomepageFirstRow from "./HomepageFirstRow/HomepageFirstRow";
-import FeatureFlag from "../sharedComponents/FeatureFlag";
 
 require('pages/homepageUpdate/homepageUpdate.scss');
 
 const HomepageUpdate = () => (
-    <FeatureFlag>
-        <PageWrapper
-            pageName="Homepage"
-            classNames="usa-da-home-page"
-            noHeader
-            metaTagProps={{ ...homePageMetaTags }}>
-            <main id="main-content" className="main-content homepage-update-content">
-                <HeroUpdate />
-                <SummaryStats />
-                <HomepageFirstRow />
-                <AwardSearch />
-                <HomepageExploreToggle />
-                <HomepageResources />
-                <ReadyToGetStarted />
-            </main>
-        </PageWrapper>
-    </FeatureFlag>);
+    <PageWrapper
+        pageName="Homepage"
+        classNames="usa-da-home-page"
+        noHeader
+        metaTagProps={{ ...homePageMetaTags }}>
+        <main id="main-content" className="main-content homepage-update-content">
+            <HeroUpdate />
+            <SummaryStats />
+            <HomepageFirstRow />
+            <AwardSearch />
+            <HomepageExploreToggle />
+            <HomepageResources />
+            <ReadyToGetStarted />
+        </main>
+    </PageWrapper>
+);
 
 export default HomepageUpdate;

--- a/src/js/containers/router/RouterRoutes.js
+++ b/src/js/containers/router/RouterRoutes.js
@@ -5,7 +5,6 @@
 
 import React from 'react';
 
-const Homepage = React.lazy(() => import('components/homepage/Homepage').then((comp) => comp));
 const HomepageUpdate = React.lazy(() => import('components/homepageUpdate/HomepageUpdate').then((comp) => comp));
 const SearchContainer = React.lazy(() => import('containers/search/SearchContainer').then((comp) => comp));
 const SearchContainerRedirect = React.lazy(() => import('containers/search/SearchContainer').then((module) => ({ default: module.SearchContainerRedirect })));

--- a/src/js/containers/router/RouterRoutes.js
+++ b/src/js/containers/router/RouterRoutes.js
@@ -46,11 +46,6 @@ const TempPage = React.lazy(() => import('components/tempPage').then((comp) => c
 export const routes = [
     {
         path: `/`,
-        component: Homepage,
-        exact: true
-    },
-    {
-        path: `/homepage_update`,
         component: HomepageUpdate,
         exact: true
     },


### PR DESCRIPTION
…ag; removed global constant for homepage_update; updated glossary link in resources section

**High level description:**

Make homepage show in Prod

**Technical details:**

in commit message, title of pr

**JIRA Ticket:**
[DEV-9178](https://federal-spending-transparency.atlassian.net/browse/DEV-9178)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
