### PR TITLE
9942 - changed it so that if no hash exists the url that is shared do…

### DIFF
--- a/src/js/components/search/SearchPage.jsx
+++ b/src/js/components/search/SearchPage.jsx
@@ -77,7 +77,10 @@ export default class SearchPage extends React.Component {
 
 
     getSlugWithHash() {
-        return `${slug}?hash=${this.props.hash}`;
+        if (this.props.hash) {
+            return `${slug}?hash=${this.props.hash}`;
+        }
+        return slug;
     }
 
     handleShare = (name) => {


### PR DESCRIPTION
…es not include hash=undefined at the end, and if nor download is available we still share the hash in the url

**High level description:**

QA feedback

**Technical details:**

changed it so that if no hash exists the url that is shared does not include hash=undefined at the end, and if nor download is available we still share the hash in the url

**JIRA Ticket:**
[DEV-9942](https://federal-spending-transparency.atlassian.net/browse/DEV-9942)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
