### PR TITLE
9299 - added function to escape special chars in the regexp

### DIFF
--- a/src/js/components/aboutTheDataSidebar/AboutTheData.jsx
+++ b/src/js/components/aboutTheDataSidebar/AboutTheData.jsx
@@ -48,6 +48,10 @@ const AboutTheData = (props) => {
 
         const results = {};
 
+        function escapeRegExp(stringToGoIntoTheRegex) {
+            return stringToGoIntoTheRegex.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+        }
+
         // look for search term in each 'fields.name' in each section
         Object.entries(schema).filter(([, section]) => section.heading !== undefined).forEach(([sectionKey, section]) => {
             const matchingFields = section.fields.filter((field) =>
@@ -58,7 +62,7 @@ const AboutTheData = (props) => {
                 const markupFields = [];
                 matchingFields.forEach((field) => {
                     // add classname to the search term in the results
-                    const regex = new RegExp(term, 'gi');
+                    const regex = new RegExp(escapeRegExp(term), 'gi');
                     const markupName = field.name.replace(regex, '<match>$&<match>');
                     const parts = markupName.split('<match>');
                     const markup = <>

--- a/src/js/components/aboutTheDataSidebar/AboutTheData.jsx
+++ b/src/js/components/aboutTheDataSidebar/AboutTheData.jsx
@@ -12,7 +12,7 @@ import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Scrollbars } from 'react-custom-scrollbars';
 import Mousetrap from "mousetrap";
-import { getDrilldownEntrySectionAndId } from 'helpers/aboutTheDataSidebarHelper';
+import { getDrilldownEntrySectionAndId, escapeRegExp } from 'helpers/aboutTheDataSidebarHelper';
 import AboutTheDataHeader from "./AboutTheDataHeader";
 import AboutTheDataListView from "./AboutTheDataListView";
 import AboutTheDataDrilldown from "./AboutTheDataDrilldown";
@@ -47,10 +47,6 @@ const AboutTheData = (props) => {
         }
 
         const results = {};
-
-        function escapeRegExp(stringToGoIntoTheRegex) {
-            return stringToGoIntoTheRegex.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
-        }
 
         // look for search term in each 'fields.name' in each section
         Object.entries(schema).filter(([, section]) => section.heading !== undefined).forEach(([sectionKey, section]) => {

--- a/src/js/helpers/aboutTheDataSidebarHelper.js
+++ b/src/js/helpers/aboutTheDataSidebarHelper.js
@@ -48,3 +48,6 @@ export const getDrilldownEntrySectionAndId = (schema, slug) => {
         }
     }
 };
+
+export const escapeRegExp = (stringToGoIntoTheRegex) => stringToGoIntoTheRegex.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+

--- a/tests/helpers/aboutTheDataSidebarHelper-test.js
+++ b/tests/helpers/aboutTheDataSidebarHelper-test.js
@@ -4,7 +4,7 @@
  */
 
 import schema from 'dataMapping/aboutTheDataSchema';
-import { getDrilldownEntry, getDrilldownEntrySectionAndId } from 'helpers/aboutTheDataSidebarHelper';
+import { getDrilldownEntry, getDrilldownEntrySectionAndId, escapeRegExp } from 'helpers/aboutTheDataSidebarHelper';
 
 describe('About the Data Sidebar Helpers', () => {
     it('should return the correct entry object', () => {
@@ -26,5 +26,13 @@ describe('About the Data Sidebar Helpers', () => {
         expect(entry.entryId).toEqual(3);
     });
 
+    it('should add an escape for special chars in the regexp', () => {
+        const term = '-/\\^$*+?.()|[]{}';
+        const result = escapeRegExp(term);
+        // this is a weird one; i'm open to better ideas
+        // and there are still more special chars that we could add to the list
+        // but it's doing what it needs to do for now
+        expect(result).toBe('\\-\\/\\\\\\^\\$\\*\\+\\?\\.\\(\\)\\|\\[\\]\\{\\}');
+    });
 });
 


### PR DESCRIPTION
**High level description:**

Added a function to escape special chars in the regexp used in search; because search wasn't working with '(', '-', etc.

**Technical details:**



**JIRA Ticket:**
[DEV-9299](https://federal-spending-transparency.atlassian.net/browse/DEV-9299)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
