### PR TITLE
9694 - changed role for the tabs and their parent; changed to aria-se…

### DIFF
--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -301,13 +301,13 @@ export default class TimePeriod extends React.Component {
                 <div className="filter-item-wrap">
                     <ul
                         className="toggle-buttons"
-                        role="menu">
+                        role="tablist">
                         <li>
                             <button
                                 className={`tab-toggle ${activeClassFY}`}
                                 value="fy"
-                                role="menuitemradio"
-                                aria-checked={this.props.activeTab === 'fy'}
+                                role="tab"
+                                aria-selected={this.props.activeTab === 'fy'}
                                 aria-label="Fiscal Year"
                                 title="Fiscal Year"
                                 onClick={this.toggleFilters}>
@@ -319,8 +319,8 @@ export default class TimePeriod extends React.Component {
                                 className={`tab-toggle ${activeClassDR}`}
                                 id="filter-date-range-tab"
                                 value="dr"
-                                role="menuitemradio"
-                                aria-checked={this.props.activeTab === 'dr'}
+                                role="tab"
+                                aria-selected={this.props.activeTab === 'dr'}
                                 aria-label="Date Range"
                                 title="Date Range"
                                 onClick={this.toggleFilters}


### PR DESCRIPTION
…lected

**High level description:**

508 issues from latest scan showed problem in the tabs in the Time Period filter

**Technical details:**

Finally figured out to just change the roles to tab and tablist; and change from aria-checked to aria-selected

**JIRA Ticket:**
[DEV-9694](https://federal-spending-transparency.atlassian.net/browse/DEV-9694)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
