### PR TITLE
Mod/9587 text change hotfix

### DIFF
--- a/src/_scss/components/_unlinkedAwardWarning.scss
+++ b/src/_scss/components/_unlinkedAwardWarning.scss
@@ -1,5 +1,8 @@
 .unlinked-award-warning__wrapper {
-  height: 90%;
+  height: 60%;
+  @media (min-width: $medium-screen) {
+    height: 18%;
+  }
   @media (min-width: $tablet-screen) {
     margin-bottom: 0;
   }

--- a/src/js/components/award/shared/InfoTooltipContent.jsx
+++ b/src/js/components/award/shared/InfoTooltipContent.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { uniqueId } from 'lodash';
-import { scrollToY } from 'helpers/scrollToHelper';
 import * as Icons from 'components/sharedComponents/icons/Icons';
 
 // Mapping of section identifier to tooltip content JSX

--- a/src/js/components/award/shared/InfoTooltipContent.jsx
+++ b/src/js/components/award/shared/InfoTooltipContent.jsx
@@ -1244,16 +1244,16 @@ CovidFlagTooltip.propTypes = {
 
 
 export const UnlinkedTooltip = (props) => {
-    const handleClick = () => {
-        const selector = `.federal-accounts`;
-        // scroll to the correct section
-        const sectionDom = document.querySelector(selector);
-        if (!sectionDom) {
-            return;
-        }
-        props.setShowTooltip(false);
-        scrollToY(sectionDom.offsetTop - 150, 700);
-    };
+    // const handleClick = () => {
+    //     const selector = `.federal-accounts`;
+    //     // scroll to the correct section
+    //     const sectionDom = document.querySelector(selector);
+    //     if (!sectionDom) {
+    //         return;
+    //     }
+    //     props.setShowTooltip(false);
+    //     scrollToY(sectionDom.offsetTop - 150, 700);
+    // };
 
     const clickCloseTooltip = () => {
         props.setShowTooltip(false);
@@ -1289,7 +1289,6 @@ export const UnlinkedTooltip = (props) => {
             </div>
             <div className="tooltip__text">
                 <p>This means all financial system data elements (File C) are unavailable on this page and in downloads for this award.</p>
-                <p>For more information, view the <a className="award-summary__unlinked-anchor" role="link" tabIndex={0} onMouseUp={handleClick}>Federal Accounts</a> section below.</p>
             </div>
         </div>);
 };

--- a/src/js/components/award/shared/InfoTooltipContent.jsx
+++ b/src/js/components/award/shared/InfoTooltipContent.jsx
@@ -1244,17 +1244,6 @@ CovidFlagTooltip.propTypes = {
 
 
 export const UnlinkedTooltip = (props) => {
-    // const handleClick = () => {
-    //     const selector = `.federal-accounts`;
-    //     // scroll to the correct section
-    //     const sectionDom = document.querySelector(selector);
-    //     if (!sectionDom) {
-    //         return;
-    //     }
-    //     props.setShowTooltip(false);
-    //     scrollToY(sectionDom.offsetTop - 150, 700);
-    // };
-
     const clickCloseTooltip = () => {
         props.setShowTooltip(false);
     };

--- a/src/js/components/sharedComponents/UnlinkedAwardWarning.jsx
+++ b/src/js/components/sharedComponents/UnlinkedAwardWarning.jsx
@@ -6,7 +6,6 @@
 import React from 'react';
 import { FlexGridRow, FlexGridCol } from 'data-transparency-ui';
 import { ExclamationTriangle } from 'components/sharedComponents/icons/Icons';
-import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 
 const propTypes = {
@@ -23,24 +22,6 @@ const UnlinkedAwardWarning = ({ topMargin, widerLayout }) => (
             <FlexGridCol className="unlinked-award-warning__column-two" width={11}>
                 <div className="unlinked-award-warning__heading">
                     This award has not been linked to any federal account.
-                </div>
-                <div className="unlinked-award-warning__text">
-                    This means all financial system data elements (File C) are unavailable on this page and in downloads for this award, including:
-                    <ul>
-                        <li>Federal and Treasury Account</li>
-                        <li>Submission Period</li>
-                        <li>Program Activity</li>
-                        <li>Object Class</li>
-                        <li>Disaster Emergency Fund Code</li>
-                        <li>Obligated Amount (as tracked in financial systems)</li>
-                        <li>Outlay amount</li>
-                    </ul>
-                    An award may be unlinked if any of the following apply:
-                    <ul>
-                        <li>The award lacks a shared ID between spending submitted through agency financial systems (File C) and spending submitted through either FPDS (D1) or FABS (D2). For more information, <Link to="/submission-statistics/data-sources">see “Number of Unlinked Awards” here</Link>.</li>
-                        <li>The award has no activity after FY17 Q2.</li>
-                        <li>The award is a loan with zero or negative subsidy cost.</li>
-                    </ul>
                 </div>
             </FlexGridCol>
         </FlexGridRow>


### PR DESCRIPTION
… the size of the warning change depending on screen size

**High level description:**

changes to unlinked awards messages

**Technical details:**

text changes; adjusted the height of the warning container; removed click handler no longer being used

**JIRA Ticket:**
[DEV-9587](https://federal-spending-transparency.atlassian.net/browse/DEV-9587)

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
