### PR TITLE
Fix - 8535 update cfda program labels

### DIFF
--- a/src/js/GlobalConstants.js
+++ b/src/js/GlobalConstants.js
@@ -14,7 +14,7 @@ const globalConstants = {
     API: process.env.USASPENDING_API,
     LOCAL: false,
     PERF_LOG: false,
-    MAPBOX_TOKEN: process.env.MAPBOX_TOKEN,
+    MAPBOX_TOKEN: 'pk.eyJ1IjoidXNhc3BlbmRpbmciLCJhIjoiY2l6ZnZjcmh0MDBtbDMybWt6NDR4cjR6ZSJ9.zsCqjJgrMDOA-i1RcCvGvg',
     QAT: (process.env.ENV === 'qat' || process.env.ENV === 'sandbox'),
     STAGING: (process.env.ENV === 'staging'),
     PROD: process.env.ENV === 'prod',

--- a/src/js/components/covid19/Covid19Tooltips.jsx
+++ b/src/js/components/covid19/Covid19Tooltips.jsx
@@ -34,7 +34,7 @@ export const AwardSpendingAgencyTT = () => (
 
 export const AwardSpendingCfdaTT = () => (
     <div className="covid-profile-tt">
-        <h2 className="tooltip__title">Award Spending by Assistance Listings (CFDA Programs))</h2>
+        <h2 className="tooltip__title">Award Spending by Assistance Listing (CFDA Programs))</h2>
         <div className="tooltip__text ul-override">
             <p>
                 This section shows a breakdown of award spending according to CFDA Program.

--- a/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
+++ b/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
@@ -141,7 +141,7 @@ const SpendingByCFDA = ({ publicLaw, handleExternalLinkClick }) => {
             }
             <div className="body__narrative-description">
                 <p>
-                    Overall financial assistance awards represent the vast majority of COVID-19 appropriated spending. <span className="glossary-term">Assistance Listings are programs</span> <GlossaryLink term="a" /> like
+                    Overall financial assistance awards represent the vast majority of COVID-19 appropriated spending. <span className="glossary-term">Assistance Listings</span>&nbsp;<GlossaryLink term="assistance-listings-cfda-program" /> are programs like
                     <a
                         href="https://beta.sam.gov/fal/ccb612a4c4bb4ba98dbd427638a63029/view?keywords=snap&sort=-relevance&index=cfda&is_active=true&page=1"
                         onClick={handleClick}>

--- a/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
+++ b/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
@@ -141,13 +141,13 @@ const SpendingByCFDA = ({ publicLaw, handleExternalLinkClick }) => {
             }
             <div className="body__narrative-description">
                 <p>
-                    Overall financial assistance awards represent the vast majority of COVID-19 appropriated spending. The <span className="glossary-term">Catalog of Federal Domestic Assistance (CFDA) Programs</span> <GlossaryLink term="cfda-program" />, also known as Assistance Listings, are programs, like
+                    Overall financial assistance awards represent the vast majority of COVID-19 appropriated spending. <span className="glossary-term">Assistance Listings are programs</span> <GlossaryLink term="a" /> like
                     <a
                         href="https://beta.sam.gov/fal/ccb612a4c4bb4ba98dbd427638a63029/view?keywords=snap&sort=-relevance&index=cfda&is_active=true&page=1"
                         onClick={handleClick}>
                         &nbsp;Supplemental Nutrition Assistance Program (SNAP)&nbsp;
                     </a>
-                    that provide financial assistance to individuals, organizations, businesses, or state, local, or tribal governments. All financial assistance awards must be associated with a CFDA Program and be explicitly authorized by law. In this section, you will see awards that CFDA Programs have funded in response to COVID-19.
+                    that provide financial assistance to individuals, organizations, businesses, or state, local, or tribal governments. All financial assistance awards must be associated with a Assistance Listing and be explicitly authorized by law. In this section, you will see awards that Assistance Listings have funded in response to COVID-19.
                 </p>
             </div>
             <div ref={moreOptionsTabsRef}>

--- a/src/js/containers/covid19/helpers/covid19.jsx
+++ b/src/js/containers/covid19/helpers/covid19.jsx
@@ -93,7 +93,7 @@ export const componentByCovid19Section = (publicLaw, handleExternalLinkClick) =>
         headerText: awardSpendingText,
         showInMenu: true,
         showInMainSection: true,
-        title: 'Award Spending by Assistance Listings'
+        title: 'Award Spending by Assistance Listing'
     },
     data_sources_and_methodology: {
         showInMenu: true,

--- a/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
+++ b/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
@@ -614,7 +614,7 @@ export class TopFilterBarContainer extends React.Component {
 
         if (selected) {
             filter.code = 'selectedCFDA';
-            filter.name = 'Assistance Listings';
+            filter.name = 'Assistance Listing';
             return filter;
         }
 


### PR DESCRIPTION
**High level description:**

Responded to QA feedback -
1) Advanced Search (AC -2) - Change Assistance Listings to Assistance Listing
2) Covid Page (AC 8 and 9) - Change Award Spending by Assistance Listings to Award Spending by Assistance Listing for both AC
3) Covid Page (AC 11) - In the Award Spending by Listing section first paragraph, fix the link to the Assistance Listings Glossary term and update the paragraph text to -
“Overall financial assistance awards represent the vast majority of COVID-19 appropriated spending. Assistance Listings [[glossary link](https://www.usaspending.gov/disaster/covid-19?glossary=cfda-program&publicLaw=all)] are programs like the Supplemental Nutrition Assistance Program (SNAP) that provide financial assistance to individuals, organizations, businesses, or state, local, or tribal governments. All financial assistance awards must be associated with an Assistance Listing and be explicitly authorized by law. In this section, you will see awards that Assistance Listings have funded in response to COVID-19.”

**Technical details:**

Just text changes and added the glossary term

**JIRA Ticket:**
[DEV-8535](https://federal-spending-transparency.atlassian.net/browse/DEV-8535)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket


Reviewer(s):
- [ ] Code review complete
