### PR TITLE
Mod 9610 status of funds hover modal

### DIFF
--- a/src/_scss/pages/agency/visualizations/_statusOfFundsChart.scss
+++ b/src/_scss/pages/agency/visualizations/_statusOfFundsChart.scss
@@ -35,7 +35,6 @@
     font-weight: $font-semibold;
     color: $gray-90;
     background-color: $color-white;
-    height: rem(100);
   }
   .tooltip__text {
     padding-left: 2rem;

--- a/src/_scss/pages/agency/visualizations/_statusOfFundsChart.scss
+++ b/src/_scss/pages/agency/visualizations/_statusOfFundsChart.scss
@@ -35,6 +35,7 @@
     font-weight: $font-semibold;
     color: $gray-90;
     background-color: $color-white;
+    height: rem(100);
   }
   .tooltip__text {
     padding-left: 2rem;
@@ -65,7 +66,6 @@
         padding-right: 0.8rem;
         margin-top: 0.4rem;
       }
-
       .tooltip__text {
         font-size: rem(14);
       }

--- a/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
@@ -180,6 +180,9 @@ const StatusOfFundsChart = ({
         }
         return null;
     };
+     const tooltipHeight = level === 1 ? 280 : 230;
+     const tooltipHeightOutlay = level === 1 ? 280 : 210;
+
     const paddingResize = () => {
         if (isLargeScreen) {
             return 0.3;
@@ -1005,7 +1008,6 @@ const StatusOfFundsChart = ({
             setSortedNums(results.sort((a, b) => (b._budgetaryResources - a._budgetaryResources)));
         }
     }, [results]);
-
     return (
         <>
             {
@@ -1015,10 +1017,10 @@ const StatusOfFundsChart = ({
                     width={288}
                     styles={!toggle ? {
                         position: 'absolute',
-                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - 270}px)`
+                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - tooltipHeight}px)`
                     } : {
                         position: 'absolute',
-                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - 210}px)`
+                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - tooltipHeightOutlay}px)`
                     }}
                     tooltipPosition="bottom"
                     tooltipComponent={tooltip(hoverData)}

--- a/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
@@ -180,8 +180,8 @@ const StatusOfFundsChart = ({
         }
         return null;
     };
-     const tooltipHeight = level === 1 ? 280 : 230;
-     const tooltipHeightOutlay = level === 1 ? 280 : 210;
+    const tooltipHeight = level === 1 ? 280 : 230;
+    const tooltipHeightOutlay = level === 1 ? 280 : 210;
 
     const paddingResize = () => {
         if (isLargeScreen) {

--- a/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
@@ -1015,10 +1015,10 @@ const StatusOfFundsChart = ({
                     width={288}
                     styles={!toggle ? {
                         position: 'absolute',
-                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - 230}px)`
+                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - 280}px)`
                     } : {
                         position: 'absolute',
-                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - 200}px)`
+                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - 280}px)`
                     }}
                     tooltipPosition="bottom"
                     tooltipComponent={tooltip(hoverData)}

--- a/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
@@ -170,6 +170,16 @@ const StatusOfFundsChart = ({
 
         return viewHeight * 1.06;
     };
+    const chartLevelText = () => {
+        if (level === 0) {
+            return <><hr /><div className="tooltip__text-note">Click a sub-component to view <br />Federal Accounts</div></>;
+        } else if (level === 1) {
+            return <><hr /><div className="tooltip__text-note">Click a Federal Account to view <br />Treasury Accounts</div></>;
+        } else if (level === 2) {
+            return <><hr /><div className="tooltip__text-note">Click a Treasury Account to view <br />Program Activities or Object Classes</div></>;
+        }
+        return null;
+    };
     const paddingResize = () => {
         if (isLargeScreen) {
             return 0.3;
@@ -213,7 +223,7 @@ const StatusOfFundsChart = ({
                             {!toggle && <div className="tooltip__text-label">FY{fy[2]}{fy[3]} Total Budgetary<br />Resources</div>}
                             {!toggle && <div className="tooltip__text-amount">{data.budgetaryResources}</div>}
                         </div>
-                        {level === 0 && (<><hr /><div className="tooltip__text-note">Click bar to view Federal Accounts</div></>)}
+                        {chartLevelText()}
                     </div>
                 </div>
             );

--- a/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
@@ -1015,10 +1015,10 @@ const StatusOfFundsChart = ({
                     width={288}
                     styles={!toggle ? {
                         position: 'absolute',
-                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - 280}px)`
+                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - 270}px)`
                     } : {
                         position: 'absolute',
-                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - 280}px)`
+                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - 210}px)`
                     }}
                     tooltipPosition="bottom"
                     tooltipComponent={tooltip(hoverData)}


### PR DESCRIPTION
**High level description:**

Added some wording to a tooltip that changes based on what status of fund level its on

**Technical details:**

Hover modal on each level of the Status of Funds chart includes the “Click bar to view [next funding level]”

“Click bar…” text is updated to the following in descending order: TBD

Click a sub-component to view Federal Accounts

Click a Federal Account to view Treasury Accounts

Click a Treasury Account to view Program Activities or Object Classes

**JIRA Ticket:**
[DEV-9610](https://federal-spending-transparency.atlassian.net/browse/DEV-9610)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
