### PR TITLE
Changed so a click will drill down  on the full bar

### DIFF
--- a/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
@@ -926,7 +926,7 @@ const StatusOfFundsChart = ({
                 .attr('id', 'out-bar');
 
             // on click drilldown
-            svg.selectAll("#out-bar").on('click', (event, d) => {
+            svg.selectAll(".bar-group").on('click', (event, d) => {
                 handleClick(d);
             });
             svg.selectAll("#out-bar").on('touchend', (event, d) => {

--- a/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
@@ -929,7 +929,7 @@ const StatusOfFundsChart = ({
             svg.selectAll(".bar-group").on('click', (event, d) => {
                 handleClick(d);
             });
-            svg.selectAll("#out-bar").on('touchend', (event, d) => {
+            svg.selectAll(".bar-group").on('touchend', (event, d) => {
                 handleClick(d);
             });
             // tab through and enter key functionality


### PR DESCRIPTION
**High level description:**

Changed the status of fund outlays chart, to where the entire bar is clickable to the next level instead of just the yellow parts.

Made sure the lowest level is not clickable. 

**Technical details:**


**JIRA Ticket:**
[DEV-9613](https://federal-spending-transparency.atlassian.net/browse/DEV-9613)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
