### PR TITLE
Removed ZZ district code

### DIFF
--- a/src/data/congressional/ct_districts.json
+++ b/src/data/congressional/ct_districts.json
@@ -24,11 +24,6 @@
             "code": "0905",
             "district": "05",
             "name": "CT-05"
-        },
-        {
-            "code": "09ZZ",
-            "district": "ZZ",
-            "name": "CT-ZZ"
         }
     ]
 }

--- a/src/data/congressional/il_districts.json
+++ b/src/data/congressional/il_districts.json
@@ -89,11 +89,6 @@
             "code": "1718",
             "district": "18",
             "name": "IL-18"
-        },
-        {
-            "code": "17ZZ",
-            "district": "ZZ",
-            "name": "IL-ZZ"
         }
     ]
 }

--- a/src/data/congressional/mi_districts.json
+++ b/src/data/congressional/mi_districts.json
@@ -69,11 +69,6 @@
             "code": "2614",
             "district": "14",
             "name": "MI-14"
-        },
-        {
-            "code": "26ZZ",
-            "district": "ZZ",
-            "name": "MI-ZZ"
         }
     ]
 }


### PR DESCRIPTION
**High level description:**

Removed the state abbreviation-ZZ from CT, MI, and IL

**Technical details:**

Technical details for the knowledge of other developers.

**JIRA Ticket:**
[DEV-9963](https://federal-spending-transparency.atlassian.net/browse/DEV-9963)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
