### PR TITLE
Added Tooltip Advanced Search Geo Map

### DIFF
--- a/src/_scss/pages/search/results/visualizations/geo/_disclaimer.scss
+++ b/src/_scss/pages/search/results/visualizations/geo/_disclaimer.scss
@@ -16,7 +16,7 @@
     background-color: $color-gold-lightest;
     border: 1px solid $color-gold-light;
     box-shadow: $box-shadow;
-    z-index: $z-header - 1;
+    z-index: 4;
 
     padding: rem(10);
 

--- a/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
+++ b/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
@@ -1,5 +1,5 @@
 .map-layer-toggle {
-    z-index: 3;
+    z-index: 4;
     background-color: $color-white;
     display: block;
     box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3);
@@ -39,6 +39,11 @@
                 margin-top: 0;
                 margin-left: 0;
             }
+            .map-layer__cd-tooltip {
+                svg { 
+                    margin-left: 8px;
+                }
+            }
         }
 
         .map-layer-option {
@@ -49,7 +54,7 @@
             font-weight: $font-normal;
             line-height: rem(18);
 
-            padding: 0 rem(5);
+            padding: 0;
             border-bottom: rem(4) solid $color-white;
 
             &.active, &:hover, &:active {

--- a/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
+++ b/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
@@ -1,5 +1,5 @@
 .map-layer-toggle {
-    z-index: 4;
+    z-index: 5;
     background-color: $color-white;
     display: block;
     box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3);

--- a/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
+++ b/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
@@ -65,6 +65,11 @@
                 display: block;
                 height: 0;
             }
+            .tooltip-pointer {
+                &.left {
+                    left: rem(-16);
+                }
+            }
         }
     }
 }

--- a/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
+++ b/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
@@ -65,11 +65,15 @@
                 display: block;
                 height: 0;
             }
+
             .tooltip-pointer {
                 &.left {
                     left: rem(-16);
                 }
             }
+        }
+        .map-layer__cd-tooltip{
+            display: inline-flex;
         }
     }
 }

--- a/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
+++ b/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
@@ -1,5 +1,5 @@
 .map-layer-toggle {
-    z-index: 2;
+    z-index: 3;
     background-color: $color-white;
     display: block;
     box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3);
@@ -74,6 +74,13 @@
         }
         .map-layer__cd-tooltip{
             display: inline-flex;
+            white-space: normal;
+            .tooltip-spacer {
+                max-width: 316px !important;
+                @media (max-width: $tablet-screen) {
+                    left: rem(-19) !important;
+                }
+            }
         }
     }
 }

--- a/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
+++ b/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
@@ -5,6 +5,9 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { TooltipWrapper } from 'data-transparency-ui';
+import { CondensedCDTooltip } from '../../../award/shared/InfoTooltipContent';
+import FeatureFlag from '../../../sharedComponents/FeatureFlag';
 
 const propTypes = {
     active: PropTypes.string,
@@ -30,7 +33,6 @@ const MapLayerToggle = (props) => {
         if (props.active === layer) {
             active = 'active';
         }
-
         return (
             <li
                 key={layer}>
@@ -41,7 +43,13 @@ const MapLayerToggle = (props) => {
                     aria-label={`Display by ${title}`}
                     data-content={title}
                     value={layer}>
-                    {title}
+                    {title === 'Congressional District' ?
+                        <div
+                            style={{ display: 'flex' }}>
+                            {title}s <FeatureFlag><TooltipWrapper className="congressional-district__tt" tooltipPosition="right" icon="info" tooltipComponent={<CondensedCDTooltip title="Congressional District" />} /></FeatureFlag>
+                        </div>
+                        :
+                        <>{title}s </>}
                 </button>
             </li>
         );

--- a/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
+++ b/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
@@ -46,7 +46,7 @@ const MapLayerToggle = (props) => {
                     {title === 'Congressional District' ?
                         <div
                             style={{ display: 'flex' }}>
-                            {title}s <FeatureFlag><TooltipWrapper className="congressional-district__tt" tooltipPosition="right" icon="info" tooltipComponent={<CondensedCDTooltip title="Congressional District" />} /></FeatureFlag>
+                            {title}s <FeatureFlag><TooltipWrapper tooltipPosition="right" icon="info" tooltipComponent={<CondensedCDTooltip title="Congressional District" />} /></FeatureFlag>
                         </div>
                         :
                         <>{title}s </>}

--- a/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
+++ b/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
@@ -28,7 +28,17 @@ const MapLayerToggle = (props) => {
     };
 
     const items = props.available.map((layer) => {
-        const title = capitalizeLabel(props.sources[layer].label);
+        let tempLabel = '';
+        if (props.sources[layer].label === 'county') {
+            tempLabel = 'counties';
+        }
+        else if (props.sources[layer].label === 'state') {
+            tempLabel = 'states';
+        }
+        else {
+            tempLabel = 'Congressional Districts';
+        }
+        const title = capitalizeLabel(tempLabel);
         let active = '';
         if (props.active === layer) {
             active = 'active';
@@ -43,14 +53,17 @@ const MapLayerToggle = (props) => {
                     aria-label={`Display by ${title}`}
                     data-content={title}
                     value={layer}>
-                    {title === 'Congressional District' ?
-                        <span
-                            style={{ display: 'flex' }}>
-                            {title}s <FeatureFlag><TooltipWrapper tooltipPosition="right" icon="info" tooltipComponent={<CondensedCDTooltip title="Congressional District" />} /></FeatureFlag>
-                        </span>
-                        :
-                        <>{title}s </>}
+                    {title}
                 </button>
+                {title === "Congressional Districts" ?
+                    <FeatureFlag>
+                        <div className="map-layer__cd-tooltip">
+                            <TooltipWrapper
+                                icon="info"
+                                tooltipComponent={<CondensedCDTooltip title="Congressional Districts" />} />
+                        </div>
+                    </FeatureFlag>
+                    : null}
             </li>
         );
     });

--- a/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
+++ b/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
@@ -44,10 +44,10 @@ const MapLayerToggle = (props) => {
                     data-content={title}
                     value={layer}>
                     {title === 'Congressional District' ?
-                        <div
+                        <span
                             style={{ display: 'flex' }}>
                             {title}s <FeatureFlag><TooltipWrapper tooltipPosition="right" icon="info" tooltipComponent={<CondensedCDTooltip title="Congressional District" />} /></FeatureFlag>
-                        </div>
+                        </span>
                         :
                         <>{title}s </>}
                 </button>


### PR DESCRIPTION
I had to also added a tooltip-pointer styling to counter act the pointer being off.

**High level description:**

Added tooltip for the congressional distract on advance search page on the maps tab.

Made State, County, and Congressional District plural 


**JIRA Ticket:**
[DEV-9666](https://federal-spending-transparency.atlassian.net/browse/DEV-9666)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
