### PR TITLE
9818 - changed the label in the sidebar back again; did not need to c…

### DIFF
--- a/src/js/components/agency/statusOfFunds/DrilldownSidebar.jsx
+++ b/src/js/components/agency/statusOfFunds/DrilldownSidebar.jsx
@@ -115,7 +115,7 @@ const DrilldownSidebar = ({
             {level >= 4 &&
                 <DrilldownSidebarLevel
                     key={dropdownSelection}
-                    label={`${dropdownSelection === 'Program Activity' ? 'Object Class' : 'Program Activity'}`}
+                    label={dropdownSelection}
                     name={prgActivityOrObjectClassName}
                     active={level === 4}
                     obligatedText={(


### PR DESCRIPTION
…hange it with the last commit

**High level description:**

Changed label in sidebar back to what it was before

**Technical details:**

changed the string 

**JIRA Ticket:**
[DEV-9818](https://federal-spending-transparency.atlassian.net/browse/DEV-9818)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
