### PR TITLE
10217 - replaced class name for header class

### DIFF
--- a/src/_scss/pages/explorer/detail/header/header.scss
+++ b/src/_scss/pages/explorer/detail/header/header.scss
@@ -5,7 +5,7 @@
     @include align-items(flex-start);
     position: relative;
 
-    .detail-_labels {
+    .detail-header__labels {
         @include flex(1 1 auto);
         // this is a truly horrific hack to make the h2 title text wrap on IE 11 in smaller screens
         // this works because flex grow will cause the content to push this flexbox's width out
@@ -111,7 +111,7 @@
         @media only screen and (max-width: 878px) and (min-width: 768px){
             transform: translate(-308px, -18px);
         }
-        
+
     }
 }
 


### PR DESCRIPTION
**High level description:**

Header in Spending Explorer whitespace was off

**Technical details:**

a classname had been unintentionally altered; i changed it back

**JIRA Ticket:**
[DEV-10217](https://federal-spending-transparency.atlassian.net/browse/DEV-10217)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
