### PR TITLE
10499 - made a class to undo nowrap for this link

### DIFF
--- a/src/_scss/pages/about/_section.scss
+++ b/src/_scss/pages/about/_section.scss
@@ -35,6 +35,9 @@
         a {
             white-space: nowrap;
         }
+        .do-wrap {
+            white-space: normal;
+        }
         p {
             font-size: rem(18);
             line-height: rem(28);

--- a/src/js/components/about/legal/AccessibilityPage.jsx
+++ b/src/js/components/about/legal/AccessibilityPage.jsx
@@ -13,8 +13,9 @@ const AccessibilityPage = () => (
         <p>
             The U.S. Department of the Treasury is committed to making USASpending.gov accessible
             to all members of the public and ensuring that it meets or exceeds the
-            requirements of&nbsp;
+            requirements of{' '}
             <a
+                className="about-section-content do-wrap"
                 target="_blank"
                 rel="noopener noreferrer"
                 href="https://section508.gov/">

--- a/src/js/components/about/legal/FOIAPage.jsx
+++ b/src/js/components/about/legal/FOIAPage.jsx
@@ -14,6 +14,7 @@ const FOIAPage = () => (
             If your FOIA request is about data and information for a specific agency, please contact
             that agency directly.&nbsp;
             <a
+                className="about-section-content do-wrap"
                 target="_blank"
                 rel="noopener noreferrer"
                 href="https://www.foia.gov/report-makerequest.html">

--- a/src/js/components/about/legal/PrivacyPage.jsx
+++ b/src/js/components/about/legal/PrivacyPage.jsx
@@ -104,8 +104,9 @@ const PrivacyPage = () => (
             to all the information and resources USASpending.gov provides.
         </p>
         <p>
-            If you&#39;d like to disable cookies,&nbsp;
+            If you&#39;d like to disable cookies,{' '}
             <a
+                className="about-section-content do-wrap"
                 target="_blank"
                 rel="noopener noreferrer"
                 href="https://www.usa.gov/optout-instructions">
@@ -140,13 +141,14 @@ const PrivacyPage = () => (
             apply retroactively.
         </p>
         <p>
-            <strong>NOTE:</strong> View or print the&nbsp;
+            <strong>NOTE:</strong> View or print the{' '}
             <a
+                className="about-section-content do-wrap"
                 target="_blank"
                 rel="noopener noreferrer"
                 href="https://www.fiscal.treasury.gov/pia.html">
                 Privacy Impact Assessment (PIA)
-            </a>&nbsp;performed on USAspending.gov.
+            </a>{' '}performed on USAspending.gov.
         </p>
     </LegalPage>
 );


### PR DESCRIPTION
**High level description:**

This link was running off the page at small screen sizes

**Technical details:**

Added a class to undo nowrap for this one link

**JIRA Ticket:**
[DEV-10499](https://federal-spending-transparency.atlassian.net/browse/DEV-10499)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
