### PR TITLE
9600 - made new tooltip for congressional districts info

### DIFF
--- a/src/_scss/components/tooltips/_customTooltipContent.scss
+++ b/src/_scss/components/tooltips/_customTooltipContent.scss
@@ -118,7 +118,7 @@
         color: $color-base;
     }
     &.homepage__covid-19-tt {
-        h2.tooltip__title {
+        h2, .tooltip__title {
             text-align: center;
         }
     }

--- a/src/_scss/components/tooltips/_customTooltipContent.scss
+++ b/src/_scss/components/tooltips/_customTooltipContent.scss
@@ -20,8 +20,8 @@
             .tooltip__title {
                 @include justify-content(center);
                 font-size: rem(16);
-            }          
-            
+            }
+
             .tooltip__close-button {
                 background-color: $color-gray-lightest;
                 .award-summary__close-button {
@@ -152,6 +152,12 @@
     p {
         font-size: rem(14);
         margin: 0;
+    }
+}
+
+.cd-tt {
+    p {
+        margin: rem(8) 0;
     }
 }
 

--- a/src/js/components/search/SearchSidebar.jsx
+++ b/src/js/components/search/SearchSidebar.jsx
@@ -38,7 +38,7 @@ import { Filter as FilterIcon } from 'components/sharedComponents/icons/Icons';
 import FilterSidebar from 'components/sharedComponents/filterSidebar/FilterSidebar';
 import * as SidebarHelper from 'helpers/sidebarHelper';
 import { TooltipWrapper } from 'data-transparency-ui';
-import { FilterTooltip } from '../../components/award/shared/InfoTooltipContent';
+import { FilterTooltip } from '../award/shared/InfoTooltipContent';
 
 const staticFilters = {
     // NOTE: if you update the title here

--- a/src/js/components/search/filters/tooltips/AdvancedSearchTooltip.jsx
+++ b/src/js/components/search/filters/tooltips/AdvancedSearchTooltip.jsx
@@ -90,11 +90,11 @@ export const DEFTooltip = () => (
 );
 
 export const CDTooltip = () => (
-    <div className="spending_types-tt">
+    <div className="homepage__covid-19-tt cd-tt">
         <h2 className="tooltip__title">
             CONGRESSIONAL DISTRICT (US ONLY)
         </h2>
-        <div className="tooltip__text cd-tt">
+        <div className="tooltip__text">
             <p>
                 <strong>Current Congressional Districts (based on 2023 redistricting)</strong>
             </p>

--- a/src/js/components/search/filters/tooltips/AdvancedSearchTooltip.jsx
+++ b/src/js/components/search/filters/tooltips/AdvancedSearchTooltip.jsx
@@ -89,6 +89,37 @@ export const DEFTooltip = () => (
     </div>
 );
 
+export const CDTooltip = () => (
+    <div className="spending_types-tt">
+        <h2 className="tooltip__title">
+            CONGRESSIONAL DISTRICT (US ONLY)
+        </h2>
+        <div className="tooltip__text cd-tt">
+            <p>
+                <strong>Current Congressional Districts (based on 2023 redistricting)</strong>
+            </p>
+            <p>
+                Use this filter to find spending based on the current geographic boundaries of each congressional district, including for awards that predated those districts.
+            </p>
+            <p>
+                Search results will reflect current congressional districts based on redistricting as a result of the 2020 Census. These districts will be in effect from 2023 – 2033.&#42;
+            </p>
+            <p>
+                <em>&#42;Court-ordered redistricting might alter the time frame a congressional district is in effect.</em>
+            </p>
+            <p>
+                <strong>Original Congressional Districts (as reported by federal agencies)</strong>
+            </p>
+            <p>
+                Use this filter to find spending based on the congressional district boundaries that were in effect when an award was issued.
+            </p>
+            <p>
+                Note that district boundaries have changed over time.
+            </p>
+        </div>
+    </div>
+);
+
 const CSSOnlyTooltipProps = {
     definition: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     heading: PropTypes.string,


### PR DESCRIPTION
**High level description:**

Make new tooltip for Congressional District info

**Technical details:**

Put it in AdvancedSearchTooltip.jsx; but used class from spending-types-tt bc that class has a line height that matches the mock for this; added a class for margin top and bottom for p elements, to match the mock

**JIRA Ticket:**
[DEV-9600](https://federal-spending-transparency.atlassian.net/browse/DEV-9600)

**Mockup:**
word doc attached to ticket

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
