### PR TITLE
9235 - added ui for search in the about the data drawer; updated some…

### DIFF
--- a/src/_scss/components/aboutTheDataSidebar/_header.scss
+++ b/src/_scss/components/aboutTheDataSidebar/_header.scss
@@ -1,29 +1,20 @@
 .usa-atd-header {
     width: 100%;
-    min-height: 200px;
-
-    padding: 20px;
-
+    padding: 24px;
     background-color: $cyan-vivid-80;
+    color: $theme-color-headline-inverse;
 
     @include clearfix();
 
     .close-button {
         @include button-unstyled;
-        width: 30px;
-        height: 30px;
-
-        position: relative;
+        width: 16px;
+        height: 16px;
         float: right;
 
         svg {
-            position: absolute;
-            top: 7px;
-            left: 7px;
-
-            width: 17px;
-            height: 17px;
-
+            width: 16px;
+            height: 16px;
             fill: $color-white;
         }
 
@@ -46,7 +37,10 @@
         padding: 0;
     }
 
-    .atd-example {
+    .usa-atd-example {
+        font-size: 14px;
+        line-height: 1.5;
+        color: $theme-color-body-inverse;
         font-style: italic;
     }
 

--- a/src/_scss/components/aboutTheDataSidebar/_searchBar.scss
+++ b/src/_scss/components/aboutTheDataSidebar/_searchBar.scss
@@ -1,36 +1,34 @@
 .atd-search-bar {
     position: relative;
-    width: 250px;
-    height: 34px;
-
-    margin: 15px 0;
+    width: 262px;
+    height: 32px;
+    margin: 16px 0;
 
     input.search-field {
         position: absolute;
         left: 0;
-
         font-size: 14px;
-        line-height: 17px;
-        color: $color-base;
-
-        padding: 10px;
-        padding-right: 25px;
-
-        width: 250px;
-        height: 34px;
+        line-height: 1.5;
+        color: $color-gray-medium;
+        padding: 8px;
+        width: 262px;
+        height: 32px;
     }
 
     .search-button {
         position: absolute;
-        right: 10px;
-        top: 10px;
+        right: 8px;
+        top: 8px;
+        bottom: 8px;
 
         @include button-unstyled;
-        width: 14px;
-        height: 14px;
+        width: 16px;
+        height: 16px;
 
         svg {
-            fill: $color-gray;
+            width: 16px;
+            height: 16px;
+            fill: $gray-cool-60;
         }
     }
 }

--- a/src/js/components/aboutTheDataSidebar/AboutTheDataHeader.jsx
+++ b/src/js/components/aboutTheDataSidebar/AboutTheDataHeader.jsx
@@ -2,9 +2,11 @@
  * AboutTheDataHeader.jsx
  * Created by Nick Torres 11/2/22
  */
+
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import * as Icons from 'components/sharedComponents/icons/Icons';
+import AboutTheDataSearchBar from "./AboutTheDataSearchBar";
 
 const propTypes = {
     children: PropTypes.element,
@@ -33,6 +35,12 @@ const AboutTheDataHeader = (props) => {
                 </button>
             </div>
             <h1 tabIndex={-1} className="usa-atd-header__title">About The Data</h1>
+
+            <AboutTheDataSearchBar />
+
+            <div className="usa-atd-example">
+                Example: &quot;Award Data&quot;
+            </div>
         </div>
     );
 };

--- a/src/js/components/aboutTheDataSidebar/AboutTheDataSearchBar.jsx
+++ b/src/js/components/aboutTheDataSidebar/AboutTheDataSearchBar.jsx
@@ -1,0 +1,42 @@
+/**
+ * AboutTheDataSearchBar.jsx
+ * Created by Brian Petway 11/30/22
+ */
+
+import React from 'react';
+import { Search } from 'components/sharedComponents/icons/Icons';
+
+const AboutTheDataSearchBar = () => {
+    const performSearch = (term) => {
+        console.log('search function engaged with term', term);
+    };
+
+    const changedSearchValue = (e) => {
+        performSearch(e.target.value);
+    };
+
+    const submitSearch = (e) => {
+        e.preventDefault();
+        performSearch(e.target[0].value);
+    };
+
+    return (
+        <div className="atd-search-bar">
+            <form onSubmit={submitSearch}>
+                <input
+                    className="search-field"
+                    type="text"
+                    placeholder="Search for a topic..."
+                    onChange={changedSearchValue} />
+                <button
+                    aria-label="Search"
+                    className="search-button"
+                    type="submit">
+                    <Search alt="Search" />
+                </button>
+            </form>
+        </div>
+    );
+};
+
+export default AboutTheDataSearchBar;

--- a/src/js/components/glossary/GlossaryHeader.jsx
+++ b/src/js/components/glossary/GlossaryHeader.jsx
@@ -13,7 +13,6 @@ const propTypes = {
     closeGlossary: PropTypes.func
 };
 
-
 const GlossaryHeader = (props) => {
     const closeButtonRef = useRef(null);
     useEffect(() => {

--- a/src/js/components/glossary/GlossarySearchBar.jsx
+++ b/src/js/components/glossary/GlossarySearchBar.jsx
@@ -41,7 +41,7 @@ export default class GlossarySearchBar extends React.Component {
         this.props.setSearchValue(term);
 
         if (term.length > 0 && term.length < 3) {
-            // do not perform a search because the search term is too search
+            // do not perform a search because the search term is too short
             // but DO allow an empty string (which indicates a request for the full list)
             return;
         }


### PR DESCRIPTION
… other styles to match mock

**High level description:**

Add the search bar to About the Data, but only the UI, no search functionality yet

**Technical details:**

Copied the pattern from the Glossary but made some style changes based on the current mock; also updated some styles, margins in the header to match mock; added a dummy function to let you know when search will happen

**JIRA Ticket:**
[DEV-9235](https://federal-spending-transparency.atlassian.net/browse/DEV-9235)

**Mockup:**
https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55/screen/638656c04dc49a7d1847997c

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
