### PR TITLE
3980 - changed tooltip text on Spending Explorer pages; had to change…

### DIFF
--- a/src/_scss/pages/explorer/detail/header/header.scss
+++ b/src/_scss/pages/explorer/detail/header/header.scss
@@ -83,7 +83,7 @@
           margin: 0;
           background-color: transparent;
 
-     
+
              svg {
                  width: rem(10);
                  height: rem(10);
@@ -96,13 +96,13 @@
         @include flex(0 1 auto);
         width: rem(150);
         margin-left: rem(10);
-        
+
         @include media($medium-screen) {
             width: rem(250);
             margin-left: rem(50);
         }
         @include media($x-large-screen) {
-            margin-left: rem(150);    
+            margin-left: rem(150);
         }
 
         .amount-header {
@@ -141,7 +141,7 @@
   z-index: 1;
   width: rem(220);
   .homepage-hero-tooltip__text_holder {
-    height: rem(90);
+    height: rem(200);
     padding: rem(7) rem(20) 0 rem(35);
   }
 

--- a/src/js/components/explorer/detail/ExplorerInfoTooltip.jsx
+++ b/src/js/components/explorer/detail/ExplorerInfoTooltip.jsx
@@ -94,7 +94,10 @@ export default class ExplorerInfoTooltip extends React.Component {
                         Data Source:
                     </div>
                     <div className="homepage-hero-tooltip__tooltip_text">
-                        USAspending.gov uses the Report on Budget Execution and Budgetary Resources
+                        Data Source: the sum of line 2190 across all remaining accounts in the
+                        <em> GTAS SF 133 Report on Budget Execution and Budgetary Resources </em>
+                        for this period, after excluding loan financing accounts. Loan program
+                        accounts <u>are</u> included.
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
… height bc more text

**High level description:**

new text for a tooltip

**Technical details:**

Same tooltip on all three Spending Explorer pages; added new text; changed height bc more text now

**JIRA Ticket:**
[DEV-3980](https://federal-spending-transparency.atlassian.net/browse/DEV-3980)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
