### PR TITLE
9601 - added new condensed congressional district tooltip object; rep…

### DIFF
--- a/src/js/components/award/shared/InfoTooltipContent.jsx
+++ b/src/js/components/award/shared/InfoTooltipContent.jsx
@@ -1349,3 +1349,26 @@ UnlinkedTooltip.propTypes = {
     setShowTooltip: PropTypes.func
 };
 
+export const CondensedCDTooltip = ({ title }) => (
+    <div className="award-summary-tooltip">
+        <div className="tooltip__title">
+            {title}
+        </div>
+        <div className="tooltip__text">
+            <p>
+                The congressional districts displayed reflect their current geographic boundaries and are based on the 2020 Census. These districts will be in effect from 2023 – 2033.&#42;
+            </p>
+            <p>
+                Additional information on congressional districts and how they are displayed on the site can be found within the Congressional District section of the <strong>About the Data</strong> module under <strong>Resources</strong>.
+            </p>
+            <p>
+                <em>&#42;Court-ordered redistricting might alter the time frame a congressional district is in effect.</em>
+            </p>
+        </div>
+    </div>
+);
+
+CondensedCDTooltip.propTypes = {
+    title: PropTypes.string
+};
+

--- a/src/js/components/award/shared/additionalInfo/Accordion.jsx
+++ b/src/js/components/award/shared/additionalInfo/Accordion.jsx
@@ -10,7 +10,7 @@ import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { createOnKeyDownHandler } from 'helpers/keyboardEventsHelper';
 import { TooltipWrapper } from "data-transparency-ui";
-import { CDTooltip } from 'components/search/filters/tooltips/AdvancedSearchTooltip';
+import { CondensedCDTooltip } from 'components/award/shared/InfoTooltipContent';
 import FeatureFlag from "../../../sharedComponents/FeatureFlag";
 
 const awardIdField = 'Unique Award Key';
@@ -120,7 +120,7 @@ export default class Accordion extends React.Component {
                                     <TooltipWrapper
                                         className="homepage__covid-19-tt"
                                         icon="info"
-                                        tooltipComponent={<CDTooltip />} />
+                                        tooltipComponent={<CondensedCDTooltip title="Congressional District" />} />
                                 </div>
                             </FeatureFlag>
                         )}

--- a/src/js/components/award/shared/overview/RecipientAddress.jsx
+++ b/src/js/components/award/shared/overview/RecipientAddress.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { AddresskeysByAwardType } from 'dataMapping/award/awardOverview';
 import { TooltipWrapper } from "data-transparency-ui";
-import { CDTooltip } from 'components/search/filters/tooltips/AdvancedSearchTooltip';
+import { CondensedCDTooltip } from 'components/award/shared/InfoTooltipContent';
 import FeatureFlag from "../../../sharedComponents/FeatureFlag";
 
 const propTypes = {
@@ -44,7 +44,7 @@ const RecipientAddress = ({ recipientLocation, aggregateRecordType }) => {
                     <TooltipWrapper
                         className="homepage__covid-19-tt"
                         icon="info"
-                        tooltipComponent={<CDTooltip />} />
+                        tooltipComponent={<CondensedCDTooltip title="Congressional District" />} />
                 </div>
             </FeatureFlag>
         </div>


### PR DESCRIPTION
…laced the tooltips from 9601 and 9602 with the new one

**High level description:**

9601 and 9602 used the wrong copy for the tooltips

**Technical details:**

Made a new condensed congressional district tooltip object, to be used in several places on a few pages

**JIRA Ticket:**
[DEV-9601](https://federal-spending-transparency.atlassian.net/browse/DEV-9601)
[DEV-9602](https://federal-spending-transparency.atlassian.net/browse/DEV-9602)

**Mockup:**
https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55/screen/63e3ce15148e7a1892878626

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
