### PR TITLE
Mod/9660 aria roles on search results tabs

### DIFF
--- a/src/_scss/pages/search/results/_tabs.scss
+++ b/src/_scss/pages/search/results/_tabs.scss
@@ -60,7 +60,7 @@
         @include align-items(center);
         position: relative;
         z-index: 2;
-        margin-left: rem(5);
+        margin-right: rem(4);
         padding: rem(20);
         background-color: $gray-cool-10;
         border-top-left-radius: 5px;
@@ -140,14 +140,6 @@
 
             &.active {
                 opacity: 1;
-            }
-        }
-    }
-
-    li {
-        &:first-child {
-            .visualization-type-tab {
-                margin-left: 0;
             }
         }
     }

--- a/src/js/components/search/visualizations/VisualizationTabItem.jsx
+++ b/src/js/components/search/visualizations/VisualizationTabItem.jsx
@@ -30,24 +30,21 @@ const VisualizationTabItem = (props) => {
     }
 
     return (
-        <li>
-            <button
-                className={`visualization-type-tab ${active}`}
-                aria-label={props.label}
-                role="menuitemradio"
-                aria-checked={props.active}
-                title={props.label}
-                onClick={clickedTab}
-                disabled={props.disabled}
-                id={props.id}>
-                <div className="icon">
-                    <Icon alt={props.label} />
-                </div>
-                <div className="label">
-                    {props.label}
-                </div>
-            </button>
-        </li>
+        <button
+            className={`visualization-type-tab ${active}`}
+            aria-label={props.label}
+            role="tab"
+            title={props.label}
+            onClick={clickedTab}
+            disabled={props.disabled}
+            id={props.id}>
+            <div className="icon">
+                <Icon alt={props.label} />
+            </div>
+            <div className="label">
+                {props.label}
+            </div>
+        </button>
     );
 };
 

--- a/src/js/components/search/visualizations/VisualizationWrapper.jsx
+++ b/src/js/components/search/visualizations/VisualizationWrapper.jsx
@@ -140,8 +140,7 @@ const VisualizationWrapper = (props) => {
                     subaward={props.subaward}
                     setSearchViewSubaward={props.setSearchViewSubaward} />
             </div>
-            <div
-                className="visualization-tabs">
+            <div className="visualization-tabs">
                 <div
                     className="visualization-tabs__list"
                     aria-label="Visualization types"

--- a/src/js/components/search/visualizations/VisualizationWrapper.jsx
+++ b/src/js/components/search/visualizations/VisualizationWrapper.jsx
@@ -81,6 +81,7 @@ const VisualizationWrapper = (props) => {
         logVisualizationTab(props.type);
         parseTab();
         setMounted(true);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     const tabs = tabOptions.map((tab) => (
@@ -140,14 +141,13 @@ const VisualizationWrapper = (props) => {
                     setSearchViewSubaward={props.setSearchViewSubaward} />
             </div>
             <div
-                className="visualization-tabs"
-                role="navigation"
-                aria-label="Visualization types">
-                <ul
+                className="visualization-tabs">
+                <div
                     className="visualization-tabs__list"
-                    role="menu">
+                    aria-label="Visualization types"
+                    role="tablist">
                     {tabs}
-                </ul>
+                </div>
                 <div className="visualization-tabs__toggle">
                     <SubawardToggle
                         subaward={props.subaward}


### PR DESCRIPTION
**High level description:**

508 scan flagged problem with the aria roles on the tabs on the Search results page

**Technical details:**

Mostly explained in the ticket; changed roles to tablist and tab; removed unneeded ul and li; removed unneeded aria properties; slightly adjusted css margin for tabs

**JIRA Ticket:**
[DEV-9660](https://federal-spending-transparency.atlassian.net/browse/DEV-9660)

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
