### PR TITLE
tooltip changes based on name length.

### DIFF
--- a/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
@@ -180,8 +180,6 @@ const StatusOfFundsChart = ({
         }
         return null;
     };
-    const tooltipHeight = level === 1 ? 280 : 230;
-    const tooltipHeightOutlay = level === 1 ? 280 : 210;
 
     const paddingResize = () => {
         if (isLargeScreen) {
@@ -201,9 +199,11 @@ const StatusOfFundsChart = ({
         }
         return 18;
     };
-
+    let tooltipName = null;
     const tooltip = (data) => {
         if (hoverData) {
+            tooltipName = data.name.length;
+            console.log(tooltipName);
             return (
                 <div className="sof-chart-tooltip">
                     <div className="tooltip__title">
@@ -1008,6 +1008,7 @@ const StatusOfFundsChart = ({
             setSortedNums(results.sort((a, b) => (b._budgetaryResources - a._budgetaryResources)));
         }
     }, [results]);
+
     return (
         <>
             {
@@ -1015,15 +1016,15 @@ const StatusOfFundsChart = ({
                 <TooltipWrapper
                     className="sof_chart-tt"
                     width={288}
-                    styles={!toggle ? {
-                        position: 'absolute',
-                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - tooltipHeight}px)`
-                    } : {
-                        position: 'absolute',
-                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - tooltipHeightOutlay}px)`
-                    }}
                     tooltipPosition="bottom"
                     tooltipComponent={tooltip(hoverData)}
+                    styles={!toggle ? {
+                        position: 'absolute',
+                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - (tooltipName + 200)}px)`
+                    } : {
+                        position: 'absolute',
+                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - (tooltipName + 200)}px)`
+                    }}
                     controlledProps={{
                         isControlled: true,
                         isVisible: isHovered,

--- a/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
@@ -202,7 +202,15 @@ const StatusOfFundsChart = ({
     let tooltipName = null;
     const tooltip = (data) => {
         if (hoverData) {
-            tooltipName = data.name.length;
+            if (data.name.length <= 33) {
+                tooltipName = data.name.length + 230;
+            }
+            else if (data.name.length > 33 && data.name.length < 66) {
+                tooltipName = data.name.length + 215;
+            }
+            else {
+                tooltipName = data.name.length + 200;
+            }
             return (
                 <div className="sof-chart-tooltip">
                     <div className="tooltip__title">
@@ -1019,10 +1027,10 @@ const StatusOfFundsChart = ({
                     tooltipComponent={tooltip(hoverData)}
                     styles={!toggle ? {
                         position: 'absolute',
-                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - (tooltipName + 200)}px)`
+                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - tooltipName}px)`
                     } : {
                         position: 'absolute',
-                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - (tooltipName + 200)}px)`
+                        transform: `translate(${mouseValue.x - 144}px,${mouseValue.y - (tooltipName - 10)}px)`
                     }}
                     controlledProps={{
                         isControlled: true,

--- a/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
@@ -203,7 +203,6 @@ const StatusOfFundsChart = ({
     const tooltip = (data) => {
         if (hoverData) {
             tooltipName = data.name.length;
-            console.log(tooltipName);
             return (
                 <div className="sof-chart-tooltip">
                     <div className="tooltip__title">


### PR DESCRIPTION
**High level description:**

Agency Profile Pages - Status of Funds Chart Hover State Preventing Mouse Click

**Technical details:**

Created a let that captures the word length and added a set px to the word length.

I tried to get a useEffect to capture it and use a more condition amount but it kept giving me memory leaking issues. This might be oversimplifying it a little bit 

**JIRA Ticket:**
[DEV-9713](https://federal-spending-transparency.atlassian.net/browse/DEV-9713)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
