### PR TITLE
Mod/9602 cd tooltip in place of performance

### DIFF
--- a/src/_scss/pages/award/visualizations/_additionalInfo.scss
+++ b/src/_scss/pages/award/visualizations/_additionalInfo.scss
@@ -108,6 +108,13 @@
                           &.generated-id {
                             word-break: break-word;
                           }
+                          &.show-tooltip {
+                            display: flex;
+                            flex-flow: row nowrap;
+                            .accordion-row__data-tooltip {
+                              align-self: flex-end;
+                            }
+                          }
                           .accordion-table__list {
                             list-style-type: none;
                             margin: 0;

--- a/src/_scss/pages/award/visualizations/_additionalInfo.scss
+++ b/src/_scss/pages/award/visualizations/_additionalInfo.scss
@@ -96,12 +96,10 @@
                         font-size: rem(14);
                         .accordion-row__title {
                           @include flex-direction(column);
-                          flex-basis: 100%;
                           flex: 1;
                         }
                         .accordion-row__data {
                           @include flex-direction(column);
-                          flex-basis: 100%;
                           flex: 1;
                           font-weight: $font-light;
                           padding-left: rem(40);

--- a/src/_scss/pages/award/visualizations/_additionalInfo.scss
+++ b/src/_scss/pages/award/visualizations/_additionalInfo.scss
@@ -111,6 +111,12 @@
                             flex-flow: row nowrap;
                             .accordion-row__data-tooltip {
                               align-self: flex-end;
+                              .tooltip-wrapper {
+                                .tooltip__icon {
+                                  height: rem(14);
+                                  width: rem(14);
+                                }
+                              }
                             }
                           }
                           .accordion-table__list {

--- a/src/_scss/pages/award/visualizations/overview/_awardOverviewLeftSection.scss
+++ b/src/_scss/pages/award/visualizations/overview/_awardOverviewLeftSection.scss
@@ -34,6 +34,12 @@
         flex-flow: row nowrap;
         .award-overview__left-section__recipient-tooltip {
             align-self: flex-end;
+            .tooltip-wrapper {
+                .tooltip__icon {
+                    height: rem(14);
+                    width: rem(14);
+                }
+            }
         }
     }
     // recipient text

--- a/src/_scss/pages/search/searchSidebar.scss
+++ b/src/_scss/pages/search/searchSidebar.scss
@@ -67,8 +67,8 @@
                     margin-top: rem(5);
                 }
             }
-            
-            .sidebar-paragraph__container{
+
+            .sidebar-paragraph__container {
                 padding-bottom: rem(16);
                 display: flex;
                 flex-flow: row;
@@ -82,12 +82,12 @@
                     .award-summary__new-category {
                             margin-bottom: rem(0);
                     }
-                    .tooltip__icon{
+                    .tooltip__icon {
                         height: rem(15);
                         width: rem(15);
                     }
                     .ul-override_filter {
-                        ul{
+                        ul {
                             padding-left: rem(16);
                             margin-top: rem(0);
                         }

--- a/src/js/components/award/shared/additionalInfo/Accordion.jsx
+++ b/src/js/components/award/shared/additionalInfo/Accordion.jsx
@@ -112,11 +112,11 @@ export default class Accordion extends React.Component {
                     key={key}
                     className="accordion-row">
                     <div className="accordion-row__title">{key}</div>
-                    <div className={`accordion-row__data${key === awardIdField ? ' generated-id' : ''}`}>
+                    <div className={`accordion-row__data${key === awardIdField ? ' generated-id' : ''} ${this.state.showCDTooltip ? ' show-tooltip' : ''}`}>
                         {data}
                         {this.state.showCDTooltip && (
                             <FeatureFlag>
-                                <div className="award-overview__left-section__recipient-tooltip">
+                                <div className="accordion-row__data-tooltip">
                                     <TooltipWrapper
                                         className="homepage__covid-19-tt"
                                         icon="info"

--- a/src/js/components/award/shared/additionalInfo/Accordion.jsx
+++ b/src/js/components/award/shared/additionalInfo/Accordion.jsx
@@ -9,6 +9,9 @@ import { compact } from 'lodash';
 import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { createOnKeyDownHandler } from 'helpers/keyboardEventsHelper';
+import { TooltipWrapper } from "data-transparency-ui";
+import { CDTooltip } from 'components/search/filters/tooltips/AdvancedSearchTooltip';
+import FeatureFlag from "../../../sharedComponents/FeatureFlag";
 
 const awardIdField = 'Unique Award Key';
 
@@ -25,7 +28,8 @@ export default class Accordion extends React.Component {
         super(props);
 
         this.state = {
-            open: false
+            open: false,
+            showCDTooltip: false
         };
 
         this.handleClick = this.handleClick.bind(this);
@@ -90,6 +94,7 @@ export default class Accordion extends React.Component {
         const { accordionData } = this.props;
         if (!accordionData) return null;
         return Object.keys(accordionData).map((key) => {
+            this.state.showCDTooltip = false;
             let data = accordionData[key] || '--';
             // display data as a link, address or list
             if (accordionData[key]) {
@@ -98,13 +103,28 @@ export default class Accordion extends React.Component {
                 if (specialType) {
                     data = this[awardInfo.type](awardInfo.data);
                 }
+                if (specialType === 'address') {
+                    this.state.showCDTooltip = true;
+                }
             }
             return (
                 <div
                     key={key}
                     className="accordion-row">
                     <div className="accordion-row__title">{key}</div>
-                    <div className={`accordion-row__data${key === awardIdField ? ' generated-id' : ''}`}>{data}</div>
+                    <div className={`accordion-row__data${key === awardIdField ? ' generated-id' : ''}`}>
+                        {data}
+                        {this.state.showCDTooltip && (
+                            <FeatureFlag>
+                                <div className="award-overview__left-section__recipient-tooltip">
+                                    <TooltipWrapper
+                                        className="homepage__covid-19-tt"
+                                        icon="info"
+                                        tooltipComponent={<CDTooltip />} />
+                                </div>
+                            </FeatureFlag>
+                        )}
+                    </div>
                 </div>
             );
         });

--- a/src/js/components/award/shared/additionalInfo/Accordion.jsx
+++ b/src/js/components/award/shared/additionalInfo/Accordion.jsx
@@ -12,20 +12,22 @@ import { createOnKeyDownHandler } from 'helpers/keyboardEventsHelper';
 
 const awardIdField = 'Unique Award Key';
 
-export default class Accordion extends React.Component {
-    static propTypes = {
-        accordionName: PropTypes.string,
-        accordionIcon: PropTypes.string,
-        iconClassName: PropTypes.string,
-        accordionData: PropTypes.object,
-        globalToggle: PropTypes.bool
-    };
+const propTypes = {
+    accordionName: PropTypes.string,
+    accordionIcon: PropTypes.string,
+    iconClassName: PropTypes.string,
+    accordionData: PropTypes.object,
+    globalToggle: PropTypes.bool
+};
 
+export default class Accordion extends React.Component {
     constructor(props) {
         super(props);
+
         this.state = {
             open: false
         };
+
         this.handleClick = this.handleClick.bind(this);
     }
 
@@ -139,3 +141,6 @@ export default class Accordion extends React.Component {
         );
     }
 }
+
+Accordion.propTypes = propTypes;
+

--- a/src/js/components/award/shared/additionalInfo/AdditionalInfo.jsx
+++ b/src/js/components/award/shared/additionalInfo/AdditionalInfo.jsx
@@ -14,11 +14,11 @@ import additionalDetailsIdv from 'dataMapping/award/additionalDetailsIdv';
 import Accordion from './Accordion';
 import IdvPeriodOfPerformance from './IdvPeriodOfPerformance';
 
-export default class AdditionalInfo extends React.Component {
-    static propTypes = {
-        overview: PropTypes.object
-    };
+const propTypes = {
+    overview: PropTypes.object
+};
 
+export default class AdditionalInfo extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
@@ -232,3 +232,5 @@ export default class AdditionalInfo extends React.Component {
         );
     }
 }
+
+AdditionalInfo.propTypes = propTypes;

--- a/src/js/components/award/shared/additionalInfo/AdditionalInfo.jsx
+++ b/src/js/components/award/shared/additionalInfo/AdditionalInfo.jsx
@@ -114,7 +114,7 @@ export default class AdditionalInfo extends React.Component {
                 globalToggle={this.state.globalToggle}
                 accordionName="Acquisition Details"
                 accordionIcon="tag"
-                accordionData={data.aquisitionDetails} />),
+                accordionData={data.acquisitionDetails} />),
             (<Accordion
                 key="CompetitionDetails"
                 globalToggle={this.state.globalToggle}

--- a/src/js/dataMapping/award/additionalDetailsContract.js
+++ b/src/js/dataMapping/award/additionalDetailsContract.js
@@ -137,8 +137,8 @@ const additionalDetailsContracts = (awardData) => {
                 data: [
                     `${recipient.location.streetAddress}`,
                     `${recipient.location.regionalAddress}`,
-                    `${recipient.location.fullCongressionalDistrict}`,
-                    `${recipient.location._country}`
+                    `${recipient.location._country}`,
+                    `${recipient.location.fullCongressionalDistrict}`
                 ]
             },
             'Business Types': {
@@ -146,7 +146,7 @@ const additionalDetailsContracts = (awardData) => {
                 data: recipient.businessCategories || []
             }
         },
-        aquisitionDetails: {
+        acquisitionDetails: {
             'Product or Service Code (PSC)': awardData.additionalDetails.pscCode,
             'North American Industry Classification System (NAICS) Code': awardData.additionalDetails.naicsCode,
             'DoD Claimant Code': awardData.additionalDetails.dodClaimantProgram,

--- a/src/js/dataMapping/award/additionalDetailsContract.js
+++ b/src/js/dataMapping/award/additionalDetailsContract.js
@@ -93,8 +93,8 @@ const additionalDetailsContracts = (awardData) => {
                 type: 'address',
                 data: [
                     `${placeOfPerformance.regionalAddress}`,
-                    `${placeOfPerformance.fullCongressionalDistrict}`,
-                    `${placeOfPerformance._country}`
+                    `${placeOfPerformance._country}`,
+                    `${placeOfPerformance.fullCongressionalDistrict}`
                 ]
             }
         },

--- a/src/js/dataMapping/award/additionalDetailsFinancialAssistance.js
+++ b/src/js/dataMapping/award/additionalDetailsFinancialAssistance.js
@@ -127,8 +127,8 @@ const additionalDetailsFinancialAssistance = (awardData) => {
                 data: [
                     `${recipient.location.streetAddress}`,
                     `${recipient.location.regionalAddress}`,
-                    `${recipient.location.fullCongressionalDistrict}`,
-                    `${recipient.location._country}`
+                    `${recipient.location._country}`,
+                    `${recipient.location.fullCongressionalDistrict}`
                 ]
             },
             'Business Types': {

--- a/src/js/dataMapping/award/additionalDetailsFinancialAssistance.js
+++ b/src/js/dataMapping/award/additionalDetailsFinancialAssistance.js
@@ -90,8 +90,8 @@ const additionalDetailsFinancialAssistance = (awardData) => {
                 type: 'address',
                 data: [
                     `${placeOfPerformance.regionalAddress}`,
-                    `${placeOfPerformance.fullCongressionalDistrict}`,
-                    `${placeOfPerformance._country}`
+                    `${placeOfPerformance._country}`,
+                    `${placeOfPerformance.fullCongressionalDistrict}`
                 ]
             }
         },

--- a/src/js/dataMapping/award/additionalDetailsIdv.js
+++ b/src/js/dataMapping/award/additionalDetailsIdv.js
@@ -110,7 +110,7 @@ const additionalDetails = (awardData) => {
                 data: recipient.businessCategories || []
             }
         },
-        aquisitionDetails: {
+        acquisitionDetails: {
             'Product or Service Code (PSC)': awardData.additionalDetails.pscCode,
             'NAICS Code': awardData.additionalDetails.naicsCode,
             'DoD Claimant Code': awardData.additionalDetails.dodClaimantProgram,

--- a/src/js/dataMapping/award/additionalDetailsIdv.js
+++ b/src/js/dataMapping/award/additionalDetailsIdv.js
@@ -101,8 +101,8 @@ const additionalDetails = (awardData) => {
                 data: [
                     `${recipient.location.streetAddress}`,
                     `${recipient.location.regionalAddress}`,
-                    `${recipient.location.fullCongressionalDistrict}`,
-                    `${recipient.location._country}`
+                    `${recipient.location._country}`,
+                    `${recipient.location.fullCongressionalDistrict}`
                 ]
             },
             'Business Types': {


### PR DESCRIPTION
**High level description:**

On Award profile pages, in the Additional Details section at the bottom of the page, in both the Place of Performance and Recipient Details accordions, change the address so that the Congressional District is last, then add the new CD tooltip to the end of that line; and add the Feature Flag to hise this in Prod

**Technical details:**

Both of these are made in the same loop in Accordion, so I added a state var to tell when to add this tooltip

**JIRA Ticket:**
[DEV-9602](https://federal-spending-transparency.atlassian.net/browse/DEV-9602)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
