### PR TITLE
9399 atd drawer behavior 2

### DIFF
--- a/src/js/components/homepageUpdate/HomepageResources/HomepageResources.jsx
+++ b/src/js/components/homepageUpdate/HomepageResources/HomepageResources.jsx
@@ -4,6 +4,9 @@
  */
 
 import React from 'react';
+import { useDispatch } from 'react-redux';
+import * as slideoutActions from 'redux/actions/slideouts/slideoutActions';
+import * as aboutTheDataActions from 'redux/actions/aboutTheDataSidebar/aboutTheDataActions';
 import { FlexGridRow, FlexGridCol } from 'data-transparency-ui';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import CardContainer from "../../sharedComponents/commonCards/CardContainer";
@@ -11,139 +14,147 @@ import CardBody from "../../sharedComponents/commonCards/CardBody";
 import CardButton from "../../sharedComponents/commonCards/CardButton";
 import Analytics from '../../../helpers/analytics/Analytics';
 
-const cardObjects = [
-    {
-        icon: (
-            <div className="homepage-resources__icon-container guide">
-                <FontAwesomeIcon icon="chart-bar" color="#112f4e" size="lg" />
-            </div>
-        ),
-        headline: 'Analyst Guide',
-        text: 'Learn how to use the data',
-        buttonText: (
-            <>
-                <div>View the guide&nbsp;&nbsp;</div>
-                <FontAwesomeIcon icon="arrow-right" />
-            </>
-        ),
-        buttonLink: '/analyst-guide',
-        action: () => Analytics.event({
-            category: 'Homepage',
-            action: 'Link',
-            label: 'learn how to use the data card'
-        })
-    },
-    {
-        icon: (
-            <div className="homepage-resources__icon-container dictionary">
-                <FontAwesomeIcon icon="database" color="#34a37e" size="lg" />
-            </div>
-        ),
-        headline: 'Data Dictionary',
-        text: 'Learn about the data elements',
-        buttonText: (
-            <>
-                <div>View the dictionary&nbsp;&nbsp;</div>
-                <FontAwesomeIcon icon="arrow-right" />
-            </>
-        ),
-        buttonLink: '/data-dictionary',
-        action: () => Analytics.event({
-            category: 'Homepage',
-            action: 'Link',
-            label: 'data dictionary card'
-        })
-    },
-    {
-        icon: (
-            <div className="homepage-resources__icon-container model">
-                <FontAwesomeIcon icon="sitemap" color="#0081a1" size="lg" />
-            </div>
-        ),
-        headline: 'About the Data',
-        text: 'Read important data disclosures',
-        buttonText: (
-            <>
-                View the disclosures&nbsp;&nbsp;
-                <FontAwesomeIcon icon="arrow-right" />
-            </>
-        ),
-        buttonLink: "/?about-the-data",
-        action: () => Analytics.event({
-            category: 'Homepage',
-            action: 'Link',
-            label: 'data model card'
-        }),
-        govLink: false
-    },
-    {
-        icon: (
-            <div className="homepage-resources__icon-container glossary">
-                <FontAwesomeIcon icon="book" color="#3333a3" size="lg" />
-            </div>
-        ),
-        headline: 'Glossary',
-        text: 'Learn about spending terms',
-        buttonText: (
-            <>
-                <div>View the glossary&nbsp;&nbsp;</div>
-                <FontAwesomeIcon icon="arrow-right" />
-            </>
-        ),
-        buttonLink: '/?glossary&',
-        action: () => Analytics.event({
-            category: 'Homepage',
-            action: 'Link',
-            label: 'glossary card'
-        })
-    }
-];
+const HomepageResources = () => {
+    const dispatch = useDispatch();
 
-const HomepageResources = () => (
-    <section className="homepage-resources__section">
-        <div style={{ display: "flex", flexDirection: "column", justifyContent: "center" }}>
-            <FlexGridRow className="grid-content">
-                <FlexGridCol width={12}>
-                    <FlexGridRow className="homepage-resources__top-label-container">
-                        <div className="homepage-resources__top-label-icon-container">
-                            <FontAwesomeIcon
-                                className="homepage-resources__book-icon"
-                                icon="book-open"
-                                size="xs" />
-                        </div>
-                        <div className="homepage-resources__top-label-text">RESOURCES</div>
-                    </FlexGridRow>
-                    <FlexGridRow className="homepage-resources__headline">Find answers to your data questions</FlexGridRow>
-                </FlexGridCol>
-                <FlexGridCol width={12}>
-                    <FlexGridRow className="homepage-resources__card-row" hasGutter gutterSize="lg">
-                        {cardObjects.map((card, index) => (
-                            <FlexGridCol
-                                className="homepage-resources__card-col"
-                                key={index}
-                                mobile={12}
-                                tablet={6}
-                                desktop={3}>
-                                <CardContainer>
-                                    {card.icon}
-                                    <CardBody
-                                        headline={card.headline}
-                                        text={card.text}>
-                                        <CardButton
-                                            variant="text"
-                                            text={card.buttonText}
-                                            link={card.buttonLink}
-                                            govLink={card.govLink}
-                                            action={card.action} />
-                                    </CardBody>
-                                </CardContainer>
-                            </FlexGridCol>
-                        ))}
-                    </FlexGridRow>
-                </FlexGridCol>
-            </FlexGridRow>
-        </div>
-    </section>
-);
+    const cardObjects = [
+        {
+            icon: (
+                <div className="homepage-resources__icon-container guide">
+                    <FontAwesomeIcon icon="chart-bar" color="#112f4e" size="lg" />
+                </div>
+            ),
+            headline: 'Analyst Guide',
+            text: 'Learn how to use the data',
+            buttonText: (
+                <>
+                    <div>View the guide&nbsp;&nbsp;</div>
+                    <FontAwesomeIcon icon="arrow-right" />
+                </>
+            ),
+            buttonLink: '/analyst-guide',
+            action: () => Analytics.event({
+                category: 'Homepage',
+                action: 'Link',
+                label: 'learn how to use the data card'
+            })
+        },
+        {
+            icon: (
+                <div className="homepage-resources__icon-container dictionary">
+                    <FontAwesomeIcon icon="database" color="#34a37e" size="lg" />
+                </div>
+            ),
+            headline: 'Data Dictionary',
+            text: 'Learn about the data elements',
+            buttonText: (
+                <>
+                    <div>View the dictionary&nbsp;&nbsp;</div>
+                    <FontAwesomeIcon icon="arrow-right" />
+                </>
+            ),
+            buttonLink: '/data-dictionary',
+            action: () => Analytics.event({
+                category: 'Homepage',
+                action: 'Link',
+                label: 'data dictionary card'
+            })
+        },
+        {
+            icon: (
+                <div className="homepage-resources__icon-container model">
+                    <FontAwesomeIcon icon="sitemap" color="#0081a1" size="lg" />
+                </div>
+            ),
+            headline: 'About the Data',
+            text: 'Read important data disclosures',
+            buttonText: (
+                <>
+                    View the disclosures&nbsp;&nbsp;
+                    <FontAwesomeIcon icon="arrow-right" />
+                </>
+            ),
+            action: () => {
+                Analytics.event({
+                    category: 'Homepage',
+                    action: 'Link',
+                    label: 'data model card'
+                });
+                dispatch(aboutTheDataActions.showAboutTheData());
+                dispatch(slideoutActions.setLastOpenedSlideout('atd'));
+            },
+            govLink: false,
+            onlyPerformAction: true
+        },
+        {
+            icon: (
+                <div className="homepage-resources__icon-container glossary">
+                    <FontAwesomeIcon icon="book" color="#3333a3" size="lg" />
+                </div>
+            ),
+            headline: 'Glossary',
+            text: 'Learn about spending terms',
+            buttonText: (
+                <>
+                    <div>View the glossary&nbsp;&nbsp;</div>
+                    <FontAwesomeIcon icon="arrow-right" />
+                </>
+            ),
+            buttonLink: '/?glossary&',
+            action: () => Analytics.event({
+                category: 'Homepage',
+                action: 'Link',
+                label: 'glossary card'
+            })
+        }
+    ];
+
+    return (
+        <section className="homepage-resources__section">
+            <div style={{ display: "flex", flexDirection: "column", justifyContent: "center" }}>
+                <FlexGridRow className="grid-content">
+                    <FlexGridCol width={12}>
+                        <FlexGridRow className="homepage-resources__top-label-container">
+                            <div className="homepage-resources__top-label-icon-container">
+                                <FontAwesomeIcon
+                                    className="homepage-resources__book-icon"
+                                    icon="book-open"
+                                    size="xs" />
+                            </div>
+                            <div className="homepage-resources__top-label-text">RESOURCES</div>
+                        </FlexGridRow>
+                        <FlexGridRow className="homepage-resources__headline">Find answers to your data questions</FlexGridRow>
+                    </FlexGridCol>
+                    <FlexGridCol width={12}>
+                        <FlexGridRow className="homepage-resources__card-row" hasGutter gutterSize="lg">
+                            {cardObjects.map((card, index) => (
+                                <FlexGridCol
+                                    className="homepage-resources__card-col"
+                                    key={index}
+                                    mobile={12}
+                                    tablet={6}
+                                    desktop={3}>
+                                    <CardContainer>
+                                        {card.icon}
+                                        <CardBody
+                                            headline={card.headline}
+                                            text={card.text}>
+                                            <CardButton
+                                                variant="text"
+                                                text={card.buttonText}
+                                                link={card.buttonLink}
+                                                govLink={card.govLink}
+                                                action={card.action} />
+                                        </CardBody>
+                                    </CardContainer>
+                                </FlexGridCol>
+                            ))}
+                        </FlexGridRow>
+                    </FlexGridCol>
+                </FlexGridRow>
+            </div>
+        </section>
+    );
+};
 
 export default HomepageResources;

--- a/src/js/components/sharedComponents/header/mobile/MobileDropdownItem.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileDropdownItem.jsx
@@ -4,12 +4,13 @@
  */
 
 import React from 'react';
+import { useDispatch } from 'react-redux';
+import * as aboutTheDataActions from 'redux/actions/aboutTheDataSidebar/aboutTheDataActions';
+import * as slideoutActions from 'redux/actions/slideouts/slideoutActions';
 import PropTypes from 'prop-types';
 import { Link, useLocation } from 'react-router-dom';
-
 import Analytics from 'helpers/analytics/Analytics';
 import { getNewUrlForGlossary } from 'helpers/glossaryHelper';
-
 import DropdownComingSoon from '../DropdownComingSoon';
 
 const propTypes = {
@@ -46,9 +47,19 @@ const MobileDropdownItem = ({
         ? getNewUrlForGlossary(pathname, url, search)
         : url;
 
+    const dispatch = useDispatch();
+
     const clickedLink = () => {
         clickedHeaderLink(newUrl);
         hideMobileNav();
+    };
+
+    const openATDMobile = (e) => {
+        clickedHeaderLink(newUrl);
+        hideMobileNav();
+        dispatch(aboutTheDataActions.showAboutTheData());
+        dispatch(slideoutActions.setLastOpenedSlideout('atd'));
+        e.preventDefault();
     };
 
     let activeClass = '';
@@ -64,6 +75,20 @@ const MobileDropdownItem = ({
             <div className="mobile-dropdown__coming-soon">
                 <DropdownComingSoon />
             </div>
+        );
+    }
+
+    if (appendToExistingUrl && title.includes("About the Data")) {
+        return (
+            <li className={`mobile-dropdown__item ${comingSoonClass}`}>
+                <Link
+                    className={`mobile-dropdown__link ${activeClass}`}
+                    onClick={openATDMobile}>
+                    {title}
+                    {isNewTab && <span className="new-badge dropdown-item"> NEW</span>}
+                </Link>
+                {comingSoonDecorator}
+            </li>
         );
     }
 
@@ -97,5 +122,4 @@ const MobileDropdownItem = ({
 };
 
 MobileDropdownItem.propTypes = propTypes;
-
 export default MobileDropdownItem;

--- a/src/js/containers/aboutTheDataSidebar/AboutTheDataListener.jsx
+++ b/src/js/containers/aboutTheDataSidebar/AboutTheDataListener.jsx
@@ -36,9 +36,12 @@ const AboutTheDataListener = ({
         history.replace(urlWithNoHash);
     }, [location, history]);
 
-    // this is not currently being used to open the atd slideout
-    // for now it is only opened from the openATD function in dropdownItem.jsx
-    // that will change if we add links to atd on other pages
+    // this is not currently being used to open the atd slideout;
+    // for now it being opened from special functions in DropdownItem,
+    // MobileDropdownItem, and HomepageResources;
+    // We aren't using this listener for ATD because it was causing
+    // the page to reload when opening the slideout;
+    // todo - figure out why this listener is causing a page reload when the GlossaryListener does not
     useEffect(() => {
         if (search.includes('about-the-data')) {
             const { "about-the-data": term } = queryParams;


### PR DESCRIPTION
**High level description:**

QA noticed that when opening ATD and Glossary from the Homepage Resources section, ATD was not opening on top of Glossary. She also noticed that at < 992 ATD was not animating correctly.

**Technical details:**

I added functions that use the ATD redux actions to the homepage Resources links and to the mobileDropdown links.
I also made a tech debt ticket to try to address why the ATDListener isn't working correctly, because it would be a lot easier to maintain this code if we were using the Listener.
https://federal-spending-transparency.atlassian.net/browse/DEV-9452

**JIRA Ticket:**
[DEV-9399](https://federal-spending-transparency.atlassian.net/browse/DEV-9399)


The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
