### PR TITLE
Bug/10513 nao filter

### DIFF
--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -107,7 +107,16 @@ const ResultsTableContainer = (props) => {
         // Append the current tab's award types to the search params if the Award Type filter
         // isn't populated. If it is, perform a search on the intersection of the current tab's
         // award types and the Award Type filter's content
-        const searchParamsTemp = Object.assign(new SearchAwardsOperation(), searchParams);
+        const searchParamsTemp = new SearchAwardsOperation();
+        searchParamsTemp.fromState(props.filters);
+
+        // if subawards is true, newAwardsOnly cannot be true, so we remove
+        // dateType for this request; also has to be done for the tabCounts request
+        if (props.subaward && searchParamsTemp.dateType) {
+            delete searchParamsTemp.dateType;
+        }
+
+        // todo - confirm that this block is still necessary, bc searchParams state var is no longer updated in updateFilters
         // generate an array of award type codes representing the current table tab we're showing
         // and use a different mapping if we're showing a subaward table vs a prime award table
         const groupsFromTableType =
@@ -265,15 +274,6 @@ const ResultsTableContainer = (props) => {
     };
 
     const updateFilters = throttle(() => {
-        const newSearch = new SearchAwardsOperation();
-        newSearch.fromState(props.filters);
-
-        // if subawards is true, newAwardsOnly cannot be true, so we remove
-        // dateType for this request; also has to be done for the tabCounts request
-        if (props.subaward && newSearch.dateType) {
-            delete newSearch.dateType;
-        }
-        setSearchParams(newSearch);
         setPage(1);
         performSearch(true);
     }, 350);
@@ -354,7 +354,8 @@ const ResultsTableContainer = (props) => {
         const searchParamsTemp = new SearchAwardsOperation();
         searchParamsTemp.fromState(props.filters);
 
-        // if subawards is true, newAwardsOnly cannot be true, so we remove dateType for this request; also has to be done for the main request, in performSearch
+        // if subawards is true, newAwardsOnly cannot be true, so we remove dateType for this request
+        // also has to be done for the main request, in performSearch
         if (props.subaward && searchParamsTemp.dateType) {
             delete searchParamsTemp.dateType;
         }
@@ -453,8 +454,6 @@ const ResultsTableContainer = (props) => {
     }, 400), [tableType, sort]);
 
     useEffect(throttle(() => {
-        loadColumns();
-
         if (initialRender.current === false) {
             if (props.subaward && !props.noApplied) {
                 // subaward toggle changed, update the search object
@@ -476,7 +475,16 @@ const ResultsTableContainer = (props) => {
                 tabCountRequest.cancel();
             }
         };
-    }, 400), [page, props.noApplied, location, props.subaward]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, 400), [props]);
+
+    useEffect(() => {
+        loadColumns();
+        if (SearchHelper.isSearchHashReady(location)) {
+            pickDefaultTab();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     if (!columns[tableType]) {
         return null;

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -104,9 +104,7 @@ const ResultsTableContainer = (props) => {
         props.setAppliedFilterCompletion(false);
         const tableTypeTemp = tableType;
 
-        // Append the current tab's award types to the search params if the Award Type filter
-        // isn't populated. If it is, perform a search on the intersection of the current tab's
-        // award types and the Award Type filter's content
+        // get searchParams from state
         const searchParamsTemp = new SearchAwardsOperation();
         searchParamsTemp.fromState(props.filters);
 
@@ -116,7 +114,6 @@ const ResultsTableContainer = (props) => {
             delete searchParamsTemp.dateType;
         }
 
-        // todo - confirm that this block is still necessary, bc searchParams state var is no longer updated in updateFilters
         // generate an array of award type codes representing the current table tab we're showing
         // and use a different mapping if we're showing a subaward table vs a prime award table
         const groupsFromTableType =
@@ -274,6 +271,12 @@ const ResultsTableContainer = (props) => {
     };
 
     const updateFilters = throttle(() => {
+        // the searchParams state var is now only used in the
+        // block using intersection in performSearch
+        const newSearch = new SearchAwardsOperation();
+        newSearch.fromState(props.filters);
+        setSearchParams(newSearch);
+
         setPage(1);
         performSearch(true);
     }, 350);

--- a/src/js/models/v1/search/SearchAwardsOperation.js
+++ b/src/js/models/v1/search/SearchAwardsOperation.js
@@ -167,9 +167,13 @@ class SearchAwardsOperation {
             }];
         }
 
-        // Add dateType to timePeriod object
+        // If new awards only has been selected
+        // Add dateType = new_awards_only to all selected fy
         if (this.dateType) {
-            filters[rootKeys.timePeriod][0][timePeriodKeys.dateType] = 'new_awards_only';
+            filters[rootKeys.timePeriod].forEach((item) => {
+                // eslint-disable-next-line no-param-reassign
+                item[timePeriodKeys.dateType] = 'new_awards_only';
+            });
         }
 
         // Add award types


### PR DESCRIPTION
**High level description:**

Filters were not being successfully added to the filters array in the spending_by_award api call.
The ticket specifies the 'New Awards Only' filter but it was true for all filters.

**Technical details:**

I added a 'Note for testing' in the ticket which will help explain the exact issue to solve here.

There were a few problems involved. Ther first was in SearchAwardsOperation, to add the 'new_awards_only' field to all fy instead of only the first one.
Another problem was that in the performSearch function, where we were making the searchParamsTemp obj, using Object.assign and the searchParams state var, it was always behind due to timing issues in the code. The updateFilters function was updating the state var but not in time for those changes to go into the searchParamsTemp obj in performSearch, and that's why the filters array in the spending_by_award api call was always behind.
I also noticed that we needed to add the statements from the ComponentDidMount block in the class component into a useEffect with [] as a dependency, to run only on initial render.

**JIRA Ticket:**
[DEV-10513](https://federal-spending-transparency.atlassian.net/browse/DEV-10513)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
