### PR TITLE
10578 - removed infoBanner from Header.jsx

### DIFF
--- a/src/js/components/sharedComponents/header/Header.jsx
+++ b/src/js/components/sharedComponents/header/Header.jsx
@@ -4,11 +4,8 @@ import PropTypes from 'prop-types';
 import GlossaryContainer from 'containers/glossary/GlossaryContainer';
 import GlobalModalContainer from 'containers/globalModal/GlobalModalContainer';
 import AboutTheDataContainer from "containers/aboutTheDataSidebar/AboutTheDataContainer";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import NavbarWrapper from './NavbarWrapper';
-import InfoBanner from "./InfoBanner";
 import GovBanner from "./GovBanner";
-import AboutTheDataLink from "../AboutTheDataLink";
 
 export default class Header extends React.Component {
     constructor(props) {

--- a/src/js/components/sharedComponents/header/Header.jsx
+++ b/src/js/components/sharedComponents/header/Header.jsx
@@ -44,13 +44,6 @@ export default class Header extends React.Component {
                 <header
                     className="site-header__wrapper"
                     aria-label="Site header">
-                    <InfoBanner
-                        icon={<FontAwesomeIcon style={{ width: "20", height: "20" }} size="lg" icon="info-circle" color="#97d4ea" />}
-                        borderTopColor="#97d4ea"
-                        borderBottomColor="#c3ebfa"
-                        backgroundColor="#e1f3f8"
-                        title={<>New congressional district data available</>}
-                        content={<>USAspending.gov now has new congressional district data as a result of the 2020 census. Districts are identified sitewide as “current” or “submitted” (i.e., original). <AboutTheDataLink slug="congressional-district-data">Learn more about redistricting and the changes you’ll find on the site.</AboutTheDataLink></>} />
                     <GovBanner />
                     <NavbarWrapper />
                 </header>


### PR DESCRIPTION
**High level description:**

Remove the InfoBanner from the Header component, but don't delete the InfoBanner component because we reuse it.

**Technical details:**

Removed InfoBanner from Header

**JIRA Ticket:**
[DEV-10578](https://federal-spending-transparency.atlassian.net/browse/DEV-10578)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
