### PR TITLE
10501 - small fix for glossary scrollbar bug

### DIFF
--- a/src/js/components/glossary/Glossary.jsx
+++ b/src/js/components/glossary/Glossary.jsx
@@ -131,7 +131,7 @@ const Glossary = (props) => {
                 </div>
                 {loadingContent}
                 <Scrollbars
-                    style={{ contentHeight }}
+                    style={{ height: contentHeight }}
                     renderTrackVertical={track}
                     renderThumbVertical={thumb}
                     ref={(s) => setScrollbar(s)}>


### PR DESCRIPTION
**High level description:**

Small bug where the scrollbar wasn't appearing in longer Glossary entries, but it was there on the main Glossary page 

**Technical details:**

Looking through prs for what might have caused this, i saw that in Glossary.jsx the Scrollbars style prop had been changed recently. Apparently it needs 'height:' in the style prop.

**JIRA Ticket:**
[DEV-10501](https://federal-spending-transparency.atlassian.net/browse/DEV-10501)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
