### PR TITLE
9252 - changed 'Data Sources' to 'Data Model'; changed the link in th…

### DIFF
--- a/src/js/components/homepageUpdate/HomepageResources/HomepageResources.jsx
+++ b/src/js/components/homepageUpdate/HomepageResources/HomepageResources.jsx
@@ -9,7 +9,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import CardContainer from "../../sharedComponents/commonCards/CardContainer";
 import CardBody from "../../sharedComponents/commonCards/CardBody";
 import CardButton from "../../sharedComponents/commonCards/CardButton";
-import ExternalLink from "../../sharedComponents/ExternalLink";
 import Analytics from '../../../helpers/analytics/Analytics';
 
 const cardObjects = [
@@ -61,19 +60,21 @@ const cardObjects = [
                 <FontAwesomeIcon icon="sitemap" color="#0081a1" size="lg" />
             </div>
         ),
-        headline: 'Data Sources',
+        headline: 'Data Model',
         text: 'Learn how our data is organized',
         buttonText: (
             <>
-                <ExternalLink url="https://fiscal.treasury.gov/data-transparency/DAIMS-current.html" isCard>View the model&nbsp;&nbsp;</ExternalLink>
+                View the model&nbsp;&nbsp;
                 <FontAwesomeIcon icon="arrow-right" />
             </>
         ),
+        buttonLink: "https://fiscal.treasury.gov/data-transparency/DAIMS-current.html",
         action: () => Analytics.event({
             category: 'Homepage',
             action: 'Link',
             label: 'data model card'
-        })
+        }),
+        govLink: true
     },
     {
         icon: (
@@ -132,6 +133,7 @@ const HomepageResources = () => (
                                             variant="text"
                                             text={card.buttonText}
                                             link={card.buttonLink}
+                                            govLink={card.govLink}
                                             action={card.action} />
                                     </CardBody>
                                 </CardContainer>

--- a/src/js/components/sharedComponents/commonCards/CardButton.jsx
+++ b/src/js/components/sharedComponents/commonCards/CardButton.jsx
@@ -54,7 +54,13 @@ const CardButton = ({
                     className={`card__button--secondary ${variantMapper[variant]}`}
                     role="button"
                     aria-label={`${text}`}>
-                    <a onClick={action} href={link}>{text}</a>
+                    <a
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={action}
+                        href={link}>
+                        {text}
+                    </a>
                 </div>
             )
                 :


### PR DESCRIPTION
… at card to be a govLink in CardButton

**High level description:**

Changes to the Resources section third card

**Technical details:**

'Data Sources' to 'Data Model'; get rid of modal saying you're leaving a gov site 

**JIRA Ticket:**
[DEV-9252](https://federal-spending-transparency.atlassian.net/browse/DEV-9252)

**Mockup:**


The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
