### PR TITLE
Hotfix: DEV-10493 - Added set state and callback to fix download failure

### DIFF
--- a/src/js/containers/search/modals/fullDownload/DownloadBottomBarContainer.jsx
+++ b/src/js/containers/search/modals/fullDownload/DownloadBottomBarContainer.jsx
@@ -151,10 +151,13 @@ export class DownloadBottomBarContainer extends React.Component {
 
     checkStatus() {
         let expectedFile = '';
+        let downloadType = '';
         if (this.props.download.expectedFile !== '') {
             expectedFile = this.props.download.expectedFile;
+            downloadType = this.props.download.type;
         } else if ((typeof this.state.expectedFile) === "object" && Object.prototype.hasOwnProperty.call(this.state.expectedFile, "file")) {
             expectedFile = this.state.expectedFile.file;
+            downloadType = this.state.expectedFile.type;
         }
 
         if (expectedFile !== '') {
@@ -163,7 +166,7 @@ export class DownloadBottomBarContainer extends React.Component {
             }
             this.statusRequest = DownloadHelper.requestDownloadStatus({
                 file_name: expectedFile,
-                type: this.props.download.type
+                type: downloadType
             });
 
             this.statusRequest.promise

--- a/src/js/containers/search/modals/fullDownload/DownloadBottomBarContainer.jsx
+++ b/src/js/containers/search/modals/fullDownload/DownloadBottomBarContainer.jsx
@@ -38,6 +38,8 @@ export class DownloadBottomBarContainer extends React.Component {
             visible: false,
             showError: false,
             showSuccess: false,
+            expectedFile: '',
+            expectedUrl: '',
             title: 'We\'re preparing your download(s)...',
             description: 'If you plan to leave the site, copy the download link before you go - you\'ll need it to access your file.'
         };
@@ -115,9 +117,12 @@ export class DownloadBottomBarContainer extends React.Component {
 
         this.request.promise
             .then((res) => {
-                this.props.setDownloadExpectedFile(res.data.file_name);
-                this.props.setDownloadExpectedUrl(res.data.file_url);
-                this.checkStatus();
+                this.setState({
+                    expectedFile: this.props.setDownloadExpectedFile(res.data.file_name),
+                    expectedUrl: this.props.setDownloadExpectedUrl(res.data.file_url)
+                }, () => {
+                    this.checkStatus();
+                });
             })
             .catch((err) => {
                 if (!isCancel(err)) {
@@ -145,12 +150,19 @@ export class DownloadBottomBarContainer extends React.Component {
     }
 
     checkStatus() {
+        let expectedFile = '';
         if (this.props.download.expectedFile !== '') {
+            expectedFile = this.props.download.expectedFile;
+        } else if ((typeof this.state.expectedFile) === "object" && Object.prototype.hasOwnProperty.call(this.state.expectedFile, "file")) {
+            expectedFile = this.state.expectedFile.file;
+        }
+
+        if (expectedFile !== '') {
             if (this.statusRequest) {
                 this.statusRequest.cancel();
             }
             this.statusRequest = DownloadHelper.requestDownloadStatus({
-                file_name: this.props.download.expectedFile,
+                file_name: expectedFile,
                 type: this.props.download.type
             });
 


### PR DESCRIPTION
**High level description:**

Added set state and callback to fix download failure

**Technical details:**

Converting the Award Container from a class component to a functional component created a timing issue with the downloadbottombar causing the download not be initiated.

**JIRA Ticket:**
[DEV-10493](https://federal-spending-transparency.atlassian.net/browse/DEV-10493)

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket

Reviewer(s):
- [ ] Code review complete
