### PR TITLE
Mod/10785 fed account fy default

### DIFF
--- a/src/js/components/search/filters/timePeriod/AllFiscalYears.jsx
+++ b/src/js/components/search/filters/timePeriod/AllFiscalYears.jsx
@@ -22,6 +22,7 @@ export default class AllFiscalYears extends React.Component {
         this.saveAllYears = this.saveAllYears.bind(this);
         this.saveSelectedYear = this.saveSelectedYear.bind(this);
     }
+
     saveSelectedYear(year) {
         let newYears;
 

--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -5,7 +5,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { currentFiscalYear } from 'helpers/fiscalYearHelper';
 import { NewAwardsTooltip } from 'components/search/filters/tooltips/AdvancedSearchTooltip';
 import { TooltipWrapper } from 'data-transparency-ui';
 import { Set } from 'immutable';
@@ -46,7 +45,6 @@ const propTypes = {
     newAwardsOnlyActive: PropTypes.bool,
     naoActiveFromFyOrDateRange: PropTypes.bool,
     federalAccountPage: PropTypes.bool
-    // latestFy: PropTypes.string
 };
 
 export default class TimePeriod extends React.Component {
@@ -62,8 +60,7 @@ export default class TimePeriod extends React.Component {
             isActive: false,
             selectedFY: new Set(),
             allFY: false,
-            clearHint: false,
-            currentFiscalYear: currentFiscalYear()
+            clearHint: false
         };
 
         // bind functions
@@ -293,15 +290,7 @@ export default class TimePeriod extends React.Component {
                 message={this.state.errorMessage} />);
         }
 
-        if (this.props.federalAccountPage) {
-            showFilter = (<AllFiscalYears
-                updateFilter={this.props.updateFilter}
-                timePeriods={this.props.timePeriods}
-                selectedFY={new Set([this.state.currentFiscalYear.toString()])} />);
-            activeClassFY = '';
-            activeClassDR = 'inactive';
-        }
-        else if (!this.props.federalAccountPage && this.props.activeTab === 'fy') {
+        if (this.props.activeTab === 'fy') {
             showFilter = (<AllFiscalYears
                 updateFilter={this.props.updateFilter}
                 timePeriods={this.props.timePeriods}

--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { currentFiscalYear } from 'helpers/fiscalYearHelper';
 import { NewAwardsTooltip } from 'components/search/filters/tooltips/AdvancedSearchTooltip';
 import { TooltipWrapper } from 'data-transparency-ui';
 import { Set } from 'immutable';
@@ -45,6 +46,7 @@ const propTypes = {
     newAwardsOnlyActive: PropTypes.bool,
     naoActiveFromFyOrDateRange: PropTypes.bool,
     federalAccountPage: PropTypes.bool
+    // latestFy: PropTypes.string
 };
 
 export default class TimePeriod extends React.Component {
@@ -60,7 +62,8 @@ export default class TimePeriod extends React.Component {
             isActive: false,
             selectedFY: new Set(),
             allFY: false,
-            clearHint: false
+            clearHint: false,
+            currentFiscalYear: currentFiscalYear()
         };
 
         // bind functions
@@ -279,10 +282,10 @@ export default class TimePeriod extends React.Component {
     }
 
     render() {
-        let errorDetails = null;
-        let showFilter = null;
-        let activeClassFY = null;
-        let activeClassDR = null;
+        let errorDetails;
+        let showFilter;
+        let activeClassFY;
+        let activeClassDR;
 
         if (this.state.showError && this.props.activeTab === 'dr') {
             errorDetails = (<DateRangeError
@@ -290,7 +293,15 @@ export default class TimePeriod extends React.Component {
                 message={this.state.errorMessage} />);
         }
 
-        if (this.props.activeTab === 'fy') {
+        if (this.props.federalAccountPage) {
+            showFilter = (<AllFiscalYears
+                updateFilter={this.props.updateFilter}
+                timePeriods={this.props.timePeriods}
+                selectedFY={new Set([this.state.currentFiscalYear.toString()])} />);
+            activeClassFY = '';
+            activeClassDR = 'inactive';
+        }
+        else if (!this.props.federalAccountPage && this.props.activeTab === 'fy') {
             showFilter = (<AllFiscalYears
                 updateFilter={this.props.updateFilter}
                 timePeriods={this.props.timePeriods}

--- a/src/js/containers/account/filters/AccountTimePeriodContainer.jsx
+++ b/src/js/containers/account/filters/AccountTimePeriodContainer.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { currentFiscalYear } from 'helpers/fiscalYearHelper';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import Immutable from 'immutable';
@@ -49,8 +50,12 @@ export class AccountTimePeriodContainer extends React.Component {
 
     componentDidMount() {
         if (this.props.latestPeriod.year) {
+            // it seems this block never happens;
+            // on page load the didUpdate block is what calls generateTimePeriods
             this.generateTimePeriods();
         }
+        // update filter to set current fy as default on page load
+        this.updateFilter({ fy: new Set([currentFiscalYear().toString()]) });
     }
 
     componentDidUpdate(prevProps) {
@@ -74,7 +79,7 @@ export class AccountTimePeriodContainer extends React.Component {
     }
 
     updateFilter(params) {
-    // set the state to a clone of the filter subobject merged with the param object
+        // set the state to a clone of the filter subobject merged with the param object
         const currentFilters = {
             dateType: this.props.filterTimePeriodType,
             fy: this.props.filterTimePeriodFY,


### PR DESCRIPTION
**High level description:**

We want to set the current fy as the default filter on Federal Accounts pages, because it's currently using all fy as the default, and if the user selects quarters the chart is all messed up

**Technical details:**

Called updateFilter from didMount in AccountTimePeriodContainer, with current fy as the param, but only after changing that current fy to a string and putting in an array and making it a Set, bc just using a string would be way too simple.

**JIRA Ticket:**
[DEV-10785](https://federal-spending-transparency.atlassian.net/browse/DEV-10785)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
