### PR TITLE
10864 - updated the height of the chart on desktop

### DIFF
--- a/src/js/components/search/visualizations/rank/spendingByCategoriesChart/SpendingByCategoriesChart.jsx
+++ b/src/js/components/search/visualizations/rank/spendingByCategoriesChart/SpendingByCategoriesChart.jsx
@@ -103,7 +103,7 @@ const SpendingByCategoriesChart = (props) => {
 
     return (
         <>
-            <ResponsiveContainer width="100%" height={isMobile ? 650 : 500}>
+            <ResponsiveContainer width="100%" height={isMobile ? 650 : 600}>
                 <BarChart
                     data={dataStuff}
                     layout="vertical"


### PR DESCRIPTION
**High level description:**
Quick follow up from design.

**Technical details:**
Made the height of the spending by categories chart taller for desktop screens (from 500px to 600px)

**JIRA Ticket:**
[DEV-10864](https://federal-spending-transparency.atlassian.net/browse/DEV-10864)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
