### PR TITLE
DEV-7691 lessens the issue with the mobile hit area without changing how the items look

### DIFF
--- a/src/_scss/layouts/default/footer/footer.scss
+++ b/src/_scss/layouts/default/footer/footer.scss
@@ -151,6 +151,11 @@
                     &:hover {
                         color: $gray-cool-5;
                     }
+                    @media(max-width:$tablet-screen) {
+                        width: 100%;
+                        display: flex;
+                        justify-content: center;
+                    }
                 }
             }
         }

--- a/src/js/components/sharedComponents/header/NavbarWrapper.jsx
+++ b/src/js/components/sharedComponents/header/NavbarWrapper.jsx
@@ -86,6 +86,7 @@ const NavbarWrapper = () => {
                 <div className="site-navigation__mobile mobile-hamburger">
                     <div className="mobile-hamburger__wrapper">
                         <button
+                            aria-label="mobile hamburger menu"
                             className="mobile-hamburger__button"
                             onClick={toggleMobileNav}>
                             <FontAwesomeIcon className="mobile-hamburger__buns" icon={faBars} size="lg" />


### PR DESCRIPTION
**High level description:**

adjust width of a tag <768, height kept the same

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
