### PR TITLE
9847 - added size for icons in second column in megamenu

### DIFF
--- a/src/js/components/sharedComponents/header/megaMenu/ItemContent.jsx
+++ b/src/js/components/sharedComponents/header/megaMenu/ItemContent.jsx
@@ -76,7 +76,7 @@ const ItemContent = ({
                                                 onMouseUp={(e) => {
                                                     if (item.url === '?about-the-data') openATD(e);
                                                 }}>
-                                                {item.icon && item.icon !== '' && item.icon !== null ? <FontAwesomeIcon role="presentation" size="lg" className="" icon={item.icon} /> : ''}
+                                                {item.icon && item.icon !== '' && item.icon !== null ? <FontAwesomeIcon role="presentation" size="lg" className="" icon={item.icon} style={{ width: "20px", height: "20px" }} /> : ''}
                                                 <div className="dropdown-item__link-desc">
                                                     <div className="dropdown-item__link-label">
                                                         {item.label}


### PR DESCRIPTION
**High level description:**

icons in the second column were not the same size

**Technical details:**

Added the inline css for height and width that was added to the other columns

**JIRA Ticket:**
[DEV-9847](https://federal-spending-transparency.atlassian.net/browse/DEV-9847)

**Mockup:**
https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55/screen/645cfcc7990ffb0e1b1781d0

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
