### PR TITLE
8716 - adjusted BaseContract.js to give empty array if there is no ps…

### DIFF
--- a/src/js/components/award/shared/description/AwardDescription.jsx
+++ b/src/js/components/award/shared/description/AwardDescription.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { FlexGridRow, FlexGridCol } from 'data-transparency-ui';
+import { FlexGridRow, FlexGridCol, NoResultsMessage } from 'data-transparency-ui';
 
 import { SpeechBubble, Glossary } from 'components/sharedComponents/icons/Icons';
 import AwardSection from '../AwardSection';
@@ -38,7 +38,7 @@ const AwardDescription = ({
         <AwardSection type="column" className="award-viz award-description">
             <AwardSectionHeader icon={<SpeechBubble />} tooltip={tooltip} title="Description" tooltipWide={isTooltipWide} />
             <div className="award-description__content">
-                <ExpandableAwardSection contentClassName="award-description__description" type="secondary" content={description} />
+                {description === "--" ? <NoResultsMessage /> : <ExpandableAwardSection contentClassName="award-description__description" type="secondary" content={description} />}
                 {naics && psc && (
                     <FlexGridRow hasGutter className="award-description__naics-psc">
                         <FlexGridCol tablet={6} className="naics-psc__section">
@@ -52,7 +52,7 @@ const AwardDescription = ({
                                     </Link>
                                 </span>
                             </div>
-                            <LineTree type="naics" data={naics} />
+                            {Object.keys(naics).length === 0 ? <NoResultsMessage /> : <LineTree type="naics" data={naics} />}
                         </FlexGridCol>
                         <FlexGridCol tablet={6} className="naics-psc__section">
                             <div className="naics-psc__heading">
@@ -65,7 +65,8 @@ const AwardDescription = ({
                                     </Link>
                                 </span>
                             </div>
-                            <LineTree type="psc" data={psc} />
+                            {/* if psc is empty object, then dtui error, else linetree */}
+                            {Object.keys(psc).length === 0 ? <NoResultsMessage /> : <LineTree type="psc" data={psc} />}
                         </FlexGridCol>
                     </FlexGridRow>
                 )}

--- a/src/js/containers/award/AwardContainer.jsx
+++ b/src/js/containers/award/AwardContainer.jsx
@@ -90,6 +90,7 @@ const AwardContainer = (props) => {
             props.setAward(financialAssistance);
         }
     };
+
     const getSelectedAward = (id) => {
         if (awardRequest) {
             // A request is currently in-flight, cancel it
@@ -129,6 +130,7 @@ const AwardContainer = (props) => {
                 }
             });
     };
+
     const fetchAwardDownloadFile = (awardCategory = props.award.category, awardId = props.match.params.awardId) => {
         Analytics.event({
             category: 'Award Profile',
@@ -145,6 +147,7 @@ const AwardContainer = (props) => {
 
         return fetchAssistanceDownloadFile(awardId);
     };
+
     const downloadData = async (awardCategory = props.award.category, awardId = props.match.params.awardId) => {
         // don't show a modal about the download
         props.setDownloadCollapsed(true);
@@ -168,10 +171,12 @@ const AwardContainer = (props) => {
             downloadRequest = null;
         }
     };
+
     useEffect(() => {
         if (props.match.params.awardId !== prevProps?.match.params.awardId) {
             getSelectedAward(props.match.params.awardId);
         }
+        /* eslint-disable-next-line react-hooks/exhaustive-deps */
     }, [props.match.params.awardId]);
 
     // eslint-disable-next-line arrow-body-style
@@ -182,6 +187,7 @@ const AwardContainer = (props) => {
             }
             props.resetAward();
         };
+        /* eslint-disable-next-line react-hooks/exhaustive-deps */
     }, []);
 
     return (

--- a/src/js/models/v2/award/BaseContract.js
+++ b/src/js/models/v2/award/BaseContract.js
@@ -34,7 +34,7 @@ BaseContract.populate = function populate(data) {
         dateSigned: data.date_signed,
         baseAndAllOptions: data.base_and_all_options,
         naics: data.naics_hierarchy,
-        psc: Object.entries(data.psc_hierarchy).reduce(pscHelper.deducePscType, pscHelper.emptyHierarchy),
+        psc: data.psc_hierarchy ? Object.entries(data.psc_hierarchy).reduce(pscHelper.deducePscType, pscHelper.emptyHierarchy) : {},
         fileC: {
             obligations: data.account_obligations_by_defc,
             outlays: data.account_outlays_by_defc


### PR DESCRIPTION
**High level description:**
Add 'No Results' default message when an award doesn't have a psc.

**Technical details:**
Added error handling to BaseContract to pass an empty object whenever there is no psc. If the component detects the empty psc object, it will give the 'No Results' default message. This has also been added if there is an empty naics object or if there is no description.

**JIRA Ticket:**
[DEV-8716](https://federal-spending-transparency.atlassian.net/browse/DEV-8716)

**Mockup:**
n/a
The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
