### PR TITLE
Mod 9370 add g analytics to atd

### DIFF
--- a/src/js/components/aboutTheDataSidebar/AboutTheDataListView.jsx
+++ b/src/js/components/aboutTheDataSidebar/AboutTheDataListView.jsx
@@ -17,6 +17,12 @@ const AboutTheDataListView = ({ section, selectItem }) => {
     const clickHandler = (e, index, section) => {
         e.preventDefault();
         selectItem(index, section);
+        Analytics.event({
+            category: 'About the Data',
+            action: 'Link',
+            label: 'About the Data'
+        });
+        console.log('herehere');
     };
 
     // eslint-disable-next-line no-shadow
@@ -26,16 +32,16 @@ const AboutTheDataListView = ({ section, selectItem }) => {
         }
     };
 
-    const handleAnalyticsAboutTheDataLink = () => Analytics.event({
-        category: 'About The Data',
-        acation: 'Link',
-        lable: 'About The Data'
+    const aboutTheDataAnalyticsHandler = () => Analytics.event({
+        category: 'About the Data',
+        action: 'Link',
+        label: 'About the Data'
     });
 
     return (<>
         <div className="atd__heading">{section.heading}</div>
         <hr />
-        {section.fields.map((list, index) => <p key={`atd-list-item-${index}`}><a className="atd__link" role="link" tabIndex={0} onKeyUp={(e) => keyHandler(e, index, section)} onClick={(e) => [clickHandler(e, index, section), handleAnalyticsAboutTheDataLink]}>{list.name}</a></p>)}
+        {section.fields.map((list, index) => <p key={`atd-list-item-${index}`}><a className="atd__link" role="link" tabIndex={0} onKeyUp={(e) => keyHandler(e, index, section)} onClick={(e) => [clickHandler(e, index, section), aboutTheDataAnalyticsHandler()]}>{list.name}</a></p>)}
     </>);
 };
 

--- a/src/js/components/aboutTheDataSidebar/AboutTheDataListView.jsx
+++ b/src/js/components/aboutTheDataSidebar/AboutTheDataListView.jsx
@@ -19,10 +19,9 @@ const AboutTheDataListView = ({ section, selectItem }) => {
         selectItem(index, section);
         Analytics.event({
             category: 'About the Data',
-            action: 'Link',
+            action: `Clicked ${section}`,
             label: 'About the Data'
         });
-        console.log('herehere');
     };
 
     // eslint-disable-next-line no-shadow
@@ -32,16 +31,10 @@ const AboutTheDataListView = ({ section, selectItem }) => {
         }
     };
 
-    const aboutTheDataAnalyticsHandler = () => Analytics.event({
-        category: 'About the Data',
-        action: 'Link',
-        label: 'About the Data'
-    });
-
     return (<>
         <div className="atd__heading">{section.heading}</div>
         <hr />
-        {section.fields.map((list, index) => <p key={`atd-list-item-${index}`}><a className="atd__link" role="link" tabIndex={0} onKeyUp={(e) => keyHandler(e, index, section)} onClick={(e) => [clickHandler(e, index, section), aboutTheDataAnalyticsHandler()]}>{list.name}</a></p>)}
+        {section.fields.map((list, index) => <p key={`atd-list-item-${index}`}><a className="atd__link" role="link" tabIndex={0} onKeyUp={(e) => keyHandler(e, index, section)} onClick={(e) => clickHandler(e, index, section)}>{list.name}</a></p>)}
     </>);
 };
 

--- a/src/js/components/aboutTheDataSidebar/AboutTheDataListView.jsx
+++ b/src/js/components/aboutTheDataSidebar/AboutTheDataListView.jsx
@@ -14,13 +14,12 @@ const propTypes = {
 
 const AboutTheDataListView = ({ section, selectItem }) => {
     // eslint-disable-next-line no-shadow
-    const clickHandler = (e, index, section) => {
+    const clickHandler = (e, index, section, list) => {
         e.preventDefault();
         selectItem(index, section);
         Analytics.event({
             category: 'About the Data',
-            action: `Clicked ${section}`,
-            label: 'About the Data'
+            action: `Clicked ${list.name}`
         });
     };
 
@@ -34,7 +33,7 @@ const AboutTheDataListView = ({ section, selectItem }) => {
     return (<>
         <div className="atd__heading">{section.heading}</div>
         <hr />
-        {section.fields.map((list, index) => <p key={`atd-list-item-${index}`}><a className="atd__link" role="link" tabIndex={0} onKeyUp={(e) => keyHandler(e, index, section)} onClick={(e) => clickHandler(e, index, section)}>{list.name}</a></p>)}
+        {section.fields.map((list, index) => <p key={`atd-list-item-${index}`}><a className="atd__link" role="link" tabIndex={0} onKeyUp={(e) => keyHandler(e, index, section)} onClick={(e) => clickHandler(e, index, section, list)}>{list.name}</a></p>)}
     </>);
 };
 

--- a/src/js/components/aboutTheDataSidebar/AboutTheDataListView.jsx
+++ b/src/js/components/aboutTheDataSidebar/AboutTheDataListView.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import Analytics from 'helpers/analytics/Analytics';
 
 const propTypes = {
     section: PropTypes.object,
@@ -25,10 +26,16 @@ const AboutTheDataListView = ({ section, selectItem }) => {
         }
     };
 
+    const handleAnalyticsAboutTheDataLink = () => Analytics.event({
+        category: 'About The Data',
+        acation: 'Link',
+        lable: 'About The Data'
+    });
+
     return (<>
         <div className="atd__heading">{section.heading}</div>
         <hr />
-        {section.fields.map((list, index) => <p key={`atd-list-item-${index}`}><a className="atd__link" role="link" tabIndex={0} onKeyUp={(e) => keyHandler(e, index, section)} onClick={(e) => clickHandler(e, index, section)}>{list.name}</a></p>)}
+        {section.fields.map((list, index) => <p key={`atd-list-item-${index}`}><a className="atd__link" role="link" tabIndex={0} onKeyUp={(e) => keyHandler(e, index, section)} onClick={(e) => [clickHandler(e, index, section), handleAnalyticsAboutTheDataLink]}>{list.name}</a></p>)}
     </>);
 };
 

--- a/src/js/components/glossary/search/ResultItem.jsx
+++ b/src/js/components/glossary/search/ResultItem.jsx
@@ -91,9 +91,8 @@ export default class ResultItem extends React.Component {
     clickedLink() {
         this.props.selectTerm(this.props.item);
         Analytics.event({
-            category: 'Homepage',
-            action: `Clicked ${this.props.item}`,
-            label: 'explorer'
+            category: 'Glossary',
+            action: `Clicked ${this.props.item}`
         });
     }
 

--- a/src/js/components/glossary/search/ResultItem.jsx
+++ b/src/js/components/glossary/search/ResultItem.jsx
@@ -88,11 +88,11 @@ export default class ResultItem extends React.Component {
         });
     }
 
-    clickedLink() {
+    clickedLink(term) {
         this.props.selectTerm(this.props.item);
         Analytics.event({
             category: 'Glossary',
-            action: `Clicked ${this.props.item}`
+            action: `Clicked ${term.target.innerText}`
         });
     }
 

--- a/src/js/components/glossary/search/ResultItem.jsx
+++ b/src/js/components/glossary/search/ResultItem.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { isEqual } from 'lodash';
+import Analytics from 'helpers/analytics/Analytics';
 
 const propTypes = {
     item: PropTypes.object,
@@ -89,6 +90,19 @@ export default class ResultItem extends React.Component {
 
     clickedLink() {
         this.props.selectTerm(this.props.item);
+        Analytics.event({
+            category: 'Homepage',
+            action: 'Link',
+            label: 'explorer'
+        });
+    }
+
+    handleGlossryAnayltic() {
+        Analytics.event({
+            category: 'Homepage',
+            action: 'Link',
+            label: 'explorer'
+        });
     }
 
     render() {

--- a/src/js/components/glossary/search/ResultItem.jsx
+++ b/src/js/components/glossary/search/ResultItem.jsx
@@ -92,15 +92,7 @@ export default class ResultItem extends React.Component {
         this.props.selectTerm(this.props.item);
         Analytics.event({
             category: 'Homepage',
-            action: 'Link',
-            label: 'explorer'
-        });
-    }
-
-    handleGlossryAnayltic() {
-        Analytics.event({
-            category: 'Homepage',
-            action: 'Link',
+            action: `Clicked ${this.props.item}`,
             label: 'explorer'
         });
     }


### PR DESCRIPTION
**High level description:**
added google analytics to about the data and glossary.

**Technical details:**


**JIRA Ticket:**
[DEV-9370](https://federal-spending-transparency.atlassian.net/browse/DEV-9370)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
