### PR TITLE
Removed country filter selection

### DIFF
--- a/src/js/containers/search/visualizations/geo/GeoVisualizationSectionContainer.jsx
+++ b/src/js/containers/search/visualizations/geo/GeoVisualizationSectionContainer.jsx
@@ -357,7 +357,9 @@ export class GeoVisualizationSectionContainer extends React.Component {
                 // do nothing
             }
             else if (onlyObject.country !== "USA") {
-                this.changeMapLayer("country");
+                // TODO - Commenting out this line to ensure the map always shows results
+                //  before DEV-10522 is completed; For DEV-10522 change this back to country
+                // this.changeMapLayer("country");
             }
             // defaults to state
         }
@@ -399,7 +401,9 @@ export class GeoVisualizationSectionContainer extends React.Component {
 
             // change map layers based on make up of items
             if (numCountries === onlyObject.size) { // only countries
-                this.changeMapLayer("country");
+                // TODO - Changing this line to state to ensure the map always shows results
+                //  before DEV-10522 is completed; For DEV-10522 change this back to country
+                this.changeMapLayer("state");
             }
             else if (numStates === onlyObject.size) { // only states
                 this.changeMapLayer("state");
@@ -416,7 +420,9 @@ export class GeoVisualizationSectionContainer extends React.Component {
                 this.changeMapLayer("state");
             }
             else if (international === true) {
-                this.changeMapLayer("country");
+                // TODO - Changing this line to state to ensure the map always shows results
+                //  before DEV-10522 is completed; For DEV-10522 change this back to country
+                this.changeMapLayer("state");
             }
         }
         else if (this.props.reduxFilters[selectedLocationByType].size === 0) {

--- a/src/js/containers/search/visualizations/geo/GeoVisualizationSectionContainer.jsx
+++ b/src/js/containers/search/visualizations/geo/GeoVisualizationSectionContainer.jsx
@@ -358,7 +358,7 @@ export class GeoVisualizationSectionContainer extends React.Component {
             }
             else if (onlyObject.country !== "USA") {
                 // TODO - Commenting out this line to ensure the map always shows results
-                //  before DEV-10522 is completed; For DEV-10522 change this back to country
+                //  before DEV-10520 is completed; For DEV-10520 change this back to country
                 // this.changeMapLayer("country");
             }
             // defaults to state
@@ -402,7 +402,7 @@ export class GeoVisualizationSectionContainer extends React.Component {
             // change map layers based on make up of items
             if (numCountries === onlyObject.size) { // only countries
                 // TODO - Changing this line to state to ensure the map always shows results
-                //  before DEV-10522 is completed; For DEV-10522 change this back to country
+                //  before DEV-10520 is completed; For DEV-10520 change this back to country
                 this.changeMapLayer("state");
             }
             else if (numStates === onlyObject.size) { // only states
@@ -421,7 +421,7 @@ export class GeoVisualizationSectionContainer extends React.Component {
             }
             else if (international === true) {
                 // TODO - Changing this line to state to ensure the map always shows results
-                //  before DEV-10522 is completed; For DEV-10522 change this back to country
+                //  before DEV-10520 is completed; For DEV-10520 change this back to country
                 this.changeMapLayer("state");
             }
         }


### PR DESCRIPTION
**High level description:**

DEV-10520 is to zoom into the region selected in the location on the Award Search map but there is a Mapbox issue that needs to be resolved first.  However, DEV-10520 is in QAT currently and selects the Map filter and maplayer based on the location.  This is fine for all filters except for the Country filter.  In QAT now if a country is selected, the map show the error message - 
![Screenshot 2024-01-24 at 3 48 25 PM](https://github.com/fedspendingtransparency/usaspending-website/assets/121010/10c5bdb7-8830-4210-8f7e-ab245bdccd26)


This PR is not for the completed ticket DEV-10520 but just "reverting" selected the Country map filter and maplayer when a country is selected in the location filter.

The following are ALL required for the PR to be merged:

Reviewer(s):
- [ ] Code review complete
