### PR TITLE
10367 - changed z-index for the map-layer-toggle; removed a console.log

### DIFF
--- a/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
+++ b/src/_scss/pages/search/results/visualizations/geo/map/_toggle.scss
@@ -1,5 +1,5 @@
 .map-layer-toggle {
-    z-index: 5;
+    z-index: 2;
     background-color: $color-white;
     display: block;
     box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3);

--- a/src/js/components/search/visualizations/geo/MapWrapper.jsx
+++ b/src/js/components/search/visualizations/geo/MapWrapper.jsx
@@ -496,7 +496,6 @@ export default class MapWrapper extends React.Component {
             selectedItem.label += " and Territories";
         }
 
-        console.log(selectedItem);
         if (showHover) {
             return (
                 <TooltipComponent


### PR DESCRIPTION
**High level description:**

Z-index issue between the map toggle and the treemap infobox on state pages. 

**Technical details:**

Was set to 5, changed it to 2, bc if at 0 or 1 then the plus and minus icons in the mapbox window are over the map toggle. Now at 2, the mapbox toggle is over the plus and minus things, and the treemap infobox is over both of them
Also removed an unneeded console.log.

**JIRA Ticket:**
[DEV-10367](https://federal-spending-transparency.atlassian.net/browse/DEV-10367)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
