### PR TITLE
fix bug with tooltip location on tablet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11172,7 +11172,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
       "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -48668,8 +48667,7 @@
     "is-alphabetical": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
-      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
-      "dev": true
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="
     },
     "is-alphanumerical": {
       "version": "2.0.1",

--- a/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
+++ b/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
@@ -88,9 +88,27 @@
                         top: rem(62) !important;
                         left: rem(-30) !important;
                     }
-                    @media ((min-width: $tablet-screen) and (max-width: $large-screen)) {
+                    @media ((min-width: $tablet-screen) and (max-width: $medium-screen)) {
                         top: rem(40) !important;
                         left: rem(-30) !important;
+
+                        .smart-bottom-right {
+                            left: 24.3rem;
+                            
+                        }
+                    }
+                    @media ((min-width: $medium-screen) and (max-width: $large-screen)) {
+                        top: rem(40) !important;
+                        left: rem(-30) !important;
+
+                        .smart-bottom-right {
+                            left: 24.3rem;
+                            
+                        }
+                    }
+                    @media ((min-width: $large-screen) and (max-width: $m-large-screen)) {
+                        top: rem(40) !important;
+                        left: rem(-20) !important;
 
                         .smart-bottom-right {
                             left: 24.3rem;

--- a/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
+++ b/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
@@ -88,7 +88,7 @@
                         top: rem(62) !important;
                         left: rem(-30) !important;
                     }
-                    @media ((min-width: $tablet-screen) and (max-width: $medium-screen)) {
+                    @media ((min-width: $tablet-screen) and (max-width: $large-screen)) {
                         top: rem(40) !important;
                         left: rem(-30) !important;
 

--- a/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
+++ b/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
@@ -88,16 +88,7 @@
                         top: rem(62) !important;
                         left: rem(-30) !important;
                     }
-                    @media ((min-width: $tablet-screen) and (max-width: $medium-screen)) {
-                        top: rem(40) !important;
-                        left: rem(-30) !important;
-
-                        .smart-bottom-right {
-                            left: 24.3rem;
-                            
-                        }
-                    }
-                    @media ((min-width: $medium-screen) and (max-width: $large-screen)) {
+                    @media ((min-width: $tablet-screen) and (max-width: $large-screen)) {
                         top: rem(40) !important;
                         left: rem(-30) !important;
 

--- a/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
+++ b/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
@@ -80,12 +80,48 @@
         .map-layer__cd-tooltip {
             display: inline-flex;
             white-space: normal;
-            .tooltip-spacer {
-                max-width: 316px !important;
-                @media (max-width: $tablet-screen) {
-                    left: rem(-19) !important;
+
+            .state-profile__map-toggle {
+                .tooltip-spacer {
+                    width: 316px !important;
+                    @media (max-width: 767px) {
+                        top: rem(62) !important;
+                        left: rem(-30) !important;
+                    }
+                    @media ((min-width: $tablet-screen) and (max-width: $medium-screen)) {
+                        top: rem(40) !important;
+                        left: rem(-30) !important;
+
+                        .smart-bottom-right {
+                            left: 24.3rem;
+                            
+                        }
+                    }
                 }
             }
+
+            .award-search__geo-toggle {
+                .tooltip-spacer {
+                    width: 316px !important;
+                    @media (max-width: 767px) {
+                        top: rem(80) !important;
+                        left: rem(-30) !important;
+                    }
+                    @media ((min-width: $tablet-screen) and (max-width: $medium-screen)) {
+                        top: rem(48) !important;
+                        left: rem(-30) !important;
+
+                        .tooltip-pointer {
+                            transform: rotate(90deg);
+                        }
+                        .smart-bottom-right {
+                            top: rem(-7) !important;
+                            left: 29.2rem !important;
+                        }
+                    }
+                }
+            }
+            
         }
     }
 }

--- a/src/js/components/search/visualizations/VisualizationWrapper.jsx
+++ b/src/js/components/search/visualizations/VisualizationWrapper.jsx
@@ -104,7 +104,7 @@ const VisualizationWrapper = (props) => {
                 content = <TimeVisualizationSectionContainer subaward={props.subaward} />;
                 break;
             case 'map':
-                content = <GeoVisualizationSectionContainer subaward={props.subaward} />;
+                content = <GeoVisualizationSectionContainer subaward={props.subaward} className="award-search__geo-toggle" />;
                 break;
             case 'rank':
                 content = <RankVisualizationWrapperContainer subaward={props.subaward} />;

--- a/src/js/components/search/visualizations/geo/GeoVisualizationSection.jsx
+++ b/src/js/components/search/visualizations/geo/GeoVisualizationSection.jsx
@@ -37,7 +37,8 @@ const propTypes = {
     noResults: PropTypes.bool,
     mapLegendToggle: PropTypes.string,
     updateMapLegendToggle: PropTypes.func,
-    subaward: PropTypes.bool
+    subaward: PropTypes.bool,
+    className: PropTypes.string
 };
 
 const availableLayers = ['state', 'county', 'congressionalDistrict'];
@@ -55,7 +56,7 @@ export default class GeoVisualizationSection extends React.Component {
             tablePreview: "",
             expanded: null
         };
-
+        this.className = "";
         this.showTooltip = this.showTooltip.bind(this);
         this.hideTooltip = this.hideTooltip.bind(this);
         this.closeDisclaimer = this.closeDisclaimer.bind(this);
@@ -311,6 +312,7 @@ export default class GeoVisualizationSection extends React.Component {
                     availableLayers={availableLayers}
                     showLayerToggle
                     center={[-95.569430, 38.852892]}
+                    className={this.props.className}
                     mapLegendToggle={this.props.mapLegendToggle}
                     updateMapLegendToggle={this.props.updateMapLegendToggle}>
                     {disclaimer}

--- a/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
+++ b/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { TooltipWrapper } from 'data-transparency-ui';
 import { CondensedCDTooltip } from '../../../award/shared/InfoTooltipContent';
 import FeatureFlag from '../../../sharedComponents/FeatureFlag';
-import { tabletScreen, largeScreen } from '../../../../dataMapping/shared/mobileBreakpoints';
+import { tabletScreen, mLargeScreen } from '../../../../dataMapping/shared/mobileBreakpoints';
 
 const propTypes = {
     active: PropTypes.string,
@@ -63,7 +63,7 @@ const MapLayerToggle = (props) => {
                             <TooltipWrapper
                                 icon="info"
                                 className={props.className}
-                                tooltipPosition={(window.innerWidth >= tabletScreen && window.innerWidth <= largeScreen) ? 'left' : 'right'}
+                                tooltipPosition={(window.innerWidth >= tabletScreen && window.innerWidth <= mLargeScreen) ? 'left' : 'right'}
                                 tooltipComponent={<CondensedCDTooltip title="Congressional Districts" />} />
                         </div>
                     </FeatureFlag>

--- a/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
+++ b/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { TooltipWrapper } from 'data-transparency-ui';
 import { CondensedCDTooltip } from '../../../award/shared/InfoTooltipContent';
 import FeatureFlag from '../../../sharedComponents/FeatureFlag';
+import { tabletScreen, mediumScreen } from '../../../../dataMapping/shared/mobileBreakpoints';
 
 const propTypes = {
     active: PropTypes.string,
@@ -60,6 +61,7 @@ const MapLayerToggle = (props) => {
                         <div className="map-layer__cd-tooltip">
                             <TooltipWrapper
                                 icon="info"
+                                tooltipPosition={(window.innerWidth >= tabletScreen && window.innerWidth <= mediumScreen) ? 'left' : 'right'}
                                 tooltipComponent={<CondensedCDTooltip title="Congressional Districts" />} />
                         </div>
                     </FeatureFlag>

--- a/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
+++ b/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { TooltipWrapper } from 'data-transparency-ui';
 import { CondensedCDTooltip } from '../../../award/shared/InfoTooltipContent';
 import FeatureFlag from '../../../sharedComponents/FeatureFlag';
-import { tabletScreen, mediumScreen } from '../../../../dataMapping/shared/mobileBreakpoints';
+import { tabletScreen, largeScreen } from '../../../../dataMapping/shared/mobileBreakpoints';
 
 const propTypes = {
     active: PropTypes.string,
@@ -63,7 +63,7 @@ const MapLayerToggle = (props) => {
                             <TooltipWrapper
                                 icon="info"
                                 className={props.className}
-                                tooltipPosition={(window.innerWidth >= tabletScreen && window.innerWidth <= mediumScreen) ? 'left' : 'right'}
+                                tooltipPosition={(window.innerWidth >= tabletScreen && window.innerWidth <= largeScreen) ? 'left' : 'right'}
                                 tooltipComponent={<CondensedCDTooltip title="Congressional Districts" />} />
                         </div>
                     </FeatureFlag>

--- a/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
+++ b/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
@@ -14,7 +14,8 @@ const propTypes = {
     active: PropTypes.string,
     available: PropTypes.array,
     changeMapLayer: PropTypes.func,
-    sources: PropTypes.object
+    sources: PropTypes.object,
+    className: PropTypes.string
 };
 
 const capitalizeLabel = (original) => {
@@ -61,6 +62,7 @@ const MapLayerToggle = (props) => {
                         <div className="map-layer__cd-tooltip">
                             <TooltipWrapper
                                 icon="info"
+                                className={props.className}
                                 tooltipPosition={(window.innerWidth >= tabletScreen && window.innerWidth <= mediumScreen) ? 'left' : 'right'}
                                 tooltipComponent={<CondensedCDTooltip title="Congressional Districts" />} />
                         </div>

--- a/src/js/components/search/visualizations/geo/MapWrapper.jsx
+++ b/src/js/components/search/visualizations/geo/MapWrapper.jsx
@@ -30,7 +30,8 @@ const propTypes = {
     center: PropTypes.array,
     stateProfile: PropTypes.bool,
     mapLegendToggle: PropTypes.string,
-    updateMapLegendToggle: PropTypes.func
+    updateMapLegendToggle: PropTypes.func,
+    className: PropTypes.string
 };
 
 const defaultProps = {
@@ -99,9 +100,8 @@ export default class MapWrapper extends React.Component {
         this.mapOperationQueue = {};
         this.loadedLayers = {};
         this.broadcastReceivers = [];
-
         this.renderCallback = null;
-
+        this.className = "";
         this.mapReady = this.mapReady.bind(this);
         this.mapRemoved = this.mapRemoved.bind(this);
 
@@ -489,14 +489,16 @@ export default class MapWrapper extends React.Component {
             showLayerToggle,
             availableLayers,
             scope,
-            changeMapLayer
+            changeMapLayer,
+            className
         } = this.props;
         if (showLayerToggle && availableLayers.length > 1) {
             return (<MapLayerToggle
                 active={scope}
                 available={availableLayers}
                 sources={mapboxSources}
-                changeMapLayer={changeMapLayer} />);
+                changeMapLayer={changeMapLayer}
+                className={className} />);
         }
         return null;
     };

--- a/src/js/components/state/overview/StateOverview.jsx
+++ b/src/js/components/state/overview/StateOverview.jsx
@@ -236,7 +236,7 @@ export default class StateOverview extends React.PureComponent {
                             <h3 className="state-overview__heading">
                                 Primary Place of Performance
                             </h3>
-                            <GeoVisualizationSectionContainer />
+                            <GeoVisualizationSectionContainer className="state-profile__map-toggle" />
                         </div>
                     </div>
                 </div>

--- a/src/js/components/state/visualizations/geo/GeoVisualizationSection.jsx
+++ b/src/js/components/state/visualizations/geo/GeoVisualizationSection.jsx
@@ -26,7 +26,8 @@ const propTypes = {
     loading: PropTypes.bool,
     error: PropTypes.bool,
     noResults: PropTypes.bool,
-    stateCenter: PropTypes.array
+    stateCenter: PropTypes.array,
+    className: PropTypes.string
 };
 
 const availableLayers = ['county', 'congressionalDistrict'];
@@ -128,6 +129,7 @@ export default class GeoVisualizationSection extends React.Component {
         return (
             <div className="geo__map-section">
                 <MapWrapper
+                    className={this.props.className}
                     data={this.props.data}
                     renderHash={this.props.renderHash}
                     scope={this.props.mapLayer}

--- a/src/js/containers/search/visualizations/geo/GeoVisualizationSectionContainer.jsx
+++ b/src/js/containers/search/visualizations/geo/GeoVisualizationSectionContainer.jsx
@@ -30,7 +30,8 @@ const propTypes = {
     noApplied: PropTypes.bool,
     subaward: PropTypes.bool,
     mapLegendToggle: PropTypes.string,
-    updateMapLegendToggle: PropTypes.func
+    updateMapLegendToggle: PropTypes.func,
+    className: PropTypes.string
 };
 
 const apiScopes = {
@@ -326,7 +327,8 @@ export class GeoVisualizationSectionContainer extends React.Component {
                 updateMapLegendToggle={this.updateMapLegendToggle}
                 mapLegendToggle={this.props.mapLegendToggle}
                 subaward={this.props.subaward}
-                isDefCodeInFilter={this.props.reduxFilters?.defCodes?.counts} />
+                isDefCodeInFilter={this.props.reduxFilters?.defCodes?.counts}
+                className={this.props.className} />
         );
     }
 }

--- a/src/js/containers/state/visualizations/geo/GeoVisualizationSectionContainer.jsx
+++ b/src/js/containers/state/visualizations/geo/GeoVisualizationSectionContainer.jsx
@@ -16,7 +16,8 @@ import * as FiscalYearHelper from 'helpers/fiscalYearHelper';
 import MapBroadcaster from 'helpers/mapBroadcaster';
 
 const propTypes = {
-    stateProfile: PropTypes.object
+    stateProfile: PropTypes.object,
+    className: PropTypes.string
 };
 
 const apiScopes = {
@@ -43,7 +44,7 @@ export class GeoVisualizationSectionContainer extends React.Component {
         this.apiRequest = null;
 
         this.mapListeners = [];
-
+        this.className = "";
         this.changeMapLayer = this.changeMapLayer.bind(this);
         this.mapLoaded = this.mapLoaded.bind(this);
         this.prepareFetch = this.prepareFetch.bind(this);
@@ -212,7 +213,8 @@ export class GeoVisualizationSectionContainer extends React.Component {
                 stateCenter={this.props.stateProfile.center}
                 noResults={this.state.data.values.length === 0}
                 changeScope={this.changeScope}
-                changeMapLayer={this.changeMapLayer} />
+                changeMapLayer={this.changeMapLayer}
+                className={this.props.className} />
         );
     }
 }

--- a/src/js/dataMapping/shared/mobileBreakpoints.js
+++ b/src/js/dataMapping/shared/mobileBreakpoints.js
@@ -10,4 +10,5 @@ export const smallScreen = 320;
 export const tabletScreen = 768;
 export const mediumScreen = 992;
 export const largeScreen = 1200;
+export const mLargeScreen = 1400;
 export const xlargeScreen = 1640;


### PR DESCRIPTION
**High level description:**

tooltip was off to the left on both of these pages between 768 and 992: 
http://localhost:3000/state/alabama/latest (map cd tooltip)
http://localhost:3000/search/?hash=2731f194e8bd5c1506ffcc23c29654d5 (spending by geography tab -> cd tooltip)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
