### PR TITLE
Mod/9885 award profile loan amounts

### DIFF
--- a/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
@@ -114,7 +114,8 @@ const AwardAmountsTable = ({
                     hide = true;
                 }
             });
-        } else {
+        }
+        else {
             allExclusions.forEach((item) => {
                 if (title === item) {
                     hide = true;

--- a/src/js/components/award/shared/awardAmounts/HorizontalSingleStackedBarViz.jsx
+++ b/src/js/components/award/shared/awardAmounts/HorizontalSingleStackedBarViz.jsx
@@ -10,15 +10,15 @@ import { scaleLinear } from 'd3-scale';
 import { throttle } from 'lodash';
 
 const BarVizData = PropTypes.shape({
-    rawValue: PropTypes.number.isRequired,
-    value: PropTypes.string.isRequired,
-    text: PropTypes.string.isRequired,
+    rawValue: PropTypes.number,
+    value: PropTypes.string,
+    text: PropTypes.string,
     color: PropTypes.string,
     improper: PropTypes.object,
     isImproper: PropTypes.bool,
     labelSortOrder: PropTypes.number,
     labelPosition: PropTypes.string,
-    denominatorValue: PropTypes.number,
+    denominatorValue: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     barWidthOverrides: PropTypes.shape({
         rawValue: PropTypes.number,
         denominatorValue: PropTypes.number

--- a/src/js/dataMapping/award/awardAmountsSection.js
+++ b/src/js/dataMapping/award/awardAmountsSection.js
@@ -25,7 +25,7 @@ export const orderedTableTitles = [
 ];
 
 export const spendingCategoriesByAwardType = {
-    loan: ['_totalOutlay', '_totalObligation', '_subsidy', '_faceValue'],
+    loan: ['_subsidy', '_faceValue'],
     contract: ['_totalObligation', '_baseExercisedOptions', '_baseAndAllOptions', '_totalOutlay'],
     idv: ['_totalObligation', '_baseExercisedOptions', '_baseAndAllOptions', '_totalOutlay'],
     idv_aggregated: ['_totalObligation', '_baseExercisedOptions', '_baseAndAllOptions', '_combinedOutlay']
@@ -88,14 +88,8 @@ export const formattedSpendingCategoriesByAwardType = {
         'infrastructureObligationFormatted'
     ],
     loan: [
-        'fileCObligatedFormatted',
-        'fileCOutlayFormatted',
         'subsidyFormatted',
-        'faceValueFormatted',
-        'totalOutlayFormatted',
-        'totalObligationFormatted',
-        'infrastructureOutlayFormatted',
-        'infrastructureObligationFormatted'
+        'faceValueFormatted'
     ]
 };
 
@@ -165,13 +159,7 @@ export const tableTitlesBySpendingCategoryAndAwardType = {
     },
     loan: {
         subsidyFormatted: 'Original Subsidy Cost',
-        faceValueFormatted: 'Face Value of Direct Loan',
-        fileCOutlayFormatted: 'COVID-19 Outlayed Amount',
-        fileCObligatedFormatted: 'COVID-19 Obligated Amount',
-        totalOutlayFormatted: 'Outlayed Amount',
-        totalObligationFormatted: 'Obligated Amount',
-        infrastructureOutlayFormatted: 'Infrastructure Outlayed Amounts',
-        infrastructureObligationFormatted: 'Infrastructure Obligated Amounts'
+        faceValueFormatted: 'Face Value of Direct Loan'
     }
 };
 

--- a/src/js/helpers/awardAmountChartHelper.js
+++ b/src/js/helpers/awardAmountChartHelper.js
@@ -248,10 +248,10 @@ export const buildLoanProps = (awardAmounts, hasOutlays, showFilecCovid, awardTy
             children: [{
                 labelPosition: 'top',
                 labelSortOrder: 1,
-                rawValue: getAwardObligatedRawValue(awardAmounts, awardType, fileCType),
-                value: getAwardObligatedValue(awardAmounts, awardType, fileCType),
-                text: getAwardTypeText(awardType, "Obligated", fileCType),
-                className: showFilecCovid ? `loan-file-c-obligated` : 'asst-obligation',
+                // rawValue: getAwardObligatedRawValue(awardAmounts, awardType, fileCType),
+                // value: getAwardObligatedValue(awardAmounts, awardType, fileCType),
+                // text: getAwardTypeText(awardType, "Obligated", fileCType),
+                // className: showFilecCovid ? `loan-file-c-obligated` : 'asst-obligation',
                 denominatorValue: awardAmounts._subsidy,
                 lineOffset: lineOffsetsBySpendingCategory.loanFileCObligated,
                 color: getAwardColor(obligatedColor, infrastructureObligatedColor, covidObligatedColor, fileCType)
@@ -270,12 +270,12 @@ export const buildLoanProps = (awardAmounts, hasOutlays, showFilecCovid, awardTy
         numerator2: {
             labelSortOrder: 0,
             labelPosition: 'top',
-            className: `${awardType}-outlayed`,
-            rawValue: getAwardOutlayRawValue(awardAmounts, awardType, fileCType),
-            value: getAwardOutlayValue(awardAmounts, awardType, fileCType),
+            // className: `${awardType}-outlayed`,
+            // rawValue: getAwardOutlayRawValue(awardAmounts, awardType, fileCType),
+            // value: getAwardOutlayValue(awardAmounts, awardType, fileCType),
             color: getAwardColor(outlayColor, infrastructureOutlayColor, covidColor, fileCType),
-            lineOffset: lineOffsetsBySpendingCategory.potential,
-            text: getAwardTypeText(awardType, "Outlayed", fileCType)
+            lineOffset: lineOffsetsBySpendingCategory.potential
+            // text: getAwardTypeText(awardType, "Outlayed", fileCType)
         }
     };
     return props;

--- a/src/js/helpers/awardAmountChartHelper.js
+++ b/src/js/helpers/awardAmountChartHelper.js
@@ -245,17 +245,10 @@ export const buildLoanProps = (awardAmounts, hasOutlays, showFilecCovid, awardTy
             text: 'Original Subsidy Cost',
             color: subsidyColor,
             denominatorValue: awardAmounts.faceValueAbbreviated,
-            children: [{
-                labelPosition: 'top',
-                labelSortOrder: 1,
-                // rawValue: getAwardObligatedRawValue(awardAmounts, awardType, fileCType),
-                // value: getAwardObligatedValue(awardAmounts, awardType, fileCType),
-                // text: getAwardTypeText(awardType, "Obligated", fileCType),
-                // className: showFilecCovid ? `loan-file-c-obligated` : 'asst-obligation',
-                denominatorValue: awardAmounts._subsidy,
-                lineOffset: lineOffsetsBySpendingCategory.loanFileCObligated,
-                color: getAwardColor(obligatedColor, infrastructureObligatedColor, covidObligatedColor, fileCType)
-            }]
+            // ticket 9885 requested we remove the obligation amounts from loans pages
+            // all the obligation info was in this children array
+            // but HorizontalSingleStackedBarViz will fail if we do not send this array
+            children: [{}]
         },
         denominator: {
             labelPosition: 'bottom',
@@ -267,16 +260,10 @@ export const buildLoanProps = (awardAmounts, hasOutlays, showFilecCovid, awardTy
             color: faceValueColor,
             text: 'Face Value of Direct Loan'
         },
-        numerator2: {
-            labelSortOrder: 0,
-            labelPosition: 'top',
-            // className: `${awardType}-outlayed`,
-            // rawValue: getAwardOutlayRawValue(awardAmounts, awardType, fileCType),
-            // value: getAwardOutlayValue(awardAmounts, awardType, fileCType),
-            color: getAwardColor(outlayColor, infrastructureOutlayColor, covidColor, fileCType),
-            lineOffset: lineOffsetsBySpendingCategory.potential
-            // text: getAwardTypeText(awardType, "Outlayed", fileCType)
-        }
+        // ticket 9885 requested we remove the outlay amounts from loans pages
+        // all the outlay info was in this numerator2 object
+        // but HorizontalSingleStackedBarViz will fail if we do not send this obj
+        numerator2: {}
     };
     return props;
 };


### PR DESCRIPTION
**High level description:**

Remove outlay and obligations from loans, in both chart and the legend below

**Technical details:**

Removed the data from the props made in buildLoanProps but had to leave the empty array and obj to send to HorizontalSingleStackedBarViz, or else it would break the page, and we don't want to refactor HorizontalSingleStackedBarViz for this ticket;
I used the first example listed in the ticket for testing to make sure the Infrastructure Obligated Amount was removed from the chart. You can use any loan to check that the rows are removed from the legend.

**JIRA Ticket:**
[DEV-9885](https://federal-spending-transparency.atlassian.net/browse/DEV-9885)


The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x ] Verified mobile/tablet/desktop/monitor responsiveness
- [x ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
