### PR TITLE
mod/10628 adjust landing pages scroll bar

### DIFF
--- a/src/_scss/pages/accountLanding/table/_table.scss
+++ b/src/_scss/pages/accountLanding/table/_table.scss
@@ -1,7 +1,7 @@
 .results-table {
     display: block;
     @media (max-width: $large-screen) {
-        overflow-x: scroll;
+        overflow-x: auto;
     }
 
     .results-table__message {

--- a/src/_scss/pages/accountLanding/table/_table.scss
+++ b/src/_scss/pages/accountLanding/table/_table.scss
@@ -1,6 +1,9 @@
 .results-table {
     display: block;
-    overflow: scroll;
+    @media (max-width: $large-screen) {
+        overflow-x: scroll;
+    }
+
     .results-table__message {
         margin: rem(90) auto;
         font-size: rem(36);

--- a/src/_scss/pages/agencyLanding/table/_table.scss
+++ b/src/_scss/pages/agencyLanding/table/_table.scss
@@ -2,7 +2,7 @@
     display: block;
 
 	@media (max-width: $large-screen) {
-		overflow-x: scroll;
+		overflow-x: auto;
 	}
 
     &.no-results {

--- a/src/_scss/pages/agencyLanding/table/_table.scss
+++ b/src/_scss/pages/agencyLanding/table/_table.scss
@@ -1,6 +1,9 @@
 .agency-landing-results-table {
     display: block;
-    overflow: scroll;   
+
+	@media (max-width: $large-screen) {
+		overflow-x: scroll;
+	}
 
     &.no-results {
         border: none;

--- a/src/_scss/pages/recipientLanding/recipientLandingPage.scss
+++ b/src/_scss/pages/recipientLanding/recipientLandingPage.scss
@@ -45,7 +45,7 @@
 
     .recipient-landing__results {
         @media (max-width: $large-screen) {
-            overflow-x: scroll;
+            overflow-x: auto;
         }
 
         .recipient-list {

--- a/src/_scss/pages/recipientLanding/recipientLandingPage.scss
+++ b/src/_scss/pages/recipientLanding/recipientLandingPage.scss
@@ -44,7 +44,10 @@
     }
 
     .recipient-landing__results {
-        overflow-x: scroll;
+        @media (max-width: $large-screen) {
+            overflow-x: scroll;
+        }
+
         .recipient-list {
             margin-top: rem(15);
         }

--- a/src/_scss/pages/stateLanding/stateLandingPage.scss
+++ b/src/_scss/pages/stateLanding/stateLandingPage.scss
@@ -7,7 +7,7 @@
 
     .state-landing__results {
         @media (max-width: $large-screen) {
-            overflow-x: scroll;
+            overflow-x: auto;
         }
 
         .state-list {

--- a/src/_scss/pages/stateLanding/stateLandingPage.scss
+++ b/src/_scss/pages/stateLanding/stateLandingPage.scss
@@ -6,7 +6,10 @@
     @import "./_table";
 
     .state-landing__results {
-        overflow-x: scroll;
+        @media (max-width: $large-screen) {
+            overflow-x: scroll;
+        }
+
         .state-list {
             margin-top: rem(15);
         }


### PR DESCRIPTION
**High level description:**
Removed the vertical scroll bar in the tables on the agencies, federal accounts, states & territories, and recipients landing pages. Also adjusted the horizontal scroll bar to only appear when the view is smaller than 1200 px.

**Technical details:**

Changed the overflow to overflow-x, and only shows when the view port is smaller than a large screen.

**JIRA Ticket:**
[DEV-10628](https://federal-spending-transparency.atlassian.net/browse/DEV-10628)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
