### PR TITLE
Mod/10052 update glossary url

### DIFF
--- a/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
+++ b/src/js/components/award/shared/awardAmounts/AwardAmountsTable.jsx
@@ -50,7 +50,6 @@ const AwardAmountsTable = ({
      * irrespective of whether the award exceedsPotential or exceedsCurrent
      * so we're relying on the parent in this case because we cant deduce the spending scenario
      **/
-
     const getOverSpendingRow = (awardAmounts = awardData, scenario = spendingScenario, type = awardAmountType) => {
         switch (scenario) {
             case ('normal'):

--- a/src/js/components/glossary/Glossary.jsx
+++ b/src/js/components/glossary/Glossary.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Scrollbars } from 'react-custom-scrollbars';
 import Mousetrap from 'mousetrap';
+import { withRouter } from "react-router-dom";
 
 import GlossaryHeader from './GlossaryHeader';
 import GlossarySearchResults from './search/GlossarySearchResults';
@@ -18,10 +19,11 @@ const propTypes = {
     loading: PropTypes.bool,
     error: PropTypes.bool,
     hideGlossary: PropTypes.func,
-    zIndexClass: PropTypes.string
+    zIndexClass: PropTypes.string,
+    history: PropTypes.object
 };
 
-export default class Glossary extends React.Component {
+export class Glossary extends React.Component {
     constructor(props) {
         super(props);
 
@@ -58,10 +60,18 @@ export default class Glossary extends React.Component {
     }
 
     closeGlossary() {
-    // close the glossary when the escape key is pressed for accessibility and general
-    // non-annoyance
+        // close the glossary when the escape key is pressed for accessibility and general
+        // non-annoyance
+        // we are now also removing the glossary search param from the url when closing the
+        // glossary
+        // we will want to update this method when changing over to a functional component
         this.props.hideGlossary();
-
+        // remove search param from url
+        if (this.props.history.location.search.includes('glossary')) {
+            this.props.history.replace({
+                search: ''
+            });
+        }
         // move focus back to the main content
         const mainContent = document.getElementById('main-focus');
         if (mainContent) {
@@ -163,3 +173,4 @@ export default class Glossary extends React.Component {
 }
 
 Glossary.propTypes = propTypes;
+export default withRouter(Glossary);

--- a/src/js/components/glossary/definition/GlossaryDefinition.jsx
+++ b/src/js/components/glossary/definition/GlossaryDefinition.jsx
@@ -58,7 +58,7 @@ export default class GlossaryDefinition extends React.Component {
     getCopyFn() {
         const separator = window.location.href.includes('?') ? '&' : '?';
         const slug = `${separator}glossary=${this.props.glossary.term.toJS().slug}`;
-        const value = window.location.href + slug;
+        const value = window.location.href.includes("glossary") ? window.location.href : window.location.href + slug;
         if (window.navigator && window.navigator.clipboard && window.navigator.clipboard.writeText) {
             window.navigator.clipboard.writeText(value);
             this.setState({ showCopiedConfirmation: true });

--- a/src/js/components/sharedComponents/GlossaryLink.jsx
+++ b/src/js/components/sharedComponents/GlossaryLink.jsx
@@ -3,7 +3,7 @@
  * Created by Lizzie Salita 7/24/20
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Link, useLocation } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -16,8 +16,12 @@ const propTypes = {
 };
 
 const GlossaryLink = ({ term, hidden }) => {
+    const [urlSearchParam, setUrlSearchParam] = useState(null);
     const { pathname, search } = useLocation();
-    const newUrl = getNewUrlForGlossary(pathname, `?glossary=${term}`, search);
+    useEffect(() => {
+        setUrlSearchParam(search.includes('glossary') ? '' : search);
+    }, [search]);
+    const newUrl = getNewUrlForGlossary(pathname, `?glossary=${term}`, urlSearchParam);
     const stopBubble = (e) => {
         e.stopPropagation();
     };


### PR DESCRIPTION
**High level description:**

QA found issues where the glossary term was added to the url multiple times when using 'Copy Link' in Share dropdown.
We also added code to remove the '?glossary' search param from the url when the Glossary is closed

**Technical details:**

Added withRouter to Glossary component to access the url info from 'window'. Check if glossary is in search param before adding to it, and remove the search param whn closing Glossary.

**JIRA Ticket:**
[DEV-10052](https://federal-spending-transparency.atlassian.net/browse/DEV-10052)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
