### PR TITLE
Mod/10052 add glossary links

### DIFF
--- a/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
@@ -22,12 +22,12 @@
             text-indent: -1.5rem;
 
             @media (max-width: $tablet-screen) {
-                padding-bottom: 4px;
+                padding-bottom: $global-margin * .5;
                 flex-basis: 100%;
             }
         }
         .award-amounts__glossary-link {
-            margin-left: 8px;
+            margin-left: $global-margin;
         }
     }
 

--- a/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
@@ -26,6 +26,9 @@
                 flex-basis: 100%;
             }
         }
+        .award-amounts__glossary-link {
+            margin-left: 8px;
+        }
     }
 
     .award-amounts__data-icon {

--- a/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
+++ b/src/_scss/pages/award/shared/awardAmountsSection/_dataTable.scss
@@ -26,7 +26,8 @@
                 flex-basis: 100%;
             }
         }
-        .award-amounts__glossary-link {
+        @import 'components/glossaryLink';
+        .usda-glossary-link svg {
             margin-left: $global-margin;
         }
     }

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
@@ -12,6 +12,7 @@ import {
 } from "dataMapping/award/awardAmountsSection";
 
 import { AWARD_AMOUNT_TYPE_PROPS } from "../../../../propTypes";
+import GlossaryLink from "../../../sharedComponents/GlossaryLink";
 
 const propTypes = {
     showFileC: PropTypes.bool,
@@ -143,7 +144,7 @@ const AwardAmountsTable = ({
             }
         ];
 
-        let include = false;
+        let include = null;
 
         allInclusions.forEach((item) => {
             if (title === item.title) {
@@ -151,7 +152,7 @@ const AwardAmountsTable = ({
             }
         });
 
-        return include;
+        return include ? <GlossaryLink term={include.glossary} /> : include;
     };
 
     return (
@@ -164,7 +165,7 @@ const AwardAmountsTable = ({
                         <div key={uniqueId(title)} className="award-amounts__data-content">
                             <div className="remove-indent">
                                 <span className={`award-amounts__data-icon ${awardTableClassMap[title]}`} />
-                                {title} {includeGlossary(title) && 'hellow'}
+                                {title} {includeGlossary(title)}
                             </div>
                             <span>{amountMapByCategoryTitle[title] === null ? "--" : amountMapByCategoryTitle[title]}</span>
                         </div>

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
@@ -152,7 +152,7 @@ const AwardAmountsTable = ({
             }
         });
 
-        return include ? <GlossaryLink term={include.glossary} /> : include;
+        return include ? <GlossaryLink term={include.glossary} /> : null;
     };
 
     return (
@@ -165,7 +165,10 @@ const AwardAmountsTable = ({
                         <div key={uniqueId(title)} className="award-amounts__data-content">
                             <div className="remove-indent">
                                 <span className={`award-amounts__data-icon ${awardTableClassMap[title]}`} />
-                                {title} {includeGlossary(title)}
+                                {title}
+                                <span className="award-amounts__glossary-link">
+                                    {includeGlossary(title)}
+                                </span>
                             </div>
                             <span>{amountMapByCategoryTitle[title] === null ? "--" : amountMapByCategoryTitle[title]}</span>
                         </div>

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
@@ -96,7 +96,12 @@ const AwardAmountsTable = ({
     const hideRow = (title) => {
         const defcByType = defcTypes.map((item) => item.codeType);
         const hasDefCode = defcByType?.indexOf(fileCType) > -1;
-        const allExclusions = ['Combined Outlayed Amounts', 'Combined Obligated Amounts', 'Outlayed Amount', 'Obligated Amount'];
+        const allExclusions = [
+            'Combined Outlayed Amounts',
+            'Combined Obligated Amounts',
+            'Outlayed Amount',
+            'Obligated Amount'
+        ];
 
         let hide = false;
 
@@ -126,6 +131,29 @@ const AwardAmountsTable = ({
         return hide;
     };
 
+    const includeGlossary = (title) => {
+        const allInclusions = [
+            {
+                title: 'Original Subsidy Cost',
+                glossary: 'loan-subsidy-cost'
+            },
+            {
+                title: 'Face Value of Direct Loan',
+                glossary: 'face-value-of-loan'
+            }
+        ];
+
+        let include = false;
+
+        allInclusions.forEach((item) => {
+            if (title === item.title) {
+                include = item;
+            }
+        });
+
+        return include;
+    };
+
     return (
         <div className={`award-amounts__data-wrapper ${awardAmountType}`} data-testid="award-amounts__data-wrapper">
             {Object.keys(amountMapByCategoryTitle).sort(sortTableTitles)
@@ -136,7 +164,7 @@ const AwardAmountsTable = ({
                         <div key={uniqueId(title)} className="award-amounts__data-content">
                             <div className="remove-indent">
                                 <span className={`award-amounts__data-icon ${awardTableClassMap[title]}`} />
-                                {title}
+                                {title} {includeGlossary(title) && 'hellow'}
                             </div>
                             <span>{amountMapByCategoryTitle[title] === null ? "--" : amountMapByCategoryTitle[title]}</span>
                         </div>

--- a/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
@@ -166,9 +166,7 @@ const AwardAmountsTable = ({
                             <div className="remove-indent">
                                 <span className={`award-amounts__data-icon ${awardTableClassMap[title]}`} />
                                 {title}
-                                <span className="award-amounts__glossary-link">
-                                    {includeGlossary(title)}
-                                </span>
+                                {includeGlossary(title)}
                             </div>
                             <span>{amountMapByCategoryTitle[title] === null ? "--" : amountMapByCategoryTitle[title]}</span>
                         </div>

--- a/src/js/containers/search/visualizations/rank/RankVisualizationWrapperContainer.jsx
+++ b/src/js/containers/search/visualizations/rank/RankVisualizationWrapperContainer.jsx
@@ -220,7 +220,6 @@ export class RankVisualizationWrapperContainer extends React.Component {
         const descriptions = [];
         const linkSeries = [];
 
-        console.log(data);
         // iterate through each response object and break it up into groups, x series, and y series
         data.results.forEach((item) => {
             const result = Object.create(BaseSpendingByCategoryResult);

--- a/src/js/containers/search/visualizations/rank/RankVisualizationWrapperContainer.jsx
+++ b/src/js/containers/search/visualizations/rank/RankVisualizationWrapperContainer.jsx
@@ -220,6 +220,7 @@ export class RankVisualizationWrapperContainer extends React.Component {
         const descriptions = [];
         const linkSeries = [];
 
+        console.log(data);
         // iterate through each response object and break it up into groups, x series, and y series
         data.results.forEach((item) => {
             const result = Object.create(BaseSpendingByCategoryResult);


### PR DESCRIPTION
**High level description:**
Award Profile Loans - Add Glossary Links to the Original Subsidy Cost and Face Value of Direct Loan legend rows.

**Technical details:**
Created function to dynamically include link to glossary terms on the Award Profile Loans legends based on the row title, specifically Original Subsidy Cost and Face Value of Direct Loan. Added margin-left in CSS to match the zeplin mock.

**JIRA Ticket:**
[DEV-10052](https://federal-spending-transparency.atlassian.net/browse/DEV-10052)

**Mockup:**
https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55/screen/64f099e79a823347d3e4325d

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
