### PR TITLE
Mod/10572 nao bug

### DIFF
--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -52,7 +52,6 @@ export default class TimePeriod extends React.Component {
         super(props);
 
         this.state = {
-            windowWidth: 0,
             startDateUI: null,
             endDateUI: null,
             showError: false,
@@ -62,12 +61,10 @@ export default class TimePeriod extends React.Component {
             selectedFY: new Set(),
             allFY: false,
             clearHint: false
-            // newAwardFilterActiveFromFYOrDateRange: false
         };
 
         // bind functions
         this.handleDateChange = this.handleDateChange.bind(this);
-        this.saveSelected = this.saveSelected.bind(this);
         this.showError = this.showError.bind(this);
         this.hideError = this.hideError.bind(this);
         this.toggleFilters = this.toggleFilters.bind(this);
@@ -82,9 +79,6 @@ export default class TimePeriod extends React.Component {
     }
 
     componentDidUpdate(prevProps, prevState) {
-        console.log('componentDidUpdate, prevProps', prevProps);
-        console.log('componentDidUpdate, this.props.naoActiveFromFyOrDateRange', this.props.naoActiveFromFyOrDateRange);
-        console.log('componentDidUpdate, this.props.subaward', this.props.subaward);
         if (!isEqual(prevProps, this.props)) {
             this.synchronizeDatePickers(this.props);
         }
@@ -97,41 +91,20 @@ export default class TimePeriod extends React.Component {
             }
         }
 
-        // todo - change name to determineIfNAOIsActive
-        this.determineNewAwardFilterState(prevProps, prevState);
-
-        if (this.props.subaward && prevProps.subaward !== this.props.subaward) {
-            console.log('in subaward true block');
-            this.props.updateNewAwardsOnlyActive(false);
-        }
-        else if (!this.props.subaward && prevProps.subaward !== this.props.subaward) {
-            // only set nao to active if it had been active before subawards was set to truet
-            // todo - we should be able to use prevProps.naoActive here, but can't, bc of multiple calls to didUpdate?
-            this.props.updateNewAwardsOnlyActive(this.props.naoActiveFromFyOrDateRange);
-        }
+        this.determineIfNAOIsActive(prevProps, prevState);
     }
 
-    // setNewAwardFilterActiveFromFYOrDateRange(bool) {
-    //     this.setState({
-    //         newAwardFilterActiveFromFYOrDateRange: bool
-    //     });
-    // }
-
-    determineNewAwardFilterState(prevProps, prevState) {
+    determineIfNAOIsActive(prevProps, prevState) {
         if (prevProps.filterTimePeriodFY !== this.props.filterTimePeriodFY) {
-            console.log('determineNewAwardFilterState, first block, this.props.filterTimePeriodFY.size', this.props.filterTimePeriodFY.size);
             this.props.updateNewAwardsOnlyActive(!!this.props.filterTimePeriodFY.size);
-            // this.setNewAwardFilterActiveFromFYOrDateRange(!!this.props.filterTimePeriodFY.size);
             this.props.updateNaoActiveFromFyOrDateRange(!!this.props.filterTimePeriodFY.size);
         }
         else if ((prevState.startDateUI !== this.state.startDateUI || prevState.endDateUI !== this.state.endDateUI) && (this.state.startDateUI || this.state.endDateUI)) {
             this.props.updateNewAwardsOnlyActive(true);
-            // this.setNewAwardFilterActiveFromFYOrDateRange(true);
             this.props.updateNaoActiveFromFyOrDateRange(true);
         }
         else if ((prevState.startDateUI !== this.state.startDateUI || prevState.endDateUI !== this.state.endDateUI) && (!this.state.startDateUI && !this.state.endDateUI)) {
             this.props.updateNewAwardsOnlyActive(false);
-            // this.setNewAwardFilterActiveFromFYOrDateRange(false);
             this.props.updateNaoActiveFromFyOrDateRange(false);
         }
     }
@@ -299,19 +272,6 @@ export default class TimePeriod extends React.Component {
         });
     }
 
-    // todo - delete this if not used
-    saveSelected(arrayFY, allSelected) {
-        console.log('saveSelected');
-        this.setState({
-            selectedFY: arrayFY,
-            allFY: allSelected
-        }, () => {
-            this.props.updateFilter({
-                fy: [...this.state.selectedFY]
-            });
-        });
-    }
-
     newAwardsClick(e) {
         this.props.updateNewAwardsOnlySelected(e.target.checked);
         if (this.hint) {
@@ -367,13 +327,13 @@ export default class TimePeriod extends React.Component {
                     htmlFor="new-awards-checkbox">
                     <input
                         type="checkbox"
-                        className={`new-awards-checkbox ${this.props.newAwardsOnlyActive ? '' : 'not-active'}`}
+                        className={`new-awards-checkbox ${this.props.subaward || !this.props.newAwardsOnlyActive ? 'not-active' : ''}`}
                         id="new-awards-checkbox"
                         value="new-awards-checkbox"
-                        disabled={!this.props.newAwardsOnlyActive}
+                        disabled={this.props.subaward || !this.props.newAwardsOnlyActive}
                         checked={this.props.newAwardsOnlySelected}
                         onChange={this.newAwardsClick} />
-                    <span className={`new-awards-label ${this.props.newAwardsOnlyActive ? '' : 'not-active'}`}>
+                    <span className={`new-awards-label ${this.props.subaward || !this.props.newAwardsOnlyActive ? 'not-active' : ''}`}>
                     Show New Awards Only
                     </span>
                 </label>

--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -91,10 +91,10 @@ export default class TimePeriod extends React.Component {
             }
         }
 
-        this.determineIfNAOIsActive(prevProps, prevState);
+        this.determineIfNaoIsActive(prevProps, prevState);
     }
 
-    determineIfNAOIsActive(prevProps, prevState) {
+    determineIfNaoIsActive(prevProps, prevState) {
         if (prevProps.filterTimePeriodFY !== this.props.filterTimePeriodFY) {
             this.props.updateNewAwardsOnlyActive(!!this.props.filterTimePeriodFY.size);
             this.props.updateNaoActiveFromFyOrDateRange(!!this.props.filterTimePeriodFY.size);

--- a/src/js/containers/search/filters/TimePeriodContainer.jsx
+++ b/src/js/containers/search/filters/TimePeriodContainer.jsx
@@ -23,7 +23,9 @@ const propTypes = {
     filterTimePeriodFY: PropTypes.instanceOf(Set),
     filterTimePeriodStart: PropTypes.string,
     filterTimePeriodEnd: PropTypes.string,
-    appliedFilters: PropTypes.object
+    appliedFilters: PropTypes.object,
+    newAwardsOnlySelected: PropTypes.bool,
+    newAwardsOnlyActive: PropTypes.bool
 };
 
 export class TimePeriodContainer extends React.Component {
@@ -151,6 +153,8 @@ export class TimePeriodContainer extends React.Component {
                 {...this.props}
                 dirtyFilters={this.dirtyFilters()}
                 newAwardsOnlySelected={this.props.newAwardsOnlySelected}
+                newAwardsOnlyActive={this.props.newAwardsOnlyActive}
+                naoActiveFromFyOrDateRange={this.props.naoActiveFromFyOrDateRange}
                 activeTab={this.state.activeTab}
                 timePeriods={this.state.timePeriods}
                 updateFilter={this.updateFilter}
@@ -167,7 +171,9 @@ export default connect(
         filterTimePeriodFY: state.filters.timePeriodFY,
         filterTimePeriodStart: state.filters.timePeriodStart,
         filterTimePeriodEnd: state.filters.timePeriodEnd,
-        newAwardsOnlySelected: state.filters.newAwardsOnly,
+        newAwardsOnlySelected: state.filters.filterNewAwardsOnlySelected,
+        newAwardsOnlyActive: state.filters.filterNewAwardsOnlyActive,
+        naoActiveFromFyOrDateRange: state.filters.filterNaoActiveFromFyOrDateRange,
         appliedFilters: state.appliedFilters.filters,
         subaward: state.searchView.subaward
     }),

--- a/src/js/redux/actions/search/searchFilterActions.js
+++ b/src/js/redux/actions/search/searchFilterActions.js
@@ -21,8 +21,18 @@ export const updateTimePeriod = (state) => ({
     end: state.endDate
 });
 
-export const updateNewAwardsOnly = (state) => ({
-    type: 'UPDATE_SEARCH_FILTER_NEW_AWARDS_ONLY',
+export const updateNewAwardsOnlySelected = (state) => ({
+    type: 'UPDATE_SEARCH_FILTER_NEW_AWARDS_ONLY_SELECTED',
+    filterValue: state
+});
+
+export const updateNewAwardsOnlyActive = (state) => ({
+    type: 'UPDATE_SEARCH_FILTER_NEW_AWARDS_ONLY_ACTIVE',
+    filterValue: state
+});
+
+export const updateNaoActiveFromFyOrDateRange = (state) => ({
+    type: 'UPDATE_SEARCH_FILTER_NAO_FROM_FY_OR_DATE_RANGE',
     filterValue: state
 });
 

--- a/src/js/redux/reducers/search/searchFiltersReducer.js
+++ b/src/js/redux/reducers/search/searchFiltersReducer.js
@@ -54,7 +54,9 @@ export const initialState = {
     timePeriodFY: Set(),
     timePeriodStart: null,
     timePeriodEnd: null,
-    newAwardsOnly: false,
+    filterNewAwardsOnlySelected: false,
+    filterNewAwardsOnlyActive: false,
+    filterNaoActiveFromFyOrDateRange: false,
     selectedLocations: OrderedMap(),
     locationDomesticForeign: 'all',
     selectedFundingAgencies: OrderedMap(),
@@ -98,10 +100,24 @@ const searchFiltersReducer = (state = initialState, action) => {
             });
         }
 
-        // New Awards Only Filter
-        case 'UPDATE_SEARCH_FILTER_NEW_AWARDS_ONLY': {
+        // New Awards Only Filter, Selected
+        case 'UPDATE_SEARCH_FILTER_NEW_AWARDS_ONLY_SELECTED': {
             return Object.assign({}, state, {
-                newAwardsOnly: action.filterValue
+                filterNewAwardsOnlySelected: action.filterValue
+            });
+        }
+
+        // New Awards Only Filter, Active
+        case 'UPDATE_SEARCH_FILTER_NEW_AWARDS_ONLY_ACTIVE': {
+            return Object.assign({}, state, {
+                filterNewAwardsOnlyActive: action.filterValue
+            });
+        }
+
+        // New Awards Only Filter, Selected bc of conditions in fy or date range
+        case 'UPDATE_SEARCH_FILTER_NAO_FROM_FY_OR_DATE_RANGE': {
+            return Object.assign({}, state, {
+                filterNaoActiveFromFyOrDateRange: action.filterValue
             });
         }
 

--- a/tests/redux/reducers/search/searchFiltersReducer-test.js
+++ b/tests/redux/reducers/search/searchFiltersReducer-test.js
@@ -129,15 +129,53 @@ describe('searchFiltersReducer', () => {
         });
     });
 
-    describe('UPDATE_SEARCH_FILTER_NEW_AWARDS_ONLY', () => {
-        it('should set the newAwardsOnly value to the provided action data', () => {
+    describe('UPDATE_SEARCH_FILTER_NEW_AWARDS_ONLY_SELECTED', () => {
+        it('should set the filterNewAwardsOnlySelected value to the provided action data', () => {
             const action = {
-                type: 'UPDATE_SEARCH_FILTER_NEW_AWARDS_ONLY',
+                type: 'UPDATE_SEARCH_FILTER_NEW_AWARDS_ONLY_SELECTED',
                 filterValue: true
             };
 
             const expected = {
-                newAwardsOnly: true
+                filterNewAwardsOnlySelected: true
+            };
+
+            const updatedState = searchFiltersReducer(undefined, action);
+
+            Object.keys(expected).forEach((key) => {
+                expect(updatedState[key]).toEqual(expected[key]);
+            });
+        });
+    });
+
+    describe('UPDATE_SEARCH_FILTER_NEW_AWARDS_ONLY_ACTIVE', () => {
+        it('should set the filterNewAwardsOnlyActive value to the provided action data', () => {
+            const action = {
+                type: 'UPDATE_SEARCH_FILTER_NEW_AWARDS_ONLY_ACTIVE',
+                filterValue: true
+            };
+
+            const expected = {
+                filterNewAwardsOnlyActive: true
+            };
+
+            const updatedState = searchFiltersReducer(undefined, action);
+
+            Object.keys(expected).forEach((key) => {
+                expect(updatedState[key]).toEqual(expected[key]);
+            });
+        });
+    });
+
+    describe('UPDATE_SEARCH_FILTER_NAO_FROM_FY_OR_DATE_RANGE', () => {
+        it('should set the filterNaoActiveFromFyOrDateRange value to the provided action data', () => {
+            const action = {
+                type: 'UPDATE_SEARCH_FILTER_NAO_FROM_FY_OR_DATE_RANGE',
+                filterValue: true
+            };
+
+            const expected = {
+                filterNaoActiveFromFyOrDateRange: true
             };
 
             const updatedState = searchFiltersReducer(undefined, action);


### PR DESCRIPTION
**High level description:**

Strange bug, described in ticket, the state of the nao filter being active or not wasn't consistent when switching from large screens to smaller, and vice versa

**Technical details:**

I ended up needing to move two of the state vars for determining if nao is active into redux; i also changed the way we handle logic for making nao inactive if subawards is true; i got rid of the saveSelected function because I saw it is never used

**JIRA Ticket:**
[DEV-10572](https://federal-spending-transparency.atlassian.net/browse/DEV-10572)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
