### PR TITLE
Updated the Training Video Links

### DIFF
--- a/src/js/components/homepageUpdate/FeaturedContent/FeaturedContent.jsx
+++ b/src/js/components/homepageUpdate/FeaturedContent/FeaturedContent.jsx
@@ -50,7 +50,7 @@ const FeaturedContent = () => {
                     </Link>
                 </FlexGridCol>
                 <FlexGridCol width={12} desktop={6} tablet={6} mobile={12}>
-                    <ExternalLink url="https://www.youtube.com/channel/UCyDn83O-0XC98H3TCV-VCGQ" isCard onClick={trackFeaturedResourcesLink}>
+                    <Link to="training-videos" isCard onClick={trackFeaturedResourcesLink}>
                         <CardContainer variant="outline" size="md">
                             <CardHero fill="#009ec1" variant="expanded" img="img/homepage-featured-content/homepage-featured-youtube.webp" />
                             <CardBody
@@ -65,7 +65,7 @@ const FeaturedContent = () => {
                                 }>
                             </CardBody>
                         </CardContainer>
-                    </ExternalLink>
+                    </Link>
                 </FlexGridCol>
             </div>
         </section>

--- a/src/js/components/homepageUpdate/FeaturedContent/FeaturedContent.jsx
+++ b/src/js/components/homepageUpdate/FeaturedContent/FeaturedContent.jsx
@@ -11,7 +11,6 @@ import Analytics from 'helpers/analytics/Analytics';
 import CardContainer from "../../sharedComponents/commonCards/CardContainer";
 import CardHero from "../../sharedComponents/commonCards/CardHero";
 import CardBody from "../../sharedComponents/commonCards/CardBody";
-import ExternalLink from "../../sharedComponents/ExternalLink";
 
 
 const FeaturedContent = () => {

--- a/src/js/dataMapping/navigation/menuOptions.jsx
+++ b/src/js/dataMapping/navigation/menuOptions.jsx
@@ -63,6 +63,16 @@ export const resourceOptions = [
         isNewTab: true
     },
     {
+        label: 'Video Tutorials',
+        type: 'training-videos',
+        url: '/training-videos',
+        shouldOpenNewTab: false,
+        enabled: true,
+        externalLink: false,
+        isNewTab: true
+
+    },
+    {
         label: 'Data Dictionary',
         type: 'data-dictionary',
         url: '/data-dictionary',


### PR DESCRIPTION
Update the homepage training video card to redirect to the training video page.

Added training video to the Resource drop down menu.

**High level description:**

Update the homepage training video card to redirect to the training video page.

Added training video to the Resource drop down menu.

**Technical details:**

NA

**JIRA Ticket:**
[DEV-9384](https://federal-spending-transparency.atlassian.net/browse/DEV-9384)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
