### PR TITLE
Mod 8653 remove unneeded coming soon labels

### DIFF
--- a/src/js/components/account/SearchSidebar.jsx
+++ b/src/js/components/account/SearchSidebar.jsx
@@ -17,8 +17,7 @@ const filters = {
     options: [
         { title: 'Time Period' },
         { title: 'Object Class' },
-        { title: 'Program Activity' },
-        { title: 'Treasury Account Symbol (TAS)' }
+        { title: 'Program Activity' }
     ],
     components: [
         AccountTimePeriodContainer,

--- a/src/js/components/search/visualizations/rank/sections/SpendingByAgencySection.jsx
+++ b/src/js/components/search/visualizations/rank/sections/SpendingByAgencySection.jsx
@@ -5,10 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import ComingSoonLabel from 'components/sharedComponents/ComingSoonLabel';
 import { getAtdDefcText } from "helpers/aboutTheDataSidebarHelper";
-
 import RankVisualizationScopeButton from '../RankVisualizationScopeButton';
 import RankVisualizationSection from './RankVisualizationSection';
 import GlossaryLink from '../../../../sharedComponents/GlossaryLink';
@@ -109,15 +106,6 @@ export default class SpendingByAgencySection extends React.Component {
                             label="Sub-Agencies"
                             active={this.props.scope === 'awarding_subagency'}
                             changeScope={this.props.changeScope} />
-                        <div className="coming-soon">
-                            <RankVisualizationScopeButton
-                                value="office"
-                                label="Offices"
-                                active={this.props.scope === 'office'}
-                                changeScope={this.props.changeScope}
-                                disabled />
-                            <ComingSoonLabel />
-                        </div>
                     </div>
                 </div>
             </RankVisualizationSection>

--- a/src/js/components/search/visualizations/rank/sections/SpendingByRecipientSection.jsx
+++ b/src/js/components/search/visualizations/rank/sections/SpendingByRecipientSection.jsx
@@ -5,7 +5,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import ComingSoonLabel from 'components/sharedComponents/ComingSoonLabel';
 import { getAtdDefcText } from "helpers/aboutTheDataSidebarHelper";
 
 import RankVisualizationScopeButton from '../RankVisualizationScopeButton';
@@ -92,15 +91,7 @@ export default class SpendingByRecipientSection extends React.Component {
                         }
                     </div>
                     <div className="visualization-scope">
-                        <div className="coming-soon">
-                            <RankVisualizationScopeButton
-                                value="recipient_parent_duns"
-                                label="Parent Recipient"
-                                active={this.props.scope === 'recipient_parent_duns'}
-                                changeScope={this.props.changeScope}
-                                disabled />
-                            <ComingSoonLabel />
-                        </div>
+
                         <RankVisualizationScopeButton
                             value="recipient"
                             label="Recipient"

--- a/src/js/components/search/visualizations/rank/sections/SpendingByRecipientSection.jsx
+++ b/src/js/components/search/visualizations/rank/sections/SpendingByRecipientSection.jsx
@@ -6,8 +6,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { getAtdDefcText } from "helpers/aboutTheDataSidebarHelper";
-
-import RankVisualizationScopeButton from '../RankVisualizationScopeButton';
 import RankVisualizationSection from './RankVisualizationSection';
 import GlossaryLink from '../../../../sharedComponents/GlossaryLink';
 import ReadMore from '../../../../sharedComponents/ReadMore';

--- a/src/js/components/search/visualizations/rank/sections/SpendingByRecipientSection.jsx
+++ b/src/js/components/search/visualizations/rank/sections/SpendingByRecipientSection.jsx
@@ -90,14 +90,6 @@ export default class SpendingByRecipientSection extends React.Component {
                             </ReadMore>
                         }
                     </div>
-                    <div className="visualization-scope">
-
-                        <RankVisualizationScopeButton
-                            value="recipient"
-                            label="Recipient"
-                            active={this.props.scope === 'recipient'}
-                            changeScope={this.props.changeScope} />
-                    </div>
                 </div>
             </RankVisualizationSection>
         );


### PR DESCRIPTION
**High level description:**

Hide all of the "Coming soon" labels and/or sections that aren't coming soon...

**Technical details:**

Technical details for the knowledge of other developers.

**JIRA Ticket:**
[DEV-8653](https://federal-spending-transparency.atlassian.net/browse/DEV-8653)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
