### PR TITLE
DEV-9605 qa issue on covid profile map

### DIFF
--- a/src/_scss/pages/covid19/recipient/recipientContainer.scss
+++ b/src/_scss/pages/covid19/recipient/recipientContainer.scss
@@ -57,8 +57,9 @@
         @import "pages/search/results/visualizations/geo/map/map";
         .map-container {
           .map-legend {
-            bottom: 6.5rem;
+            bottom: 4rem;
             left: 1.5rem;
+            z-index: 1;
             @include media($tablet-screen) {
               bottom: 6rem;
               right: 1rem;
@@ -123,6 +124,10 @@
                   @include display(flex);
                   align-items: center;
                   .tooltip-wrapper {
+                    .tooltip-spacer {
+                      z-index: 15;
+                    }
+
                     .tooltip-pointer {
                       left: -0.7rem;
                     }
@@ -243,6 +248,10 @@
           //Hide info button that was added after mapbox package update to v1.13.0
           & .mapboxgl-ctrl-attrib-button {
               display: none !important;
+          }
+
+          & .mapboxgl-ctrl-attrib {
+            display: none !important;
           }
 
           @import "pages/search/results/visualizations/geo/_disclaimer";

--- a/src/_scss/pages/search/results/visualizations/geo/geoVisualization.scss
+++ b/src/_scss/pages/search/results/visualizations/geo/geoVisualization.scss
@@ -23,6 +23,9 @@
     & .mapboxgl-ctrl-attrib-button {
         display: none !important;
     }
+    & .mapboxgl-ctrl-attrib {
+        display: none !important;
+      }
 
     @import "./_disclaimer";
     @import "./_message";

--- a/src/_scss/pages/search/results/visualizations/geo/map/map.scss
+++ b/src/_scss/pages/search/results/visualizations/geo/map/map.scss
@@ -28,7 +28,7 @@
             float: right;
             right: rem(5);
             bottom: rem(80);
-            z-index: 3;
+            z-index: 2;
             .first-row,
             .second-row {
                 @include display(flex);

--- a/src/_scss/pages/search/results/visualizations/geo/map/map.scss
+++ b/src/_scss/pages/search/results/visualizations/geo/map/map.scss
@@ -27,7 +27,7 @@
             position: absolute;
             float: right;
             right: rem(5);
-            bottom: rem(80);
+            bottom: rem(40);
             z-index: 2;
             .first-row,
             .second-row {

--- a/src/_scss/pages/state/visualizations/geo/geoVisualization.scss
+++ b/src/_scss/pages/state/visualizations/geo/geoVisualization.scss
@@ -17,5 +17,8 @@
         display: none !important;
     }
 
+    & .mapboxgl-ctrl-attrib {
+        display: none !important;
+    }
     @import "./_message";
 }


### PR DESCRIPTION
**High level description:**

fix qa issue where map controls cover up tooltip on mobile on covid profile page

**JIRA Ticket:**
[DEV-9605](https://federal-spending-transparency.atlassian.net/browse/DEV-9605)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
