### PR TITLE
7760 - added aria-hidden=true to the icons in the top five tables

### DIFF
--- a/src/js/components/recipient/topFive/TopFive.jsx
+++ b/src/js/components/recipient/topFive/TopFive.jsx
@@ -109,6 +109,7 @@ export default class TopFive extends React.Component {
                         <img
                             className="category-table__title-icon"
                             src={`img/state-categories/${this.props.category}.png`}
+                            aria-hidden="true"
                             alt="" />
                         <div className="category-table__title-name">
                             {recipientCategoryTitles[this.props.category]}

--- a/src/js/components/state/topFive/TopFive.jsx
+++ b/src/js/components/state/topFive/TopFive.jsx
@@ -51,6 +51,7 @@ const TopFive = (props) => {
                 <img
                     className="category-table__title-icon"
                     src={`img/state-categories/${props.category}.png`}
+                    aria-hidden="true"
                     alt="" />
                 <div className="category-table__title-name">
                     {props.category === "district" ?


### PR DESCRIPTION
**High level description:**

Based on results of 508 scan, add aria-hidden=true to the icons in the top five tables on Recipient and State pages

**Technical details:**

added aria-hidden

**JIRA Ticket:**
[DEV-7760](https://federal-spending-transparency.atlassian.net/browse/DEV-7760)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
