### PR TITLE
9405 Added the "--" to fields that have no value. Updated tooltip based on…

### DIFF
--- a/src/js/components/award/shared/InfoTooltipContent.jsx
+++ b/src/js/components/award/shared/InfoTooltipContent.jsx
@@ -1125,11 +1125,12 @@ export const ContractAwardAmountsInfo = (
         </div>
         <div className="tooltip__text">
             <p>This section illustrates how much the government has spent on this award.</p>
-            <p>The Obligated Amount of a contract represents the amount an agency has promised to pay the vendor in its financial system. It usually matches the current value of the contract, but certain agencies (e.g., DOD) are allowed to incrementally fund some contracts in their financial systems. In these cases, the Obligated Amount may lag behind the Current Award Amount.</p>
-            <p>The current value of a contract (Current Award Amount) represents the value of the base contract and any exercised options. </p>
-            <p>The potential value of a contract (Potential Award Amount) represents the value of the base contract and all options, if they happen to be exercised in the future. This is sometimes called the contract ceiling or capacity.</p>
+            <p>The outlayed amount of a contract represents the amount an agency has paid the vendor as recorded in the agency’s financial system. Please note that the Office of Management and Budget (OMB) required agencies to provide outlay data at the award summary level for each award that received COVID-19 supplemental funding starting in Fiscal Year (FY) 2020, and for all awards starting in FY 2022. As a result, award-level outlay data are incomplete prior to FY 2022, and almost entirely absent prior to FY 2020.</p>
+            <p>The obligated amount of a contract represents the amount an agency has promised to pay the vendor as recorded in the agency's financial system. It usually matches the current value of the contract, but certain agencies (e.g., DOD) are allowed to incrementally fund some contracts in their financial systems. In these cases, the obligated amount may lag behind the current award amount.</p>
+            <p>The current value of a contract (current award amount) represents the value of the base contract and any exercised options. </p>
+            <p>The potential value of a contract (potential award amount) represents the value of the base contract and all options, if they happen to be exercised in the future. This is sometimes called the contract ceiling or capacity.</p>
             <p>If a recipient fails to deliver on the terms of the contract, the contract can end or be modified, reducing the current and potential value through a deobligation.</p>
-            <p>This visual depicts the Obligated Amount, Current Award Amount, and Potential Award Amount of the contract.</p>
+            <p>This visual depicts the obligated amount, current award amount, and potential award amount of the contract.</p>
             <p>Hover over the chart for more information about the specific amounts displayed.</p>
         </div>
     </div>

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
@@ -137,7 +137,7 @@ const AwardAmountsTable = ({
                                 <span className={`award-amounts__data-icon ${awardTableClassMap[title]}`} />
                                 {title}
                             </div>
-                            <span>{amountMapByCategoryTitle[title]}</span>
+                            <span>{amountMapByCategoryTitle[title] === "$0.00" || amountMapByCategoryTitle[title] === null ? "--" : amountMapByCategoryTitle[title]}</span>
                         </div>
                 ))
             }


### PR DESCRIPTION
… mac

**High level description:**

Added the "-- to field with no values.
UPdated tooltip in award amount based on mac

**Technical details:**

Technical details for the knowledge of other developers.

**JIRA Ticket:**
[DEV-9405](https://federal-spending-transparency.atlassian.net/browse/DEV-9405)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
