### PR TITLE
9806 - added new text in two places, about unlinked awards

### DIFF
--- a/src/js/components/aboutTheData/DataSourcesAndMethodologiesPage.jsx
+++ b/src/js/components/aboutTheData/DataSourcesAndMethodologiesPage.jsx
@@ -244,10 +244,10 @@ const DataSourcesAndMethodologiesPage = () => {
                                     <p>For each column, the numbers are based on the sum of two counts:</p>
                                     <ol className="about-section-content__numbered-list">
                                         <li>
-                                            The count of the agency’s D1 or D2 awards with activity in the selected submission period (i.e., <span className="about-section-content__italic">action_date</span> in the period) that aren’t linked to any of the agency’s File C awards <span className="about-section-content__italic">across all time.</span>
+                                            The count of the agency’s D1 or D2 awards with activity in the selected submission period (i.e., action_date in the period) that aren’t linked to any of the agency’s File C awards across all time.
                                         </li>
                                         <li>
-                                            The count of the agency’s File C awards with obligation activity in the selected submission period that aren’t linked to any D1 or D2 awards <span className="about-section-content__italic">across all time.</span>
+                                            The count of the agency’s File C awards with obligation activity in the selected submission period that aren’t linked to any D1 or D2 award across all time. Obligation activity is defined as having non-null values in the Transaction Obligated Amount column. (Note that rows with null obligation activity are rows with outlay balance data.)
                                         </li>
                                     </ol>
                                     <p>

--- a/src/js/components/aboutTheData/DataSourcesAndMethodologiesPage.jsx
+++ b/src/js/components/aboutTheData/DataSourcesAndMethodologiesPage.jsx
@@ -247,7 +247,7 @@ const DataSourcesAndMethodologiesPage = () => {
                                             The count of the agency’s D1 or D2 awards with activity in the selected submission period (i.e., action_date in the period) that aren’t linked to any of the agency’s File C awards across all time.
                                         </li>
                                         <li>
-                                            The count of the agency’s File C awards with obligation activity in the selected submission period that aren’t linked to any D1 or D2 award across all time. Obligation activity is defined as having non-null values in the Transaction Obligated Amount column. (Note that rows with null obligation activity are rows with outlay balance data.)
+                                            The count of the agency’s File C awards with obligation activity in the selected submission period that aren’t linked to any D1 or D2 awards across all time. Obligation activity is defined as having non-null values in the Transaction Obligated Amount column. (Note that rows with null obligation activity are rows with outlay balance data.)
                                         </li>
                                     </ol>
                                     <p>

--- a/src/js/components/bulkDownload/accounts/filters/SubmissionTypeFilter.jsx
+++ b/src/js/components/bulkDownload/accounts/filters/SubmissionTypeFilter.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { CheckCircle, ExclamationCircle } from 'components/sharedComponents/icons/Icons';
+import { Link } from "react-router-dom";
 
 const propTypes = {
     submissionTypes: PropTypes.array,
@@ -67,7 +68,16 @@ export default class SubmissionTypeFilter extends React.Component {
                 </h3>
                 <div className="download-filter__content">
                     {submissionTypes}
-                    <p className="download-filter__content-note"><span className="download-filter__content-note_bold">*Note:</span> To facilitate processing of these files for download, File C award records are separated into three buckets: contract awards (with linked awards between File C and File D1), financial assistance awards (with linked awards between File C and File D2), and unlinked awards (with awards in File C that are not linked to any award in Files D1 or D2). Each bucket will include one or more files, depending on the size of your download request. Please note that any files with unlinked awards will include the same columns as the files with linked awards; however, the columns that involve data from Files D1 and D2 will be blank in the files with unlinked awards.</p>
+                    <p className="download-filter__content-note"><span className="download-filter__content-note_bold">*Note:</span>
+                        To facilitate processing of these files for download, File C award records are separated into three buckets: contract awards (with linked awards between File C and File D1), financial assistance awards (with linked awards between File C and File D2), and unlinked awards (with awards in File C that are not linked to any award in Files D1 or D2). Each bucket will include one or more files, depending on the size of your download request.
+                    </p>
+                    <p className="download-filter__content-note">
+                        Files with unlinked awards will include the same columns as files with linked awards; however, the columns that involve data from Files D1 and D2 will be blank in the files with unlinked awards. In addition, please note that files with unlinked awards will include award records with obligation activity or outlay activity, in order to show all agency File C award records that are unlinked to Files D1 or D2. (Note that in the{' '}
+                        <Link to="/submission-statistics">
+                            Agency Submission Statistics
+                        </Link>{' '}
+                        page, the counts of unlinked awards in File C use only awards with obligation activity.)
+                    </p>
                 </div>
             </div>
         );


### PR DESCRIPTION
**High level description:**

Add text in two places, explaining more about unlinked awards

**Technical details:**

added the text where specified; removed the italics class from the html in the ds&m page because that class doesn't exist in the css for that page

**JIRA Ticket:**
[DEV-9806](https://federal-spending-transparency.atlassian.net/browse/DEV-9806)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
