### PR TITLE
Mod 9701 fortmat mobile nav menu

### DIFF
--- a/src/_scss/layouts/default/header/nav/mobile/_animations.scss
+++ b/src/_scss/layouts/default/header/nav/mobile/_animations.scss
@@ -1,20 +1,38 @@
 .mobile-nav-animations {
     // slide in animation
     @keyframes mobileNavEnter {
+        // slide in from top
+        //0% {
+        //    transform: translate(0, -100vh);
+        //}
+        //100% {
+        //    transform: translate(0, 0);
+        //}
+
+        // left to right variation
         0% {
-            transform: translate(0, -100vh);
+            transform: translateX(-100%);
         }
         100% {
-            transform: translate(0, 0);
+            transform: translateX(0);
         }
     }
 
     @keyframes mobileNavExit {
+        // slide out to top
+        //0% {
+        //    transform: translate(0, 0);
+        //}
+        //100% {
+        //    transform: translate(0, -100vh);
+        //}
+
+        // right to left variation
         0% {
-            transform: translate(0, 0);
+            transform: translateX(0);
         }
         100% {
-            transform: translate(0, -100vh);
+            transform: translateX(-100%);
         }
     }
 
@@ -41,7 +59,7 @@
     }
 
     .mobile-nav-slide-exit, .mobile-nav-slide-exit-active {
-        @include animation(mobileNavExit 0.195s ease-in forwards);
+        @include animation(mobileNavExit 0.225s ease-in forwards);
     }
 
     .mobile-nav-side-slide-enter, .mobile-nav-side-slide-enter-active {

--- a/src/_scss/layouts/default/header/nav/mobile/_animations.scss
+++ b/src/_scss/layouts/default/header/nav/mobile/_animations.scss
@@ -2,55 +2,33 @@
     // slide in animation
     @keyframes mobileNavEnter {
         // slide in from top
-        //0% {
-        //    transform: translate(0, -100vh);
-        //}
-        //100% {
-        //    transform: translate(0, 0);
-        //}
-
-        // left to right variation
         0% {
-            transform: translateX(-100%);
+            transform: translate(0, -100vh);
         }
         100% {
-            transform: translateX(0);
+            transform: translate(0, 0);
         }
     }
 
     @keyframes mobileNavExit {
         // slide out to top
-        //0% {
-        //    transform: translate(0, 0);
-        //}
-        //100% {
-        //    transform: translate(0, -100vh);
-        //}
-
-        // right to left variation
         0% {
-            transform: translateX(0);
+            transform: translate(0, 0);
         }
         100% {
-            transform: translateX(-100%);
+            transform: translate(0, -100vh);
         }
     }
 
+    // this one applies to the mobile-dropdown__list
+    // and we only have Enter here because we're using
+    // display none to hide it
     @keyframes mobileNavSideEnter {
         0% {
             transform: translateX(100%);
         }
         100% {
             transform: translateX(0);
-        }
-    }
-
-    @keyframes mobileNavSideExit {
-        0% {
-            transform: translateX(0);
-        }
-        100% {
-            transform: translateX(100%);
         }
     }
 
@@ -64,9 +42,5 @@
 
     .mobile-nav-side-slide-enter, .mobile-nav-side-slide-enter-active {
         @include animation(mobileNavSideEnter 0.225s ease-in forwards);
-    }
-
-    .mobile-nav-side-slide-exit, .mobile-nav-side-slide-exit-active {
-        @include animation(mobileNavSideExit 0.225s ease-in forwards);
     }
 }

--- a/src/_scss/layouts/default/header/nav/mobile/_animations.scss
+++ b/src/_scss/layouts/default/header/nav/mobile/_animations.scss
@@ -16,7 +16,25 @@
         100% {
             transform: translate(0, -100vh);
         }
-    }  
+    }
+
+    @keyframes mobileNavSideEnter {
+        0% {
+            transform: translateX(100%);
+        }
+        100% {
+            transform: translateX(0);
+        }
+    }
+
+    @keyframes mobileNavSideExit {
+        0% {
+            transform: translateX(0);
+        }
+        100% {
+            transform: translateX(100%);
+        }
+    }
 
     .mobile-nav-slide-enter, .mobile-nav-slide-enter-active {
         @include animation(mobileNavEnter 0.225s ease-in forwards);
@@ -24,5 +42,13 @@
 
     .mobile-nav-slide-exit, .mobile-nav-slide-exit-active {
         @include animation(mobileNavExit 0.195s ease-in forwards);
+    }
+
+    .mobile-nav-side-slide-enter, .mobile-nav-side-slide-enter-active {
+        @include animation(mobileNavSideEnter 0.225s ease-in forwards);
+    }
+
+    .mobile-nav-side-slide-exit, .mobile-nav-side-slide-exit-active {
+        @include animation(mobileNavSideExit 0.225s ease-in forwards);
     }
 }

--- a/src/_scss/layouts/default/header/nav/mobile/_dropdown.scss
+++ b/src/_scss/layouts/default/header/nav/mobile/_dropdown.scss
@@ -132,7 +132,7 @@
         @include display(flex);
         @include justify-content(center);
         @include align-items(center);
-    
+
         &:hover, &:active, &.mobile-dropdown__link_active {
             text-decoration: none;
         }

--- a/src/_scss/layouts/default/header/nav/mobile/_nav.scss
+++ b/src/_scss/layouts/default/header/nav/mobile/_nav.scss
@@ -2,10 +2,6 @@
     ul.mobile-nav-content__list {
         @include unstyled-list;
 
-        .mobile-nav__animation {
-            animation: mobileNavEnter 0.225s ease-in forwards;
-        }
-
         @keyframes mobileNavEnter {
             0% {
                 transform: translate(0, -100vh);
@@ -22,6 +18,14 @@
             100% {
                 transform: translate(0, -100vh);
             }
+        }
+
+        .animation-enter {
+            animation: mobileNavEnter 0.1s ease-in forwards;
+        }
+
+        .animation-exit {
+            animation: mobileNavExit 0.1s ease-in forwards;
         }
 
         li.mobile-nav-content__list-item {

--- a/src/_scss/layouts/default/header/nav/mobile/_nav.scss
+++ b/src/_scss/layouts/default/header/nav/mobile/_nav.scss
@@ -2,30 +2,30 @@
     ul.mobile-nav-content__list {
         @include unstyled-list;
 
-        @keyframes mobileNavEnter {
+        @keyframes mobileNavEnterLtoR {
             0% {
-                transform: translate(0, -100vh);
+                transform: translateX(-100%);
             }
             100% {
-                transform: translate(0, 0);
+                transform: translateX(0);
             }
         }
 
-        @keyframes mobileNavExit {
+        @keyframes mobileNavExitRtoL {
             0% {
-                transform: translate(0, 0);
+                transform: translateX(0);
             }
             100% {
-                transform: translate(0, -100vh);
+                transform: translateX(-100%);
             }
         }
 
         .animation-enter {
-            animation: mobileNavEnter 0.1s ease-in forwards;
+            animation: mobileNavEnterLtoR 0.225s ease-in forwards;
         }
 
         .animation-exit {
-            animation: mobileNavExit 0.1s ease-in forwards;
+            animation: mobileNavExitRtoL 0.225s ease-in forwards;
         }
 
         li.mobile-nav-content__list-item {

--- a/src/_scss/layouts/default/header/nav/mobile/_nav.scss
+++ b/src/_scss/layouts/default/header/nav/mobile/_nav.scss
@@ -7,11 +7,6 @@
             margin: rem(0) rem(16) rem(24) rem(16);
             @media (min-width: $tablet-screen) {
                 margin: rem(0) rem(32) rem(24) rem(32);
-        }
-            &.mobile-nav-content__list-item_no-phone {
-                @media screen and (max-width: 450px) {
-                    display: none;
-                }
             }
         }
 
@@ -46,7 +41,7 @@
             margin: rem(0) rem(16) rem(24) rem(16);
             @media (min-width: $tablet-screen) {
                 margin: rem(0) rem(32) rem(24) rem(32);
-        }
+            }
         }
     }
 }

--- a/src/_scss/layouts/default/header/nav/mobile/_nav.scss
+++ b/src/_scss/layouts/default/header/nav/mobile/_nav.scss
@@ -2,6 +2,28 @@
     ul.mobile-nav-content__list {
         @include unstyled-list;
 
+        .mobile-nav__animation {
+            animation: mobileNavEnter 0.225s ease-in forwards;
+        }
+
+        @keyframes mobileNavEnter {
+            0% {
+                transform: translate(0, -100vh);
+            }
+            100% {
+                transform: translate(0, 0);
+            }
+        }
+
+        @keyframes mobileNavExit {
+            0% {
+                transform: translate(0, 0);
+            }
+            100% {
+                transform: translate(0, -100vh);
+            }
+        }
+
         li.mobile-nav-content__list-item {
             text-align: left;
             margin: rem(0) rem(16) rem(24) rem(16);

--- a/src/_scss/layouts/default/header/nav/mobile/_nav.scss
+++ b/src/_scss/layouts/default/header/nav/mobile/_nav.scss
@@ -11,21 +11,10 @@
             }
         }
 
-        @keyframes mobileNavExitRtoL {
-            0% {
-                transform: translateX(0);
-            }
-            100% {
-                transform: translateX(-100%);
-            }
-        }
-
+        // there is no need for an animation-exit class here bc
+        // we're using display none which overrides the animation
         .animation-enter {
             animation: mobileNavEnterLtoR 0.225s ease-in forwards;
-        }
-
-        .animation-exit {
-            animation: mobileNavExitRtoL 0.225s ease-in forwards;
         }
 
         li.mobile-nav-content__list-item {

--- a/src/_scss/layouts/default/header/nav/mobile/_top.scss
+++ b/src/_scss/layouts/default/header/nav/mobile/_top.scss
@@ -34,21 +34,10 @@
         }
     }
 
-    @keyframes mobileNavExitRtoL {
-        0% {
-            transform: translateX(0);
-        }
-        100% {
-            transform: translateX(-100%);
-        }
-    }
-
+    // there is no need for an animation-exit class here bc
+    // we're using display none which overrides the animation
     .animation-enter {
         animation: mobileNavEnterLtoR 0.225s ease-in forwards;
-    }
-
-    .animation-exit {
-        animation: mobileNavExitRtoL 0.225s ease-in forwards;
     }
 
     margin: rem(0) rem(16);

--- a/src/_scss/layouts/default/header/nav/mobile/_top.scss
+++ b/src/_scss/layouts/default/header/nav/mobile/_top.scss
@@ -25,12 +25,38 @@
     @include flex-direction(row);
     @include align-items(center);
 
+    @keyframes mobileNavEnterLtoR {
+        0% {
+            transform: translateX(-100%);
+        }
+        100% {
+            transform: translateX(0);
+        }
+    }
+
+    @keyframes mobileNavExitRtoL {
+        0% {
+            transform: translateX(0);
+        }
+        100% {
+            transform: translateX(-100%);
+        }
+    }
+
+    .animation-enter {
+        animation: mobileNavEnterLtoR 0.225s ease-in forwards;
+    }
+
+    .animation-exit {
+        animation: mobileNavExitRtoL 0.225s ease-in forwards;
+    }
+
     margin: rem(0) rem(16);
     @media (min-width: $tablet-screen) {
         margin: rem(0) rem(32);
 }
     .mobile-nav_back-button-container {
-        display: flex;  
+        display: flex;
         color: #2378c3;
         background-color: $color-white;
         padding-top: rem(23);
@@ -75,7 +101,7 @@
                 color: $gray-cool-90;
             }
         }
-        .mobile-nav-header__close-button-section { 
+        .mobile-nav-header__close-button-section {
             margin-top: rem(12) !important;
             @include button-unstyled;
             height: rem(26);

--- a/src/_scss/layouts/default/header/nav/mobile/mobileNav.scss
+++ b/src/_scss/layouts/default/header/nav/mobile/mobileNav.scss
@@ -5,7 +5,7 @@
     left: 0;
     right: 0;
     z-index: $z-mobile-nav;
-    overflow-y: auto;
+    overflow: hidden;
     background-color: $color-white;
     @media (min-width: $medium-screen) {
         display: none;

--- a/src/_scss/layouts/default/header/nav/mobile/mobileNav.scss
+++ b/src/_scss/layouts/default/header/nav/mobile/mobileNav.scss
@@ -5,7 +5,7 @@
     left: 0;
     right: 0;
     z-index: $z-mobile-nav;
-    overflow: hidden;
+    overflow-y: auto;
     background-color: $color-white;
     @media (min-width: $medium-screen) {
         display: none;

--- a/src/_scss/layouts/default/header/nav/mobile/mobileNav.scss
+++ b/src/_scss/layouts/default/header/nav/mobile/mobileNav.scss
@@ -15,10 +15,11 @@
         position: relative;
         padding: rem(0) rem(0);
     }
-    ul.mobile-dropdown__list {
+
+    .mobile-dropdown__list {
         padding-left: 0 !important;
-        text-align: left;
     }
+
     @import "./_top";
     @import "./_nav";
     @import "./_dropdown";

--- a/src/js/components/sharedComponents/header/NavbarWrapper.jsx
+++ b/src/js/components/sharedComponents/header/NavbarWrapper.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { CSSTransition, TransitionGroup } from "react-transition-group";
 import { Link, useLocation } from 'react-router-dom';
 import Analytics from 'helpers/analytics/Analytics';
 import MobileNav from './mobile/MobileNav';
@@ -21,7 +22,8 @@ const NavbarWrapper = () => {
         if (showMobileNav) {
             // disable body scrolling
             document.querySelector('body').classList.add('show-mobile-nav');
-        } else {
+        }
+        else {
             // re-enable body scrolling
             document.querySelector('body').classList.remove('show-mobile-nav');
         }
@@ -84,7 +86,18 @@ const NavbarWrapper = () => {
                         </button>
                     </div>
                 </div>
-                {showMobileNav && <MobileNav hideMobileNav={hideMobileNav} />}
+                <div className="mobile-nav-animations">
+                    <TransitionGroup>
+                        {showMobileNav && (
+                            <CSSTransition
+                                classNames="mobile-nav-slide"
+                                timeout={{ enter: 225, exit: 195 }}
+                                exit>
+                                <MobileNav hideMobileNav={hideMobileNav} />
+                            </CSSTransition>
+                        )}
+                    </TransitionGroup>
+                </div>
                 <div className="site-navigation__menu full-menu">
                     <MegaMenu />
                 </div>

--- a/src/js/components/sharedComponents/header/NavbarWrapper.jsx
+++ b/src/js/components/sharedComponents/header/NavbarWrapper.jsx
@@ -91,8 +91,7 @@ const NavbarWrapper = () => {
                         {showMobileNav && (
                             <CSSTransition
                                 classNames="mobile-nav-slide"
-                                timeout={{ enter: 225, exit: 195 }}
-                                exit>
+                                timeout={{ enter: 225, exit: 225 }}>
                                 <MobileNav hideMobileNav={hideMobileNav} />
                             </CSSTransition>
                         )}

--- a/src/js/components/sharedComponents/header/NavbarWrapper.jsx
+++ b/src/js/components/sharedComponents/header/NavbarWrapper.jsx
@@ -9,6 +9,10 @@ const NavbarWrapper = () => {
     const [showMobileNav, setShowMobileNav] = useState(false);
     const [isHomepage, setIsHomepage] = useState(false);
 
+    // the purpose of this var is to prevent the usas logo from sliding in from
+    // the left when the menu opens initially
+    const [mobileNavInitialState, setMobileNavInitialState] = useState(true);
+
     const { pathname } = useLocation();
 
     useEffect(() => {
@@ -27,8 +31,7 @@ const NavbarWrapper = () => {
             // re-enable body scrolling
             document.querySelector('body').classList.remove('show-mobile-nav');
         }
-    }
-    , [showMobileNav]);
+    }, [showMobileNav]);
 
     const clickedHeaderLink = (route) => {
         Analytics.event({
@@ -45,6 +48,7 @@ const NavbarWrapper = () => {
     // re-enable body scrolling
         document.querySelector('body').classList.remove('show-mobile-nav');
         setShowMobileNav(false);
+        setMobileNavInitialState(true);
     };
 
     const toggleMobileNav = () => {
@@ -92,7 +96,10 @@ const NavbarWrapper = () => {
                             <CSSTransition
                                 classNames="mobile-nav-slide"
                                 timeout={{ enter: 225, exit: 225 }}>
-                                <MobileNav hideMobileNav={hideMobileNav} />
+                                <MobileNav
+                                    hideMobileNav={hideMobileNav}
+                                    mobileNavInitialState={mobileNavInitialState}
+                                    setMobileNavInitialState={setMobileNavInitialState} />
                             </CSSTransition>
                         )}
                     </TransitionGroup>

--- a/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
@@ -117,8 +117,8 @@ const MobileNav = (props) => {
                 <ul className="mobile-nav-content__list" style={detailMobileNavIsHidden ? {} : { display: "none" }}>
                     {navbarConfig.map((n, index) => (
                         <>
-                            <hr className="mobile-nav-content__divider" />
-                            <li className="mobile-nav-content__list-item">
+                            <hr className="mobile-nav-content__divider mobile-nav__animation" />
+                            <li className="mobile-nav-content__list-item mobile-nav__animation">
                                 {index === 0 ?
                                     <Link
                                         className="mobile-nav-content__link"

--- a/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
@@ -114,7 +114,9 @@ const MobileNav = (props) => {
                     hideMobileNav={props.hideMobileNav} />
             </div>
             <div className="mobile-nav-content">
-                <ul className="mobile-nav-content__list" style={detailMobileNavIsHidden ? {} : { display: "none" }}>
+                <ul
+                    className="mobile-nav-content__list"
+                    style={detailMobileNavIsHidden ? {} : { display: "none" }}>
                     {navbarConfig.map((n, index) => (
                         <>
                             <hr className={`mobile-nav-content__divider ${detailMobileNavIsHidden ? " animation-enter" : " animation-exit"}`} />
@@ -149,7 +151,9 @@ const MobileNav = (props) => {
                         </>
                     ))}
                 </ul>
-                <ul className="mobile-dropdown__list mobile-nav-animations">
+                <ul
+                    className="mobile-dropdown__list mobile-nav-animations"
+                    style={!detailMobileNavIsHidden ? {} : { display: "none" }}>
                     <TransitionGroup>
                         {currentIndex && (
                             <CSSTransition

--- a/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
@@ -117,8 +117,8 @@ const MobileNav = (props) => {
                 <ul className="mobile-nav-content__list" style={detailMobileNavIsHidden ? {} : { display: "none" }}>
                     {navbarConfig.map((n, index) => (
                         <>
-                            <hr className="mobile-nav-content__divider mobile-nav__animation" />
-                            <li className="mobile-nav-content__list-item mobile-nav__animation">
+                            <hr className={`mobile-nav-content__divider ${detailMobileNavIsHidden ? " animation-enter" : " animation-exit"}`} />
+                            <li className={`mobile-nav-content__list-item ${detailMobileNavIsHidden ? " animation-enter" : " animation-exit"}`}>
                                 {index === 0 ?
                                     <Link
                                         className="mobile-nav-content__link"
@@ -153,8 +153,8 @@ const MobileNav = (props) => {
                     <TransitionGroup>
                         {currentIndex && (
                             <CSSTransition
-                                classNames="mobile-nav-slide"
-                                timeout={{ enter: 225, exit: 195 }}
+                                classNames="mobile-nav-side-slide"
+                                timeout={{ enter: 225, exit: 225 }}
                                 exit>
                                 <MobileDropdownItem
                                     {...props}

--- a/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
@@ -92,6 +92,7 @@ const MobileNav = (props) => {
         clickedHeaderLink(route);
         props.hideMobileNav();
     };
+
     const checkCurrentProfile = () => {
         const currentUrl = location.pathname;
         if (url !== currentUrl) {
@@ -110,7 +111,7 @@ const MobileNav = (props) => {
                 <MobileTop
                     closeDetailedMobileNav={closeDetailedMobileNav}
                     detailMobileNavIsHidden={detailMobileNavIsHidden}
-                    hideMobileNav={clickedLink} />
+                    hideMobileNav={props.hideMobileNav} />
             </div>
             <div className="mobile-nav-content">
                 <ul className="mobile-nav-content__list" style={detailMobileNavIsHidden ? {} : { display: "none" }}>

--- a/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
@@ -34,7 +34,9 @@ const clickedHeaderLink = (route) => {
 
 const propTypes = {
     hideMobileNav: PropTypes.func,
-    location: PropTypes.object
+    location: PropTypes.object,
+    mobileNavInitialState: PropTypes.bool,
+    setMobileNavInitialState: PropTypes.func
 };
 
 const navbarConfig = [
@@ -72,13 +74,14 @@ const navbarConfig = [
 ];
 
 const MobileNav = (props) => {
-    const { location } = props;
+    const { location, mobileNavInitialState, setMobileNavInitialState } = props;
     const [url, setUrl] = useState('');
     const [detailMobileNavIsHidden, setDetailMobileNavIsHidden] = useState(true);
     const [currentIndex, setCurrentIndex] = useState(null);
 
     const openDetailedMobileNav = (index) => {
         setDetailMobileNavIsHidden(false);
+        setMobileNavInitialState(false);
         setCurrentIndex(index);
     };
 
@@ -111,6 +114,7 @@ const MobileNav = (props) => {
                 <MobileTop
                     closeDetailedMobileNav={closeDetailedMobileNav}
                     detailMobileNavIsHidden={detailMobileNavIsHidden}
+                    mobileNavInitialState={mobileNavInitialState}
                     hideMobileNav={props.hideMobileNav} />
             </div>
             <div className="mobile-nav-content">
@@ -120,7 +124,7 @@ const MobileNav = (props) => {
                     {navbarConfig.map((n, index) => (
                         <>
                             <hr className={`mobile-nav-content__divider ${detailMobileNavIsHidden ? " animation-enter" : " animation-exit"}`} />
-                            <li className={`mobile-nav-content__list-item ${detailMobileNavIsHidden ? " animation-enter" : " animation-exit"}`}>
+                            <li className={`mobile-nav-content__list-item ${detailMobileNavIsHidden ? " animation-enter" : " "}`}>
                                 {index === 0 ?
                                     <Link
                                         className="mobile-nav-content__link"

--- a/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import { CSSTransition, TransitionGroup } from "react-transition-group";
 import PropTypes from 'prop-types';
 import { withRouter, Link } from 'react-router-dom';
 import Analytics from 'helpers/analytics/Analytics';
@@ -73,16 +74,16 @@ const navbarConfig = [
 const MobileNav = (props) => {
     const { location } = props;
     const [url, setUrl] = useState('');
-    const [detailMobileNavIsHidden, setHideDetailMobileNav] = useState(true);
+    const [detailMobileNavIsHidden, setDetailMobileNavIsHidden] = useState(true);
     const [currentIndex, setCurrentIndex] = useState(null);
 
     const openDetailedMobileNav = (index) => {
-        setHideDetailMobileNav(false);
+        setDetailMobileNavIsHidden(false);
         setCurrentIndex(index);
     };
 
     const closeDetailedMobileNav = () => {
-        setHideDetailMobileNav(true);
+        setDetailMobileNavIsHidden(true);
         setCurrentIndex(null);
     };
 
@@ -147,21 +148,30 @@ const MobileNav = (props) => {
                         </>
                     ))}
                 </ul>
-                <ul className="mobile-dropdown__list" style={detailMobileNavIsHidden ? { display: "none" } : {}}>
-                    {currentIndex && <MobileDropdownItem
-                        {...props}
-                        mainTitle={navbarConfig[currentIndex].title}
-                        label={navbarConfig[currentIndex].title}
-                        title={navbarConfig[currentIndex].title}
-                        section1Items={navbarConfig[currentIndex].section1Items}
-                        section2Items={navbarConfig[currentIndex].section2Items}
-                        section3Items={navbarConfig[currentIndex].section3Items}
-                        section1Options={navbarConfig[currentIndex].section1Options}
-                        section2Options={navbarConfig[currentIndex].section2Options}
-                        section3Options={navbarConfig[currentIndex].section3Options}
-                        index={currentIndex}
-                        onClick={clickedLink}
-                        active={url} />}
+                <ul className="mobile-dropdown__list mobile-nav-animations">
+                    <TransitionGroup>
+                        {currentIndex && (
+                            <CSSTransition
+                                classNames="mobile-nav-slide"
+                                timeout={{ enter: 225, exit: 195 }}
+                                exit>
+                                <MobileDropdownItem
+                                    {...props}
+                                    mainTitle={navbarConfig[currentIndex].title}
+                                    label={navbarConfig[currentIndex].title}
+                                    title={navbarConfig[currentIndex].title}
+                                    section1Items={navbarConfig[currentIndex].section1Items}
+                                    section2Items={navbarConfig[currentIndex].section2Items}
+                                    section3Items={navbarConfig[currentIndex].section3Items}
+                                    section1Options={navbarConfig[currentIndex].section1Options}
+                                    section2Options={navbarConfig[currentIndex].section2Options}
+                                    section3Options={navbarConfig[currentIndex].section3Options}
+                                    index={currentIndex}
+                                    onClick={clickedLink}
+                                    active={url} />
+                            </CSSTransition>
+                        )}
+                    </TransitionGroup>
                 </ul>
             </div>
         </div>

--- a/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
@@ -123,7 +123,7 @@ const MobileNav = (props) => {
                     style={detailMobileNavIsHidden ? {} : { display: "none" }}>
                     {navbarConfig.map((n, index) => (
                         <>
-                            <hr className={`mobile-nav-content__divider ${detailMobileNavIsHidden ? " animation-enter" : " animation-exit"}`} />
+                            <hr className={`mobile-nav-content__divider ${detailMobileNavIsHidden ? " animation-enter" : " "}`} />
                             <li className={`mobile-nav-content__list-item ${detailMobileNavIsHidden ? " animation-enter" : " "}`}>
                                 {index === 0 ?
                                     <Link

--- a/src/js/components/sharedComponents/header/mobile/MobileTop.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileTop.jsx
@@ -34,7 +34,7 @@ export default class MobileTop extends React.Component {
             <div>
                 <GovBanner />
                 <div className="mobile-nav-header">
-                    <div style={this.props.detailMobileNavIsHidden ? {} : { display: "none" }} className="mobile-nav-header__logo site-logo">
+                    <div style={this.props.detailMobileNavIsHidden ? {} : { display: "none" }} className={`mobile-nav-header__logo site-logo ${this.props.detailMobileNavIsHidden ? " animation-enter" : " animation-exit"}`}>
                         <div className="site-logo__wrapper" id="logo-nav">
                             <Link
                                 className="site-logo__link"
@@ -71,7 +71,7 @@ export default class MobileTop extends React.Component {
                     </div>
                     <div className="mobile-nav-header__close">
                         <button
-                            className={this.props.detailMobileNavIsHidden ? "mobile-nav-header__close-button" : "mobile-nav-header__close-button-section"}
+                            className={this.props.detailMobileNavIsHidden ? "mobile-nav-header__close-button animation-enter" : "mobile-nav-header__close-button-section animation-exit"}
                             title="Close menu"
                             aria-label="Close menu"
                             onClick={(e) => this.props.hideMobileNav(e)}>

--- a/src/js/components/sharedComponents/header/mobile/MobileTop.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileTop.jsx
@@ -8,7 +8,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Analytics from 'helpers/analytics/Analytics';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import GovBanner from "./../GovBanner";
 
 const clickedHeaderLink = (route) => {
     Analytics.event({
@@ -32,9 +31,8 @@ export default class MobileTop extends React.Component {
     render() {
         return (
             <div>
-                <GovBanner />
                 <div className="mobile-nav-header">
-                    <div style={this.props.detailMobileNavIsHidden ? {} : { display: "none" }} className={`mobile-nav-header__logo site-logo ${this.props.detailMobileNavIsHidden ? " animation-enter" : " animation-exit"}`}>
+                    <div style={this.props.detailMobileNavIsHidden ? {} : { display: "none" }} className={`mobile-nav-header__logo site-logo ${(this.props.detailMobileNavIsHidden && !this.props.mobileNavInitialState) ? " animation-enter" : " "}`}>
                         <div className="site-logo__wrapper" id="logo-nav">
                             <Link
                                 className="site-logo__link"
@@ -87,5 +85,6 @@ export default class MobileTop extends React.Component {
 MobileTop.propTypes = {
     hideMobileNav: PropTypes.func,
     detailMobileNavIsHidden: PropTypes.bool,
-    closeDetailedMobileNav: PropTypes.func
+    closeDetailedMobileNav: PropTypes.func,
+    mobileNavInitialState: PropTypes.bool
 };

--- a/src/js/components/sharedComponents/header/mobile/MobileTop.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileTop.jsx
@@ -71,7 +71,8 @@ export default class MobileTop extends React.Component {
                     </div>
                     <div className="mobile-nav-header__close">
                         <button
-                            className={this.props.detailMobileNavIsHidden ? "mobile-nav-header__close-button animation-enter" : "mobile-nav-header__close-button-section animation-exit"}
+                            // className={this.props.detailMobileNavIsHidden ? "mobile-nav-header__close-button animation-enter" : "mobile-nav-header__close-button-section animation-exit"}
+                            className={this.props.detailMobileNavIsHidden ? "mobile-nav-header__close-button" : "mobile-nav-header__close-button-section"}
                             title="Close menu"
                             aria-label="Close menu"
                             onClick={(e) => this.props.hideMobileNav(e)}>

--- a/src/js/components/sharedComponents/header/mobile/MobileTop.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileTop.jsx
@@ -85,5 +85,7 @@ export default class MobileTop extends React.Component {
 }
 
 MobileTop.propTypes = {
-    hideMobileNav: PropTypes.func
+    hideMobileNav: PropTypes.func,
+    detailMobileNavIsHidden: PropTypes.bool,
+    closeDetailedMobileNav: PropTypes.func
 };

--- a/src/js/components/sharedComponents/header/mobile/MobileTop.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileTop.jsx
@@ -71,7 +71,6 @@ export default class MobileTop extends React.Component {
                     </div>
                     <div className="mobile-nav-header__close">
                         <button
-                            // className={this.props.detailMobileNavIsHidden ? "mobile-nav-header__close-button animation-enter" : "mobile-nav-header__close-button-section animation-exit"}
                             className={this.props.detailMobileNavIsHidden ? "mobile-nav-header__close-button" : "mobile-nav-header__close-button-section"}
                             title="Close menu"
                             aria-label="Close menu"


### PR DESCRIPTION
**High level description:**

this pr is only for the animation on the mobile menu

**Technical details:**

Added the animation that was used on the old mobile menu; also had to add a version of that animation to the elements in the mobile-nav-content block so the content list will animate out when user uses Back button; and cleaned up some css and removed the GA tracking from the close button
update after design review:
removed unneeded animation classes for exit because display none overrides them anyway; added a state var to prevent the usas logo from sliding in from the left when the menu opens; removed tophat from the mobile menu, as requested by design

**JIRA Ticket:**
[DEV-9701](https://federal-spending-transparency.atlassian.net/browse/DEV-9701)

**Mockup:**
https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55?seid=640fadbaf4af993897d93cdd

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
