### PR TITLE
9976 - fixed spacing between new stay in touch sections

### DIFF
--- a/src/_scss/layouts/default/footer/_stayInTouch.scss
+++ b/src/_scss/layouts/default/footer/_stayInTouch.scss
@@ -12,7 +12,7 @@
   .stay-in-touch__container-row {
     @media (min-width: $medium-screen) {
       flex-flow: row nowrap;
-      justify-content: flex-start;
+      justify-content: space-between;
     }
 
     @media (min-width: $m-large-screen) {


### PR DESCRIPTION
**High level description:**

Spacing isn't correct between the new Stay in Touch sections

**Technical details:**

Changed from justify-content: flex-start to space-between

**JIRA Ticket:**
[DEV-9976](https://federal-spending-transparency.atlassian.net/browse/DEV-9976)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
