### PR TITLE
10182 - added redux action and reducer for isSofChartLoaded; added lo…

### DIFF
--- a/src/js/components/agency/AgencyPage.jsx
+++ b/src/js/components/agency/AgencyPage.jsx
@@ -5,7 +5,6 @@
 
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { throttle } from "lodash";
 import {
     ComingSoon,
     ErrorMessage,

--- a/src/js/components/agency/AgencyPage.jsx
+++ b/src/js/components/agency/AgencyPage.jsx
@@ -60,6 +60,7 @@ export const AgencyProfileV2 = ({
 
     const [activeSection, setActiveSection] = useState(query.section || 'overview');
     const { name } = useSelector((state) => state.agency.overview);
+    const { isStatusOfFundsChartLoaded } = useSelector((state) => state.agency);
 
     const dataThroughDates = useSelector((state) => state.agency.dataThroughDates);
     const overviewDataThroughDate = dataThroughDates?.overviewDataThroughDate;
@@ -134,21 +135,12 @@ export const AgencyProfileV2 = ({
         }
     };
 
-    useEffect(throttle(() => {
-        // this allows the page to jump to a section on page load, when
-        // using a link to open the page
-        // prevents a console error about react unmounted component leak
-        let isMounted = true;
-        if (isMounted) {
-            const urlSection = query.section;
-            if (urlSection) {
-                jumpToSection(urlSection);
-            }
+    useEffect(() => {
+        if (isStatusOfFundsChartLoaded && query.section) {
+            jumpToSection(query.section);
         }
-        return () => {
-            isMounted = false;
-        };
-    }, 100), [history, query.section]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [query.section, isStatusOfFundsChartLoaded]);
 
     return (
         <PageWrapper

--- a/src/js/components/agency/statusOfFunds/StatusOfFunds.jsx
+++ b/src/js/components/agency/statusOfFunds/StatusOfFunds.jsx
@@ -5,13 +5,21 @@
 
 import React, { useCallback, useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, connect } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { tabletScreen } from 'dataMapping/shared/mobileBreakpoints';
 import { throttle } from "lodash";
 
 import { FlexGridRow, FlexGridCol, Pagination, LoadingMessage, ErrorMessage } from 'data-transparency-ui';
-import { setDataThroughDates, setSelectedSubcomponent, setSelectedFederalAccount, setSelectedTas, setSelectedPrgActivityOrObjectClass, setCurrentLevelNameAndId, setLevel4ApiResponse } from "redux/actions/agency/agencyActions";
+import { setDataThroughDates,
+    setSelectedSubcomponent,
+    setSelectedFederalAccount,
+    setSelectedTas,
+    setSelectedPrgActivityOrObjectClass,
+    setCurrentLevelNameAndId,
+    setLevel4ApiResponse,
+    setIsSofChartLoaded }
+    from "redux/actions/agency/agencyActions";
 import { fetchSubcomponentsList, fetchFederalAccountsList, fetchTasList, fetchProgramActivityByTas, fetchObjectClassByTas } from 'apis/agency';
 import { parseRows, getLevel5Data } from 'helpers/agency/StatusOfFundsVizHelper';
 import { useStateWithPrevious } from 'helpers';
@@ -23,10 +31,11 @@ import VisualizationSection from './VisualizationSection';
 import IntroSection from './IntroSection';
 
 const propTypes = {
-    fy: PropTypes.string
+    fy: PropTypes.string,
+    onChartLoaded: PropTypes.func.isRequired
 };
 
-const StatusOfFunds = ({ fy }) => {
+const StatusOfFunds = ({ fy, onChartLoaded }) => {
     const dispatch = useDispatch();
     const [level, setLevel] = useState(0);
     const [loading, setLoading] = useState(true);
@@ -305,6 +314,13 @@ const StatusOfFunds = ({ fy }) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [fy, overview.toptierCode]);
 
+    useEffect(() => {
+        if (!loading && !error) {
+            onChartLoaded(true);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [error, loading]);
+
     const setDrilldownLevel = (selectedLevel, parentData, objectClassFlag) => {
         if (selectedLevel === 1) {
             fetchFederalAccounts(parentData);
@@ -444,4 +460,12 @@ const StatusOfFunds = ({ fy }) => {
 };
 
 StatusOfFunds.propTypes = propTypes;
-export default StatusOfFunds;
+
+export default connect(
+    (state) => ({
+        isChartLoaded: state.agency.isStatusOfFundsChartLoaded
+    }),
+    (dispatch) => ({
+        onChartLoaded: (bool) => dispatch(setIsSofChartLoaded(bool))
+    })
+)(StatusOfFunds);

--- a/src/js/redux/actions/agency/agencyActions.js
+++ b/src/js/redux/actions/agency/agencyActions.js
@@ -115,6 +115,11 @@ export const setDataThroughDates = (dates) => ({
     dates
 });
 
+export const setIsSofChartLoaded = (bool) => ({
+    type: 'SET_IS_SOF_CHART_LOADED',
+    payload: bool
+});
+
 export const resetAgency = () => ({
     type: 'RESET_AGENCY'
 });

--- a/src/js/redux/reducers/agency/agencyReducer.js
+++ b/src/js/redux/reducers/agency/agencyReducer.js
@@ -42,7 +42,8 @@ export const initialState = {
     currentLevelNameAndId: null,
     level4ApiResponse: null,
     agencySubcomponentsList,
-    awardSpendingDataThroughDate: null
+    awardSpendingDataThroughDate: null,
+    isStatusOfFundsChartLoaded: false
 };
 
 const agencyReducer = (state = initialState, action) => {
@@ -168,6 +169,9 @@ const agencyReducer = (state = initialState, action) => {
                     ...action.dates
                 }
             };
+        case 'SET_IS_SOF_CHART_LOADED': {
+            return Object.assign({}, state, { isStatusOfFundsChartLoaded: action.payload });
+        }
         case 'RESET_AGENCY':
             return Object.assign({}, initialState);
         default:


### PR DESCRIPTION
…gic to use that bool to call jumpToSection

**High level description:**

make the agency page jump to the section correctly when being opened from a url with a section in it

**Technical details:**

added redux action and reducer for isSofChartLoaded; added logic to use that bool to call jumpToSection from agencyPage; removed some throttling logic from the AgencyPage useEffect that seems no longer needed

**JIRA Ticket:**
[DEV-10182](https://federal-spending-transparency.atlassian.net/browse/DEV-10182)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
