### PR TITLE
Fix/10832 gray out amount type when countries is selected

### DIFF
--- a/src/_scss/components/_titleBarFilter.scss
+++ b/src/_scss/components/_titleBarFilter.scss
@@ -54,6 +54,7 @@
         button[class^='filter__dropdown-button'].not-enabled {
             border: solid 2px rgba(251, 252, 253, 0.25); // $gray-cool-1 rgb value
             pointer-events: none;
+            cursor:not-allowed;
             .filter__dropdown-left-icon {
                 svg {
                     color: $gray-cool-10;
@@ -76,7 +77,8 @@
 
         button[class^='filter__dropdown-button'].enabled {
             border: solid 2px rgba(251, 252, 253, 0.5); // $gray-cool-1 rgb value
-
+            pointer-events: all;
+            cursor: pointer;
             .filter__dropdown-left-icon {
                 svg {
                     color: $gray-cool-10;

--- a/src/_scss/components/_titleBarFilter.scss
+++ b/src/_scss/components/_titleBarFilter.scss
@@ -16,6 +16,7 @@
     span[class^=' filter__dropdown-label'].not-enabled {
         color: $gray-cool-10;
         opacity: 0.5;
+        pointer-events: none;
     }
 
     span[class^=' filter__dropdown-label'].enabled {
@@ -52,7 +53,7 @@
 
         button[class^='filter__dropdown-button'].not-enabled {
             border: solid 2px rgba(251, 252, 253, 0.25); // $gray-cool-1 rgb value
-
+            pointer-events: none;
             .filter__dropdown-left-icon {
                 svg {
                     color: $gray-cool-10;

--- a/src/js/components/search/visualizations/geo/AdvancedSearchMapFilters.jsx
+++ b/src/js/components/search/visualizations/geo/AdvancedSearchMapFilters.jsx
@@ -29,7 +29,7 @@ const AdvancedSearchMapFilters = ({ filters, activeFilters, isOpen }) => (
                         <div className="map__filters-wrapper">
                             <span className="map__filters-label">{filters[filter].label}</span>
                             <NewPicker
-                                enabled
+                                enabled={filters[filter].enabled}
                                 size="sm"
                                 classname="map__filters-button"
                                 dropdownClassname="map__filters-dropdown"

--- a/src/js/components/search/visualizations/geo/MapWrapper.jsx
+++ b/src/js/components/search/visualizations/geo/MapWrapper.jsx
@@ -111,7 +111,6 @@ const MapWrapper = (props) => {
     });
     const [center, setCenter] = useState(props.center);
     const [isFiltersOpen, setIsFiltersOpen] = useState(true);
-    const [mapFilters, setMapFilters] = useState(cloneDeep(props.filters));
     const broadcastReceivers = [];
     let renderCallback = null;
     let mapOperationQueue = {};
@@ -533,18 +532,32 @@ const MapWrapper = (props) => {
 
     const toggleFilters = () => setIsFiltersOpen(!isFiltersOpen);
 
-    const filters = throttle(() => {
+    const filters = () => {
         const { activeFilters } = props;
+        let mapFilters = cloneDeep(props.filters);
 
         if (!mapFilters || !activeFilters) return null;
+        const awardTypeFilters = props.awardTypeFilters.map((filter) => filter.internal).filter((filter) => filter !== 'all').filter((filter) => filter !== 'loans');
+        if (awardTypeFilters.includes(activeFilters.awardType)) {
+            mapFilters.spendingType.options.pop();
+        }
 
+        if (props.activeFilters.territory === 'country') {
+            mapFilters = Object.assign({}, { territory: mapFilters.territory, amountType: { ...mapFilters.amountType, enabled: false } });
+        } else {
+            mapFilters = Object.assign({}, { territory: mapFilters.territory, amountType: { ...mapFilters.amountType, enabled: true } });
+        }
         return (
             <AdvancedSearchMapFilters
                 filters={mapFilters}
                 activeFilters={props.activeFilters}
                 isOpen={isFiltersOpen} />
         );
-    }, 500);
+    };
+
+    useEffect(() => {
+
+    }, [props.activeFilters.territory]);
     useEffect(() => {
         displayData();
         if (!props.stateProfile) {
@@ -583,18 +596,6 @@ const MapWrapper = (props) => {
         setCenter(props.center);
     }, [props.center]);
 
-    // useEffect(() => {
-    //     console.debug("props: ", props.activeFilters, props.filters, mapFilters);
-    //     if (props.activeFilters.territory === 'country') {
-    //         setMapFilters({ territory: mapFilters.territory, amountType: { ...mapFilters.amountType, enabled: false } });
-    //     } else {
-    //         setMapFilters({ territory: mapFilters.territory, amountType: { ...mapFilters.amountType, enabled: true } });
-    //     }
-    // }, [props.activeFilters.territory]);
-
-    // useEffect(() => {
-    //     setMapFilters(Object.assign({}, { territory: { ...mapFilters.territory }, amountType: { ...mapFilters.amountType } }));
-    // }, [props.activeFilters.amountType]);
     return (
         <div className="map-container">
             <MapBox

--- a/src/js/components/search/visualizations/geo/MapWrapper.jsx
+++ b/src/js/components/search/visualizations/geo/MapWrapper.jsx
@@ -535,7 +535,7 @@ const MapWrapper = (props) => {
     const filters = () => {
         const { activeFilters } = props;
         let mapFilters = cloneDeep(props.filters);
-
+        let active = cloneDeep(props.activeFilters);
         if (!mapFilters || !activeFilters) return null;
         const awardTypeFilters = props.awardTypeFilters.map((filter) => filter.internal).filter((filter) => filter !== 'all').filter((filter) => filter !== 'loans');
         if (awardTypeFilters.includes(activeFilters.awardType)) {
@@ -544,13 +544,14 @@ const MapWrapper = (props) => {
 
         if (props.activeFilters.territory === 'country') {
             mapFilters = Object.assign({}, { territory: mapFilters.territory, amountType: { ...mapFilters.amountType, enabled: false } });
+            active = Object.assign({}, { ...active, amountType: 'totalSpending' });
         } else {
             mapFilters = Object.assign({}, { territory: mapFilters.territory, amountType: { ...mapFilters.amountType, enabled: true } });
         }
         return (
             <AdvancedSearchMapFilters
                 filters={mapFilters}
-                activeFilters={props.activeFilters}
+                activeFilters={active}
                 isOpen={isFiltersOpen} />
         );
     };

--- a/src/js/components/search/visualizations/geo/MapWrapper.jsx
+++ b/src/js/components/search/visualizations/geo/MapWrapper.jsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { uniq, cloneDeep, throttle } from 'lodash';
+import { uniq, cloneDeep } from 'lodash';
 import * as MapHelper from 'helpers/mapHelper';
 import MapBroadcaster from 'helpers/mapBroadcaster';
 import { prohibitedCountryCodes } from 'helpers/search/visualizations/geoHelper';

--- a/src/js/components/search/visualizations/geo/MapWrapper.jsx
+++ b/src/js/components/search/visualizations/geo/MapWrapper.jsx
@@ -542,12 +542,13 @@ const MapWrapper = (props) => {
             mapFilters.spendingType.options.pop();
         }
 
-        if (props.activeFilters.territory === 'country') {
+        if (props.activeFilters?.territory === 'country') {
             mapFilters = Object.assign({}, { territory: mapFilters.territory, amountType: { ...mapFilters.amountType, enabled: false } });
             active = Object.assign({}, { ...active, amountType: 'totalSpending' });
         } else {
             mapFilters = Object.assign({}, { territory: mapFilters.territory, amountType: { ...mapFilters.amountType, enabled: true } });
         }
+
         return (
             <AdvancedSearchMapFilters
                 filters={mapFilters}
@@ -556,9 +557,6 @@ const MapWrapper = (props) => {
         );
     };
 
-    useEffect(() => {
-
-    }, [props.activeFilters.territory]);
     useEffect(() => {
         displayData();
         if (!props.stateProfile) {

--- a/src/js/components/search/visualizations/geo/MapWrapper.jsx
+++ b/src/js/components/search/visualizations/geo/MapWrapper.jsx
@@ -591,7 +591,7 @@ const MapWrapper = (props) => {
         } else {
             setMapFilters({ territory: mapFilters.territory, amountType: { ...mapFilters.amountType, enabled: true } });
         }
-    }, [props.activeFilters]);
+    }, [props.activeFilters.territory]);
     return (
         <div className="map-container">
             <MapBox

--- a/src/js/components/search/visualizations/geo/MapWrapper.jsx
+++ b/src/js/components/search/visualizations/geo/MapWrapper.jsx
@@ -113,6 +113,7 @@ const MapWrapper = (props) => {
     });
     const [center, setCenter] = useState(props.center);
     const [isFiltersOpen, setIsFiltersOpen] = useState(true);
+    const [mapFilters, setMapFilters] = useState(cloneDeep(props.filters));
     const broadcastReceivers = [];
     let renderCallback = null;
     let mapOperationQueue = {};
@@ -536,13 +537,7 @@ const MapWrapper = (props) => {
 
     const filters = () => {
         const { activeFilters } = props;
-        const mapFilters = cloneDeep(props.filters);
-
         if (!mapFilters || !activeFilters) return null;
-        const awardTypeFilters = props.awardTypeFilters.map((filter) => filter.internal).filter((filter) => filter !== 'all').filter((filter) => filter !== 'loans');
-        if (awardTypeFilters.includes(activeFilters.awardType)) {
-            mapFilters.spendingType.options.pop();
-        }
 
         return (
             <AdvancedSearchMapFilters
@@ -589,6 +584,14 @@ const MapWrapper = (props) => {
         setCenter(props.center);
     }, [props.center]);
 
+    useEffect(() => {
+        console.debug("props: ", props.activeFilters, mapFilters);
+        if (props.activeFilters.territory === 'country') {
+            setMapFilters({ territory: mapFilters.territory, amountType: { ...mapFilters.amountType, enabled: false } });
+        } else {
+            setMapFilters({ territory: mapFilters.territory, amountType: { ...mapFilters.amountType, enabled: true } });
+        }
+    }, [props.activeFilters]);
     return (
         <div className="map-container">
             <MapBox

--- a/src/js/components/search/visualizations/geo/MapWrapper.jsx
+++ b/src/js/components/search/visualizations/geo/MapWrapper.jsx
@@ -5,12 +5,10 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { uniq, cloneDeep } from 'lodash';
-
+import { uniq, cloneDeep, throttle } from 'lodash';
 import * as MapHelper from 'helpers/mapHelper';
 import MapBroadcaster from 'helpers/mapBroadcaster';
 import { prohibitedCountryCodes } from 'helpers/search/visualizations/geoHelper';
-
 import MapBox from './map/MapBox';
 import MapLegend from './MapLegend';
 import { stateFIPSByAbbreviation } from "../../../../dataMapping/state/stateNames";
@@ -113,7 +111,7 @@ const MapWrapper = (props) => {
     });
     const [center, setCenter] = useState(props.center);
     const [isFiltersOpen, setIsFiltersOpen] = useState(true);
-    const [mapFilters, setMapFilters] = useState(cloneDeep(props.filters));
+    const [mapFilters, setMapFilters] = useState(props.filters);
     const broadcastReceivers = [];
     let renderCallback = null;
     let mapOperationQueue = {};
@@ -535,8 +533,9 @@ const MapWrapper = (props) => {
 
     const toggleFilters = () => setIsFiltersOpen(!isFiltersOpen);
 
-    const filters = () => {
+    const filters = throttle(() => {
         const { activeFilters } = props;
+
         if (!mapFilters || !activeFilters) return null;
 
         return (
@@ -545,7 +544,7 @@ const MapWrapper = (props) => {
                 activeFilters={props.activeFilters}
                 isOpen={isFiltersOpen} />
         );
-    };
+    }, 500);
     useEffect(() => {
         displayData();
         if (!props.stateProfile) {
@@ -584,14 +583,18 @@ const MapWrapper = (props) => {
         setCenter(props.center);
     }, [props.center]);
 
-    useEffect(() => {
-        console.debug("props: ", props.activeFilters, mapFilters);
-        if (props.activeFilters.territory === 'country') {
-            setMapFilters({ territory: mapFilters.territory, amountType: { ...mapFilters.amountType, enabled: false } });
-        } else {
-            setMapFilters({ territory: mapFilters.territory, amountType: { ...mapFilters.amountType, enabled: true } });
-        }
-    }, [props.activeFilters.territory]);
+    // useEffect(() => {
+    //     console.debug("props: ", props.activeFilters, props.filters, mapFilters);
+    //     if (props.activeFilters.territory === 'country') {
+    //         setMapFilters({ territory: mapFilters.territory, amountType: { ...mapFilters.amountType, enabled: false } });
+    //     } else {
+    //         setMapFilters({ territory: mapFilters.territory, amountType: { ...mapFilters.amountType, enabled: true } });
+    //     }
+    // }, [props.activeFilters.territory]);
+
+    // useEffect(() => {
+    //     setMapFilters(Object.assign({}, { territory: { ...mapFilters.territory }, amountType: { ...mapFilters.amountType } }));
+    // }, [props.activeFilters.amountType]);
     return (
         <div className="map-container">
             <MapBox

--- a/src/js/components/search/visualizations/geo/MapWrapper.jsx
+++ b/src/js/components/search/visualizations/geo/MapWrapper.jsx
@@ -111,7 +111,7 @@ const MapWrapper = (props) => {
     });
     const [center, setCenter] = useState(props.center);
     const [isFiltersOpen, setIsFiltersOpen] = useState(true);
-    const [mapFilters, setMapFilters] = useState(props.filters);
+    const [mapFilters, setMapFilters] = useState(cloneDeep(props.filters));
     const broadcastReceivers = [];
     let renderCallback = null;
     let mapOperationQueue = {};

--- a/src/js/dataMapping/covid19/recipient/map/map.js
+++ b/src/js/dataMapping/covid19/recipient/map/map.js
@@ -133,6 +133,7 @@ export const advancedSearchFilters = {
     },
     amountType: {
         label: 'AMOUNT TYPE',
+        enabled: true,
         options: [
             {
                 value: 'totalSpending',

--- a/src/js/dataMapping/covid19/recipient/map/map.js
+++ b/src/js/dataMapping/covid19/recipient/map/map.js
@@ -112,6 +112,7 @@ export const filters = {
 export const advancedSearchFilters = {
     territory: {
         label: 'AREA TYPE',
+        enabled: true,
         options: [
             {
                 value: 'country',


### PR DESCRIPTION
**High level description:**

gray out the second map dropdown when the first one is set to countries on the advanced search map

**JIRA Ticket:**
[DEV-10832](https://federal-spending-transparency.atlassian.net/browse/DEV-10832)

**Mockup:**
https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55/screen/660da169e6fd6a139eebb6d1

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
