### PR TITLE
DEV-10989 fix text on spending by categories when it is not a link

### DIFF
--- a/src/_scss/pages/search/results/visualizations/rank/rankVisualization.scss
+++ b/src/_scss/pages/search/results/visualizations/rank/rankVisualization.scss
@@ -29,6 +29,10 @@
                 cursor: pointer;
             }
         }
+
+        .category-spending__not-link {
+            color: $gray-60;
+        }
     }
 
     @import '../../../../../components/visualizations/legend';

--- a/src/_scss/pages/search/results/visualizations/rank/rankVisualization.scss
+++ b/src/_scss/pages/search/results/visualizations/rank/rankVisualization.scss
@@ -29,10 +29,6 @@
                 cursor: pointer;
             }
         }
-
-        .category-spending__not-link {
-            color: $gray-60;
-        }
     }
 
     @import '../../../../../components/visualizations/legend';

--- a/src/js/components/search/visualizations/rank/spendingByCategoriesChart/SpendingByCategoriesChart.jsx
+++ b/src/js/components/search/visualizations/rank/spendingByCategoriesChart/SpendingByCategoriesChart.jsx
@@ -68,9 +68,8 @@ const SpendingByCategoriesChart = (props) => {
                     <Text
                         textAnchor={isMobile ? "start" : "end"}
                         fontSize={14}
-                        className="category-spending__not-link"
                         width={isMobile ? labelWidthVar : labelWidthVar + 16}
-                        fill="#5c5c5c">
+                        color="#5c5c5c">
                         {tickFormatter(payload.value, isSmMobile)}
                     </Text>
                 }

--- a/src/js/components/search/visualizations/rank/spendingByCategoriesChart/SpendingByCategoriesChart.jsx
+++ b/src/js/components/search/visualizations/rank/spendingByCategoriesChart/SpendingByCategoriesChart.jsx
@@ -68,6 +68,7 @@ const SpendingByCategoriesChart = (props) => {
                     <Text
                         textAnchor={isMobile ? "start" : "end"}
                         fontSize={14}
+                        className="category-spending__not-link"
                         width={isMobile ? labelWidthVar : labelWidthVar + 16}
                         fill="#5c5c5c">
                         {tickFormatter(payload.value, isSmMobile)}


### PR DESCRIPTION
**High level description:**
change the color of spending by categories text when it isn't a link

**JIRA Ticket:**
[DEV-10989](https://federal-spending-transparency.atlassian.net/browse/DEV-10989)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
