### PR TITLE
fix double reload when you click subawards then sub contracts

### DIFF
--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -438,7 +438,7 @@ const ResultsTableContainer = (props) => {
         if (SearchHelper.isSearchHashReady(location)) {
             pickDefaultTab();
         }
-    }, [location]);
+    }, []);
 
     useEffect(throttle(() => {
         if (props.subaward && !props.noApplied) {

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -3,7 +3,7 @@
   * Created by Kevin Li 11/8/16
   **/
 
-import React, { useState, useEffect, useLayoutEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
@@ -438,6 +438,15 @@ const ResultsTableContainer = (props) => {
         if (SearchHelper.isSearchHashReady(location)) {
             pickDefaultTab();
         }
+
+        return () => {
+            if (searchRequest) {
+                searchRequest.cancel();
+            }
+            if (tabCountRequest) {
+                tabCountRequest.cancel();
+            }
+        };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -451,15 +460,6 @@ const ResultsTableContainer = (props) => {
             pickDefaultTab();
         }
     }, 250, { trailing: true }), [props.subaward, props.noApplied, location, page, tableType]);
-
-    useLayoutEffect(() => () => {
-        if (searchRequest) {
-            searchRequest.cancel();
-        }
-        if (tabCountRequest) {
-            tabCountRequest.cancel();
-        }
-    }, []);
 
     const tableTypeTemp = tableType;
     if (!columns[tableTypeTemp]) {

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -3,7 +3,7 @@
   * Created by Kevin Li 11/8/16
   **/
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useLayoutEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
@@ -438,6 +438,7 @@ const ResultsTableContainer = (props) => {
         if (SearchHelper.isSearchHashReady(location)) {
             pickDefaultTab();
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     useEffect(throttle(() => {
@@ -451,7 +452,7 @@ const ResultsTableContainer = (props) => {
         }
     }, 250, { trailing: true }), [props.subaward, props.noApplied, location, page, tableType]);
 
-    useEffect(() => () => {
+    useLayoutEffect(() => () => {
         if (searchRequest) {
             searchRequest.cancel();
         }


### PR DESCRIPTION
**High level description:**

fix double load on sub awards -> sub contracts 
**JIRA Ticket:**
[DEV-10214](https://federal-spending-transparency.atlassian.net/browse/DEV-10214)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
