### PR TITLE
10710 - added aria label to sof chart outlays toggle

### DIFF
--- a/src/js/components/sharedComponents/RoundedToggle.jsx
+++ b/src/js/components/sharedComponents/RoundedToggle.jsx
@@ -17,7 +17,7 @@ const RoundedToggle = ({
 }) => (
     <div className="rounded-toggle__wrapper">
         <p className="rounded-toggle__label">{label}</p>
-        <label className="rounded-toggle__switch" htmlFor="outlays-toggle">
+        <label className="rounded-toggle__switch" htmlFor="outlays-toggle" aria-label="toggle to view outlays">
             {toggle && <input type="checkbox" id="outlays-toggle" onKeyDown={onKeyToggle} onClick={onToggle} defaultChecked tabIndex="0" />}
             {!toggle && <input type="checkbox" id="outlays-toggle" onKeyDown={onKeyToggle} onClick={onToggle} tabIndex="0" />}
             <span className="rounded-toggle__slider rounded-toggle__round" />


### PR DESCRIPTION
**High level description:**

Ticket for the latest 508 scan

**Technical details:**

Added aria label to the Outlays toggle in Status of Funds chart. This was labelled as Critical in the scan.

**JIRA Ticket:**
[DEV-10710](https://federal-spending-transparency.atlassian.net/browse/DEV-10710)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
