### PR TITLE
10257 - changed how we find largest negative value for the chart

### DIFF
--- a/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
@@ -340,15 +340,14 @@ const StatusOfFundsChart = ({
             const maxPosObl = positiveObligationsArray.length ? positiveObligationsArray.reduce((a, b) => Math.max(a, b)) : null;
             const maxNegObl = negativeObligationsArray.length ? negativeObligationsArray.reduce((a, b) => Math.max(Math.abs(a), Math.abs(b))) : null;
 
-            const arrayOfMaxValues = [];
-            arrayOfMaxValues.push(Math.abs(maxNegTbr) > Math.abs(maxPosTbr) ? maxNegTbr : maxPosTbr);
-            arrayOfMaxValues.push(Math.abs(maxNegObl) > Math.abs(maxPosObl) ? maxNegObl : maxPosObl);
+            const largestPosValue = Math.max(maxPosTbr, maxPosObl);
+            const largestNegValue = Math.max(maxNegTbr, maxNegObl) * -1;
 
             if (negativeTbr || negativeObl) {
-                x.domain(d3.extent(arrayOfMaxValues)).nice(2);
+                x.domain([largestNegValue, largestPosValue]).nice(2);
             }
             else {
-                x.domain([0, Math.max(maxPosTbr, maxPosObl)]).nice(2);
+                x.domain([0, largestPosValue]).nice(2);
             }
 
             // extract sorted agency names
@@ -696,15 +695,14 @@ const StatusOfFundsChart = ({
             const maxPosOutlay = positiveOutlaysArray.length ? positiveOutlaysArray.reduce((a, b) => Math.max(a, b)) : null;
             const maxNegOutlay = negativeOutlaysArray.length ? negativeOutlaysArray.reduce((a, b) => Math.max(Math.abs(a), Math.abs(b))) : null;
 
-            const arrayOfMaxValues = [];
-            arrayOfMaxValues.push(Math.abs(maxNegTbr) > Math.abs(maxPosTbr) ? maxNegTbr : maxPosTbr);
-            arrayOfMaxValues.push(Math.abs(maxNegOutlay) > Math.abs(maxPosOutlay) ? maxNegOutlay : maxPosOutlay);
+            const largestPosValue = Math.max(maxPosTbr, maxPosOutlay);
+            const largestNegValue = Math.max(maxNegTbr, maxNegOutlay) * -1;
 
             if (negativeTbr || negativeOutlay) {
-                x.domain(d3.extent(arrayOfMaxValues)).nice(2);
+                x.domain([largestNegValue, largestPosValue]).nice(2);
             }
             else {
-                x.domain([0, Math.max(maxPosTbr, maxPosOutlay)]).nice(2);
+                x.domain([0, largestPosValue]).nice(2);
             }
 
             // extract sorted agency names

--- a/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
@@ -335,6 +335,7 @@ const StatusOfFundsChart = ({
                 }
             });
 
+            // useless comment to kick off another build
             const maxPosTbr = positiveTbrArray.length ? positiveTbrArray.reduce((a, b) => Math.max(a, b)) : null;
             const maxNegTbr = negativeTbrArray.length ? negativeTbrArray.reduce((a, b) => Math.max(Math.abs(a), Math.abs(b))) : null;
             const maxPosObl = positiveObligationsArray.length ? positiveObligationsArray.reduce((a, b) => Math.max(a, b)) : null;

--- a/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
@@ -335,7 +335,6 @@ const StatusOfFundsChart = ({
                 }
             });
 
-            // useless comment to kick off another build
             const maxPosTbr = positiveTbrArray.length ? positiveTbrArray.reduce((a, b) => Math.max(a, b)) : null;
             const maxNegTbr = negativeTbrArray.length ? negativeTbrArray.reduce((a, b) => Math.max(Math.abs(a), Math.abs(b))) : null;
             const maxPosObl = positiveObligationsArray.length ? positiveObligationsArray.reduce((a, b) => Math.max(a, b)) : null;


### PR DESCRIPTION
**High level description:**

There's a bug in the chart when there are negative values.

**Technical details:**

I changed how we're selecting the largest negative value and the logic for setting the domain when there is a negative value

**JIRA Ticket:**
[DEV-10257](https://federal-spending-transparency.atlassian.net/browse/DEV-10257)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
