### PR TITLE
Bug/9226 loans with covid spending chart

### DIFF
--- a/src/js/components/award/shared/awardAmounts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsChart.jsx
@@ -548,11 +548,6 @@ const AwardAmountsChart = ({
         const hasInfrastructure = fileCType === "infrastructure";
         const hasOutlays = awardAmounts._combinedOutlay > 0 || awardAmounts._totalOutlay > 0;
 
-        console.log('isNormal', isNormal);
-        console.log('showFilecCovid', showFilecCovid);
-        console.log('hasInfrastructure', hasInfrastructure);
-        console.log('hasOutlays', hasOutlays);
-
         if (asstAwardTypesWithSimilarAwardAmountData.includes(type) && isNormal) {
             const isNffZero = awardAmounts._nonFederalFunding === 0;
 

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsChart.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsChart.jsx
@@ -548,6 +548,11 @@ const AwardAmountsChart = ({
         const hasInfrastructure = fileCType === "infrastructure";
         const hasOutlays = awardAmounts._combinedOutlay > 0 || awardAmounts._totalOutlay > 0;
 
+        console.log('isNormal', isNormal);
+        console.log('showFilecCovid', showFilecCovid);
+        console.log('hasInfrastructure', hasInfrastructure);
+        console.log('hasOutlays', hasOutlays);
+
         if (asstAwardTypesWithSimilarAwardAmountData.includes(type) && isNormal) {
             const isNffZero = awardAmounts._nonFederalFunding === 0;
 

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsSection.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsSection.jsx
@@ -34,8 +34,6 @@ const AwardAmountsSection = ({
 
     const tabTypes = generateDefcTabs(awardOverview);
 
-    console.log('active', active);
-
     return (
         <AwardSection type="column" className="award-viz award-amounts">
             <div className="award__col__content">

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsSection.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsSection.jsx
@@ -25,7 +25,7 @@ const AwardAmountsSection = ({
 }) => {
     const [active, setActive] = useState("overall");
 
-    const spendingScenario = determineSpendingScenarioByAwardType(awardType, awardOverview, active === "infrastructure");
+    const spendingScenario = determineSpendingScenarioByAwardType(awardType, awardOverview, active);
     const tooltip = getToolTipBySectionAndAwardType('awardAmounts', awardType);
 
     const switchTab = (tab) => {
@@ -33,6 +33,8 @@ const AwardAmountsSection = ({
     };
 
     const tabTypes = generateDefcTabs(awardOverview);
+
+    console.log('active', active);
 
     return (
         <AwardSection type="column" className="award-viz award-amounts">

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
@@ -50,6 +50,10 @@ const AwardAmountsTable = ({
      * so we're relying on the parent in this case because we cant deduce the spending scenario
      **/
 
+    console.log('awardData', awardData);
+    console.log('spendingScenario', spendingScenario);
+    console.log('showFileC', showFileC);
+
     const getOverSpendingRow = (awardAmounts = awardData, scenario = spendingScenario, type = awardAmountType) => {
         switch (scenario) {
             case ('normal'):
@@ -114,7 +118,8 @@ const AwardAmountsTable = ({
                     hide = true;
                 }
             });
-        } else {
+        }
+        else {
             allExclusions.forEach((item) => {
                 if (title === item) {
                     hide = true;

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
@@ -49,11 +49,6 @@ const AwardAmountsTable = ({
      * irrespective of whether the award exceedsPotential or exceedsCurrent
      * so we're relying on the parent in this case because we cant deduce the spending scenario
      **/
-
-    console.log('awardData', awardData);
-    console.log('spendingScenario', spendingScenario);
-    console.log('showFileC', showFileC);
-
     const getOverSpendingRow = (awardAmounts = awardData, scenario = spendingScenario, type = awardAmountType) => {
         switch (scenario) {
             case ('normal'):

--- a/src/js/helpers/awardAmountHelper.js
+++ b/src/js/helpers/awardAmountHelper.js
@@ -123,7 +123,6 @@ export const determineLoanSpendingScenario = (awardAmountObj, covidSpending) => 
     if (_subsidy < 0 || _faceValue < 0) return 'insufficientData';
 
     if (covidSpending) {
-        console.log('in new block');
         if (_totalOutlay > _fileCObligated || _totalOutlay > _subsidy || _totalOutlay > _faceValue || _fileCObligated > _subsidy || _fileCObligated > _faceValue || _subsidy > _faceValue) return 'insufficientData';
         if (_totalOutlay <= _fileCObligated <= _subsidy <= _faceValue) return 'normal';
     }

--- a/src/js/helpers/awardAmountHelper.js
+++ b/src/js/helpers/awardAmountHelper.js
@@ -114,18 +114,20 @@ export const determineFileCSpendingScenario = (awardType, awardAmountObj) => {
     return (fileCScenario === 'normal') ? 'normal' : 'insufficientData';
 };
 
-export const determineLoanSpendingScenario = (awardAmountObj) => {
+export const determineLoanSpendingScenario = (awardAmountObj, covidSpending) => {
     const {
-        _totalOutlay, _totalObligation, _subsidy, _faceValue
+        _totalOutlay, _totalObligation, _subsidy, _faceValue, _fileCObligated
     } = awardAmountObj;
-
-    console.log('_totalOutlay', _totalOutlay);
-    console.log('_totalObligation', _totalObligation);
-    console.log('_subsidy', _subsidy);
-    console.log('_faceValue', _faceValue);
 
     if (_subsidy === 0 && _faceValue === 0) return 'insufficientData';
     if (_subsidy < 0 || _faceValue < 0) return 'insufficientData';
+
+    if (covidSpending) {
+        console.log('in new block');
+        if (_totalOutlay > _fileCObligated || _totalOutlay > _subsidy || _totalOutlay > _faceValue || _fileCObligated > _subsidy || _fileCObligated > _faceValue || _subsidy > _faceValue) return 'insufficientData';
+        if (_totalOutlay <= _fileCObligated <= _subsidy <= _faceValue) return 'normal';
+    }
+
     if (_totalOutlay > _totalObligation || _totalOutlay > _subsidy || _totalOutlay > _faceValue || _totalObligation > _subsidy || _totalObligation > _faceValue || _subsidy > _faceValue) return 'insufficientData';
 
     if (_totalObligation === 0 && _totalOutlay === 0) {
@@ -150,8 +152,8 @@ export const determineInfrastructureSpendingScenario = (awardType, awardAmountOb
     return (fileCScenario === 'normal') ? 'normal' : 'insufficientData';
 };
 
-export const determineSpendingScenarioByAwardType = (awardType, awardAmountObj, infrastructure) => {
-    if (infrastructure) {
+export const determineSpendingScenarioByAwardType = (awardType, awardAmountObj, activeTab) => {
+    if (activeTab === "infrastructure") {
         if (determineInfrastructureSpendingScenario(awardType, awardAmountObj) !== 'normal') return 'insufficientData';
     }
 
@@ -161,7 +163,7 @@ export const determineSpendingScenarioByAwardType = (awardType, awardAmountObj, 
     }
 
     if (awardType === 'loan') {
-        return (determineLoanSpendingScenario(awardAmountObj));
+        return (determineLoanSpendingScenario(awardAmountObj, activeTab === 'covid'));
     }
 
     // Small, bigger, and biggest define the expected ratio between spending categories

--- a/src/js/helpers/awardAmountHelper.js
+++ b/src/js/helpers/awardAmountHelper.js
@@ -119,6 +119,11 @@ export const determineLoanSpendingScenario = (awardAmountObj) => {
         _totalOutlay, _totalObligation, _subsidy, _faceValue
     } = awardAmountObj;
 
+    console.log('_totalOutlay', _totalOutlay);
+    console.log('_totalObligation', _totalObligation);
+    console.log('_subsidy', _subsidy);
+    console.log('_faceValue', _faceValue);
+
     if (_subsidy === 0 && _faceValue === 0) return 'insufficientData';
     if (_subsidy < 0 || _faceValue < 0) return 'insufficientData';
     if (_totalOutlay > _totalObligation || _totalOutlay > _subsidy || _totalOutlay > _faceValue || _totalObligation > _subsidy || _totalObligation > _faceValue || _subsidy > _faceValue) return 'insufficientData';


### PR DESCRIPTION
**High level description:**

Loans with Covid spending weren't being charted when they should have been

**Technical details:**

Added a path for Loans with covid spending to use the covid obligation number rather than total obligation when making comparisons to determine if chart can be drawn

**JIRA Ticket:**
[DEV-9226](https://federal-spending-transparency.atlassian.net/browse/DEV-9226)

**Mockup:**

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
