### PR TITLE
9425 - Added loading and error messages to the video modal 

### DIFF
--- a/src/_scss/components/_genericErrorMessage.scss
+++ b/src/_scss/components/_genericErrorMessage.scss
@@ -1,0 +1,36 @@
+.generic-error-message-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+  background-color: $gray-90;
+
+  .error-message {
+    text-align: center;
+    color: $gray-2;
+
+    .error-message__paragraph-one {
+      font-size: $font-size-24;
+      text-align: center;
+      font-weight: $font-semibold;
+      margin-bottom: rem(4);
+      margin-top: rem(0);
+    }
+
+    .error-message__paragraph-two {
+      font-size: $font-size-16;
+      margin-top: rem(4);
+    }
+
+    .error-message__button {
+      background: none;
+      border-radius: rem(4);
+      border: solid rem(1) $gray-cool-10;
+      color: $gray-cool-10;
+      width: rem(147);
+      height: rem(40);
+      font-weight: $font-semibold;
+    }
+  }
+}

--- a/src/_scss/pages/modals/video/_trainingVideoModal.scss
+++ b/src/_scss/pages/modals/video/_trainingVideoModal.scss
@@ -1,4 +1,6 @@
 .usa-dt-modal {
+    @import "components/_genericErrorMessage";
+
     width: 100% - $grid-column;
     @media(min-width: $x-large-screen) {
         width: 100% - $grid-column * 3;

--- a/src/js/components/sharedComponents/TrainingVideoModal.jsx
+++ b/src/js/components/sharedComponents/TrainingVideoModal.jsx
@@ -100,7 +100,7 @@ const TrainingVideoModal = (props) => {
                         desktop={12}
                         mobile={12}
                         tablet={12}>
-                        <LoadingWrapper isLoading={isLoading} />
+                        <LoadingWrapper isLoading={isLoading}>&nbsp;</LoadingWrapper>
                     </FlexGridCol>
                 </div>
                 <div className="usa-dt-modal__body" id="usa-dt-modal__body" style={{ display: "none" }}>

--- a/src/js/components/sharedComponents/TrainingVideoModal.jsx
+++ b/src/js/components/sharedComponents/TrainingVideoModal.jsx
@@ -11,6 +11,7 @@ import YouTube from 'react-youtube';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { FlexGridCol } from "data-transparency-ui";
 import parseChapters from "../../helpers/trainingVideoHelper";
+import { LoadingWrapper } from "../sharedComponents/Loading";
 
 const propTypes = {
     mounted: PropTypes.bool,
@@ -99,7 +100,7 @@ const TrainingVideoModal = (props) => {
                         desktop={12}
                         mobile={12}
                         tablet={12}>
-                            Loading
+                        <LoadingWrapper isLoading={isLoading} />
                     </FlexGridCol>
                 </div>
                 <div className="usa-dt-modal__body" id="usa-dt-modal__body" style={{ display: "none" }}>

--- a/src/js/components/sharedComponents/TrainingVideoModal.jsx
+++ b/src/js/components/sharedComponents/TrainingVideoModal.jsx
@@ -135,7 +135,7 @@ const TrainingVideoModal = (props) => {
                             <YouTube
                                 id="usa-dt-modal__yt-video"
                                 onError={handleError}
-                                videoId={`${props.id}abc`}
+                                videoId={props.id}
                                 opts={{
                                     height: '400',
                                     width: '922',

--- a/src/js/components/sharedComponents/TrainingVideoModal.jsx
+++ b/src/js/components/sharedComponents/TrainingVideoModal.jsx
@@ -12,6 +12,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { FlexGridCol } from "data-transparency-ui";
 import parseChapters from "../../helpers/trainingVideoHelper";
 import { LoadingWrapper } from "../sharedComponents/Loading";
+import GenericErrorMessage from "../trainingVideos/GenericErrorMessage";
 
 const propTypes = {
     mounted: PropTypes.bool,
@@ -91,7 +92,7 @@ const TrainingVideoModal = (props) => {
                     onClick={props.hideModal}>
                     <FontAwesomeIcon icon="chevron-left" className="left-chevron-icon" alt="Back" />
                     <span className="training__back__label">
-                Back
+                        Back
                     </span>
                 </div>
                 <div className="usa-dt-modal__body" id="usa-dt-modal__loading">
@@ -126,21 +127,27 @@ const TrainingVideoModal = (props) => {
                         mobile={12}
                         tablet={12}
                         className="usa-dt-modal__video">
-                        <YouTube
-                            id="usa-dt-modal__yt-video"
-                            onError={handleError}
-                            videoId={props.id}
-                            opts={{
-                                height: '400',
-                                width: '922',
-                                playerVars: {
+                        {isError ?
+                            <GenericErrorMessage
+                                message="Sorry, we're unable to load this video."
+                                emailSubject="Training%20Videos%20Error" />
+                            :
+                            <YouTube
+                                id="usa-dt-modal__yt-video"
+                                onError={handleError}
+                                videoId={`${props.id}abc`}
+                                opts={{
+                                    height: '400',
+                                    width: '922',
+                                    playerVars: {
                                     // https://developers.google.com/youtube/player_parameters
-                                    autoplay: 1,
-                                    start: chapterTimestamp
-                                }
-                            }}
-                            onReady={youTubeOnReady}
-                            title="YouTube video player" />
+                                        autoplay: 1,
+                                        start: chapterTimestamp
+                                    }
+                                }}
+                                onReady={youTubeOnReady}
+                                title="YouTube video player" />
+                        }
                     </FlexGridCol>
                 </div>
             </div>

--- a/src/js/components/sharedComponents/TrainingVideoModal.jsx
+++ b/src/js/components/sharedComponents/TrainingVideoModal.jsx
@@ -25,6 +25,8 @@ const propTypes = {
 const TrainingVideoModal = (props) => {
     const [chapterTimestamp, setChapterTimestamp] = useState(0);
     const [parsedDescription, setParsedDescription] = useState(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isError, setIsError] = useState(false);
 
     const updatePlayerChapter = (e, time) => {
         setChapterTimestamp(time);
@@ -53,6 +55,14 @@ const TrainingVideoModal = (props) => {
                 chapterEls[i].addEventListener('keyup', (keyEv) => chapterKeypressHandler(keyEv, chapterTime));
             }
         }
+
+        setIsLoading(false);
+        setIsError(false);
+    };
+
+    const handleError = () => {
+        setIsLoading(false);
+        setIsError(true);
     };
 
     return (
@@ -79,44 +89,46 @@ const TrainingVideoModal = (props) => {
                 Back
                     </span>
                 </div>
-                <div className="usa-dt-modal__body">
-                    <FlexGridCol
-                        className="usa-dt-modal__card"
-                        desktopxl={5}
-                        desktop={6}
-                        tablet={0}
-                        mobile={0}>
-                        <div className="usa-dt-modal__title">
-                            {props.title}
-                        </div>
-                        <div tabIndex={0} id="video-description" className="usa-dt-modal__body-text">
-                            {parsedDescription}
-                        </div>
-                        <div className="usa-dt-modal__meta">
-                            {props.publishedAt}
-                        </div>
-                    </FlexGridCol>
-                    <FlexGridCol
-                        desktopxl={12}
-                        desktop={12}
-                        mobile={12}
-                        tablet={12}
-                        className="usa-dt-modal__video">
-                        <YouTube
-                            videoId={props.id}
-                            opts={{
-                                height: '400',
-                                width: '922',
-                                playerVars: {
-                                    // https://developers.google.com/youtube/player_parameters
-                                    autoplay: 1,
-                                    start: chapterTimestamp
-                                }
-                            }}
-                            onReady={youTubeOnReady}
-                            title="YouTube video player" />;
-                    </FlexGridCol>
-                </div>
+                {isLoading &&
+                    <div className="usa-dt-modal__body">
+                        <FlexGridCol
+                            className="usa-dt-modal__card"
+                            desktopxl={5}
+                            desktop={6}
+                            tablet={0}
+                            mobile={0}>
+                            <div className="usa-dt-modal__title">
+                                {props.title}
+                            </div>
+                            <div tabIndex={0} id="video-description" className="usa-dt-modal__body-text">
+                                {parsedDescription}
+                            </div>
+                            <div className="usa-dt-modal__meta">
+                                {props.publishedAt}
+                            </div>
+                        </FlexGridCol>
+                        <FlexGridCol
+                            desktopxl={12}
+                            desktop={12}
+                            mobile={12}
+                            tablet={12}
+                            className="usa-dt-modal__video">
+                            <YouTube
+                                onError={handleError}
+                                videoId={props.id}
+                                opts={{
+                                    height: '400',
+                                    width: '922',
+                                    playerVars: {
+                                        // https://developers.google.com/youtube/player_parameters
+                                        autoplay: 1,
+                                        start: chapterTimestamp
+                                    }
+                                }}
+                                onReady={youTubeOnReady}
+                                title="YouTube video player" />
+                        </FlexGridCol>
+                    </div>}
             </div>
         </Modal>);
 };

--- a/src/js/components/sharedComponents/TrainingVideoModal.jsx
+++ b/src/js/components/sharedComponents/TrainingVideoModal.jsx
@@ -44,6 +44,13 @@ const TrainingVideoModal = (props) => {
     }, [props.description]);
 
     const youTubeOnReady = (e) => {
+        let elem = document.getElementById("usa-dt-modal__body");
+        elem.style.display = "flex";
+
+        elem = document.getElementById("usa-dt-modal__loading");
+        elem.style.display = "none";
+        setIsLoading(false);
+        setIsError(false);
         e.target.playVideo();
         const body = document.getElementById('video-description');
         const chapterEls = body?.getElementsByClassName("videoChapter");
@@ -55,9 +62,6 @@ const TrainingVideoModal = (props) => {
                 chapterEls[i].addEventListener('keyup', (keyEv) => chapterKeypressHandler(keyEv, chapterTime));
             }
         }
-
-        setIsLoading(false);
-        setIsError(false);
     };
 
     const handleError = () => {
@@ -89,46 +93,55 @@ const TrainingVideoModal = (props) => {
                 Back
                     </span>
                 </div>
-                {isLoading &&
-                    <div className="usa-dt-modal__body">
-                        <FlexGridCol
-                            className="usa-dt-modal__card"
-                            desktopxl={5}
-                            desktop={6}
-                            tablet={0}
-                            mobile={0}>
-                            <div className="usa-dt-modal__title">
-                                {props.title}
-                            </div>
-                            <div tabIndex={0} id="video-description" className="usa-dt-modal__body-text">
-                                {parsedDescription}
-                            </div>
-                            <div className="usa-dt-modal__meta">
-                                {props.publishedAt}
-                            </div>
-                        </FlexGridCol>
-                        <FlexGridCol
-                            desktopxl={12}
-                            desktop={12}
-                            mobile={12}
-                            tablet={12}
-                            className="usa-dt-modal__video">
-                            <YouTube
-                                onError={handleError}
-                                videoId={props.id}
-                                opts={{
-                                    height: '400',
-                                    width: '922',
-                                    playerVars: {
-                                        // https://developers.google.com/youtube/player_parameters
-                                        autoplay: 1,
-                                        start: chapterTimestamp
-                                    }
-                                }}
-                                onReady={youTubeOnReady}
-                                title="YouTube video player" />
-                        </FlexGridCol>
-                    </div>}
+                <div className="usa-dt-modal__body" id="usa-dt-modal__loading">
+                    <FlexGridCol
+                        desktopxl={12}
+                        desktop={12}
+                        mobile={12}
+                        tablet={12}>
+                            Loading
+                    </FlexGridCol>
+                </div>
+                <div className="usa-dt-modal__body" id="usa-dt-modal__body" style={{ display: "none" }}>
+                    <FlexGridCol
+                        className="usa-dt-modal__card"
+                        desktopxl={5}
+                        desktop={6}
+                        tablet={0}
+                        mobile={0}>
+                        <div className="usa-dt-modal__title">
+                            {props.title}
+                        </div>
+                        <div tabIndex={0} id="video-description" className="usa-dt-modal__body-text">
+                            {parsedDescription}
+                        </div>
+                        <div className="usa-dt-modal__meta">
+                            {props.publishedAt}
+                        </div>
+                    </FlexGridCol>
+                    <FlexGridCol
+                        desktopxl={12}
+                        desktop={12}
+                        mobile={12}
+                        tablet={12}
+                        className="usa-dt-modal__video">
+                        <YouTube
+                            id="usa-dt-modal__yt-video"
+                            onError={handleError}
+                            videoId={props.id}
+                            opts={{
+                                height: '400',
+                                width: '922',
+                                playerVars: {
+                                    // https://developers.google.com/youtube/player_parameters
+                                    autoplay: 1,
+                                    start: chapterTimestamp
+                                }
+                            }}
+                            onReady={youTubeOnReady}
+                            title="YouTube video player" />
+                    </FlexGridCol>
+                </div>
             </div>
         </Modal>);
 };

--- a/src/js/components/trainingVideos/GenericErrorMessage.jsx
+++ b/src/js/components/trainingVideos/GenericErrorMessage.jsx
@@ -1,0 +1,26 @@
+/**
+ * GenericErrorMessage.jsx
+ * Created by Andrea Blackwell 1/19/23
+ */
+
+import React from 'react';
+import PropTypes from "prop-types";
+
+const propTypes = {
+    message: PropTypes.string,
+    emailSubject: PropTypes.string
+};
+
+const GeneralErrorMessage = ({ message, emailSubject }) => (
+    <div className="generic-error-message-container">
+        <div className="error-message">
+            <p className="error-message__paragraph-one">Something went wrong</p>
+            <p className="error-message__paragraph-two">{message}</p>
+            {/* eslint-disable-next-line no-return-assign */}
+            <button className="error-message__button" onClick={() => window.location = `mailto:usaspending.help@fiscal.treasury.gov?subject=${emailSubject}`}>Report this error</button>
+        </div>
+    </div>
+);
+
+GeneralErrorMessage.propTypes = propTypes;
+export default GeneralErrorMessage;

--- a/src/js/components/trainingVideos/featuredVideo/FeaturedVideo.jsx
+++ b/src/js/components/trainingVideos/featuredVideo/FeaturedVideo.jsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import PropTypes from "prop-types";
+import PropTypes, { oneOfType } from "prop-types";
 import { FlexGridRow, FlexGridCol, ShareIcon } from 'data-transparency-ui';
 import { mediumScreen } from 'dataMapping/shared/mobileBreakpoints';
 import { handleShareOptionClick } from 'helpers/socialShare';
@@ -13,8 +13,8 @@ import VideoThumbnail from '../videoThumbnails/VideoThumbnail';
 
 
 const propTypes = {
-    featuredVideo: PropTypes.array,
-    url: PropTypes.func
+    featuredVideo: PropTypes.object,
+    url: oneOfType([PropTypes.string, PropTypes.func])
 };
 
 const FeaturedVideo = ({ featuredVideo }) => {

--- a/src/js/components/trainingVideos/videoCard/VideoCard.jsx
+++ b/src/js/components/trainingVideos/videoCard/VideoCard.jsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import PropTypes from "prop-types";
+import PropTypes, { oneOfType } from "prop-types";
 import { ShareIcon } from 'data-transparency-ui';
 import { handleShareOptionClick } from 'helpers/socialShare';
 import { mediumScreen } from 'dataMapping/shared/mobileBreakpoints';
@@ -22,7 +22,7 @@ const propTypes = {
     publishedAt: PropTypes.string,
     onClick: PropTypes.func,
     onKeyUp: PropTypes.func,
-    url: PropTypes.func
+    url: oneOfType([PropTypes.string, PropTypes.func])
 };
 
 const VideoCard = ({


### PR DESCRIPTION
**High level description:**

Added loading and error messages to the video modal.  I'm only capturing this one error state for now.  https://app.zeplin.io/project/6307b25775991866c016769c/screen/63c18f0672594e058214f824. The other 2 error states in the mock require more thought and research.  I'm not sure how we would check for the other two error states without hitting the api.

**JIRA Ticket:**
[DEV-9425](https://federal-spending-transparency.atlassian.net/browse/DEV-9425)

**Mockup:**
https://app.zeplin.io/project/6307b25775991866c016769c/screen/63c18f0672594e058214f824

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Code review complete
