### PR TITLE
Mod 9187 removed the data sources/quality from about page

### DIFF
--- a/src/js/components/about/AboutContent.jsx
+++ b/src/js/components/about/AboutContent.jsx
@@ -6,8 +6,6 @@
 import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { find, throttle } from 'lodash';
-import { useDispatch } from 'react-redux';
-import { showModal } from 'redux/actions/modal/modalActions';
 import { useQueryParams } from 'helpers/queryParams';
 import { stickyHeaderHeight } from 'dataMapping/stickyHeader/stickyHeader';
 import { getStickyBreakPointForSidebar } from 'helpers/stickyHeaderHelper';
@@ -16,8 +14,6 @@ import Sidebar from '../sharedComponents/sidebar/Sidebar';
 
 import Mission from './Mission';
 import Background from './Background';
-import DataSources from './DataSources';
-import DataQuality from './DataQuality';
 import MoreInfo from './MoreInfo';
 import Contact from './Contact';
 import Development from './Development';
@@ -78,13 +74,6 @@ const AboutContent = () => {
         setActiveSection(section);
     };
 
-    const dispatch = useDispatch();
-    const onExternalLinkClick = (e) => {
-        e.persist();
-        if (e?.target) {
-            dispatch(showModal(e.target.parentNode.getAttribute('data-href') || e.target.getAttribute('data-href') || e.target.value));
-        }
-    };
 
     useEffect(throttle(() => {
         // prevents a console error about react unmounted component leak

--- a/src/js/components/about/AboutContent.jsx
+++ b/src/js/components/about/AboutContent.jsx
@@ -35,14 +35,6 @@ const aboutSections = [
         label: 'Background'
     },
     {
-        section: 'about-the-data',
-        label: 'Data Sources'
-    },
-    {
-        section: 'data-quality',
-        label: 'Data Quality'
-    },
-    {
         section: 'development',
         label: 'Development and Releases'
     },
@@ -126,8 +118,6 @@ const AboutContent = () => {
                 <div className="about-padded-content">
                     <Mission />
                     <Background />
-                    <DataSources onExternalLinkClick={onExternalLinkClick} />
-                    <DataQuality onExternalLinkClick={onExternalLinkClick} />
                     <Development />
                     <Careers />
                     <Licensing />


### PR DESCRIPTION
**High level description:**

Removed both the data source and data quality from the about page

**Technical details:**
inside of AboutContent component, I removed data source and quality form the side bar and the actual page its self. 

**JIRA Ticket:**
[DEV-9187](https://federal-spending-transparency.atlassian.net/browse/DEV-9187)

**Mockup:**
NO mocks

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
