### PR TITLE
DEV-9543 clarify modal

### DIFF
--- a/src/_scss/pages/modals/filter/_filterModal.scss
+++ b/src/_scss/pages/modals/filter/_filterModal.scss
@@ -42,12 +42,22 @@
             background-color: $color-white;
 
             .filter-modal__top-description {
+                margin-bottom: 0;
+                margin-top: 0;
+            }
+
+            .filter-modal__top-description, .filter-modal__top-description-2 {
                 font-size: rem(16);
                 font-weight: normal;
                 font-stretch: normal;
                 font-style: normal;
                 line-height: 1.5;
                 letter-spacing: normal;
+            }
+
+            .filter-modal__top-description-2 {
+                margin-top: 4px;
+                margin-bottom: 0;
             }
 
             .filter-modal__example {
@@ -76,6 +86,16 @@
                 .filter-modal__description {
                     font-size: rem(16);
                     font-weight: normal;
+                    font-stretch: normal;
+                    font-style: normal;
+                    line-height: 1.5;
+                    letter-spacing: normal;
+                    color: $color-base;
+                }
+
+                .filter-modal__operator {
+                    font-size: rem(16);
+                    font-weight: $font-semibold;
                     font-stretch: normal;
                     font-style: normal;
                     line-height: 1.5;

--- a/src/js/components/search/table/ResultsTableSection.jsx
+++ b/src/js/components/search/table/ResultsTableSection.jsx
@@ -99,7 +99,7 @@ export default class ResultsTableSection extends React.Component {
                 Award summaries contain all the individual transactions and modifications that share the same unique award ID.
                 If you selected any Time Period filter, your results will include prime awards where the
                 {<span className="award-search__glossary-term"> earliest</span>}{' '}{<GlossaryLink term="base-transaction-action-date" />} and
-                {<span className="award-search__glossary-term"> latest</span>}{' '}{<GlossaryLink term="latest-transaction-action-date" />},
+                {<span className="award-search__glossary-term"> latest</span>}{' '}{<GlossaryLink term="latest-transaction-action-date" />}{' '}
                 transactions overlap with your selected time period (regardless of whether any transactions occur within that period).
                 </p>
             </>);

--- a/src/js/components/sharedComponents/FilterModal.jsx
+++ b/src/js/components/sharedComponents/FilterModal.jsx
@@ -52,9 +52,12 @@ const FilterModal = (props) => {
                     </div>
                 </div>
                 <div className="filter-modal__body">
-                    <div className="filter-modal__top-description">
-                        Active filters from within the same filter category function as an OR, and active filters across categories function as an AND. There are also some filters which search to see if the selected value is included within an award summary using INCLUDES or IN operators.
-                    </div>
+                    <p className="filter-modal__top-description">
+                    Active filters in Award Search use Boolean Operators, which are simple words (AND, OR) used to combine or exclude keywords in order to limit or modify search results. When selecting from the categories of filters in Award Search (e.g., “Time Period”, “Location” or “Recipient Type”), these operators function differently depending on whether you have selected multiple filters from within the same category (e.g., searching for spending to multiple states under the Location category), or across categories (e.g., searching for award spending in one location to one type of recipient).
+                    </p>
+                    <p className="filter-modal__top-description-2">
+                    Generally, active filters within the same category function as an OR, while active filters across categories function as an AND. There are also some filters which search to see if the selected value is included within an award summary using INCLUDES or IN operators.
+                    </p>
                     <div className="filter-modal__example">
                         <div className="filter-modal__title">
                             Example 1: An AND operator is used across filter categories
@@ -66,7 +69,7 @@ const FilterModal = (props) => {
                                 alt="" />
                         </div>
                         <div className="filter-modal__description">
-                            If the selected Time Period is "FY 2021" and the selected Recipient Type is "All Women Owned Business," the resulting awards will include all awards with any activity in Fiscal Year 2021 AND were given to a Women Owned Business.
+                        If the selected Time Period is “FY 2021” and the selected Recipient Type is “All Women Owned Business”, the search results will include all awards with any activity in Fiscal Year 2021 <span className="filter-modal__operator">AND</span>{' '}awards also issued to a Women Owned Business.
                         </div>
                     </div>
                     <div className="filter-modal__example">
@@ -80,12 +83,12 @@ const FilterModal = (props) => {
                                 alt="" />
                         </div>
                         <div className="filter-modal__description">
-                            If the selected Time Period is "Fy 2021" and the selected Recipient Types are "All Women Owned Business" and "All Veteran Owned Business," the resulting awards include all awards with any activity in Fiscal Year 2021 AND were also given to a Women Owned Business OR a Veteran Owned Business.
+                        If the selected Time Period is “FY 2021” and the selected Recipient Types are “All Women Owned Business” and “All Veteran Owned Business”, the search results will include all awards with any activity in Fiscal Year 2021 <span className="filter-modal__operator">AND</span>{' '}awards issued to a Women Owned Business <span className="filter-modal__operator">OR</span>{' '}a Veteran Owned Business.
                         </div>
                     </div>
                     <div className="filter-modal__example">
                         <div className="filter-modal__title">
-                            Example 3: INCLUDES or IN operators are used to check if active filters are included in lists associated with prime award summaries
+                            Example 3:  INCLUDES or IN operators are used to check if active filters are included in lists associated with prime award summaries
                         </div>
                         <div className="filter-modal__image">
                             <img
@@ -94,7 +97,7 @@ const FilterModal = (props) => {
                                 alt="" />
                         </div>
                         <div className="filter-modal__description">
-                            If the selected Recipient Type filters are "All Women Owned Business" and "All Veteran Owned Business" the resulting awards are identified because their prime award summary is on a list of awards that are associated with each Recipient Type. Another filter that also identifies awards because of their inclusion in a list of the Disaster Emergency Fund Code (DEFC) filter.
+                        If the selected Recipient Type filters are “All Women Owned Business” and “All Veteran Owned Business”, the resulting awards are identified because their prime award summary is on a list of awards that are associated with each Recipient Type. Another filter that also identifies awards because of their inclusion in a list is the Disaster Emergency Fund Code (DEFC) filter.
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
**High level description:**

the mac was hiding on the ticket so I didn't see it at first
i talked with the PO so that the mac won't be hidden on jira in the future for FE devs
there was also a comma as part of 9542 that needed to be deleted and i did it in this PR as opposed to creating a whole new one
The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
