### PR TITLE
10650 - Fixed zoom level when the contiguous US is selected

### DIFF
--- a/src/js/components/search/visualizations/geo/map/MapBox.jsx
+++ b/src/js/components/search/visualizations/geo/map/MapBox.jsx
@@ -55,7 +55,7 @@ const MapBox = forwardRef((props, ref) => {
 
         if (isStateSelected()) {
             const stateCode = props.stateInfo?.code || props.singleLocationSelected?.state;
-            if (stateCode !== '') {
+            if (stateCode && stateCode !== '') {
                 const state = statesBySqMile.find((s) => s.code === stateCode);
                 if (state?.size > 500000) {
                     zoomLevel = 3.0;


### PR DESCRIPTION
Bug fix - 
From testing "without filtering a location the map is set to the "US States.." toggle but is really zoomed into the US map."