### PR TITLE
10569 - Hotfix:  Advanced search - Fixed issue where new table rows are not returned after scrolling to the bottom of the table

### DIFF
--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -394,7 +394,6 @@ const ResultsTableContainer = (props) => {
             // more pages are available, load them
             setPage(page + 1);
             setLoadNextPage(true);
-            // performSearch();
         }
     };
 

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -93,6 +93,8 @@ const ResultsTableContainer = (props) => {
     const [error, setError] = useState(false);
     const [results, setResults] = useState([]);
     const [tableInstance, setTableInstance] = useState(`${uniqueId()}`);
+    const [isLoadingNextPage, setLoadNextPage] = useState(false);
+
     const initialRender = useRef(true);
 
     const performSearch = throttle((newSearch = false) => {
@@ -391,7 +393,8 @@ const ResultsTableContainer = (props) => {
         if (!lastPage) {
             // more pages are available, load them
             setPage(page + 1);
-            performSearch();
+            setLoadNextPage(true);
+            // performSearch();
         }
     };
 
@@ -476,7 +479,14 @@ const ResultsTableContainer = (props) => {
                 tabCountRequest.cancel();
             }
         };
-    }, 400), [page, props.noApplied, location, props.subaward]);
+    }, 400), [props.noApplied, location, props.subaward]);
+
+    useEffect(throttle(() => {
+        if (isLoadingNextPage) {
+            performSearch();
+            setLoadNextPage(false);
+        }
+    }, 400), [isLoadingNextPage]);
 
     if (!columns[tableType]) {
         return null;


### PR DESCRIPTION
**High level description:**

Advanced search - Fixed issue where new table rows are not returned after scrolling to the bottom of the table

**Technical details:**

Updated when we're performing a new search based on paging.  Paging should happen when the user scrolls to the bottom of the table.

**JIRA Ticket:**
[DEV-10569](https://federal-spending-transparency.atlassian.net/browse/DEV-10569)

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket

Reviewer(s):
- [ ] Code review complete
