### PR TITLE
DEV-10721 fix federal account filter crashing

### DIFF
--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -72,6 +72,7 @@ export default class TimePeriod extends React.Component {
         this.removeDateRange = this.removeDateRange.bind(this);
         this.clearHint = this.clearHint.bind(this);
         this.newAwardsClick = this.newAwardsClick.bind(this);
+        this.determineIfNaoIsActive = this.determineIfNaoIsActive.bind(this);
     }
 
     componentDidMount() {
@@ -175,7 +176,6 @@ export default class TimePeriod extends React.Component {
         }
     }
 
-
     toggleFilters(e) {
         this.clearHint(true);
         this.props.changeTab(e.target.value);
@@ -247,7 +247,6 @@ export default class TimePeriod extends React.Component {
             });
         }
     }
-
     removeDateRange() {
         this.clearHint(true);
         this.props.updateFilter({

--- a/src/js/containers/account/filters/AccountTimePeriodContainer.jsx
+++ b/src/js/containers/account/filters/AccountTimePeriodContainer.jsx
@@ -9,6 +9,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import Immutable from 'immutable';
 import { flowRight } from 'lodash';
+import * as searchFilterActions from 'redux/actions/search/searchFilterActions';
 
 import { LATEST_PERIOD_PROPS, SUBMISSION_PERIOD_PROPS } from "propTypes";
 
@@ -92,6 +93,7 @@ export class AccountTimePeriodContainer extends React.Component {
             // checkbox from the Federal Accounts page
             <TimePeriod
                 {...this.props}
+                {...searchFilterActions}
                 latestFy={this.props.latestPeriod.year}
                 activeTab={this.props.filterTimePeriodType}
                 timePeriods={this.state.timePeriods}


### PR DESCRIPTION
**High level description:**
federal account crashing when you click an FY, needed to pass in searchFilterActions

**JIRA Ticket:**
[DEV-10721](https://federal-spending-transparency.atlassian.net/browse/DEV-10721)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
