### PR TITLE
DEV-9710 hide hover on advanced search on mobile when the menu is open

### DIFF
--- a/src/js/components/search/SearchResults.jsx
+++ b/src/js/components/search/SearchResults.jsx
@@ -73,7 +73,7 @@ const SearchResults = (props) => {
                     toggleMobileFilters={props.toggleMobileFilters} />
             </div>
             <div className="tablet-search__modal">
-                <Button
+                {!props.showMobileFilters && <Button
                     onClick={(e) => {
                         e.persist();
                         dispatch(showModal(window.location.href, 'filter'));
@@ -90,7 +90,7 @@ const SearchResults = (props) => {
                     buttonType="text"
                     backgroundColor="light"
                     imageAlignment="right"
-                    image={<FontAwesomeIcon icon="window-restore" />} />
+                    image={<FontAwesomeIcon icon="window-restore" />} />}
             </div>
             <div className="full-search-results-wrapper">
                 <TopFilterBarContainer {...props} />


### PR DESCRIPTION
**High level description:**

when mobile menu is open "Learn how active filters work" isn't rendered, basically the same as 'hiding' it underneath the open menu except the dom is smaller

**JIRA Ticket:**
[DEV-9710](https://federal-spending-transparency.atlassian.net/browse/DEV-9710)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
