### PR TITLE
10407 - added third css rule to apply fade effect to left and right a…

### DIFF
--- a/src/_scss/layouts/default/stickyHeader/_inpagenav.scss
+++ b/src/_scss/layouts/default/stickyHeader/_inpagenav.scss
@@ -27,7 +27,6 @@
       width: rem(1600);
     }
 
-    // todo - get these two masks to apply at the same time, when needed
     // for some reason IntelliJ thinks this linear-gradient is not valid, but it does compile and it does work
     &.left-fade-effect {
       @media(min-width: $medium-screen) {
@@ -59,6 +58,26 @@
         @media(min-width: $large-screen) {
           -webkit-mask-image: linear-gradient(to left, transparent, rgba(0, 0, 0, 1) 40px);
           mask-image: linear-gradient(to left, transparent, rgba(0, 0, 0, 1) 40px);
+        }
+      }
+    }
+
+    // when both classes are present we need to apply the fade effect to both sides
+    // but listing both linear-gradient rules from above did not work
+    // so we're approximating the px values with percentages here, and slightly different syntax
+    &.left-fade-effect.right-fade-effect {
+      ul {
+        -webkit-mask-image: linear-gradient(to left, transparent, black 4%, black 96%, transparent 100%);
+        mask-image: linear-gradient(to left, transparent, black 4%, black 96%, transparent 100%);
+
+        @media(min-width: $medium-screen) {
+          -webkit-mask-image: linear-gradient(to left, transparent, black 6%, black 94%, transparent 100%);
+          mask-image: linear-gradient(to left, transparent, black 6%, black 94%, transparent 100%);
+        }
+
+        @media(min-width: $large-screen) {
+          -webkit-mask-image: linear-gradient(to left, transparent, black 8%, black 92%, transparent 100%);;
+          mask-image: linear-gradient(to left, transparent, black 8%, black 92%, transparent 100%);;
         }
       }
     }

--- a/src/js/components/inPageNav/InPageNav.jsx
+++ b/src/js/components/inPageNav/InPageNav.jsx
@@ -192,7 +192,9 @@ const InPageNav = ({ sections, activeSection, jumpToSection }) => {
 
     return (
         <div className="in-page-nav__container">
-            <nav ref={navBar} className={`in-page-nav__wrapper ${isOverflowLeft ? 'left-fade-effect' : ''} ${isOverflowRight ? 'right-fade-effect' : ''} `}>
+            <nav
+                ref={navBar}
+                className={`in-page-nav__wrapper ${isOverflowLeft ? 'left-fade-effect' : ''} ${isOverflowRight ? 'right-fade-effect' : ''} `}>
                 {isOverflowLeft && !isMobile &&
                     <div
                         className="in-page-nav__paginator left"


### PR DESCRIPTION
…t the same time

**High level description:**

Make the fade effect appear on both left and right sides when appropriate

**Technical details:**

Finally found a way to use one linear-gradient rule to do this. But it doesn't work with px so I used percentages. Linear-gradient syntax is confusing.

**JIRA Ticket:**
[DEV-10407](https://federal-spending-transparency.atlassian.net/browse/DEV-10407)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
