### PR TITLE
10257 - added abs value to the last comparison for max neg values, fo…

### DIFF
--- a/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
+++ b/src/js/components/agency/visualizations/StatusOfFundsChart.jsx
@@ -341,7 +341,7 @@ const StatusOfFundsChart = ({
             const maxNegObl = negativeObligationsArray.length ? negativeObligationsArray.reduce((a, b) => Math.max(Math.abs(a), Math.abs(b))) : null;
 
             const largestPosValue = Math.max(maxPosTbr, maxPosObl);
-            const largestNegValue = Math.max(maxNegTbr, maxNegObl) * -1;
+            const largestNegValue = Math.max(Math.abs(maxNegTbr), Math.abs(maxNegObl)) * -1;
 
             if (negativeTbr || negativeObl) {
                 x.domain([largestNegValue, largestPosValue]).nice(2);
@@ -696,7 +696,7 @@ const StatusOfFundsChart = ({
             const maxNegOutlay = negativeOutlaysArray.length ? negativeOutlaysArray.reduce((a, b) => Math.max(Math.abs(a), Math.abs(b))) : null;
 
             const largestPosValue = Math.max(maxPosTbr, maxPosOutlay);
-            const largestNegValue = Math.max(maxNegTbr, maxNegOutlay) * -1;
+            const largestNegValue = Math.max(Math.abs(maxNegTbr), Math.abs(maxNegOutlay)) * -1;
 
             if (negativeTbr || negativeOutlay) {
                 x.domain([largestNegValue, largestPosValue]).nice(2);


### PR DESCRIPTION
…r outlays too

**High level description:**

This is a fix for a case that QA found in QAT.

**Technical details:**

I added abs value to the last comparison for the negative values, to determine the largest one;
NOTE: because of differences on the data in qat and local (which uses Prod data), we can't reproduce in local the problem she found in qat. So you need to either force that negative amount on that Program Activity where the bug is seen, or switch to using qat endpoints in local to see it

**JIRA Ticket:**
[DEV-10257](https://federal-spending-transparency.atlassian.net/browse/DEV-10257)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
