### PR TITLE
9712 - increased size of box shadow to make it more visible when focused

### DIFF
--- a/src/_scss/components/_roundedtoggle.scss
+++ b/src/_scss/components/_roundedtoggle.scss
@@ -17,13 +17,13 @@
     height: 20px;
     bottom: 0;
   }
-  
+
   .rounded-toggle__switch input {
     opacity: 0;
     width: 0;
     height: 0;
   }
-  
+
   .rounded-toggle__slider {
     position: absolute;
     cursor: pointer;
@@ -35,7 +35,7 @@
     -webkit-transition: .4s;
     transition: .4s;
   }
-  
+
   .rounded-toggle__slider:before {
     position: absolute;
     content: "";
@@ -46,26 +46,26 @@
     -webkit-transition: .4s;
     transition: .4s;
   }
-  
+
   input:checked + .rounded-toggle__slider {
     background-color: $color-primary !important;
   }
-  
+
   input:focus + .rounded-toggle__slider {
-    box-shadow: 0 0 2px $color-primary !important;
+    box-shadow: 0 0 4px $color-primary !important;
   }
-  
+
   input:checked + .rounded-toggle__slider:before {
     -webkit-transform: translateX(22px);
     -ms-transform: translateX(22px);
     transform: translateX(22px);
     border: 1px solid $color-gray !important;
   }
-  
+
   .rounded-toggle__slider.rounded-toggle__round {
     border-radius: 34px;
   }
-  
+
   .rounded-toggle__slider.rounded-toggle__round:before {
     border-radius: 50%;
   }


### PR DESCRIPTION
**High level description:**

On an Agency page, in the Stats of Funds section, when the 'View Outlays' toggle is in focus, increase its visibility.

**Technical details:**

The original idea was to make it exactly the same as the Subawards toggle on the Search page, but that would require changing this component pretty significantly, so the faster, easier option was to increase the size of the outline on focus.

**JIRA Ticket:**
[DEV-9712](https://federal-spending-transparency.atlassian.net/browse/DEV-9712)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
