### PR TITLE
Mod/9601 award page cd tooltip

### DIFF
--- a/src/_scss/components/tooltips/_customTooltipContent.scss
+++ b/src/_scss/components/tooltips/_customTooltipContent.scss
@@ -20,8 +20,8 @@
             .tooltip__title {
                 @include justify-content(center);
                 font-size: rem(16);
-            }          
-            
+            }
+
             .tooltip__close-button {
                 background-color: $color-gray-lightest;
                 .award-summary__close-button {
@@ -152,6 +152,12 @@
     p {
         font-size: rem(14);
         margin: 0;
+    }
+}
+
+.cd-tt {
+    p {
+        margin: rem(8) 0;
     }
 }
 

--- a/src/_scss/pages/award/visualizations/overview/_awardOverviewLeftSection.scss
+++ b/src/_scss/pages/award/visualizations/overview/_awardOverviewLeftSection.scss
@@ -29,8 +29,12 @@
         margin-bottom: rem(2.5);
     }
     // recipient address
-    .award-overview__left-section__recipient__recipient-address {
-      padding-bottom: rem(20);
+    .award-overview__left-section__recipient-address-container {
+        display: flex;
+        flex-flow: row nowrap;
+        .award-overview__left-section__recipient-tooltip {
+            align-self: flex-end;
+        }
     }
     // recipient text
     .award-overview__left-section__aggregated-text {

--- a/src/js/components/award/shared/overview/RecipientAddress.jsx
+++ b/src/js/components/award/shared/overview/RecipientAddress.jsx
@@ -6,6 +6,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { AddresskeysByAwardType } from 'dataMapping/award/awardOverview';
+import { TooltipWrapper } from "data-transparency-ui";
+import { CDTooltip } from 'components/search/filters/tooltips/AdvancedSearchTooltip';
+import FeatureFlag from "../../../sharedComponents/FeatureFlag";
 
 const propTypes = {
     aggregateRecordType: PropTypes.string,
@@ -32,8 +35,18 @@ const RecipientAddress = ({ recipientLocation, aggregateRecordType }) => {
         .map((addressKey) => recipientLocation[addressKey] || '')
         .some(regExTest);
     return (
-        <div className="award-overview__left-section__recipient__recipient-address">
-            { !addressContainsLetters ? '--' : recipientAddress }
+        <div className="award-overview__left-section__recipient-address-container">
+            <div className="award-overview__left-section__recipient__recipient-address">
+                { !addressContainsLetters ? '--' : recipientAddress }
+            </div>
+            <FeatureFlag>
+                <div className="award-overview__left-section__recipient-tooltip">
+                    <TooltipWrapper
+                        className="homepage__covid-19-tt"
+                        icon="info"
+                        tooltipComponent={<CDTooltip />} />
+                </div>
+            </FeatureFlag>
         </div>
     );
 };

--- a/src/js/components/search/filters/tooltips/AdvancedSearchTooltip.jsx
+++ b/src/js/components/search/filters/tooltips/AdvancedSearchTooltip.jsx
@@ -89,6 +89,37 @@ export const DEFTooltip = () => (
     </div>
 );
 
+export const CDTooltip = () => (
+    <div className="spending_types-tt">
+        <h2 className="tooltip__title">
+            CONGRESSIONAL DISTRICT (US ONLY)
+        </h2>
+        <div className="tooltip__text cd-tt">
+            <p>
+                <strong>Current Congressional Districts (based on 2023 redistricting)</strong>
+            </p>
+            <p>
+                Use this filter to find spending based on the current geographic boundaries of each congressional district, including for awards that predated those districts.
+            </p>
+            <p>
+                Search results will reflect current congressional districts based on redistricting as a result of the 2020 Census. These districts will be in effect from 2023 – 2033.&#42;
+            </p>
+            <p>
+                <em>&#42;Court-ordered redistricting might alter the time frame a congressional district is in effect.</em>
+            </p>
+            <p>
+                <strong>Original Congressional Districts (as reported by federal agencies)</strong>
+            </p>
+            <p>
+                Use this filter to find spending based on the congressional district boundaries that were in effect when an award was issued.
+            </p>
+            <p>
+                Note that district boundaries have changed over time.
+            </p>
+        </div>
+    </div>
+);
+
 const CSSOnlyTooltipProps = {
     definition: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     heading: PropTypes.string,

--- a/src/js/dataMapping/award/awardOverview.js
+++ b/src/js/dataMapping/award/awardOverview.js
@@ -14,8 +14,8 @@ export const AddresskeysByAwardType = {
         'streetAddress1',
         '_address2',
         'recipientRegionalAddress',
-        'recipientCongressionalDistrict',
-        'countryName'
+        'countryName',
+        'recipientCongressionalDistrict'
     ],
     financialAssistanceForeign: [
         'streetAddress1',
@@ -27,8 +27,8 @@ export const AddresskeysByAwardType = {
         'streetAddress1',
         '_address2',
         'recipientRegionalAddress',
-        'recipientCongressionalDistrict',
-        'countryName'
+        'countryName',
+        'recipientCongressionalDistrict'
     ],
     nonFinancialAssistanceForeign: [
         'streetAddress1',
@@ -36,10 +36,10 @@ export const AddresskeysByAwardType = {
         'recipientRegionalAddressContractsAndIDV',
         'countryName'
     ],
-    redactedDueToPIIDomestic: ['recipientRegionalAddress', 'recipientCongressionalDistrict', 'countryName'],
+    redactedDueToPIIDomestic: ['recipientRegionalAddress', 'countryName', 'recipientCongressionalDistrict'],
     redactedDueToPIIForeign: ['recipientRegionalAddress', 'countryName'],
-    aggregatedByState: ['stateName', 'recipientCongressionalDistrict', 'countryName'],
-    aggregatedByCounty: ['countyAndState', 'recipientCongressionalDistrict', 'countryName'],
+    aggregatedByState: ['stateName', 'countryName', 'recipientCongressionalDistrict'],
+    aggregatedByCounty: ['countyAndState', 'countryName', 'recipientCongressionalDistrict'],
     aggregatedByCountry: ['countryName']
 };
 


### PR DESCRIPTION
**High level description:**

On Award Profile page, move the Congressional District to follow the rest of the address and add the new CD tooltip there

**Technical details:**

Moved the CD line in addresses for all types of awards where CD was present; added the new CD tooltip; used flax for styling

**JIRA Ticket:**
[DEV-9601](https://federal-spending-transparency.atlassian.net/browse/DEV-9601)

**Mockup:**
not attached to ticket

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
