### PR TITLE
9480 - added isFeaturedVideo prop to Duration to change 'bottom' posi…

### DIFF
--- a/src/_scss/pages/trainingVideos/_videoThumbnail.scss
+++ b/src/_scss/pages/trainingVideos/_videoThumbnail.scss
@@ -64,16 +64,19 @@
       color: $gray-cool-1;
       border-radius: 4px;
       position: absolute;
-      bottom: 0;
+      bottom: -8px;
       right: 0;
       margin: 4px;
-      padding: 2px 4px;
+      padding: 0 4px 2px 4px;
       font-size: $font-size-16;
       line-height: $font-size-16;
       font-weight: 800;
       display: inline-flex;
       flex-direction: row;
       align-items: center;
+        &.featured-video {
+          bottom: 0;
+        }
 
       .duration-text {
         max-height: $font-size-16;

--- a/src/js/components/trainingVideos/featuredVideo/FeaturedVideo.jsx
+++ b/src/js/components/trainingVideos/featuredVideo/FeaturedVideo.jsx
@@ -44,7 +44,7 @@ const FeaturedVideo = ({ featuredVideo }) => {
         }, 50);
         window.addEventListener('resize', handleResize);
         return () => window.removeEventListener('resize', handleResize);
-    }, []);
+    }, [windowWidth]);
     const launchModal = (e) => {
         e.persist();
         dispatch(showTrainingVideoModal({
@@ -96,6 +96,7 @@ const FeaturedVideo = ({ featuredVideo }) => {
                             url={VideoThumbnail.url}
                             showPlay
                             showDuration
+                            isFeaturedVideo
                             title={featuredVideo.title}
                             alt={featuredVideo.title} />
                     </FlexGridCol>

--- a/src/js/components/trainingVideos/videoThumbnails/Duration.jsx
+++ b/src/js/components/trainingVideos/videoThumbnails/Duration.jsx
@@ -7,11 +7,12 @@ import React from "react";
 import PropTypes from "prop-types";
 
 const propTypes = {
-    duration: PropTypes.string
+    duration: PropTypes.string,
+    isFeaturedVideo: PropTypes.bool
 };
 
-const Duration = ({ duration }) => (
-    <div className="overlay-duration">
+const Duration = ({ duration, isFeaturedVideo }) => (
+    <div className={`overlay-duration ${isFeaturedVideo ? 'featured-video' : ''}`}>
         <span className="duration-text">{duration}</span>
     </div>
 );

--- a/src/js/components/trainingVideos/videoThumbnails/VideoThumbnail.jsx
+++ b/src/js/components/trainingVideos/videoThumbnails/VideoThumbnail.jsx
@@ -14,11 +14,12 @@ const propTypes = {
     showDuration: PropTypes.bool,
     thumbnailUrl: PropTypes.string,
     title: PropTypes.string,
-    duration: PropTypes.string
+    duration: PropTypes.string,
+    isFeaturedVideo: PropTypes.bool
 };
 
 const VideoThumbnail = ({
-    showPlay, showDuration, thumbnailUrl, title, duration
+    showPlay, showDuration, thumbnailUrl, title, duration, isFeaturedVideo
 }) => (
     <FlexGridRow>
         <FlexGridCol width={12} className="video-thumbnail__column-container">
@@ -27,7 +28,7 @@ const VideoThumbnail = ({
                 {showPlay && <PlayButton />}
             </FlexGridRow>
             <FlexGridRow className="video-thumbnail__duration-overlay">
-                {showDuration && <Duration duration={duration} />}
+                {showDuration && <Duration duration={duration} isFeaturedVideo={isFeaturedVideo} />}
             </FlexGridRow>
         </FlexGridCol>
     </FlexGridRow>


### PR DESCRIPTION
…tion; slight change to padding-top in overlay-duration class to center the numbers in the box

**High level description:**

Small changes to css for the Duration Overlay in the Training Videos thumbnails

**Technical details:**

Added prop for isFeaturedVideo; changed padding-top;
I think we can leave the windowWidth dep in the handleResize useEffect in FeaturedVideo, it was added by the linter bc of the exhaustive-deps rule but I think this one is good and not breaking anything - it is a dep, after all.

**JIRA Ticket:**
[DEV-9480](https://federal-spending-transparency.atlassian.net/browse/DEV-9480)

**Mockup:**
https://app.zeplin.io/project/6307b25775991866c016769c/screen/63472dc7ee19fb538b35e6b8
But the Duration Overlay no longer matches the mock bc of changes agreed on by design and devs

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
