### PR TITLE
9425 - Adjusted font styling per QA feedback. 

### DIFF
--- a/src/_scss/components/_genericErrorMessage.scss
+++ b/src/_scss/components/_genericErrorMessage.scss
@@ -32,6 +32,7 @@
       color: $gray-cool-10;
       width: rem(147);
       height: rem(40);
+      font-weight: $font-semibold;
       font-size: $font-size-16;
       padding: 0;
     }

--- a/src/_scss/components/_genericErrorMessage.scss
+++ b/src/_scss/components/_genericErrorMessage.scss
@@ -21,6 +21,7 @@
     .error-message__paragraph-two {
       font-size: $font-size-16;
       margin-top: rem(4);
+      color: $gray-10;
     }
 
     .error-message__button {
@@ -31,6 +32,7 @@
       width: rem(147);
       height: rem(40);
       font-weight: $font-semibold;
+      font-size: $font-size-16;
     }
   }
 }

--- a/src/_scss/components/_genericErrorMessage.scss
+++ b/src/_scss/components/_genericErrorMessage.scss
@@ -12,6 +12,7 @@
 
     .error-message__paragraph-one {
       font-size: $font-size-24;
+      line-height: rem(30);
       text-align: center;
       font-weight: $font-semibold;
       margin-bottom: rem(4);
@@ -31,8 +32,8 @@
       color: $gray-cool-10;
       width: rem(147);
       height: rem(40);
-      font-weight: $font-semibold;
       font-size: $font-size-16;
+      padding: 0;
     }
   }
 }

--- a/src/_scss/pages/homepageUpdate/_wordOfTheDay.scss
+++ b/src/_scss/pages/homepageUpdate/_wordOfTheDay.scss
@@ -130,5 +130,6 @@
     width: rem(147);
     height: rem(40);
     font-weight: $font-semibold;
+    font-size: $font-size-16;
   }
 }

--- a/src/_scss/pages/homepageUpdate/_wordOfTheDay.scss
+++ b/src/_scss/pages/homepageUpdate/_wordOfTheDay.scss
@@ -127,7 +127,7 @@
     border-radius: rem(4);
     border: solid rem(1) $gray-cool-10;
     background-color: #1a4480;
-    width: rem(155);
+    width: rem(147);
     height: rem(40);
     font-weight: $font-semibold;
     font-size: $font-size-16;

--- a/src/_scss/pages/homepageUpdate/_wordOfTheDay.scss
+++ b/src/_scss/pages/homepageUpdate/_wordOfTheDay.scss
@@ -127,9 +127,10 @@
     border-radius: rem(4);
     border: solid rem(1) $gray-cool-10;
     background-color: #1a4480;
-    width: rem(147);
+    width: rem(155);
     height: rem(40);
     font-weight: $font-semibold;
     font-size: $font-size-16;
+    padding: 0;
   }
 }

--- a/src/js/components/sharedComponents/TrainingVideoModal.jsx
+++ b/src/js/components/sharedComponents/TrainingVideoModal.jsx
@@ -135,7 +135,7 @@ const TrainingVideoModal = (props) => {
                             <YouTube
                                 id="usa-dt-modal__yt-video"
                                 onError={handleError}
-                                videoId={props.id}
+                                videoId={`${props.id}aaa`}
                                 opts={{
                                     height: '400',
                                     width: '922',

--- a/src/js/components/sharedComponents/TrainingVideoModal.jsx
+++ b/src/js/components/sharedComponents/TrainingVideoModal.jsx
@@ -135,7 +135,7 @@ const TrainingVideoModal = (props) => {
                             <YouTube
                                 id="usa-dt-modal__yt-video"
                                 onError={handleError}
-                                videoId={`${props.id}aaa`}
+                                videoId={props.id}
                                 opts={{
                                     height: '400',
                                     width: '922',


### PR DESCRIPTION
**High level description:**

* Something went wrong message should be font weight 16px (see Slack message in brus-frontend-ux channel)
* Sorry, we’re unable to load this video. - Font color should be #e6e6e6 per Zeplin
* Report this error button text should be 16px per Zeplin

**Technical details:**

Technical details for the knowledge of other developers.

**JIRA Ticket:**
[DEV-9425](https://federal-spending-transparency.atlassian.net/browse/DEV-9425)

**Mockup:**
https://app.zeplin.io/project/6307b25775991866c016769c/screen/63c18f0672594e058214f824

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket


Reviewer(s):
- [ ] Code review complete
