### PR TITLE
9346 - reverted several instances of 'data-sources' that were changed…

### DIFF
--- a/scripts/sitemaps/pages.js
+++ b/scripts/sitemaps/pages.js
@@ -21,7 +21,7 @@ const routes = [
     '/state',
     '/recipient',
     '/disaster/covid-19',
-    '/disaster/covid-19/about-the-data',
+    '/disaster/covid-19/data-sources',
     '/data-dictionary'
 ];
 

--- a/src/js/components/about/AboutContent.jsx
+++ b/src/js/components/about/AboutContent.jsx
@@ -35,7 +35,7 @@ const aboutSections = [
         label: 'Background'
     },
     {
-        section: 'about-the-data',
+        section: 'data-sources',
         label: 'Data Sources'
     },
     {

--- a/src/js/components/aboutTheData/DataSourcesAndMethodologiesPage.jsx
+++ b/src/js/components/aboutTheData/DataSourcesAndMethodologiesPage.jsx
@@ -56,9 +56,9 @@ const sections = [
     }
 ];
 
-require('pages/aboutTheData/aboutTheData.scss');
+require('pages/data-sources/index.scss');
 
-const jumpToSection = createJumpToSectionForSidebar("about-the-data", sections.reduce((acc, obj) => ({
+const jumpToSection = createJumpToSectionForSidebar("data-sources", sections.reduce((acc, obj) => ({
     ...acc,
     [obj.section]: { title: obj.label }
 }), {}));

--- a/src/js/components/covid19/DataSourcesAndMethodologiesPage.jsx
+++ b/src/js/components/covid19/DataSourcesAndMethodologiesPage.jsx
@@ -69,7 +69,7 @@ const sections = [
     }
 ];
 
-require('pages/aboutTheData/aboutTheData.scss');
+require('pages/data-sources/index.scss');
 
 const getDefCValues = (errorMsg, isLoading, codes) => {
     if (isLoading) return "Loading...";
@@ -115,7 +115,7 @@ const renderDefCodes = (errorMsg, isLoading, codes) => {
         ));
 };
 
-const jumpToSection = createJumpToSectionForSidebar("about-the-data", sections.reduce((acc, obj) => ({
+const jumpToSection = createJumpToSectionForSidebar("data-sources", sections.reduce((acc, obj) => ({
     ...acc,
     [obj.section]: { title: obj.label }
 }), {}));
@@ -153,7 +153,7 @@ export default () => {
     };
 
     const handleShare = (name) => {
-        handleShareOptionClick(name, "disaster/covid-19/about-the-data", getEmailSocialShareData);
+        handleShareOptionClick(name, "disaster/covid-19/data-sources", getEmailSocialShareData);
     };
 
     return (
@@ -167,7 +167,7 @@ export default () => {
             toolBarComponents={[
                 <ShareIcon
                     onShareOptionClick={handleShare}
-                    url={getBaseUrl("disaster/covid-19/about-the-data")} />
+                    url={getBaseUrl("disaster/covid-19/data-sources")} />
             ]}>
             <>
                 {dataDisclaimerBanner !== 'hide' && (

--- a/src/js/containers/router/RouterRoutes.js
+++ b/src/js/containers/router/RouterRoutes.js
@@ -182,12 +182,12 @@ export const routes = [
         exact: true
     },
     {
-        path: '/submission-statistics/about-the-data',
+        path: '/submission-statistics/data-sources',
         component: SubmissionStatisticsDataSources,
         exact: true
     },
     {
-        path: '/disaster/covid-19/about-the-data',
+        path: '/disaster/covid-19/data-sources',
         component: DataSourcesAndMethodologiesPage,
         exact: true
     },

--- a/src/js/dataMapping/navigation/menuOptions.jsx
+++ b/src/js/dataMapping/navigation/menuOptions.jsx
@@ -77,7 +77,7 @@ export const resourceOptions = [
     },
     {
         label: 'Data Sources',
-        type: 'about-the-data',
+        type: 'data-sources',
         enabled: true,
         url: '/data-sources',
         callToAction: 'Explore the Data Sources',


### PR DESCRIPTION
… to 'about-the-data'

**High level description:**

Covid and Submission Statistics pages were not loading; the About page Data Sources section scrollTo was not working

**Technical details:**

reverted several instances of 'data-sources' changed to 'about-the-data' due to find and replace

**JIRA Ticket:**
[DEV-9346](https://federal-spending-transparency.atlassian.net/browse/DEV-9346)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
