### PR TITLE
Mod/10285 agency reducer unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "mousetrap": "^1.6.1",
         "swiper": "^8.3.2",
         "react-copy-to-clipboard": "^5.0.1",
-        "postcss": "^8.4.31",
+        "postcss": "8.4.31",
         "file-loader": "^6.2.0",
         "d3": "^7.6.1",
         "date-fns": "^2.16.1",
@@ -141,7 +141,7 @@
         "webidl-conversions": "^6.1.0",
         "eslint-plugin-import": "^2.1.0",
         "is-extendable": "^1.0.1",
-        "trim-newlines": "^4.0.2",
+        "trim-newlines": "4.0.2",
         "webpack-dev-server": "^4.15.1",
         "jest-util": "^29.7.0",
         "babel-loader": "^9.1.0",
@@ -156,7 +156,7 @@
         "querystring-es3": "^0.2.1",
         "webpack-cli": "^5.1.4",
         "kind-of": "^6.0.3",
-        "glob-parent": "^6.0.2",
+        "glob-parent": "6.0.2",
         "webpack-merge": "^5.9.0",
         "@babel/node": "^7.10.5",
         "@mdx-js/loader": "^2.1.5",
@@ -994,7 +994,7 @@
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
         "picocolors": "^0.2.1",
-        "postcss": "^7.0.32",
+        "postcss": "8.4.31",
         "postcss-value-parser": "^4.1.0"
       },
       "bin": {
@@ -1036,7 +1036,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/loud-rejection": {
@@ -1707,7 +1707,7 @@
       "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
       "dev": true,
       "dependencies": {
-        "postcss": "^7.0.6",
+        "postcss": "8.4.31",
         "postcss-selector-parser": "^6.0.0"
       },
       "engines": {
@@ -2028,7 +2028,7 @@
         "@babel/parser": "^7.12.11",
         "@babel/plugin-transform-react-jsx": "^7.12.12",
         "@babel/preset-env": "^7.12.11",
-        "@babel/traverse": "^7.12.11",
+        "@babel/traverse": "7.23.2",
         "@babel/types": "^7.12.11",
         "@storybook/csf": "0.0.2--canary.4566f4d.1",
         "@storybook/mdx1-csf": "^0.0.1",
@@ -2592,7 +2592,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/extglob": {
@@ -3658,13 +3658,13 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
       "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
       "dependencies": {
-        "icss-utils": "^5.0.0"
+        "icss-utils": "5.0.0"
       },
       "engines": {
         "node": "^10 || ^12 || >= 14"
       },
       "peerDependencies": {
-        "postcss": "^8.1.0"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/dotenv-expand": {
@@ -3839,7 +3839,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/websocket-driver": {
@@ -4527,7 +4527,7 @@
         "@jest/expect-utils": "^29.7.0",
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/core": "^7.11.6",
-        "semver": "^7.5.3",
+        "semver": "7.5.3",
         "natural-compare": "^1.4.0",
         "jest-matcher-utils": "^29.7.0",
         "@babel/plugin-syntax-jsx": "^7.7.2",
@@ -5019,7 +5019,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dependencies": {
-        "semver": "^6.0.0"
+        "semver": "7.5.3"
       },
       "engines": {
         "node": ">=8"
@@ -5038,9 +5038,9 @@
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.7.tgz",
       "integrity": "sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==",
       "dependencies": {
-        "icss-utils": "^5.1.0",
+        "icss-utils": "5.0.0",
         "loader-utils": "^2.0.0",
-        "postcss": "^8.2.15",
+        "postcss": "8.4.31",
         "postcss-modules-extract-imports": "^3.0.0",
         "postcss-modules-local-by-default": "^4.0.0",
         "postcss-modules-scope": "^3.0.0",
@@ -5410,7 +5410,7 @@
         "webpack": "4",
         "html-webpack-plugin": "^4.0.0",
         "url-loader": "^4.1.1",
-        "postcss": "^7.0.36",
+        "postcss": "8.4.31",
         "file-loader": "^6.2.0",
         "css-loader": "^3.6.0",
         "@storybook/ui": "6.5.16",
@@ -5586,7 +5586,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
-        "semver": "bin/semver.js"
+        "semver": "7.5.3"
       }
     },
     "node_modules/utils-merge": {
@@ -5812,7 +5812,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -7455,10 +7455,10 @@
       "dependencies": {
         "camelcase": "^5.3.1",
         "cssesc": "^3.0.0",
-        "icss-utils": "^4.1.1",
+        "icss-utils": "5.0.0",
         "loader-utils": "^1.2.3",
         "normalize-path": "^3.0.0",
-        "postcss": "^7.0.32",
+        "postcss": "8.4.31",
         "postcss-modules-extract-imports": "^2.0.0",
         "postcss-modules-local-by-default": "^3.0.2",
         "postcss-modules-scope": "^2.2.0",
@@ -8016,11 +8016,11 @@
         "@babel/helper-compilation-targets": "^7.13.0",
         "@babel/helper-module-imports": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/traverse": "^7.13.0",
+        "@babel/traverse": "7.23.2",
         "debug": "^4.1.1",
         "lodash.debounce": "^4.0.8",
         "resolve": "^1.14.2",
-        "semver": "^6.1.2"
+        "semver": "7.5.3"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0-0"
@@ -8493,7 +8493,7 @@
         "node": "^10 || ^12 || >= 14"
       },
       "peerDependencies": {
-        "postcss": "^8.1.0"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -8641,8 +8641,8 @@
       "integrity": "sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==",
       "dev": true,
       "dependencies": {
-        "icss-utils": "^4.1.1",
-        "postcss": "^7.0.32",
+        "icss-utils": "5.0.0",
+        "postcss": "8.4.31",
         "postcss-selector-parser": "^6.0.2",
         "postcss-value-parser": "^4.1.0"
       },
@@ -8918,7 +8918,7 @@
       "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
       "dev": true,
       "dependencies": {
-        "postcss": "^7.0.5"
+        "postcss": "8.4.31"
       },
       "engines": {
         "node": ">= 6"
@@ -9366,7 +9366,7 @@
         "@babel/parser": "^7.14.7",
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^7.5.4"
+        "semver": "7.5.3"
       },
       "engines": {
         "node": ">=10"
@@ -9741,7 +9741,7 @@
       "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
       "dev": true,
       "dependencies": {
-        "postcss": "^7.0.14"
+        "postcss": "8.4.31"
       },
       "engines": {
         "node": ">= 6"
@@ -11399,7 +11399,7 @@
       "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
       "dev": true,
       "dependencies": {
-        "postcss": "^7.0.14"
+        "postcss": "8.4.31"
       },
       "engines": {
         "node": ">= 6"
@@ -11523,7 +11523,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/jest-matcher-utils/node_modules/pretty-format": {
@@ -11715,7 +11715,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.2"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/loader-utils": {
@@ -12589,7 +12589,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/object.fromentries": {
@@ -12690,7 +12690,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/@storybook/builder-webpack4/node_modules/postcss": {
@@ -12891,7 +12891,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/fs-write-stream-atomic": {
@@ -12957,7 +12957,7 @@
         "lru-cache": "^6.0.0"
       },
       "bin": {
-        "semver": "bin/semver.js"
+        "semver": "7.5.3"
       },
       "engines": {
         "node": ">=10"
@@ -13274,7 +13274,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/public-encrypt/node_modules/bn.js": {
@@ -14071,7 +14071,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/jest-matcher-utils": {
@@ -15291,7 +15291,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dependencies": {
-        "semver": "^6.0.0"
+        "semver": "7.5.3"
       },
       "engines": {
         "node": ">=8"
@@ -15470,8 +15470,8 @@
       "integrity": "sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==",
       "dev": true,
       "dependencies": {
-        "icss-utils": "^4.1.1",
-        "postcss": "^7.0.32",
+        "icss-utils": "5.0.0",
+        "postcss": "8.4.31",
         "postcss-selector-parser": "^6.0.2",
         "postcss-value-parser": "^4.1.0"
       },
@@ -15804,7 +15804,7 @@
       "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
       "dev": true,
       "dependencies": {
-        "postcss": "^7.0.5"
+        "postcss": "8.4.31"
       },
       "engines": {
         "node": ">= 6"
@@ -16548,7 +16548,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/umzug": {
@@ -16836,7 +16836,7 @@
       "integrity": "sha512-a41J4NW8HyZa1I1vAndrraTlPZ/eZoga2ZgS7fEr0tZJGVU4xqdE80CEm0CcNjha5EZ8fTBYLKHF0kqDUuAwQw==",
       "dependencies": {
         "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.10",
+        "@babel/traverse": "7.23.2",
         "@babel/types": "^7.22.10"
       },
       "engines": {
@@ -16868,7 +16868,7 @@
         "import-fresh": "^3.1.0",
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
+        "yaml": "2.2.2"
       },
       "engines": {
         "node": ">=8"
@@ -17392,7 +17392,7 @@
         "node": "^10 || ^12 || >= 14"
       },
       "peerDependencies": {
-        "postcss": "^8.1.0"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/lighthouse/node_modules/open": {
@@ -18336,7 +18336,7 @@
         "debug": "^4.1.0",
         "@babel/helpers": "^7.12.5",
         "json5": "2.2.3",
-        "@babel/traverse": "^7.12.9",
+        "@babel/traverse": "7.23.2",
         "@babel/types": "^7.12.7",
         "@babel/code-frame": "^7.10.4",
         "gensync": "^1.0.0-beta.1",
@@ -18725,7 +18725,7 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.3.tgz",
       "integrity": "sha512-2/u2zraspoACtrbFRnTijMiQtb4GW4BvatjaG/bCjYQo8kLTdevCUlwuBHx2sCnSyrI3x3qj4ZK1j5LQBgzmwA==",
       "dependencies": {
-        "icss-utils": "^5.0.0",
+        "icss-utils": "5.0.0",
         "postcss-selector-parser": "^6.0.2",
         "postcss-value-parser": "^4.1.0"
       },
@@ -18733,7 +18733,7 @@
         "node": "^10 || ^12 || >= 14"
       },
       "peerDependencies": {
-        "postcss": "^8.1.0"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/regex-not": {
@@ -18864,7 +18864,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/color-convert": {
@@ -19349,7 +19349,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/lodash": {
@@ -19495,7 +19495,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/sane/node_modules/get-stream": {
@@ -20326,7 +20326,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/@webassemblyjs/helper-code-frame/node_modules/@webassemblyjs/wast-printer": {
@@ -21143,7 +21143,7 @@
         "node": "^10 || ^12 || >=14"
       },
       "peerDependencies": {
-        "postcss": "^8.0.9"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/is-decimal": {
@@ -21410,7 +21410,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/lighthouse/node_modules/cliui": {
@@ -22300,7 +22300,7 @@
         "lru-cache": "^6.0.0"
       },
       "bin": {
-        "semver": "bin/semver.js"
+        "semver": "7.5.3"
       },
       "engines": {
         "node": ">=10"
@@ -22720,7 +22720,7 @@
         "lru-cache": "^6.0.0"
       },
       "bin": {
-        "semver": "bin/semver.js"
+        "semver": "7.5.3"
       },
       "engines": {
         "node": ">=10"
@@ -23003,7 +23003,7 @@
         "@jridgewell/trace-mapping": "^0.3.18",
         "cssnano": "^6.0.1",
         "jest-worker": "^29.4.3",
-        "postcss": "^8.4.24",
+        "postcss": "8.4.31",
         "schema-utils": "^4.0.1",
         "serialize-javascript": "^6.0.1"
       },
@@ -23633,9 +23633,9 @@
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.7.tgz",
       "integrity": "sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==",
       "dependencies": {
-        "icss-utils": "^5.1.0",
+        "icss-utils": "5.0.0",
         "loader-utils": "^2.0.0",
-        "postcss": "^8.2.15",
+        "postcss": "8.4.31",
         "postcss-modules-extract-imports": "^3.0.0",
         "postcss-modules-local-by-default": "^4.0.0",
         "postcss-modules-scope": "^3.0.0",
@@ -24571,7 +24571,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
-        "semver": "bin/semver.js"
+        "semver": "7.5.3"
       }
     },
     "node_modules/@storybook/builder-webpack4/node_modules/eslint-scope": {
@@ -27290,7 +27290,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/unist-util-remove/node_modules/unist-util-is": {
@@ -28431,7 +28431,7 @@
         "url": "https://opencollective.com/cssnano"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/create-jest/node_modules/@types/yargs": {
@@ -28638,7 +28638,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/@storybook/manager-webpack4/node_modules/renderkid": {
@@ -28851,7 +28851,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/@storybook/manager-webpack4/node_modules/html-minifier-terser/node_modules/terser/node_modules/commander": {
@@ -29326,8 +29326,8 @@
       "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
       "dev": true,
       "dependencies": {
-        "icss-utils": "^4.0.0",
-        "postcss": "^7.0.6"
+        "icss-utils": "5.0.0",
+        "postcss": "8.4.31"
       }
     },
     "node_modules/@storybook/manager-webpack4/node_modules/pkg-dir": {
@@ -29351,7 +29351,7 @@
         "lru-cache": "^6.0.0"
       },
       "bin": {
-        "semver": "bin/semver.js"
+        "semver": "7.5.3"
       },
       "engines": {
         "node": ">=10"
@@ -29500,8 +29500,8 @@
       "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
       "dev": true,
       "dependencies": {
-        "icss-utils": "^4.0.0",
-        "postcss": "^7.0.6"
+        "icss-utils": "5.0.0",
+        "postcss": "8.4.31"
       }
     },
     "node_modules/@jest/test-sequencer/node_modules/supports-color": {
@@ -29622,7 +29622,7 @@
       "integrity": "sha512-9SiofaZ9CWpQWxOwRh1b/r85KD5y7GgvsNt1056k6OYLvWUun0czCvogfJgylC22uJTwW1KzY3Gz65NZRlvoiQ==",
       "dev": true,
       "dependencies": {
-        "postcss": "^7.0.26"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/shebang-command": {
@@ -31500,7 +31500,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -31968,10 +31968,10 @@
       "dependencies": {
         "camelcase": "^5.3.1",
         "cssesc": "^3.0.0",
-        "icss-utils": "^4.1.1",
+        "icss-utils": "5.0.0",
         "loader-utils": "^1.2.3",
         "normalize-path": "^3.0.0",
-        "postcss": "^7.0.32",
+        "postcss": "8.4.31",
         "postcss-modules-extract-imports": "^2.0.0",
         "postcss-modules-local-by-default": "^3.0.2",
         "postcss-modules-scope": "^2.2.0",
@@ -32037,7 +32037,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "postcss": "^7.0.0 || ^8.0.1",
+        "postcss": "8.4.31",
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
@@ -32074,7 +32074,7 @@
       "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
       "dev": true,
       "dependencies": {
-        "postcss": "^7.0.6",
+        "postcss": "8.4.31",
         "postcss-selector-parser": "^6.0.0"
       },
       "engines": {
@@ -32538,7 +32538,7 @@
       "integrity": "sha512-YNF+mZ/Wu2FU/gvmzuWtYc8rloubL7wfXCTgouFrnjGVXPA/EeYYA7pupXWrb3Iv1cTBeSSxxJIbK23l4MRNqg==",
       "dev": true,
       "dependencies": {
-        "@babel/traverse": "^7.1.6",
+        "@babel/traverse": "7.23.2",
         "@babel/types": "^7.2.0",
         "c8": "^7.6.0"
       },
@@ -32777,7 +32777,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/restore-cursor/node_modules/mimic-fn": {
@@ -32802,7 +32802,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -32916,7 +32916,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/jest-leak-detector/node_modules/pretty-format": {
@@ -33000,8 +33000,8 @@
       "integrity": "sha512-xDAXtEVGlD0gJ07iclwWVkLoZOpEvAWaSyf6W18S2pOC//K8+qUDIx8IIT3D+HjnmkJPQeesOPv5aiUaJsCM2g==",
       "dev": true,
       "dependencies": {
-        "icss-utils": "^5.1.0",
-        "postcss": "^8.4.21",
+        "icss-utils": "5.0.0",
+        "postcss": "8.4.31",
         "postcss-modules-extract-imports": "^3.0.0",
         "postcss-modules-local-by-default": "^4.0.3",
         "postcss-modules-scope": "^3.0.0",
@@ -33292,7 +33292,7 @@
         "node": "^14 || ^16 || >= 18"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/json-parse-better-errors": {
@@ -33560,7 +33560,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/postcss-normalize-display-values": {
@@ -33575,7 +33575,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/proxy-addr": {
@@ -34032,7 +34032,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/dottie": {
@@ -34148,7 +34148,7 @@
         "@babel/helpers": "^7.22.10",
         "@babel/parser": "^7.22.10",
         "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.10",
+        "@babel/traverse": "7.23.2",
         "@babel/types": "^7.22.10",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
@@ -34275,7 +34275,7 @@
         "node": "^10 || ^12 || >= 14"
       },
       "peerDependencies": {
-        "postcss": "^8.1.0"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/@storybook/mdx1-csf/node_modules/is-plain-obj": {
@@ -34534,7 +34534,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/react-transition-group": {
@@ -35801,14 +35801,14 @@
       "license": "ISC",
       "dependencies": {
         "loader-utils": "^3.2.1",
-        "trim": "^1.0.1",
+        "trim": "1.0.1",
         "core-js": "^3.4.5",
         "@storybook/manager-webpack5": "^6.5.9",
         "@storybook/addon-controls": "^6.5.9",
         "lodash": "^4.17.15",
         "@fortawesome/react-fontawesome": "^0.1.7",
         "acorn": "^8.7.1",
-        "decode-uri-component": "^0.2.2",
+        "decode-uri-component": "0.2.2",
         "require-from-string": "^2.0.2",
         "accounting": "^0.4.1",
         "typescript": "^4.7.4",
@@ -35822,9 +35822,9 @@
         "@fortawesome/fontawesome-svg-core": "^1.2.25",
         "classnames": "^2.2.6",
         "copy-to-clipboard": "^3.3.1",
-        "json5": "^2.2.3",
+        "json5": "2.2.3",
         "ajv-keywords": "^5.1.0",
-        "glob-parent": "6.0.1",
+        "glob-parent": "6.0.2",
         "react-transition-group": "^4.4.1",
         "express": "^4.18.2",
         "react": "^17.0.2",
@@ -35888,7 +35888,7 @@
         "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/jest-runner/node_modules/p-limit": {
@@ -36024,7 +36024,7 @@
         }
       ],
       "dependencies": {
-        "semver": "^7.3.5",
+        "semver": "7.5.3",
         "sequelize-pool": "^7.1.0",
         "lodash": "^4.17.21",
         "@types/validator": "^13.7.1",
@@ -36034,7 +36034,7 @@
         "wkx": "^0.5.0",
         "pg-connection-string": "^2.5.0",
         "dottie": "^2.0.2",
-        "validator": "^13.7.0",
+        "validator": "13.7.0",
         "inflection": "^1.13.2",
         "@types/debug": "^4.1.7",
         "retry-as-promised": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "webpack-merge": "^5.9.0"
   },
   "resolutions": {
+    "@babel/traverse": "7.23.2",
     "trim-newlines": "4.0.2",
     "glob-parent": "6.0.2",
     "**/glob-parent": "6.0.2",

--- a/src/js/components/agency/statusOfFunds/StatusOfFunds.jsx
+++ b/src/js/components/agency/statusOfFunds/StatusOfFunds.jsx
@@ -74,7 +74,6 @@ const StatusOfFunds = ({ fy, onChartLoaded }) => {
 
     const maxLevel = 4;
 
-    // TODO not sure if this is necessary
     // eslint-disable-next-line eqeqeq
     let statusDataThroughDate = useLatestAccountData()[1].toArray().filter((i) => i.submission_fiscal_year == fy)[0].period_end_date;
 

--- a/src/js/redux/actions/agency/agencyActions.js
+++ b/src/js/redux/actions/agency/agencyActions.js
@@ -52,11 +52,6 @@ export const setLevel4ApiResponse = (resObject) => ({
     resObject
 });
 
-// export const setLevel5Data = (childrenArray) => ({
-//     type: 'SET_LEVEL_5_DATA',
-//     childrenArray
-// });
-
 export const setAgencyRecipients = (recipientDistribution) => ({
     type: 'SET_AGENCY_RECIPIENTS',
     recipientDistribution
@@ -65,15 +60,6 @@ export const setAgencyRecipients = (recipientDistribution) => ({
 export const resetAgencyRecipients = () => ({
     type: 'RESET_AGENCY_RECIPIENTS'
 });
-
-// export const setSubagencyCount = (subagencyCount) => ({
-//     type: 'SET_SUBAGENCY_COUNT',
-//     subagencyCount
-// });
-//
-// export const resetSubagencyCount = () => ({
-//     type: 'RESET_SUBAGENCY_COUNT'
-// });
 
 export const setSubagencyTotals = (spendingBySubagencyTotals) => ({
     type: 'SET_SUBAGENCY_TOTALS',
@@ -91,24 +77,6 @@ export const setAgencySlugs = (agencySlugs, topTierCodes, agencyIds, agencyOutla
     agencyIds,
     agencyOutlays
 });
-
-// export const setAgencySubcomponents = (agencySubcomponentsList) => ({
-//     type: 'SET_SUBCOMPONENTS_LIST',
-//     agencySubcomponentsList
-// });
-
-// export const resetAgencySubcomponents = () => ({
-//     type: 'RESET_SUBCOMPONENTS_LIST'
-// });
-
-// export const setFederalAccountsList = (agencyFederalAccountsList) => ({
-//     type: 'SET_FEDERAL_ACC_LIST',
-//     agencyFederalAccountsList
-// });
-
-// export const resetFederalAccountsList = () => ({
-//     type: 'RESET_FEDERAL_ACC_LIST'
-// });
 
 export const setDataThroughDates = (dates) => ({
     type: 'SET_DATA_THROUGH_DATES',

--- a/src/js/redux/actions/agency/agencyActions.js
+++ b/src/js/redux/actions/agency/agencyActions.js
@@ -66,14 +66,14 @@ export const resetAgencyRecipients = () => ({
     type: 'RESET_AGENCY_RECIPIENTS'
 });
 
-export const setSubagencyCount = (subagencyCount) => ({
-    type: 'SET_SUBAGENCY_COUNT',
-    subagencyCount
-});
-
-export const resetSubagencyCount = () => ({
-    type: 'RESET_SUBAGENCY_COUNT'
-});
+// export const setSubagencyCount = (subagencyCount) => ({
+//     type: 'SET_SUBAGENCY_COUNT',
+//     subagencyCount
+// });
+//
+// export const resetSubagencyCount = () => ({
+//     type: 'RESET_SUBAGENCY_COUNT'
+// });
 
 export const setSubagencyTotals = (spendingBySubagencyTotals) => ({
     type: 'SET_SUBAGENCY_TOTALS',
@@ -101,14 +101,14 @@ export const setAgencySlugs = (agencySlugs, topTierCodes, agencyIds, agencyOutla
 //     type: 'RESET_SUBCOMPONENTS_LIST'
 // });
 
-export const setFederalAccountsList = (agencyFederalAccountsList) => ({
-    type: 'SET_FEDERAL_ACC_LIST',
-    agencyFederalAccountsList
-});
+// export const setFederalAccountsList = (agencyFederalAccountsList) => ({
+//     type: 'SET_FEDERAL_ACC_LIST',
+//     agencyFederalAccountsList
+// });
 
-export const resetFederalAccountsList = () => ({
-    type: 'RESET_FEDERAL_ACC_LIST'
-});
+// export const resetFederalAccountsList = () => ({
+//     type: 'RESET_FEDERAL_ACC_LIST'
+// });
 
 export const setDataThroughDates = (dates) => ({
     type: 'SET_DATA_THROUGH_DATES',

--- a/src/js/redux/actions/agency/agencyActions.js
+++ b/src/js/redux/actions/agency/agencyActions.js
@@ -52,10 +52,10 @@ export const setLevel4ApiResponse = (resObject) => ({
     resObject
 });
 
-export const setLevel5Data = (childrenArray) => ({
-    type: 'SET_LEVEL_5_DATA',
-    childrenArray
-});
+// export const setLevel5Data = (childrenArray) => ({
+//     type: 'SET_LEVEL_5_DATA',
+//     childrenArray
+// });
 
 export const setAgencyRecipients = (recipientDistribution) => ({
     type: 'SET_AGENCY_RECIPIENTS',
@@ -80,6 +80,10 @@ export const setSubagencyTotals = (spendingBySubagencyTotals) => ({
     spendingBySubagencyTotals
 });
 
+export const resetSubagencyTotals = () => ({
+    type: 'RESET_SUBAGENCY_TOTALS'
+});
+
 export const setAgencySlugs = (agencySlugs, topTierCodes, agencyIds, agencyOutlays) => ({
     type: 'SET_AGENCY_SLUGS',
     agencySlugs,
@@ -88,18 +92,14 @@ export const setAgencySlugs = (agencySlugs, topTierCodes, agencyIds, agencyOutla
     agencyOutlays
 });
 
-export const resetSubagencyTotals = () => ({
-    type: 'RESET_SUBAGENCY_TOTALS'
-});
+// export const setAgencySubcomponents = (agencySubcomponentsList) => ({
+//     type: 'SET_SUBCOMPONENTS_LIST',
+//     agencySubcomponentsList
+// });
 
-export const setAgencySubcomponents = (agencySubcomponentsList) => ({
-    type: 'SET_SUBCOMPONENTS_LIST',
-    agencySubcomponentsList
-});
-
-export const resetAgencySubcomponents = () => ({
-    type: 'RESET_SUBCOMPONENTS_LIST'
-});
+// export const resetAgencySubcomponents = () => ({
+//     type: 'RESET_SUBCOMPONENTS_LIST'
+// });
 
 export const setFederalAccountsList = (agencyFederalAccountsList) => ({
     type: 'SET_FEDERAL_ACC_LIST',

--- a/src/js/redux/reducers/agency/agencyReducer.js
+++ b/src/js/redux/reducers/agency/agencyReducer.js
@@ -6,7 +6,7 @@
 import BaseAgencyRecipients from 'models/v2/agency/BaseAgencyRecipients';
 import BaseAgencySubagencyCount from 'models/v2/agency/BaseAgencySubagencyCount';
 import BaseSubagencySpendingRow from 'models/v2/agency/BaseSubagencySpendingRow';
-import BaseAgencySubcomponentsList from 'models/v2/agency/BaseAgencySubcomponentsList';
+// import BaseAgencySubcomponentsList from 'models/v2/agency/BaseAgencySubcomponentsList';
 
 // Create an empty recipient object for the initial state
 const recipientDistribution = Object.create(BaseAgencyRecipients);
@@ -18,8 +18,8 @@ subagencyCount.populate();
 const spendingBySubagencyTotals = Object.create(BaseSubagencySpendingRow);
 spendingBySubagencyTotals.populateCore();
 
-const agencySubcomponentsList = Object.create(BaseAgencySubcomponentsList);
-agencySubcomponentsList.populate();
+// const agencySubcomponentsList = Object.create(BaseAgencySubcomponentsList);
+// agencySubcomponentsList.populate();
 
 export const initialState = {
     overview: {
@@ -41,7 +41,7 @@ export const initialState = {
     selectedPrgActivityOrObjectClass: null,
     currentLevelNameAndId: null,
     level4ApiResponse: null,
-    agencySubcomponentsList,
+    // agencySubcomponentsList,
     awardSpendingDataThroughDate: null,
     isStatusOfFundsChartLoaded: false
 };
@@ -123,6 +123,11 @@ const agencyReducer = (state = initialState, action) => {
                 ...state,
                 spendingBySubagencyTotals: action.spendingBySubagencyTotals
             };
+        case 'RESET_SUBAGENCY_TOTALS':
+            return {
+                ...state,
+                spendingBySubagencyTotals: initialState.spendingBySubagencyTotals
+            };
         case 'SET_AGENCY_SLUGS':
             return {
                 ...state,
@@ -131,36 +136,31 @@ const agencyReducer = (state = initialState, action) => {
                 agencyIds: action.agencyIds,
                 agencyOutlays: action.agencyOutlays
             };
-        case 'RESET_SUBAGENCY_TOTALS':
-            return {
-                ...state,
-                spendingBySubagencyTotals: initialState.spendingBySubagencyTotals
-            };
-        case 'SET_SUBCOMPONENTS_LIST':
-            return {
-                ...state,
-                agencySubcomponentsList: action.agencySubcomponentsList
-            };
-        case 'RESET_SUBCOMPONENTS_LIST':
-            return {
-                ...state,
-                agencySubcomponentsList: initialState.agencySubcomponentsList
-            };
-        case 'SET_FEDERAL_ACC_LIST':
-            return {
-                ...state,
-                agencySubcomponentsList: action.agencySubcomponentsList
-            };
-        case 'RESET_FEDERAL_ACC_LIST':
-            return {
-                ...state,
-                agencySubcomponentsList: action.agencySubcomponentsList
-            };
-        case 'SET_TAS_LIST':
-            return {
-                ...state,
-                agencySubcomponentsList: initialState.agencySubcomponentsList
-            };
+        // case 'SET_SUBCOMPONENTS_LIST':
+        //     return {
+        //         ...state,
+        //         agencySubcomponentsList: action.agencySubcomponentsList
+        //     };
+        // case 'RESET_SUBCOMPONENTS_LIST':
+        //     return {
+        //         ...state,
+        //         agencySubcomponentsList: initialState.agencySubcomponentsList
+        //     };
+        // case 'SET_FEDERAL_ACC_LIST':
+        //     return {
+        //         ...state,
+        //         agencySubcomponentsList: action.agencySubcomponentsList
+        //     };
+        // case 'RESET_FEDERAL_ACC_LIST':
+        //     return {
+        //         ...state,
+        //         agencySubcomponentsList: action.agencySubcomponentsList
+        //     };
+        // case 'SET_TAS_LIST':
+        //     return {
+        //         ...state,
+        //         agencySubcomponentsList: initialState.agencySubcomponentsList
+        //     };
         case 'SET_DATA_THROUGH_DATES':
             return {
                 ...state,

--- a/src/js/redux/reducers/agency/agencyReducer.js
+++ b/src/js/redux/reducers/agency/agencyReducer.js
@@ -121,7 +121,6 @@ const agencyReducer = (state = initialState, action) => {
                 agencyIds: action.agencyIds,
                 agencyOutlays: action.agencyOutlays
             };
-
         case 'SET_DATA_THROUGH_DATES':
             return {
                 ...state,

--- a/src/js/redux/reducers/agency/agencyReducer.js
+++ b/src/js/redux/reducers/agency/agencyReducer.js
@@ -6,7 +6,6 @@
 import BaseAgencyRecipients from 'models/v2/agency/BaseAgencyRecipients';
 import BaseAgencySubagencyCount from 'models/v2/agency/BaseAgencySubagencyCount';
 import BaseSubagencySpendingRow from 'models/v2/agency/BaseSubagencySpendingRow';
-// import BaseAgencySubcomponentsList from 'models/v2/agency/BaseAgencySubcomponentsList';
 
 // Create an empty recipient object for the initial state
 const recipientDistribution = Object.create(BaseAgencyRecipients);
@@ -17,9 +16,6 @@ subagencyCount.populate();
 
 const spendingBySubagencyTotals = Object.create(BaseSubagencySpendingRow);
 spendingBySubagencyTotals.populateCore();
-
-// const agencySubcomponentsList = Object.create(BaseAgencySubcomponentsList);
-// agencySubcomponentsList.populate();
 
 export const initialState = {
     overview: {
@@ -41,7 +37,6 @@ export const initialState = {
     selectedPrgActivityOrObjectClass: null,
     currentLevelNameAndId: null,
     level4ApiResponse: null,
-    // agencySubcomponentsList,
     awardSpendingDataThroughDate: null,
     isStatusOfFundsChartLoaded: false
 };
@@ -108,16 +103,6 @@ const agencyReducer = (state = initialState, action) => {
                 ...state,
                 recipientDistribution: initialState.recipientDistribution
             };
-        // case 'SET_SUBAGENCY_COUNT':
-        //     return {
-        //         ...state,
-        //         subagencyCount: action.subagencyCount
-        //     };
-        // case 'RESET_SUBAGENCY_COUNT':
-        //     return {
-        //         ...state,
-        //         subagencyCount: initialState.subagencyCount
-        //     };
         case 'SET_SUBAGENCY_TOTALS':
             return {
                 ...state,
@@ -136,31 +121,7 @@ const agencyReducer = (state = initialState, action) => {
                 agencyIds: action.agencyIds,
                 agencyOutlays: action.agencyOutlays
             };
-        // case 'SET_SUBCOMPONENTS_LIST':
-        //     return {
-        //         ...state,
-        //         agencySubcomponentsList: action.agencySubcomponentsList
-        //     };
-        // case 'RESET_SUBCOMPONENTS_LIST':
-        //     return {
-        //         ...state,
-        //         agencySubcomponentsList: initialState.agencySubcomponentsList
-        //     };
-        // case 'SET_FEDERAL_ACC_LIST':
-        //     return {
-        //         ...state,
-        //         agencySubcomponentsList: action.agencySubcomponentsList
-        //     };
-        // case 'RESET_FEDERAL_ACC_LIST':
-        //     return {
-        //         ...state,
-        //         agencySubcomponentsList: action.agencySubcomponentsList
-        //     };
-        // case 'SET_TAS_LIST':
-        //     return {
-        //         ...state,
-        //         agencySubcomponentsList: initialState.agencySubcomponentsList
-        //     };
+
         case 'SET_DATA_THROUGH_DATES':
             return {
                 ...state,

--- a/src/js/redux/reducers/agency/agencyReducer.js
+++ b/src/js/redux/reducers/agency/agencyReducer.js
@@ -108,16 +108,16 @@ const agencyReducer = (state = initialState, action) => {
                 ...state,
                 recipientDistribution: initialState.recipientDistribution
             };
-        case 'SET_SUBAGENCY_COUNT':
-            return {
-                ...state,
-                subagencyCount: action.subagencyCount
-            };
-        case 'RESET_SUBAGENCY_COUNT':
-            return {
-                ...state,
-                subagencyCount: initialState.subagencyCount
-            };
+        // case 'SET_SUBAGENCY_COUNT':
+        //     return {
+        //         ...state,
+        //         subagencyCount: action.subagencyCount
+        //     };
+        // case 'RESET_SUBAGENCY_COUNT':
+        //     return {
+        //         ...state,
+        //         subagencyCount: initialState.subagencyCount
+        //     };
         case 'SET_SUBAGENCY_TOTALS':
             return {
                 ...state,

--- a/tests/redux/reducers/agency/agencyReducer-test.js
+++ b/tests/redux/reducers/agency/agencyReducer-test.js
@@ -8,7 +8,7 @@
 import BaseAgencyOverview from 'models/v2/agency/BaseAgencyOverview';
 import BaseAgencyBudgetaryResources from 'models/v2/agency/BaseAgencyBudgetaryResources';
 import BaseAgencyRecipients from 'models/v2/agency/BaseAgencyRecipients';
-import BaseAgencySubagencyCount from 'models/v2/agency/BaseAgencySubagencyCount';
+import BaseSubagencySpendingRow from 'models/v2/agency/BaseSubagencySpendingRow';
 import BaseStatusOfFundsLevel from 'models/v2/agency/BaseStatusOfFundsLevel';
 import agencyReducer, { initialState } from 'redux/reducers/agency/agencyReducer';
 import { mockAgency } from '../../../models/agency/BaseAgencyOverview-test';
@@ -71,9 +71,9 @@ describe('agencyReducer', () => {
 
     describe('RESET_AWARD_OBLIGATIONS', () => {
         it('should reset award obligations to its initial state', () => {
-            let state = agencyReducer(undefined, {
+            let state = agencyReducer({
                 _awardObligations: 123456789.01
-            });
+            }, {});
 
             const action = {
                 type: 'RESET_AWARD_OBLIGATIONS'
@@ -196,9 +196,9 @@ describe('agencyReducer', () => {
 
     describe('RESET_AGENCY_RECIPIENTS', () => {
         it('should reset award obligations to its initial state', () => {
-            let state = agencyReducer(undefined, {
+            let state = agencyReducer({
                 recipientDistribution: { test: 'hello' }
-            });
+            }, {});
 
             const action = {
                 type: 'RESET_AGENCY_RECIPIENTS'
@@ -210,38 +210,6 @@ describe('agencyReducer', () => {
             expect(Object.getPrototypeOf(state.recipientDistribution)).toEqual(BaseAgencyRecipients);
         });
     });
-
-    // describe('SET_SUBAGENCY_COUNT', () => {
-    //     it('should set subagencyCount to the provided value', () => {
-    //         let state = agencyReducer(undefined, {});
-    //
-    //         const action = {
-    //             type: 'SET_SUBAGENCY_COUNT',
-    //             subagencyCount: { officeCount: '10' }
-    //         };
-    //
-    //         state = agencyReducer(state, action);
-    //
-    //         expect(state.subagencyCount.officeCount).toEqual('10');
-    //     });
-    // });
-    //
-    // describe('RESET_SUBAGENCY_COUNT', () => {
-    //     it('should reset subagencyCount to its initial state', () => {
-    //         let state = agencyReducer(undefined, {
-    //             subagencyCount: { officeCount: '10' }
-    //         });
-    //
-    //         const action = {
-    //             type: 'RESET_SUBAGENCY_COUNT'
-    //         };
-    //
-    //         state = agencyReducer(state, action);
-    //
-    //         expect(state.subagencyCount).toEqual(initialState.subagencyCount);
-    //         expect(Object.getPrototypeOf(state.subagencyCount)).toEqual(BaseAgencySubagencyCount);
-    //     });
-    // });
 
     describe('SET_SUBAGENCY_TOTALS', () => {
         it('should set spendingBySubagencyTotals to the provided value', () => {
@@ -258,22 +226,20 @@ describe('agencyReducer', () => {
         });
     });
 
-    xdescribe('RESET_SUBAGENCY_TOTALS', () => {
+    describe('RESET_SUBAGENCY_TOTALS', () => {
         it('should reset spendingBySubagencyTotals to its initial state', () => {
-            let state = agencyReducer(undefined, {
+            let state = agencyReducer({
                 spendingBySubagencyTotals: 'totals'
-            });
+            }, {});
 
             const action = {
-                type: 'RESET_SUBAGENCY_TOTALS',
-                spendingBySubagencyTotals: 'totals'
+                type: 'RESET_SUBAGENCY_TOTALS'
             };
-
-            expect(state.spendingBySubagencyTotals).toEqual('wrong');
 
             state = agencyReducer(state, action);
 
-            // expect(state.spendingBySubagencyTotals).toEqual('totals');
+            expect(state.spendingBySubagencyTotals).toEqual(initialState.spendingBySubagencyTotals);
+            expect(Object.getPrototypeOf(state.spendingBySubagencyTotals)).toEqual(BaseSubagencySpendingRow);
         });
     });
 

--- a/tests/redux/reducers/agency/agencyReducer-test.js
+++ b/tests/redux/reducers/agency/agencyReducer-test.js
@@ -5,6 +5,7 @@
  * Created by Lizzie Salita 5/26/20
  */
 
+import dayjs from "dayjs";
 import BaseAgencyOverview from 'models/v2/agency/BaseAgencyOverview';
 import BaseAgencyBudgetaryResources from 'models/v2/agency/BaseAgencyBudgetaryResources';
 import BaseAgencyRecipients from 'models/v2/agency/BaseAgencyRecipients';
@@ -14,7 +15,6 @@ import agencyReducer, { initialState } from 'redux/reducers/agency/agencyReducer
 import { mockAgency } from '../../../models/agency/BaseAgencyOverview-test';
 import { mockBudgetaryResources } from '../../../models/agency/BaseAgencyBudgetaryResources-test';
 import { mockSubcomponent } from '../../../models/agency/BaseStatusOfFundsLevel-test';
-import dayjs from "dayjs";
 
 const agencyOverview = Object.create(BaseAgencyOverview);
 agencyOverview.populate(mockAgency);
@@ -264,13 +264,11 @@ describe('agencyReducer', () => {
         });
     });
 
-    xdescribe('SET_DATA_THROUGH_DATES', () => {
+    describe('SET_DATA_THROUGH_DATES', () => {
         it('should set dataThroughDates to the provided value', () => {
             let state = agencyReducer(undefined, {});
 
             const today = dayjs();
-
-            console.log('today', today);
 
             const action = {
                 type: 'SET_DATA_THROUGH_DATES',
@@ -279,7 +277,7 @@ describe('agencyReducer', () => {
 
             state = agencyReducer(state, action);
 
-            expect(state.dataThroughDates).toEqual('totals');
+            expect(state.dataThroughDates).toEqual(today);
         });
     });
 

--- a/tests/redux/reducers/agency/agencyReducer-test.js
+++ b/tests/redux/reducers/agency/agencyReducer-test.js
@@ -14,6 +14,7 @@ import agencyReducer, { initialState } from 'redux/reducers/agency/agencyReducer
 import { mockAgency } from '../../../models/agency/BaseAgencyOverview-test';
 import { mockBudgetaryResources } from '../../../models/agency/BaseAgencyBudgetaryResources-test';
 import { mockSubcomponent } from '../../../models/agency/BaseStatusOfFundsLevel-test';
+import dayjs from "dayjs";
 
 const agencyOverview = Object.create(BaseAgencyOverview);
 agencyOverview.populate(mockAgency);
@@ -239,6 +240,97 @@ describe('agencyReducer', () => {
 
             expect(state.subagencyCount).toEqual(initialState.subagencyCount);
             expect(Object.getPrototypeOf(state.subagencyCount)).toEqual(BaseAgencySubagencyCount);
+        });
+    });
+
+    describe('SET_SUBAGENCY_TOTALS', () => {
+        it('should set spendingBySubagencyTotals to the provided value', () => {
+            let state = agencyReducer(undefined, {});
+
+            const action = {
+                type: 'SET_SUBAGENCY_TOTALS',
+                spendingBySubagencyTotals: 'totals'
+            };
+
+            state = agencyReducer(state, action);
+
+            expect(state.spendingBySubagencyTotals).toEqual('totals');
+        });
+    });
+
+    xdescribe('RESET_SUBAGENCY_TOTALS', () => {
+        it('should reset spendingBySubagencyTotals to its initial state', () => {
+            let state = agencyReducer(undefined, {
+                spendingBySubagencyTotals: 'totals'
+            });
+
+            const action = {
+                type: 'RESET_SUBAGENCY_TOTALS',
+                spendingBySubagencyTotals: 'totals'
+            };
+
+            expect(state.spendingBySubagencyTotals).toEqual('wrong');
+
+            state = agencyReducer(state, action);
+
+            // expect(state.spendingBySubagencyTotals).toEqual('totals');
+        });
+    });
+
+    xdescribe('SET_AGENCY_SLUGS', () => {
+        it('should set agencySlugs, topTierCodes, agencyIds, agencyOutlays to the provided values', () => {
+            let state = agencyReducer(undefined, {});
+
+            const action = {
+                type: 'SET_SUBAGENCY_TOTALS',
+                agencySlugs: { slugs: 'slugs' }
+                // topTierCodes: 'codes',
+                // agencyIds: 'ids',
+                // agencyOutlays: 'outlays'
+            };
+
+            state = agencyReducer(state, action);
+
+            // expect(Object.getPrototypeOf(state.agencySlugs)).toEqual('wrong');
+
+            expect(state.agencySlugs).toMatchObject({ slugs: 'slugs' });
+            // expect(state.agencySlugs).toEqual('totals');
+            // expect(state.agencySlugs).toEqual('totals');
+            // expect(state.agencySlugs).toEqual('totals');
+        });
+    });
+
+    xdescribe('SET_DATA_THROUGH_DATES', () => {
+        it('should set dataThroughDates to the provided value', () => {
+            let state = agencyReducer(undefined, {});
+
+            const today = dayjs();
+
+            console.log('today', today);
+
+            const action = {
+                type: 'SET_DATA_THROUGH_DATES',
+                dates: today
+            };
+
+            state = agencyReducer(state, action);
+
+            expect(state.dataThroughDates).toEqual('totals');
+        });
+    });
+
+    describe('SET_IS_SOF_CHART_LOADED', () => {
+        it('should set isStatusOfFundsChartLoaded to the provided value', () => {
+            let state = agencyReducer(undefined, {});
+
+            const action = {
+                type: 'SET_IS_SOF_CHART_LOADED',
+                payload: 'chart status'
+            };
+
+            state = agencyReducer(state, action);
+
+            expect(state.isStatusOfFundsChartLoaded).toEqual('chart status');
         });
     });
 

--- a/tests/redux/reducers/agency/agencyReducer-test.js
+++ b/tests/redux/reducers/agency/agencyReducer-test.js
@@ -243,26 +243,24 @@ describe('agencyReducer', () => {
         });
     });
 
-    xdescribe('SET_AGENCY_SLUGS', () => {
+    describe('SET_AGENCY_SLUGS', () => {
         it('should set agencySlugs, topTierCodes, agencyIds, agencyOutlays to the provided values', () => {
             let state = agencyReducer(undefined, {});
 
             const action = {
-                type: 'SET_SUBAGENCY_TOTALS',
-                agencySlugs: { slugs: 'slugs' }
-                // topTierCodes: 'codes',
-                // agencyIds: 'ids',
-                // agencyOutlays: 'outlays'
+                type: 'SET_AGENCY_SLUGS',
+                agencySlugs: { slugs: 'slugs' },
+                topTierCodes: { codes: 'codes' },
+                agencyIds: { ids: 'ids' },
+                agencyOutlays: { outlays: 'outlays' }
             };
 
             state = agencyReducer(state, action);
 
-            // expect(Object.getPrototypeOf(state.agencySlugs)).toEqual('wrong');
-
-            expect(state.agencySlugs).toMatchObject({ slugs: 'slugs' });
-            // expect(state.agencySlugs).toEqual('totals');
-            // expect(state.agencySlugs).toEqual('totals');
-            // expect(state.agencySlugs).toEqual('totals');
+            expect(state.agencySlugs).toEqual({ slugs: 'slugs' });
+            expect(state.topTierCodes).toEqual({ codes: 'codes' });
+            expect(state.agencyIds).toEqual({ ids: 'ids' });
+            expect(state.agencyOutlays).toEqual({ outlays: 'outlays' });
         });
     });
 

--- a/tests/redux/reducers/agency/agencyReducer-test.js
+++ b/tests/redux/reducers/agency/agencyReducer-test.js
@@ -211,37 +211,37 @@ describe('agencyReducer', () => {
         });
     });
 
-    describe('SET_SUBAGENCY_COUNT', () => {
-        it('should set subagencyCount to the provided value', () => {
-            let state = agencyReducer(undefined, {});
-
-            const action = {
-                type: 'SET_SUBAGENCY_COUNT',
-                subagencyCount: { officeCount: '10' }
-            };
-
-            state = agencyReducer(state, action);
-
-            expect(state.subagencyCount.officeCount).toEqual('10');
-        });
-    });
-
-    describe('RESET_SUBAGENCY_COUNT', () => {
-        it('should reset subagencyCount to its initial state', () => {
-            let state = agencyReducer(undefined, {
-                subagencyCount: { officeCount: '10' }
-            });
-
-            const action = {
-                type: 'RESET_SUBAGENCY_COUNT'
-            };
-
-            state = agencyReducer(state, action);
-
-            expect(state.subagencyCount).toEqual(initialState.subagencyCount);
-            expect(Object.getPrototypeOf(state.subagencyCount)).toEqual(BaseAgencySubagencyCount);
-        });
-    });
+    // describe('SET_SUBAGENCY_COUNT', () => {
+    //     it('should set subagencyCount to the provided value', () => {
+    //         let state = agencyReducer(undefined, {});
+    //
+    //         const action = {
+    //             type: 'SET_SUBAGENCY_COUNT',
+    //             subagencyCount: { officeCount: '10' }
+    //         };
+    //
+    //         state = agencyReducer(state, action);
+    //
+    //         expect(state.subagencyCount.officeCount).toEqual('10');
+    //     });
+    // });
+    //
+    // describe('RESET_SUBAGENCY_COUNT', () => {
+    //     it('should reset subagencyCount to its initial state', () => {
+    //         let state = agencyReducer(undefined, {
+    //             subagencyCount: { officeCount: '10' }
+    //         });
+    //
+    //         const action = {
+    //             type: 'RESET_SUBAGENCY_COUNT'
+    //         };
+    //
+    //         state = agencyReducer(state, action);
+    //
+    //         expect(state.subagencyCount).toEqual(initialState.subagencyCount);
+    //         expect(Object.getPrototypeOf(state.subagencyCount)).toEqual(BaseAgencySubagencyCount);
+    //     });
+    // });
 
     describe('SET_SUBAGENCY_TOTALS', () => {
         it('should set spendingBySubagencyTotals to the provided value', () => {

--- a/tests/redux/reducers/agency/agencyReducer-test.js
+++ b/tests/redux/reducers/agency/agencyReducer-test.js
@@ -1,6 +1,6 @@
 /**
  * @jest-environment jsdom
- * 
+ *
  * agencyReducer-test.js
  * Created by Lizzie Salita 5/26/20
  */
@@ -100,6 +100,81 @@ describe('agencyReducer', () => {
 
             expect(Object.getPrototypeOf(state.selectedSubcomponent)).toEqual(BaseStatusOfFundsLevel);
             expect(state.selectedSubcomponent.name).toEqual(mockSubcomponent.name);
+        });
+    });
+
+    describe('SET_FEDERAL_ACCOUNT', () => {
+        it('should set federalAccount to the provided value', () => {
+            let state = agencyReducer(undefined, {});
+
+            const action = {
+                type: 'SET_FEDERAL_ACCOUNT',
+                federalAccount: 'account'
+            };
+
+            state = agencyReducer(state, action);
+
+            expect(state.selectedFederalAccount).toEqual('account');
+        });
+    });
+
+    describe('SET_TAS', () => {
+        it('should set selectedTas to the provided value', () => {
+            let state = agencyReducer(undefined, {});
+
+            const action = {
+                type: 'SET_TAS',
+                tas: 'TAS'
+            };
+
+            state = agencyReducer(state, action);
+
+            expect(state.selectedTas).toEqual('TAS');
+        });
+    });
+
+    describe('SET_PA_OR_OC', () => {
+        it('should set selectedPrgActivityOrObjectClass to the provided value', () => {
+            let state = agencyReducer(undefined, {});
+
+            const action = {
+                type: 'SET_PA_OR_OC',
+                prgActivityOrObjectClass: 'Program Activity'
+            };
+
+            state = agencyReducer(state, action);
+
+            expect(state.selectedPrgActivityOrObjectClass).toEqual('Program Activity');
+        });
+    });
+
+    describe('SET_CURRENT_LEVEL_NAME_AND_ID', () => {
+        it('should set currentLevelNameAndId to the provided value', () => {
+            let state = agencyReducer(undefined, {});
+
+            const action = {
+                type: 'SET_CURRENT_LEVEL_NAME_AND_ID',
+                nameAndId: { name: 'name', id: 'id' }
+            };
+
+            state = agencyReducer(state, action);
+
+            expect(state.currentLevelNameAndId).toEqual({ name: 'name', id: 'id' });
+        });
+    });
+
+    describe('SET_LEVEL_4_API_RESPONSE', () => {
+        it('should set level4ApiResponse to the provided value', () => {
+            let state = agencyReducer(undefined, {});
+
+            const action = {
+                type: 'SET_LEVEL_4_API_RESPONSE',
+                resObject: { one: 'one', two: 'two' }
+            };
+
+            state = agencyReducer(state, action);
+
+            expect(state.level4ApiResponse).toEqual({ one: 'one', two: 'two' });
         });
     });
 


### PR DESCRIPTION
**High level description:**

Write missing unit tests for agencyReducer

**Technical details:**

I found that several of these actions were no longer used so I removed them, and the tests for them, if those tests existed.
I corrected a pattern that was used to set the initial state in the tests for the reset functions - the old version was not actually setting the initial state in the test so the tests were not actually testing anything.
Other than that, I wrote tests for the functions that did not have them yet.

**JIRA Ticket:**
[DEV-10285](https://federal-spending-transparency.atlassian.net/browse/DEV-10285)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
