### PR TITLE
9888 - changed logic for determining the domain in the chart

### DIFF
--- a/src/_scss/layouts/default/footer/_stayInTouch.scss
+++ b/src/_scss/layouts/default/footer/_stayInTouch.scss
@@ -10,9 +10,6 @@
   }
 
   .stay-in-touch__container-row {
-    @media (min-width: $tablet-screen) and (max-width: $medium-screen) {
-      text-align: center;
-    }
     @media (min-width: $medium-screen) {
       flex-flow: row nowrap;
       justify-content: flex-start;
@@ -40,9 +37,6 @@
 
       .stay-in-touch__title-row {
         flex-flow: row nowrap;
-        @media (min-width: $tablet-screen) and (max-width: $medium-screen) {
-          justify-content: center;
-        }
       }
     }
 
@@ -109,10 +103,6 @@
           svg {
             margin-left: $global-margin;
           }
-        }
-        @media (min-width: $tablet-screen) and (max-width: $medium-screen) {
-          display: flex;
-          justify-content: center;
         }
       }
     }

--- a/src/_scss/layouts/default/footer/_stayInTouch.scss
+++ b/src/_scss/layouts/default/footer/_stayInTouch.scss
@@ -10,6 +10,9 @@
   }
 
   .stay-in-touch__container-row {
+    @media (min-width: $tablet-screen) and (max-width: $medium-screen) {
+      text-align: center;
+    }
     @media (min-width: $medium-screen) {
       flex-flow: row nowrap;
       justify-content: flex-start;
@@ -37,6 +40,9 @@
 
       .stay-in-touch__title-row {
         flex-flow: row nowrap;
+        @media (min-width: $tablet-screen) and (max-width: $medium-screen) {
+          justify-content: center;
+        }
       }
     }
 
@@ -103,6 +109,10 @@
           svg {
             margin-left: $global-margin;
           }
+        }
+        @media (min-width: $tablet-screen) and (max-width: $medium-screen) {
+          display: flex;
+          justify-content: center;
         }
       }
     }

--- a/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
@@ -332,16 +332,8 @@ const StatusOfFundsChart = ({
             const maxNegObl = negativeObligationsArray.length ? negativeObligationsArray.reduce((a, b) => Math.max(Math.abs(a), Math.abs(b))) : null;
 
             const arrayOfMaxValues = [];
-            if (negativeTbr) {
-                arrayOfMaxValues.push(maxNegTbr);
-            }
-            else arrayOfMaxValues.push(maxPosTbr);
-            if (negativeObl) {
-                arrayOfMaxValues.push(maxNegObl);
-            }
-            else {
-                arrayOfMaxValues.push(maxPosObl);
-            }
+            arrayOfMaxValues.push(Math.abs(maxNegTbr) > Math.abs(maxPosTbr) ? maxNegTbr : maxPosTbr);
+            arrayOfMaxValues.push(Math.abs(maxNegObl) > Math.abs(maxPosObl) ? maxNegObl : maxPosObl);
 
             if (negativeTbr || negativeObl) {
                 x.domain(d3.extent(arrayOfMaxValues)).nice(2);

--- a/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
@@ -690,16 +690,8 @@ const StatusOfFundsChart = ({
             const maxNegOutlay = negativeOutlaysArray.length ? negativeOutlaysArray.reduce((a, b) => Math.max(Math.abs(a), Math.abs(b))) : null;
 
             const arrayOfMaxValues = [];
-            if (negativeTbr) {
-                arrayOfMaxValues.push(maxNegTbr);
-            }
-            else arrayOfMaxValues.push(maxPosTbr);
-            if (negativeOutlay) {
-                arrayOfMaxValues.push(maxNegOutlay);
-            }
-            else {
-                arrayOfMaxValues.push(maxPosOutlay);
-            }
+            arrayOfMaxValues.push(Math.abs(maxNegTbr) > Math.abs(maxPosTbr) ? maxNegTbr : maxPosTbr);
+            arrayOfMaxValues.push(Math.abs(maxNegOutlay) > Math.abs(maxPosOutlay) ? maxNegOutlay : maxPosOutlay);
 
             if (negativeTbr || negativeOutlay) {
                 x.domain(d3.extent(arrayOfMaxValues)).nice(2);

--- a/src/js/components/sharedComponents/StayInTouch.jsx
+++ b/src/js/components/sharedComponents/StayInTouch.jsx
@@ -21,19 +21,28 @@ const StayInTouch = (pageName) => {
         action: 'Link',
         label: 'sign-up'
     });
-
-    const handleSignUp = () => {
-        trackLinkSignUp();
-        window.location.href = "mailto:join-usaspending@lists.fiscal.treasury.gov?subject=Yes!%20I'd%20like%20to%20receive%20updates.";
-    };
     const trackLinkLearnMore = () => Analytics.event({
         category: pageName,
         action: 'Link',
         label: 'learn-more'
     });
+    const trackLinkSurvey = () => Analytics.event({
+        category: pageName,
+        action: 'Survey',
+        label: 'survey'
+    });
+
+    const handleSignUp = () => {
+        trackLinkSignUp();
+        window.location.href = "mailto:join-usaspending@lists.fiscal.treasury.gov?subject=Yes!%20I'd%20like%20to%20receive%20updates.";
+    };
     const handleLearnMore = () => {
         trackLinkLearnMore();
         window.open("/about?section=training", "_self");
+    };
+    const handleSurveyClick = () => {
+        trackLinkSurvey();
+        console.log('open survey here');
     };
 
     return (
@@ -42,7 +51,8 @@ const StayInTouch = (pageName) => {
                 <FlexGridCol
                     className="stay-in-touch__title-col"
                     mobile={12}
-                    tablet={12}>
+                    tablet={12}
+                    desktop={3}>
                     <FlexGridRow className="stay-in-touch__title-row">
                         <div className="stay-in-touch__icon-container">
                             <FontAwesomeIcon icon={faPaperPlane} />
@@ -55,7 +65,32 @@ const StayInTouch = (pageName) => {
                 <FlexGridCol
                     className="stay-in-touch__second-row-container top"
                     mobile={12}
-                    tablet={6}>
+                    tablet={12}
+                    desktop={3}>
+                    <div className="stay-in-touch__second-row-title">
+                        Your Data, Your Story
+                    </div>
+                    <div className="stay-in-touch__second-row-text">
+                        Love USAspending.gov? Help others learn about how you use the data!
+                    </div>
+                    <div className="stay-in-touch__second-row-link">
+                        <Button
+                            copy="Share your story"
+                            buttonTitle="Share your story"
+                            buttonSize="md"
+                            onClick={handleSurveyClick}
+                            buttonType="text"
+                            backgroundColor="light"
+                            imageAlignment="right"
+                            textAlignment="left"
+                            image={<FontAwesomeIcon icon={faArrowRight} style={{ height: '16px', width: '14px' }} />} />
+                    </div>
+                </FlexGridCol>
+                <FlexGridCol
+                    className="stay-in-touch__second-row-container top"
+                    mobile={12}
+                    tablet={12}
+                    desktop={3}>
                     <div className="stay-in-touch__second-row-title">
                                 Get release notes delivered to your inbox
                     </div>
@@ -78,7 +113,8 @@ const StayInTouch = (pageName) => {
                 <FlexGridCol
                     className="stay-in-touch__second-row-container"
                     mobile={12}
-                    tablet={6}>
+                    tablet={12}
+                    desktop={3}>
                     <div className="stay-in-touch__second-row-title">
                                 Request a USAspending training session
                     </div>


### PR DESCRIPTION
**High level description:**

Chart was weird when there was a large pos number and a small neg number; example in ticket

**Technical details:**

Updated the logic that determines the domain in the chart; so now it uses the larger of the absolute value of the largest positive or negative number

**JIRA Ticket:**
[DEV-9888](https://federal-spending-transparency.atlassian.net/browse/DEV-9888)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
