### PR TITLE
10064 - made the css rules that transform the placement of the toolti…

### DIFF
--- a/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
+++ b/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
@@ -41,7 +41,7 @@
                 margin-left: 0;
             }
             .map-layer__cd-tooltip {
-                svg { 
+                svg {
                     margin-left: rem(5);
                     margin-right: rem(7.5);
                 }
@@ -98,16 +98,16 @@
 
                         .smart-bottom-right {
                             left: rem(235);
-                            
+
                         }
                     }
-                    @media ((min-width: $large-screen) and (max-width: $m-large-screen)) {
+                    @media ((min-width: $large-screen) and (max-width: $x-large-screen)) {
                         top: rem(40) !important;
                         left: rem(-20) !important;
 
                         .smart-bottom-right {
                             left: rem(235);
-                            
+
                         }
                     }
                 }
@@ -134,7 +134,7 @@
                     }
                 }
             }
-            
+
         }
     }
 }

--- a/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
+++ b/src/js/components/search/visualizations/geo/MapLayerToggle.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { TooltipWrapper } from 'data-transparency-ui';
 import { CondensedCDTooltip } from '../../../award/shared/InfoTooltipContent';
-import { tabletScreen, mLargeScreen } from '../../../../dataMapping/shared/mobileBreakpoints';
+import { tabletScreen, xLargeScreen } from '../../../../dataMapping/shared/mobileBreakpoints';
 
 const propTypes = {
     active: PropTypes.string,
@@ -61,7 +61,7 @@ const MapLayerToggle = (props) => {
                         <TooltipWrapper
                             icon="info"
                             className={props.className}
-                            tooltipPosition={(window.innerWidth >= tabletScreen && window.innerWidth <= mLargeScreen) ? 'left' : 'right'}
+                            tooltipPosition={(window.innerWidth >= tabletScreen && window.innerWidth <= xLargeScreen) ? 'left' : 'right'}
                             tooltipComponent={<CondensedCDTooltip title="Congressional Districts" />} />
                     </div>
                     : null}

--- a/src/js/dataMapping/shared/mobileBreakpoints.js
+++ b/src/js/dataMapping/shared/mobileBreakpoints.js
@@ -11,4 +11,4 @@ export const tabletScreen = 768;
 export const mediumScreen = 992;
 export const largeScreen = 1200;
 export const mLargeScreen = 1400;
-export const xlargeScreen = 1640;
+export const xLargeScreen = 1640;


### PR DESCRIPTION
…p apply to screen sizes up to 1640

**High level description:**

tooltip placement at approx 1400-1500 was causing tooltip to run off right edge of screen

**Technical details:**

made the css rules that transform the placement of the tooltip apply to screen sizes up to 1640

**JIRA Ticket:**
[DEV-10064](https://federal-spending-transparency.atlassian.net/browse/DEV-10064)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
