### PR TITLE
DEV-9928 tabbing outside of megamenu will now close menu

### DIFF
--- a/src/js/components/sharedComponents/header/megaMenu/AnimatedNavbar.jsx
+++ b/src/js/components/sharedComponents/header/megaMenu/AnimatedNavbar.jsx
@@ -200,8 +200,9 @@ export default class AnimatedNavbar extends Component {
                                         section1Icon={currentSection1Icon}
                                         section2Icon={currentSection2Icon}
                                         section3Icon={currentSection3Icon}
-                                        menuIndex={index} />
-                                    {PrevDropdown && <PrevDropdown section1Items={prevSection1Props} section2Items={prevSection2Props} section3Items={prevSection3Props} menuIndex={index} />}
+                                        menuIndex={index}
+                                        closeDropdown={this.onMouseLeave} />
+                                    {PrevDropdown && <PrevDropdown section1Items={prevSection1Props} section2Items={prevSection2Props} section3Items={prevSection3Props} menuIndex={index} closeDropdown={this.onMouseLeave} />}
                                 </DropdownContainer>
                             )}
                         </NavbarItem>

--- a/src/js/components/sharedComponents/header/megaMenu/ItemContent.jsx
+++ b/src/js/components/sharedComponents/header/megaMenu/ItemContent.jsx
@@ -19,7 +19,8 @@ const ItemContent = ({
     section1Icon,
     section2Icon,
     section3Icon,
-    menuIndex
+    menuIndex,
+    closeDropdown
 }) => {
     const dispatch = useDispatch();
 
@@ -105,7 +106,12 @@ const ItemContent = ({
                                             <FlexGridRow width={6} desktop={6}>
                                                 <a
                                                     className="dropdown--item__link"
-                                                    href={item.url}>
+                                                    href={item.url}
+                                                    onBlur={() => {
+                                                        if (item.label === 'Release Notes') {
+                                                            closeDropdown();
+                                                        }
+                                                    }}>
                                                     {item.icon && item.icon !== '' && item.icon !== null ? <FontAwesomeIcon role="presentation" style={{ width: "20px", height: "20px" }} icon={item.icon} /> : ''}
                                                     <div className="dropdown-item__link-desc">
                                                         <div className="dropdown-item__link-label">

--- a/src/js/components/sharedComponents/header/megaMenu/ItemContent.jsx
+++ b/src/js/components/sharedComponents/header/megaMenu/ItemContent.jsx
@@ -107,8 +107,8 @@ const ItemContent = ({
                                                 <a
                                                     className="dropdown--item__link"
                                                     href={item.url}
-                                                    onBlur={() => {
-                                                        if (item.label === 'Release Notes') {
+                                                    onKeyDown={(e) => {
+                                                        if (item.label === 'Release Notes' && e.key === 'Tab') {
                                                             closeDropdown();
                                                         }
                                                     }}>


### PR DESCRIPTION
**High level description:**

fixed tabbing outside megamenu

**JIRA Ticket:**
[DEV-9928](https://federal-spending-transparency.atlassian.net/browse/DEV-9928)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
