### PR TITLE
9748 - added toTitleCase fn for all names because Program Activity na…

### DIFF
--- a/src/js/helpers/agency/StatusOfFundsVizHelper.js
+++ b/src/js/helpers/agency/StatusOfFundsVizHelper.js
@@ -30,3 +30,4 @@ export const parseRows = (data, id) => {
     return parsedData;
 };
 
+export const toTitleCase = (str) => str.toLowerCase().split(' ').map((word) => (word.charAt(0).toUpperCase() + word.slice(1))).join(' ');

--- a/src/js/models/v2/agency/BaseAgencySubcomponentsList.js
+++ b/src/js/models/v2/agency/BaseAgencySubcomponentsList.js
@@ -2,12 +2,14 @@
  * BaseAgencySubcomponentsList.js
  * Created by Afna Saifudeen 12/14/21
  */
+
 import { formatMoneyWithUnitsShortLabel } from 'helpers/moneyFormatter';
+import { toTitleCase } from 'helpers/agency/StatusOfFundsVizHelper';
 
 const BaseAgencySubcomponentsList = {
     populate(data, id) {
         this.id = id || data?.id || data?.code || '';
-        this.name = data?.name || '';
+        this.name = data?.name ? toTitleCase(data?.name) : '';
         /* eslint-disable camelcase */
         this._budgetaryResources = data?.total_budgetary_resources || data?.budgetary_resources_amount || 0;
         this._obligations = data?.total_obligations || data?.obligated_amount || 0;


### PR DESCRIPTION
…mes are all caps

**High level description:**

QA pointed out that the labels for Program Activities, level 4, were all caps

**Technical details:**

Added a toTitleCase fn and sending all agency names through it now

**JIRA Ticket:**
[DEV-9748](https://federal-spending-transparency.atlassian.net/browse/DEV-9748)

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
