### PR TITLE
10568 - adjusted width of text under the Download button on Custom Aw…

### DIFF
--- a/src/_scss/pages/bulkDownload/downloadData.scss
+++ b/src/_scss/pages/bulkDownload/downloadData.scss
@@ -39,15 +39,13 @@
 
     .download-info {
         @include grid-column(16);
+        margin-left: rem(10);
+        width: 94%;
         @include media($medium-screen) {
             @include grid-column(7);
             border-left: solid 1px #e1e1e1;
             padding: rem(15) rem(30) 0 rem(30);
-        }
-
-        @media(max-width: $medium-screen){
-            margin-left: 0;
-            width: 78%;
+            width: 94%;
         }
 
         h3.download-info__title {


### PR DESCRIPTION
…ard and Custom Account download pages

**High level description:**

Grace requested a change - make the text under the Download buttons on Custom Award and Custom Accout download pages the full width of the container

**Technical details:**

I increased the width of that text at mobiel and large screens.
There are still other issues with content width at phone size screens, but we aren't fixing all of them with this ticket.

**JIRA Ticket:**
[DEV-10568](https://federal-spending-transparency.atlassian.net/browse/DEV-10568)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
