### PR TITLE
Hotfix/10135 new awards only

### DIFF
--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -35,7 +35,8 @@ const propTypes = {
     disableDateRange: PropTypes.bool,
     dirtyFilters: PropTypes.symbol,
     subaward: PropTypes.bool,
-    newAwardsOnlySelected: PropTypes.bool
+    newAwardsOnlySelected: PropTypes.bool,
+    federalAccountPage: PropTypes.bool
 };
 
 export default class TimePeriod extends React.Component {
@@ -402,7 +403,7 @@ export default class TimePeriod extends React.Component {
                     </ul>
                     { showFilter }
                     { errorDetails }
-                    { newAwardsFilter }
+                    { !this.props.federalAccountPage && newAwardsFilter }
                     {!this.state.clearHint &&
                     <SubmitHint
                         ref={(component) => {

--- a/src/js/containers/account/filters/AccountTimePeriodContainer.jsx
+++ b/src/js/containers/account/filters/AccountTimePeriodContainer.jsx
@@ -88,6 +88,8 @@ export class AccountTimePeriodContainer extends React.Component {
 
     render() {
         return (
+            // the federalAccountPage prop is used to hide the New Awards Only
+            // checkbox from the Federal Accounts page
             <TimePeriod
                 {...this.props}
                 latestFy={this.props.latestPeriod.year}

--- a/src/js/containers/account/filters/AccountTimePeriodContainer.jsx
+++ b/src/js/containers/account/filters/AccountTimePeriodContainer.jsx
@@ -95,6 +95,7 @@ export class AccountTimePeriodContainer extends React.Component {
                 timePeriods={this.state.timePeriods}
                 updateFilter={this.updateFilter}
                 changeTab={this.changeTab}
+                federalAccountPage
                 disableDateRange />
         );
     }


### PR DESCRIPTION
**High level description:**

Get rid of the New Awards Only checkbox on the Federal Accounts page, in the Time Period filter in the filter sidebar 

**Technical details:**

added bool to use to only show New Awards Only filter on Search page, not on Federal Accounts page

**JIRA Ticket:**
[DEV-10135](https://federal-spending-transparency.atlassian.net/browse/DEV-10135)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
