### PR TITLE
10099 - Added event names to GA events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ db.sql
 # local lighthouse reports
 .lighthouseci/
 
+# local settings
+/src/js/LocalConstants.js
+

--- a/.gitignore
+++ b/.gitignore
@@ -77,4 +77,5 @@ db.sql
 
 # local settings
 /src/js/LocalConstants.js
+*/LocalConstants.js
 

--- a/src/js/components/aboutTheDataSidebar/AboutTheDataListView.jsx
+++ b/src/js/components/aboutTheDataSidebar/AboutTheDataListView.jsx
@@ -18,6 +18,7 @@ const AboutTheDataListView = ({ section, selectItem }) => {
         e.preventDefault();
         selectItem(index, section);
         Analytics.event({
+            event: 'atd_entry_name',
             category: 'About the Data',
             action: `Clicked ${list.name}`
         });

--- a/src/js/components/award/table/DetailsTabBar.jsx
+++ b/src/js/components/award/table/DetailsTabBar.jsx
@@ -22,6 +22,7 @@ export default class DetailsTabBar extends React.Component {
             const onClick = tab.internal === 'subaward'
                 ? () => {
                     Analytics.event({
+                        event: 'award_history_table_tab',
                         category: 'Award Page',
                         action: 'Subaward Table',
                         label: `${this.props.awardId}`

--- a/src/js/components/covid19/Covid19Page.jsx
+++ b/src/js/components/covid19/Covid19Page.jsx
@@ -96,7 +96,7 @@ const Covid19Page = ({ loading }) => {
             left: 0,
             behavior: 'smooth'
         });
-        Analytics.event({ category: 'COVID-19 - Profile', action: `${section} - click` });
+        Analytics.event({ event: 'covid_profile', category: 'COVID-19 - Profile', action: `${section} - click` });
     };
 
     useEffect(() => {

--- a/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
+++ b/src/js/components/covid19/assistanceListing/SpendingByCFDA.jsx
@@ -69,7 +69,7 @@ const SpendingByCFDA = ({ publicLaw, handleExternalLinkClick }) => {
     const changeActiveTab = (tab) => {
         const selectedTab = financialAssistanceTabs.find((item) => item.internal === tab).internal;
         setActiveTab(selectedTab);
-        Analytics.event({ category: 'COVID-19 - Award Spending by CFDA', action: `${activeTab} - click` });
+        Analytics.event({ event: 'covid_award_spending_cfda', category: 'COVID-19 - Award Spending by CFDA', action: `${activeTab} - click` });
     };
 
     // Keep track of previous tab to prevent duplicate requests in summary

--- a/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
+++ b/src/js/components/covid19/awardSpendingAgency/AwardSpendingAgency.jsx
@@ -128,7 +128,7 @@ const AwardSpendingAgency = ({ publicLaw }) => {
             subtitle: tabSubtitle
         });
 
-        Analytics.event({ category: 'COVID-19 - Award Spending by Agency', action: `${tabSubtitle} - click` });
+        Analytics.event({ event: 'covid_award_spending_agency', category: 'COVID-19 - Award Spending by Agency', action: `${tabSubtitle} - click` });
     };
 
     const scrollIntoViewTable = (loading, error, errorOrLoadingRef, tableWrapperRef, margin, scrollOptions) => {

--- a/src/js/components/covid19/budgetCategories/BudgetCategories.jsx
+++ b/src/js/components/covid19/budgetCategories/BudgetCategories.jsx
@@ -70,7 +70,7 @@ const BudgetCategories = ({ publicLaw }) => {
         const tabInternal = tabs.filter((item) => item.internal === tab)[0].internal;
 
         setActiveTab(tabInternal);
-        Analytics.event({ category: 'COVID-19 - Profile', action: `Total Spending - ${activeTab}` });
+        Analytics.event({ event: 'covid_profile', category: 'COVID-19 - Profile', action: `Total Spending - ${activeTab}` });
     };
 
     useEffect(() => {

--- a/src/js/components/covid19/recipient/RecipientSection.jsx
+++ b/src/js/components/covid19/recipient/RecipientSection.jsx
@@ -21,7 +21,7 @@ const RecipientSection = ({ publicLaw }) => {
     const changeActiveTab = (tab) => {
         const tabInternal = tabs.find((item) => item.internal === tab).internal;
         setActiveTab(tabInternal);
-        Analytics.event({ category: 'covid-19 - profile', action: `award spending by recipient - ${activeTab}` });
+        Analytics.event({ event: 'covid_profile', category: 'covid-19 - profile', action: `award spending by recipient - ${activeTab}` });
     };
     return (
         <div className="body__content recipient__container">

--- a/src/js/components/dataDives/EquityCovidSpendingPage.jsx
+++ b/src/js/components/dataDives/EquityCovidSpendingPage.jsx
@@ -21,6 +21,7 @@ require('pages/equityCovidSpendingPage/equityCovidSpendingPage.scss');
 const EquityCovidSpendingPage = () => {
     const analyticsEvent = (action) => {
         Analytics.event({
+            event: 'Data Dives',
             category: 'Data Dives: Equity Covid Spending Page',
             action
         });

--- a/src/js/components/dataDives/shared/MainCards.jsx
+++ b/src/js/components/dataDives/shared/MainCards.jsx
@@ -32,6 +32,7 @@ const MainCards = ({ contentObject }) => {
 
     const analyticsEvent = (item) => {
         Analytics.event({
+            event: 'Data Dives',
             category: 'Data Dives: Equity Covid Spending Page Main Card',
             action: `Clicked ${item} See Project Button`
         });

--- a/src/js/components/explorer/detail/header/DetailHeader.jsx
+++ b/src/js/components/explorer/detail/header/DetailHeader.jsx
@@ -35,6 +35,7 @@ const propTypes = {
 
 const exitExplorer = (target) => {
     Analytics.event({
+        event: 'Spending Explorer - Award Click Exit',
         category: 'Spending Explorer - Exit',
         action: target
     });

--- a/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
+++ b/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
@@ -54,6 +54,7 @@ export default class ExplorerSidebar extends React.Component {
         // only log analytic event after 10 seconds
         this._queuedAnalyticEvent = window.setTimeout(() => {
             Analytics.event({
+                event: 'spending-explorer-time-period',
                 category: 'Spending Explorer - Time Period',
                 action: `Q${quarter} FY${fiscalYear}`
             });

--- a/src/js/components/explorer/detail/visualization/ExplorerVisualization.jsx
+++ b/src/js/components/explorer/detail/visualization/ExplorerVisualization.jsx
@@ -48,6 +48,7 @@ export default class ExplorerVisualization extends React.Component {
         window.addEventListener('resize', this.measureWidth);
 
         Analytics.event({
+            event: 'Spending Explorer - Visualization Type',
             category: 'Spending Explorer - Visualization Type',
             action: this.state.viewType
         });
@@ -75,6 +76,7 @@ export default class ExplorerVisualization extends React.Component {
         });
 
         Analytics.event({
+            event: 'Spending Explorer - Visualization Type',
             category: 'Spending Explorer - Visualization Type',
             action: viewType
         });

--- a/src/js/components/glossary/search/GlossarySearchResults.jsx
+++ b/src/js/components/glossary/search/GlossarySearchResults.jsx
@@ -19,6 +19,7 @@ const propTypes = {
 export default class GlossarySearchResults extends React.Component {
     static logGlossaryTermEvent(term) {
         Analytics.event({
+            event: 'glossary-link',
             category: 'Glossary',
             action: 'Clicked Glossary Term',
             label: term

--- a/src/js/components/glossary/search/ResultItem.jsx
+++ b/src/js/components/glossary/search/ResultItem.jsx
@@ -91,6 +91,7 @@ export default class ResultItem extends React.Component {
     clickedLink(term) {
         this.props.selectTerm(this.props.item);
         Analytics.event({
+            event: 'glossary-link',
             category: 'Glossary',
             action: `Clicked ${term.target.innerText}`
         });

--- a/src/js/components/homepageUpdate/AwardSearch/AwardSearch.jsx
+++ b/src/js/components/homepageUpdate/AwardSearch/AwardSearch.jsx
@@ -126,6 +126,7 @@ const AwardSearch = () => {
             });
     };
     const trackClick = (buttonName) => Analytics.event({
+        event: 'homepage_search_award_data_section',
         category: 'Homepage',
         action: 'Link',
         label: `carousel ${buttonName}`

--- a/src/js/components/homepageUpdate/FeaturedContent/FeaturedContent.jsx
+++ b/src/js/components/homepageUpdate/FeaturedContent/FeaturedContent.jsx
@@ -11,11 +11,13 @@ import Analytics from 'helpers/analytics/Analytics';
 
 const FeaturedContent = () => {
     const trackFeaturedCovidLink = () => Analytics.event({
+        event: 'homepage_featured_content_links',
         category: 'Homepage',
         action: 'Link',
         label: 'covid-19 featured content'
     });
     const trackFeaturedResourcesLink = () => Analytics.event({
+        event: 'homepage_featured_content_links',
         category: 'Homepage',
         action: 'Link',
         label: 'resources featured content'

--- a/src/js/components/homepageUpdate/HomepageExploreToggle/HomepageExploreToggle.jsx
+++ b/src/js/components/homepageUpdate/HomepageExploreToggle/HomepageExploreToggle.jsx
@@ -19,6 +19,7 @@ const exploreData = [
         buttonLink: '/agency',
         buttonSize: 'sm',
         action: () => Analytics.event({
+            event: 'homepage_explore-the-data',
             category: 'Homepage',
             action: 'Link',
             label: 'explore agency profiles card'
@@ -32,6 +33,7 @@ const exploreData = [
         buttonLink: '/recipient',
         buttonSize: 'sm',
         action: () => Analytics.event({
+            event: 'homepage_explore-the-data',
             category: 'Homepage',
             action: 'Link',
             label: 'view recipient profiles card'
@@ -45,6 +47,7 @@ const exploreData = [
         buttonLink: '/state',
         buttonSize: 'sm',
         action: () => Analytics.event({
+            event: 'homepage_explore-the-data',
             category: 'Homepage',
             action: 'Link',
             label: 'browse state profiles card'
@@ -61,6 +64,7 @@ const accessData = [
         buttonText: 'Go to award data download',
         buttonLink: '/download_center/custom_award_data',
         action: () => Analytics.event({
+            event: 'homepage_explore-the-data',
             category: 'Homepage',
             action: 'Link',
             label: 'custom award data download card'
@@ -74,6 +78,7 @@ const accessData = [
         buttonLink: '/download_center/custom_account_data',
         buttonSize: 'sm',
         action: () => Analytics.event({
+            event: 'homepage_explore-the-data',
             category: 'Homepage',
             action: 'Link',
             label: 'account data download'
@@ -87,6 +92,7 @@ const accessData = [
         buttonLink: 'https://api.usaspending.gov/docs/endpoints',
         govLink: true,
         action: () => Analytics.event({
+            event: 'homepage_explore-the-data',
             category: 'Homepage',
             action: 'Link',
             label: 'view api endpoints'

--- a/src/js/components/homepageUpdate/HomepageResources/HomepageResources.jsx
+++ b/src/js/components/homepageUpdate/HomepageResources/HomepageResources.jsx
@@ -32,6 +32,7 @@ const HomepageResources = () => {
             ),
             buttonLink: '/federal-spending-guide',
             action: () => Analytics.event({
+                event: 'homepage_find-resources',
                 category: 'Homepage',
                 action: 'Link',
                 label: 'learn how to use the data card'
@@ -53,6 +54,7 @@ const HomepageResources = () => {
             ),
             buttonLink: '/data-dictionary',
             action: () => Analytics.event({
+                event: 'homepage_find-resources',
                 category: 'Homepage',
                 action: 'Link',
                 label: 'data dictionary card'
@@ -74,6 +76,7 @@ const HomepageResources = () => {
             ),
             action: () => {
                 Analytics.event({
+                    event: 'homepage_find-resources',
                     category: 'Homepage',
                     action: 'Link',
                     label: 'data model card'
@@ -101,6 +104,7 @@ const HomepageResources = () => {
             ),
             action: () => {
                 Analytics.event({
+                    event: 'homepage_find-resources',
                     category: 'Homepage',
                     action: 'Link',
                     label: 'glossary card'

--- a/src/js/components/homepageUpdate/ReadyToGetStarted/ReadyToGetStarted.jsx
+++ b/src/js/components/homepageUpdate/ReadyToGetStarted/ReadyToGetStarted.jsx
@@ -17,6 +17,7 @@ const cardObjects = [
         buttonText: 'Go to Award Search',
         buttonLink: '/search',
         action: () => Analytics.event({
+            event: 'homepage_ready-to-get-started',
             category: 'Homepage',
             action: 'Link',
             label: 'award search card'
@@ -31,6 +32,7 @@ const cardObjects = [
         buttonText: 'Dive into Spending Explorer',
         buttonLink: '/explorer',
         action: () => Analytics.event({
+            event: 'homepage_ready-to-get-started',
             category: 'Homepage',
             action: 'Link',
             label: 'spending explorer card'
@@ -45,6 +47,7 @@ const cardObjects = [
         buttonText: 'Browse Recipient Profiles',
         buttonLink: '/recipient',
         action: () => Analytics.event({
+            event: 'homepage_ready-to-get-started',
             category: 'Homepage',
             action: 'Link',
             label: 'spending profiles card'
@@ -59,6 +62,7 @@ const cardObjects = [
         buttonText: 'Read about the Data Sources',
         buttonLink: '/data-sources',
         action: () => Analytics.event({
+            event: 'homepage_ready-to-get-started',
             category: 'Homepage',
             action: 'Link',
             label: 'resources card'

--- a/src/js/components/homepageUpdate/SummaryStats.jsx
+++ b/src/js/components/homepageUpdate/SummaryStats.jsx
@@ -23,6 +23,7 @@ const SummaryStats = () => {
     const [, , { year: latestFy, period: latestPeriod }] = useLatestAccountData();
 
     const trackExplorerLink = () => Analytics.event({
+        event: 'homepage-summary-stats',
         category: 'Homepage',
         action: 'Link',
         label: 'explorer'

--- a/src/js/components/homepageUpdate/WordOfTheDay/WordOfTheDay.jsx
+++ b/src/js/components/homepageUpdate/WordOfTheDay/WordOfTheDay.jsx
@@ -133,6 +133,7 @@ const WordOfTheDay = () => {
 
     const readMoreAction = () => {
         Analytics.event({
+            event: 'homepage-word-of-the-day',
             category: 'Homepage',
             action: 'Link',
             label: 'word of the day'

--- a/src/js/components/homepageUpdate/features/FeatureDropdown.jsx
+++ b/src/js/components/homepageUpdate/features/FeatureDropdown.jsx
@@ -11,6 +11,7 @@ import Analytics from 'helpers/analytics/Analytics';
 
 const clickedHomepageLink = (route) => {
     Analytics.event({
+        event: 'homepage_link_click',
         category: 'Homepage - Link',
         action: route
     });

--- a/src/js/components/homepageUpdate/heroUpdate/HeroUpdate.jsx
+++ b/src/js/components/homepageUpdate/heroUpdate/HeroUpdate.jsx
@@ -18,11 +18,13 @@ const HeroUpdate = () => {
     const [isLargeScreen, setIsLargeScreen] = useState(window.innerWidth >= mediumScreen);
 
     const trackSearchLink = () => Analytics.event({
+        event: 'homepage_start_searching_awards',
         category: 'Homepage',
         action: 'Link',
         label: 'search'
     });
     const trackAboutLink = () => Analytics.event({
+        event: 'homepage_link',
         category: 'Homepage',
         action: 'Link',
         label: 'about'

--- a/src/js/components/keyword/KeywordPage.jsx
+++ b/src/js/components/keyword/KeywordPage.jsx
@@ -70,6 +70,7 @@ export default class KeywordPage extends React.Component {
         this.props.startDownload();
         this.showModal();
         Analytics.event({
+            event: 'keyword-download',
             category: 'Keyword Search - Download',
             action: this.props.keyword
         });

--- a/src/js/components/sharedComponents/FooterExternalLink.jsx
+++ b/src/js/components/sharedComponents/FooterExternalLink.jsx
@@ -15,6 +15,7 @@ const propTypes = {
 
 const clickedFooterLink = (route) => {
     Analytics.event({
+        event: 'footer-external-links',
         category: 'Footer - Link',
         action: route
     });

--- a/src/js/components/sharedComponents/StayInTouch.jsx
+++ b/src/js/components/sharedComponents/StayInTouch.jsx
@@ -21,16 +21,19 @@ const StayInTouch = (pageName) => {
     const dispatch = useDispatch();
 
     const trackLinkSignUp = () => Analytics.event({
+        event: 'stay-in-touch',
         category: pageName,
         action: 'Link',
         label: 'sign-up'
     });
     const trackLinkLearnMore = () => Analytics.event({
+        event: 'stay-in-touch',
         category: pageName,
         action: 'Link',
         label: 'learn-more'
     });
     const trackLinkSurvey = () => Analytics.event({
+        event: 'stay-in-touch',
         category: pageName,
         action: 'Survey',
         label: 'survey'

--- a/src/js/components/sharedComponents/Subscribe.jsx
+++ b/src/js/components/sharedComponents/Subscribe.jsx
@@ -15,6 +15,7 @@ export default class Subscribe extends React.Component {
     };
 
     trackLink = () => Analytics.event({
+        event: 'stay-in-touch',
         category: this.props.pageName,
         action: 'Link',
         label: 'sign-up'

--- a/src/js/components/sharedComponents/Training.jsx
+++ b/src/js/components/sharedComponents/Training.jsx
@@ -17,6 +17,7 @@ const propTypes = {
 
 const Training = (pageName) => {
     const trackLink = () => Analytics.event({
+        event: 'stay-in-touch',
         category: pageName,
         action: 'Link',
         label: 'learn-more'

--- a/src/js/components/sharedComponents/header/DropdownItem.jsx
+++ b/src/js/components/sharedComponents/header/DropdownItem.jsx
@@ -25,6 +25,7 @@ const propTypes = {
 
 const clickedHeaderLink = (route) => {
     Analytics.event({
+        event: 'Header - Link',
         category: 'Header - Link',
         action: route
     });

--- a/src/js/components/sharedComponents/header/NavbarWrapper.jsx
+++ b/src/js/components/sharedComponents/header/NavbarWrapper.jsx
@@ -36,6 +36,7 @@ const NavbarWrapper = React.memo(() => {
 
     const clickedHeaderLink = (route) => {
         Analytics.event({
+            event: 'Header - Link',
             category: 'Header - Link',
             action: route
         });

--- a/src/js/components/sharedComponents/header/mobile/MobileDropdownItem.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileDropdownItem.jsx
@@ -25,6 +25,7 @@ const propTypes = {
 };
 const clickedHeaderLink = (route) => {
     Analytics.event({
+        event: 'Header - Link',
         category: 'Header - Link',
         action: route
     });

--- a/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileNav.jsx
@@ -75,6 +75,7 @@ const MobileNav = React.memo((props) => {
 
     const clickedHeaderLink = (route) => {
         Analytics.event({
+            event: 'Header Link - Mobile',
             category: 'Header - Link',
             action: route
         });

--- a/src/js/components/sharedComponents/header/mobile/MobileTop.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileTop.jsx
@@ -11,6 +11,7 @@ import { Link } from 'react-router-dom';
 
 const clickedHeaderLink = (route) => {
     Analytics.event({
+        event: 'Header Link - Mobile',
         category: 'Header - Link',
         action: route
     });

--- a/src/js/containers/Footer.jsx
+++ b/src/js/containers/Footer.jsx
@@ -31,6 +31,7 @@ const propTypes = {
 
 const clickedFooterLink = (route) => {
     Analytics.event({
+        event: 'footer-external-links',
         category: 'Footer - Link',
         action: route
     });

--- a/src/js/containers/award/AwardContainer.jsx
+++ b/src/js/containers/award/AwardContainer.jsx
@@ -133,6 +133,7 @@ const AwardContainer = (props) => {
 
     const fetchAwardDownloadFile = (awardCategory = props.award.category, awardId = props.match.params.awardId) => {
         Analytics.event({
+            event: 'award-profile-download-initiated',
             category: 'Award Profile',
             action: 'Download Initiated',
             label: `Award Id ${awardId}`

--- a/src/js/containers/covid19/LinkToAdvancedSearchContainer.jsx
+++ b/src/js/containers/covid19/LinkToAdvancedSearchContainer.jsx
@@ -39,6 +39,7 @@ const FooterLinkToAdvancedSearchContainer = () => {
         addDefCodesToAdvancedSearchFilter();
         history.push('/search');
         Analytics.event({
+            event: 'covid-advanced-search-click',
             category: 'COVID-19 - More Information',
             action: 'advanced search click'
         });
@@ -46,6 +47,7 @@ const FooterLinkToAdvancedSearchContainer = () => {
 
     const clickedCustomAcctData = () => {
         Analytics.event({
+            event: 'covid-custom-account-click',
             category: 'COVID-19 - More Information',
             action: 'custom account data click'
         });

--- a/src/js/containers/covid19/assistanceListing/SpendingByCFDAContainer.jsx
+++ b/src/js/containers/covid19/assistanceListing/SpendingByCFDAContainer.jsx
@@ -194,6 +194,7 @@ const SpendingByCFDAContainer = ({ activeTab, scrollIntoView }) => {
         ));
         history.push('/search');
         Analytics.event({
+            event: 'covid_spending_assistance_listing',
             category: `COVID-19 - Award Spending by Assistance Listing - ${activeTab}`,
             action: 'CFDA listing click',
             label: cfdaData.description

--- a/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
+++ b/src/js/containers/covid19/awardSpendingAgency/AwardSpendingAgencyTableContainer.jsx
@@ -130,6 +130,7 @@ const AwardSpendingAgencyTableContainer = (props) => {
 
     const clickedAgencyProfile = (agencyName) => {
         Analytics.event({
+            event: 'covid_spending_agency',
             category: `COVID-19 - Total Spending by Agency - ${props.type}`,
             action: 'agency profile click',
             label: agencyName

--- a/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
+++ b/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
@@ -361,7 +361,7 @@ const BudgetCategoriesTableContainer = (props) => {
 
     const spendingCategoryOnChange = (key) => {
         setSpendingCategory(key);
-        Analytics.event({ category: 'covid-19 - profile', action: `total spending - ${props.type} - ${spendingCategory}` });
+        Analytics.event({ event: 'covid_profile', category: 'covid-19 - profile', action: `total spending - ${props.type} - ${spendingCategory}` });
     };
 
     const spendingViewPicker = () => (

--- a/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
+++ b/src/js/containers/covid19/budgetCategories/BudgetCategoriesTableContainer.jsx
@@ -148,6 +148,7 @@ const BudgetCategoriesTableContainer = (props) => {
 
     const clickedAgencyProfile = (agencyName) => {
         Analytics.event({
+            event: 'covid_spending_agency',
             category: `COVID-19 - Total Spending by Budget Category - ${props.type}`,
             action: `${spendingCategory} - agency profile click`,
             label: agencyName
@@ -156,6 +157,7 @@ const BudgetCategoriesTableContainer = (props) => {
 
     const clickedFedAcctProfile = (accountName) => {
         Analytics.event({
+            event: 'covid_spending_budget',
             category: `COVID-19 - Total Spending by Budget Category - ${props.type}`,
             action: `${spendingCategory} - federal account profile click`,
             label: accountName

--- a/src/js/containers/covid19/recipient/RecipientTableContainer.jsx
+++ b/src/js/containers/covid19/recipient/RecipientTableContainer.jsx
@@ -104,6 +104,7 @@ const loanColumns = [
 
 const clickedRecipientProfile = (recipientName) => {
     Analytics.event({
+        event: 'covid_spending_recipient',
         category: 'COVID-19 - Award Spending by Recipient - Recipients',
         action: 'recipient profile click',
         label: recipientName

--- a/src/js/containers/covid19/recipient/SpendingByRecipientContainer.jsx
+++ b/src/js/containers/covid19/recipient/SpendingByRecipientContainer.jsx
@@ -66,7 +66,7 @@ const SpendingByRecipientContainer = () => {
     const changeActiveTab = (tab) => {
         const selectedTab = awardTypeTabs.find((item) => item.internal === tab).internal;
         setActiveTab(selectedTab);
-        Analytics.event({ category: 'COVID-19 - Award Spending by Recipient - Recipients', action: `${activeTab} - click` });
+        Analytics.event({ event: 'covid_spending_recipient', category: 'COVID-19 - Award Spending by Recipient - Recipients', action: `${activeTab} - click` });
     };
 
     useEffect(() => {

--- a/src/js/containers/covid19/recipient/map/MapContainer.jsx
+++ b/src/js/containers/covid19/recipient/map/MapContainer.jsx
@@ -114,6 +114,7 @@ export class MapContainer extends React.Component {
             () => this.prepareFetch(true)
         );
         Analytics.event({
+            event: 'covid_spending_recipient_locations',
             category: 'covid-19 - award spending by recipient - recipient locations',
             action: `${this.state.activeFilters.awardType} - amount type - ${value}`
         });
@@ -132,6 +133,7 @@ export class MapContainer extends React.Component {
             () => this.prepareFetch(true)
         );
         Analytics.event({
+            event: 'covid_spending_recipient_locations',
             category: 'covid-19 - award spending by recipient - recipient locations',
             action: `${this.state.activeFilters.awardType} - area type - ${value}`
         });
@@ -146,6 +148,7 @@ export class MapContainer extends React.Component {
             () => this.prepareFetch(true)
         );
         Analytics.event({
+            event: 'covid_spending_recipient_locations',
             category: 'covid-19 - award spending by recipient - recipient locations',
             action: `${this.state.activeFilters.awardType} - spending type - ${value}`
         });
@@ -160,6 +163,7 @@ export class MapContainer extends React.Component {
             () => this.prepareFetch(true)
         );
         Analytics.event({
+            event: 'covid_spending_recipient_locations',
             category: 'covid-19 - award spending by recipient - recipient locations',
             action: `${this.state.activeFilters.awardType} - recipient type - ${value}`
         });
@@ -174,6 +178,7 @@ export class MapContainer extends React.Component {
             () => this.prepareFetch(true)
         );
         Analytics.event({
+            event: 'covid_spending_recipient_locations',
             category: 'covid-19 - award spending by recipient - recipient locations',
             action: `award type - ${value}`
         });

--- a/src/js/containers/explorer/detail/DetailContentContainer.jsx
+++ b/src/js/containers/explorer/detail/DetailContentContainer.jsx
@@ -108,6 +108,7 @@ export class DetailContentContainer extends React.Component {
 
         // log the analytics event for a Spending Explorer starting point
         Analytics.event({
+            event: 'Spending Explorer - Starting Point',
             category: 'Spending Explorer - Starting Point',
             action: rootType
         });
@@ -299,6 +300,7 @@ export class DetailContentContainer extends React.Component {
         }
 
         Analytics.event({
+            event: 'Spending Explorer - Data Type',
             category: 'Spending Explorer - Data Type',
             action: request.subdivision
         });
@@ -320,6 +322,7 @@ export class DetailContentContainer extends React.Component {
             window.open(`/award/${id}`, "_blank");
 
             Analytics.event({
+                event: 'Spending Explorer - Award Click Exit',
                 category: 'Spending Explorer - Exit',
                 action: `/award/${id}`
             });
@@ -385,6 +388,7 @@ export class DetailContentContainer extends React.Component {
         });
 
         Analytics.event({
+            event: 'Spending Explorer - Drilldown',
             category: 'Spending Explorer - Drilldown',
             action: filterBy,
             label: `${data.name} - ${data.id}`

--- a/src/js/containers/keyword/KeywordContainer.jsx
+++ b/src/js/containers/keyword/KeywordContainer.jsx
@@ -63,6 +63,7 @@ const KeywordContainer = (props) => {
         history.replace(`/keyword_search/${slug}`);
 
         Analytics.event({
+            event: 'keyword',
             category: 'Keyword Search - Keyword',
             action: keywordParam
         });

--- a/src/js/containers/keyword/table/ResultsTableContainer.jsx
+++ b/src/js/containers/keyword/table/ResultsTableContainer.jsx
@@ -259,6 +259,7 @@ export default class ResultsTableContainer extends React.Component {
             if (this.props.keyword) {
                 this.performSearch(true);
                 Analytics.event({
+                    event: 'keyword',
                     category: 'Keyword Search - Table Tab',
                     action: tab
                 });

--- a/src/js/containers/recipient/RecipientTimeVisualizationSectionContainer.jsx
+++ b/src/js/containers/recipient/RecipientTimeVisualizationSectionContainer.jsx
@@ -26,6 +26,7 @@ const propTypes = {
 
 const logPeriodEvent = (period) => {
     Analytics.event({
+        event: 'recipient_profile_viz_time_period',
         category: 'Recipient - Time - Period',
         action: period
     });

--- a/src/js/dataMapping/covid19/recipient/map/map.js
+++ b/src/js/dataMapping/covid19/recipient/map/map.js
@@ -148,6 +148,7 @@ export const mapboxSources = {
 
 export const logMapLayerEvent = (layer) => {
     Analytics.event({
+        event: 'covid_map_layer',
         category: 'COVID-19 - Map - Map Layer',
         action: layer
     });
@@ -155,6 +156,7 @@ export const logMapLayerEvent = (layer) => {
 
 export const logMapScopeEvent = (scope) => {
     Analytics.event({
+        event: 'covid_map_location_type',
         category: 'COVID-19 - Map - Location Type',
         action: scope
     });

--- a/src/js/helpers/analytics/Analytics.js
+++ b/src/js/helpers/analytics/Analytics.js
@@ -42,10 +42,9 @@ const Analytics = {
                 event_nonInteraction: args.nonInteraction || undefined
             });
         }
-
         this._execute(
             'send',
-            'event',
+            args.event || 'event',
             `${this._prefix}${args.category}`,
             args.action,
             args.label || undefined,

--- a/src/js/helpers/socialShare.jsx
+++ b/src/js/helpers/socialShare.jsx
@@ -22,31 +22,41 @@ const openShareWindow = (url) => {
 const handleShareClickFacebook = (url) => {
     const finalUrl = `${socialUrls.facebook}${encodeURIComponent(url)}`;
     openShareWindow(finalUrl);
-    Analytics.event({ category: `${url}`, action: 'share link click', label: 'facebook' });
+    Analytics.event({
+        event: 'Social Share Facebook', category: `${url}`, action: 'share link click', label: 'facebook'
+    });
 };
 
 const handleShareClickTwitter = (url) => {
     const finalUrl = `${socialUrls.twitter}${encodeURIComponent(url)}`;
     openShareWindow(finalUrl);
-    Analytics.event({ category: `${url}`, action: 'share link click', label: 'twitter' });
+    Analytics.event({
+        event: 'Social Share Twitter', category: `${url}`, action: 'share link click', label: 'twitter'
+    });
 };
 
 const handleShareClickLinkedin = (url) => {
     const finalUrl = `${socialUrls.linkedin}${encodeURIComponent(url)}`;
     openShareWindow(finalUrl);
-    Analytics.event({ category: `${url}`, action: 'share link click', label: 'linkedIn' });
+    Analytics.event({
+        event: 'Social Share LinkedIn', category: `${url}`, action: 'share link click', label: 'linkedIn'
+    });
 };
 
 const handleShareClickReddit = (url) => {
     const finalUrl = `${socialUrls.reddit}${encodeURIComponent(url)}`;
     openShareWindow(finalUrl);
-    Analytics.event({ category: `${url}`, action: 'share link click', label: 'reddit' });
+    Analytics.event({
+        event: 'Social Share Reddit', category: `${url}`, action: 'share link click', label: 'reddit'
+    });
 };
 
 const handleShareClickEmail = (subject, body) => {
     const finalUrl = `mailto:?subject=${subject}&body=${body}`;
     window.location.href = finalUrl;
-    Analytics.event({ category: `${subject}`, action: 'share link click', label: 'email' });
+    Analytics.event({
+        event: 'Social Share Email', category: `${subject}`, action: 'share link click', label: 'email'
+    });
 };
 
 export const getBaseUrl = (slug) => `https://www.usaspending.gov/${slug}`;
@@ -59,7 +69,9 @@ const handlersBySocialMedium = {
         handleShareClickEmail(subject, body);
     },
     linkedin: (url) => handleShareClickLinkedin(url),
-    copy: (slug) => Analytics.event({ category: slug, action: 'copy link', label: `${getBaseUrl(slug)}` })
+    copy: (slug) => Analytics.event({
+        event: 'Social Share Copy', category: slug, action: 'copy link', label: `${getBaseUrl(slug)}`
+    })
 };
 
 export const getSocialShareFn = (socialMedium, url) => {
@@ -86,7 +98,8 @@ export const handleShareOptionClick = (name, url, emailArgs) => {
     }
     else if (name !== 'copy') {
         fn(url);
-    } else {
+    }
+    else {
         fn();
     }
 };


### PR DESCRIPTION
**High level description:**

The DAP account supports GTM but doesn't support GTM custom events yet.  This information was not made available in DAP documentation or communications until recently.  Therefore, we have to keep our existing analytic events in code until DAP supports GTM custom events. 



**Technical details:**

I added event names to our events in code to match the GTM event names and updated the Spreadsheet on the PME to keep a link between the GTM custom events and the events in code.  Events can't be tested until they're deployed to PROD.

**JIRA Ticket:**
[DEV-10099](https://federal-spending-transparency.atlassian.net/browse/DEV-10099)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket

Reviewer(s):
- [ ] Code review complete
