### PR TITLE
9821 - fix for Covid page not jumping to section when given section i…

### DIFF
--- a/src/js/helpers/covid19Helper.js
+++ b/src/js/helpers/covid19Helper.js
@@ -79,9 +79,12 @@ export const jumpToSection = (
     idPrefix = 'covid19',
     sections = componentByCovid19Section()
 ) => {
+    // need to search by snakeCase; had to use kebabCase for url
+    const snakeCaseSection = snakeCase(section);
+
     // we've been provided a section to jump to
     // check if it's a valid section
-    const matchedSection = Object.keys(sections).find((key) => key === section);
+    const matchedSection = Object.keys(sections).find((key) => key === snakeCaseSection);
 
     if (!matchedSection) {
     // no matching section
@@ -89,7 +92,7 @@ export const jumpToSection = (
     }
 
     // find the section in dom
-    const selector = `#${idPrefix}-${snakeCase(section)}`;
+    const selector = `#${idPrefix}-${snakeCaseSection}`;
     const sectionDom = document.querySelector(selector);
 
     if (!sectionDom) {


### PR DESCRIPTION
…n url, needed to change back to snakeCase to match the sections array name

**High level description:**

Allie found a bug when opening the Covid page with a section in the url;

**Technical details:**

Needed to search for the section name using snakeCase, it was changed to kebebCase in the url

**JIRA Ticket:**
[DEV-9821](https://federal-spending-transparency.atlassian.net/browse/DEV-9821)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
