### PR TITLE
9344 - added the markdown link component back the  file-d2 file

### DIFF
--- a/src/content/about-the-data/file-d2.mdx
+++ b/src/content/about-the-data/file-d2.mdx
@@ -8,7 +8,7 @@ submit transaction-level data for financial assistance awards such
 as grants, loans, and direct payments. File D2 contains information
 about award transaction obligation, award transaction description,
 action date, awarding agency, recipient code, recipient location,
-place of performance, and assistance listing (or CFDA program), 
+place of performance, and assistance listing (or CFDA program),
 among other details.
 
-New data must be submitted to USAspending.gov every month (for loans) or every two weeks (for other financial assistance award types). See the entry below on [Frequency of Updates to Prime Award Data for Financial Assistance.](https://fsgov-my.sharepoint.com/personal/andrew_ly_fiscal_treasury_gov/Documents/Link%20to%20entry%20below)
+New data must be submitted to USAspending.gov every month (for loans) or every two weeks (for other financial assistance award types). See the entry below on <AboutTheDataMarkdownLink slug="frequency-of-updates-to-prime-award-data-for-financial-assistance" name='Frequency of Updates to Prime Award Data for Financial Assistance' />.


### PR DESCRIPTION
**High level description:**

The link in File D2 stopped working

**Technical details:**

Had to revert back to the code that was overwritten somehow, using the markdownLink component

**JIRA Ticket:**
[DEV-9344](https://federal-spending-transparency.atlassian.net/browse/DEV-9344)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
