### PR TITLE
DEV-9720/DEV-9722 make labels perceptible when you're focused on them

### DIFF
--- a/src/_scss/pages/search/results/visualizations/rank/chart/_item.scss
+++ b/src/_scss/pages/search/results/visualizations/rank/chart/_item.scss
@@ -1,20 +1,38 @@
 .chart-group {
+
     .group-background {
         fill: #F7F7F7;
+
         &.even {
             fill: $color-white;
         }
     }
-    .group-label {
-        font-size: rem(14);
-        color: $color-base;
-        fill: $color-base;
-    }
-    .group-label-link {
-	    fill: $color-link;
-	    a:visited {
-		    fill: $color-link;
-	    }
+
+    .group-label__anchor {
+        &:hover {
+            cursor: pointer;
+        }
+        &:focus {
+            stroke: $color-primary-darker;
+            stroke-width:.5px;
+        }
+        .group-label {
+            font-size: rem(14);
+            color: $color-base;
+            fill: $color-base;
+        }
+
+        .group-label-link {
+            fill: $color-link;
+
+            &:visited {
+                fill: $color-link;
+            }
+
+            &:hover {
+                cursor: pointer;
+            }
+        }
     }
 }
 
@@ -22,11 +40,13 @@
     .chart-bar {
         fill: $color-vis-dark;
         opacity: 0.85;
+
         &:hover,
         &.hover {
             fill: $color-active;
         }
     }
+
     .chart-bar-hitzone {
         fill: transparent;
     }

--- a/src/js/components/search/visualizations/rank/chart/ChartGroup.jsx
+++ b/src/js/components/search/visualizations/rank/chart/ChartGroup.jsx
@@ -47,24 +47,10 @@ export default class ChartGroup extends React.Component {
         if (this.props.linkID !== '' && this.props.linkID !== 'agency_v2/') {
             linkClass = ' group-label-link';
         }
-        let title = (
-            <text
-                className={`group-label ${linkClass}`}
-                ref={(text) => {
-                    this.svgText = text;
-                }}>
-                {label}
-            </text>
-        );
-
-        /* eslint-disable jsx-a11y/anchor-is-valid */
-        // the link is actually valid since the URL root will provide an absolute URL
-        /* with ticket 7829, agencies with no agency page will not have an
-        agencySlug but will still have the v2 agencyString in their linkId,
-        so we need to make sure that isn't the case before making the link*/
+        let title = null;
         if (this.props.linkID !== '' && this.props.linkID !== 'agency_v2/') {
             title = (
-                <a target="_blank" rel="noopener noreferrer" xlinkHref={`${this.props.urlRoot}${this.props.linkID}`} >
+                <a className="group-label__anchor" target="_blank" rel="noopener noreferrer" href={`${this.props.urlRoot}${this.props.linkID}`} >
                     <text
                         className={`group-label ${linkClass}`}
                         ref={(text) => {
@@ -75,8 +61,6 @@ export default class ChartGroup extends React.Component {
                 </a>
             );
         }
-        /* eslint-enable jsx-a11y/anchor-is-valid */
-
         return title;
     }
 


### PR DESCRIPTION
**High level description:**

make labels noticeable when you're tabbed on them

**Technical Details**
since these labels are anchor tags and not just text, they don't show up with the outline around them, tried several things to get this to work and I think the smartest solution is to add stroke/stroke width to the labels when you're focused on them, it prevents us from having to overhaul the labels completely and keep the original functionality

the labels aren't just text, they are svg text which is what i think is causing the issue

**JIRA Ticket:**
[DEV-9720](https://federal-spending-transparency.atlassian.net/browse/DEV-9720)
[DEV-9722](https://federal-spending-transparency.atlassian.net/browse/DEV-9722)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
