### PR TITLE
10316 - removed line-clamp, added height that is equal to seven lines…

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "@mdx-js/react": "^2.1.5",
     "accounting": "^0.4.1",
     "ajv": "^8.11.0",
-    "axios": "^0.26.0",
+    "axios": "^1.6.1",
     "buffer": "^6.0.3",
     "clean-webpack-plugin": "^4.0.0",
     "commander": "4.1.1",

--- a/src/_scss/pages/modals/video/_trainingVideoModal.scss
+++ b/src/_scss/pages/modals/video/_trainingVideoModal.scss
@@ -67,11 +67,9 @@
                     color: $gray-60;
                     font-size: rem(16);
                     line-height: 1.5;
-                    display: -webkit-box;
                     margin-top: 24px;
                     margin-bottom: 24px;
-                    -webkit-line-clamp: 7;
-                    -webkit-box-orient: vertical;
+                    height: rem(176);
 
                     &::-webkit-scrollbar {
                         border-radius: 2.5px;


### PR DESCRIPTION
…, which is what line-clamp was set to

**High level description:**

The ellipsis in the video modal was persisting after the user scrolled down and the rest of the description was visible.

**Technical details:**

We decided the best solution was to remove the ellipsis from the description in the modal.

**JIRA Ticket:**
[DEV-10316](https://federal-spending-transparency.atlassian.net/browse/DEV-10316)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
