### PR TITLE
9722 weird error

### DIFF
--- a/src/js/components/search/visualizations/rank/chart/ChartGroup.jsx
+++ b/src/js/components/search/visualizations/rank/chart/ChartGroup.jsx
@@ -47,7 +47,15 @@ export default class ChartGroup extends React.Component {
         if (this.props.linkID !== '' && this.props.linkID !== 'agency_v2/') {
             linkClass = ' group-label-link';
         }
-        let title = null;
+        let title = (
+            <text
+                className={`group-label ${linkClass}`}
+                ref={(text) => {
+                    this.svgText = text;
+                }}>
+                {label}
+            </text>
+        );
         if (this.props.linkID !== '' && this.props.linkID !== 'agency_v2/') {
             title = (
                 <a className="group-label__anchor" target="_blank" rel="noopener noreferrer" href={`${this.props.urlRoot}${this.props.linkID}`} >
@@ -79,7 +87,7 @@ export default class ChartGroup extends React.Component {
     truncateText() {
     // determine if the text needs to be truncated
     // get the current label width
-        const fullWidth = this.svgText.getBBox().width;
+        const fullWidth = this.svgText?.getBBox().width;
 
         // there's a 12px margin on both sides of the label space
         const maxWidth = this.props.labelWidth - 24;


### PR DESCRIPTION
**High level description:**

use this as an example /search/?hash=1b502463b0d4bdd52d42a959d1798d53 then go to sub-agencies, previously this crashed but now it does not crash, the subagencies are not clickable or tabbable just like in prod

9722 shouldn't have existed bc the labels weren't clickable on purpose but i broke them, so here we are

**JIRA Ticket:**
[DEV-9722](https://federal-spending-transparency.atlassian.net/browse/DEV-9722)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
