### PR TITLE
9935 - used window.open to open the links to awards in a new tab

### DIFF
--- a/src/js/containers/explorer/detail/DetailContentContainer.jsx
+++ b/src/js/containers/explorer/detail/DetailContentContainer.jsx
@@ -317,8 +317,8 @@ export class DetailContentContainer extends React.Component {
         const filterBy = this.props.explorer.active.subdivision;
         if (filterBy === 'award') {
             // we are at the bottom of the path, go to the award page
-            // TODO: fix for BrowserRouter
-            this.props.history.push(`/award/${id}`);
+            // and open in new tab
+            window.open(`/award/${id}`, "_blank");
 
             Analytics.event({
                 category: 'Spending Explorer - Exit',


### PR DESCRIPTION
**High level description:**

Make Spending Explorer links to awards open in a new tab

**Technical details:**

used window.open instead of history.push;
path to get to an example:
		obj class > contractual services > health & human services > prg mgmnt, centers for... > prg operations
		then you get a bunch of recipients that you can click on, and will show another level,
then you see some awards that will open an award profile


**JIRA Ticket:**
[DEV-9935](https://federal-spending-transparency.atlassian.net/browse/DEV-9935)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
