### PR TITLE
Removed the input for on Glossary Definition Component

### DIFF
--- a/src/_scss/pages/glossary/_definition.scss
+++ b/src/_scss/pages/glossary/_definition.scss
@@ -5,6 +5,9 @@
     .glossary-share-icon:hover {
         color: $color-white;
     }
+    .definition-tabs{
+        margin-top: rem(24);
+    }
 
     h2.term {
         font-size: 24px;

--- a/src/js/components/glossary/definition/GlossaryDefinition.jsx
+++ b/src/js/components/glossary/definition/GlossaryDefinition.jsx
@@ -126,7 +126,6 @@ export default class GlossaryDefinition extends React.Component {
         });
         return (
             <div className="glossary-definition">
-                <input readOnly id="slug" type="text" className="text" style={{ opacity: 0 }} value={url} />
                 <DefinitionTabs
                     hasPlain={this.state.hasPlain}
                     hasOfficial={this.state.hasOfficial}


### PR DESCRIPTION
Removed an input element according to the 508 scan.

**High level description:**

Removed an input element that wasn't doing anything due to 508 scan

**JIRA Ticket:**
[DEV-9657](https://federal-spending-transparency.atlassian.net/browse/DEV-9657)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
