### PR TITLE
10515 - removed a div with second usa-dt-modal class on it

### DIFF
--- a/src/js/components/covid19/assistanceListing/CFDADetailModal.jsx
+++ b/src/js/components/covid19/assistanceListing/CFDADetailModal.jsx
@@ -34,115 +34,113 @@ const CFDADetailModal = ({
             dialogClass="usa-dt-modal"
             verticallyCenter
             escapeExits>
-            <div className="usa-dt-modal">
-                <div className="usa-dt-modal__header">
-                    <h1 className="usa-dt-modal__title">
-                        {data.code && data.description ? `${data.code}: ${data.description}` : `${data.code}${data.description}`}
-                    </h1>
-                    <button
-                        className="usa-dt-modal__close-button"
-                        onClick={closeModal}
-                        title="Close"
-                        aria-label="Close">
-                        <FontAwesomeIcon icon="times" size="lg" />
-                    </button>
-                </div>
-                <div className="usa-dt-modal__body-covid19-cfda">
-                    <div className="usa-dt-modal__column">
-                        <div className="usa-dt-modal__section">
-                            <div className="usa-dt-modal__section__title">
-                                <h6>Administrative Agency</h6>
-                            </div>
-                            <div className="usa-dt-modal__section__description">
-                                <p className="administrative-agency">{data.cfda_federal_agency || '--'}</p>
-                            </div>
+            <div className="usa-dt-modal__header">
+                <h1 className="usa-dt-modal__title">
+                    {data.code && data.description ? `${data.code}: ${data.description}` : `${data.code}${data.description}`}
+                </h1>
+                <button
+                    className="usa-dt-modal__close-button"
+                    onClick={closeModal}
+                    title="Close"
+                    aria-label="Close">
+                    <FontAwesomeIcon icon="times" size="lg" />
+                </button>
+            </div>
+            <div className="usa-dt-modal__body-covid19-cfda">
+                <div className="usa-dt-modal__column">
+                    <div className="usa-dt-modal__section">
+                        <div className="usa-dt-modal__section__title">
+                            <h6>Administrative Agency</h6>
                         </div>
-                        <div className="usa-dt-modal__section">
-                            <div className="usa-dt-modal__section__title">
-                                <h6>Objectives</h6>
-                            </div>
-                            <div className="usa-dt-modal__section__description">
-                                <ReadMore text={data.cfda_objectives || '--'} />
-                            </div>
-                        </div>
-                        <div className="usa-dt-modal__section">
-                            <div className="usa-dt-modal__section__title">
-                                <h6>Program Website</h6>
-                            </div>
-                            <div className="usa-dt-modal__section__description">
-                                {data.cfda_website ?
-                                    <button
-                                        onClick={displayRedirectModal}
-                                        value={data.cfda_website}>
-                                        {data.cfda_website} <FontAwesomeIcon icon="external-link-alt" />
-                                    </button>
-                                    : '--'
-                                }
-                            </div>
-                        </div>
-                        <div className="usa-dt-modal__section">
-                            <div className="usa-dt-modal__section__title">
-                                <h6>Assistance Listing on SAM.gov</h6>
-                            </div>
-                            <div className="usa-dt-modal__section__description">
-                                {data.resource_link ?
-                                    <button
-                                        onClick={displayRedirectModal}
-                                        value={data.resource_link}>
-                                        {data.resource_link} <FontAwesomeIcon icon="external-link-alt" />
-                                    </button>
-                                    : '--'
-                                }
-                            </div>
+                        <div className="usa-dt-modal__section__description">
+                            <p className="administrative-agency">{data.cfda_federal_agency || '--'}</p>
                         </div>
                     </div>
-                    <div className="usa-dt-modal__column">
-                        <div className="usa-dt-modal__section">
-                            <div className="usa-dt-modal__section__title">
-                                <h6>Opportunities on Grants.gov From This Program</h6>
-                            </div>
-                            <div className="usa-dt-modal__section__description">
+                    <div className="usa-dt-modal__section">
+                        <div className="usa-dt-modal__section__title">
+                            <h6>Objectives</h6>
+                        </div>
+                        <div className="usa-dt-modal__section__description">
+                            <ReadMore text={data.cfda_objectives || '--'} />
+                        </div>
+                    </div>
+                    <div className="usa-dt-modal__section">
+                        <div className="usa-dt-modal__section__title">
+                            <h6>Program Website</h6>
+                        </div>
+                        <div className="usa-dt-modal__section__description">
+                            {data.cfda_website ?
                                 <button
                                     onClick={displayRedirectModal}
-                                    value={`https://www.grants.gov/search-grants.html?cfda=${data.code}`}>
-                                    {`https://www.grants.gov/search-grants.html?cfda=${data.code}`} <FontAwesomeIcon icon="external-link-alt" />
+                                    value={data.cfda_website}>
+                                    {data.cfda_website} <FontAwesomeIcon icon="external-link-alt" />
                                 </button>
-                                {data.code && <CFDAOpportunityTotals code={data.code} />}
-                            </div>
+                                : '--'
+                            }
                         </div>
-                        <div className="usa-dt-modal__section">
-                            <div className="usa-dt-modal__section__title">
-                                <h6>Applicant Elligibility</h6>
-                            </div>
-                            <div className="usa-dt-modal__section__description">
-                                <ReadMore text={data.applicant_eligibility || '--'} />
-                            </div>
+                    </div>
+                    <div className="usa-dt-modal__section">
+                        <div className="usa-dt-modal__section__title">
+                            <h6>Assistance Listing on SAM.gov</h6>
                         </div>
-                        <div className="usa-dt-modal__section">
-                            <div className="usa-dt-modal__section__title">
-                                <h6>Beneficiary Eligibility</h6>
-                            </div>
-                            <div className="usa-dt-modal__section__description">
-                                <ReadMore text={data.beneficiary_eligibility || '--'} />
-                            </div>
+                        <div className="usa-dt-modal__section__description">
+                            {data.resource_link ?
+                                <button
+                                    onClick={displayRedirectModal}
+                                    value={data.resource_link}>
+                                    {data.resource_link} <FontAwesomeIcon icon="external-link-alt" />
+                                </button>
+                                : '--'
+                            }
                         </div>
                     </div>
                 </div>
-                <div className="usa-dt-modal__footer">
-                    <div className="usa-dt-modal__footer__body">
-                        <div className="usa-dt-modal__footer__title">
-                            <h5>View this CFDA Program in Advanced Search</h5>
+                <div className="usa-dt-modal__column">
+                    <div className="usa-dt-modal__section">
+                        <div className="usa-dt-modal__section__title">
+                            <h6>Opportunities on Grants.gov From This Program</h6>
                         </div>
-                        <div className="usa-dt-modal__footer__description">
-                            <p>To see all COVID-19 awards funded by the program and more, visit the Advanced Search page</p>
-                        </div>
-                        <div className="usa-dt-modal__footer__button">
+                        <div className="usa-dt-modal__section__description">
                             <button
-                                onClick={updateAdvancedSearchFilters}
-                                value={data.code}>
-                                View in Advanced Search
+                                onClick={displayRedirectModal}
+                                value={`https://www.grants.gov/search-grants.html?cfda=${data.code}`}>
+                                {`https://www.grants.gov/search-grants.html?cfda=${data.code}`} <FontAwesomeIcon icon="external-link-alt" />
                             </button>
+                            {data.code && <CFDAOpportunityTotals code={data.code} />}
                         </div>
+                    </div>
+                    <div className="usa-dt-modal__section">
+                        <div className="usa-dt-modal__section__title">
+                            <h6>Applicant Elligibility</h6>
+                        </div>
+                        <div className="usa-dt-modal__section__description">
+                            <ReadMore text={data.applicant_eligibility || '--'} />
+                        </div>
+                    </div>
+                    <div className="usa-dt-modal__section">
+                        <div className="usa-dt-modal__section__title">
+                            <h6>Beneficiary Eligibility</h6>
+                        </div>
+                        <div className="usa-dt-modal__section__description">
+                            <ReadMore text={data.beneficiary_eligibility || '--'} />
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div className="usa-dt-modal__footer">
+                <div className="usa-dt-modal__footer__body">
+                    <div className="usa-dt-modal__footer__title">
+                        <h5>View this CFDA Program in Advanced Search</h5>
+                    </div>
+                    <div className="usa-dt-modal__footer__description">
+                        <p>To see all COVID-19 awards funded by the program and more, visit the Advanced Search page</p>
+                    </div>
+                    <div className="usa-dt-modal__footer__button">
+                        <button
+                            onClick={updateAdvancedSearchFilters}
+                            value={data.code}>
+                                View in Advanced Search
+                        </button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
**High level description:**

The layout in this modal was off

**Technical details:**

I noticed that the usa-dt-modal class has width: 91.67% on it, and that for this modal there were two divs with that classname. The first one set the width for the modal in relation to the page, and the second one was setting the width in realtion to the modal. Removing the div with the second usa-dt-modal class solved the problem and didn't affect the rest of the layout.
The 'Files Changed' for this pr is misleading. All I did was remove the div that was right under the <Modal> element.

**JIRA Ticket:**
[DEV-10515](https://federal-spending-transparency.atlassian.net/browse/DEV-10515)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
