### PR TITLE
9806 - two small copy changes, feedback from qa

### DIFF
--- a/src/js/components/bulkDownload/accounts/filters/SubmissionTypeFilter.jsx
+++ b/src/js/components/bulkDownload/accounts/filters/SubmissionTypeFilter.jsx
@@ -68,15 +68,15 @@ export default class SubmissionTypeFilter extends React.Component {
                 </h3>
                 <div className="download-filter__content">
                     {submissionTypes}
-                    <p className="download-filter__content-note"><span className="download-filter__content-note_bold">*Note:</span>
+                    <p className="download-filter__content-note"><span className="download-filter__content-note_bold">*Note: </span>
                         To facilitate processing of these files for download, File C award records are separated into three buckets: contract awards (with linked awards between File C and File D1), financial assistance awards (with linked awards between File C and File D2), and unlinked awards (with awards in File C that are not linked to any award in Files D1 or D2). Each bucket will include one or more files, depending on the size of your download request.
                     </p>
                     <p className="download-filter__content-note">
                         Files with unlinked awards will include the same columns as files with linked awards; however, the columns that involve data from Files D1 and D2 will be blank in the files with unlinked awards. In addition, please note that files with unlinked awards will include award records with obligation activity or outlay activity, in order to show all agency File C award records that are unlinked to Files D1 or D2. (Note that in the{' '}
                         <Link to="/submission-statistics">
-                            Agency Submission Statistics
-                        </Link>{' '}
-                        page, the counts of unlinked awards in File C use only awards with obligation activity.)
+                            Agency Submission Statistics page
+                        </Link>
+                        , the counts of unlinked awards in File C use only awards with obligation activity.)
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
**High level description:**

Feedback from QA, two small changes in the second page that was changed; Allie left comment on the ticket explaining

**Technical details:**

Added a space after 'Note:'; made the word 'page' included in the Link

**JIRA Ticket:**
[DEV-9806](https://federal-spending-transparency.atlassian.net/browse/DEV-9806)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
