### PR TITLE
DEV-10984 undo title filter bar change

### DIFF
--- a/src/js/components/search/SearchPage.jsx
+++ b/src/js/components/search/SearchPage.jsx
@@ -4,7 +4,6 @@
  **/
 
 import React, { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { throttle } from 'lodash';
 import { DownloadIconButton, ShareIcon, FlexGridRow, FlexGridCol } from 'data-transparency-ui';
@@ -55,7 +54,6 @@ const SearchPage = ({
     const [stateHash, setStateHash] = useState(hash);
     const [windowWidth, setWindowWidth] = useState(0);
     const [isMobile, setIsMobile] = useState(window.innerWidth < mediumScreen);
-    const hasResults = useSelector((state) => state.titleBarFilter.hasResults);
 
     // TODO: Remove this state once new Advance Search is done and toggle no longer needed
     const [toggleTempSearchPage, setToggleTempSearchPage] = useState(true);
@@ -149,7 +147,7 @@ const SearchPage = ({
             title="Advanced Search"
             metaTagProps={MetaTagHelper.getSearchPageMetaTags(stateHash)}
             toolBarComponents={[
-                <SubawardDropdown size="sm" label="Filter by:" enabled={hasResults} setSearchViewSubaward={setSearchViewSubaward} selectedValue="prime" />,
+                <SubawardDropdown size="sm" label="Filter by:" enabled setSearchViewSubaward={setSearchViewSubaward} selectedValue="prime" />,
                 <ShareIcon
                     isEnabled
                     url={getBaseUrl(getSlugWithHash())}

--- a/src/js/containers/search/SearchSidebarSubmitContainer.jsx
+++ b/src/js/containers/search/SearchSidebarSubmitContainer.jsx
@@ -13,7 +13,6 @@ import { initialState } from 'redux/reducers/search/searchFiltersReducer';
 import * as appliedFilterActions from 'redux/actions/search/appliedFilterActions';
 import { clearAllFilters as clearStagedFilters } from 'redux/actions/search/searchFilterActions';
 import { resetMapLegendToggle } from 'redux/actions/search/mapLegendToggleActions';
-import { setHasResults } from "../../redux/actions/search/titleBarFilterActions";
 import {
     convertFiltersToAnalyticEvents,
     sendAnalyticEvents,
@@ -36,8 +35,7 @@ const propTypes = {
     resetNaicsTree: PropTypes.func,
     resetMapLegendToggle: PropTypes.func,
     setAppliedFilterCompletion: PropTypes.func,
-    resetAppliedFilters: PropTypes.func,
-    setHasResults: PropTypes.func
+    resetAppliedFilters: PropTypes.func
 };
 
 export class SearchSidebarSubmitContainer extends React.Component {
@@ -111,7 +109,6 @@ export class SearchSidebarSubmitContainer extends React.Component {
         this.props.clearStagedFilters();
         this.props.resetAppliedFilters();
         this.props.resetMapLegendToggle();
-        this.props.setHasResults(false);
     }
 
     render() {
@@ -131,14 +128,12 @@ export default connect(
         requestsComplete: state.appliedFilters._complete,
         isEmpty: state.appliedFilters._empty,
         stagedFilters: state.filters,
-        appliedFilters: state.appliedFilters.filters,
-        hasResults: state.titleBarFilter.hasResults
+        appliedFilters: state.appliedFilters.filters
     }),
     (dispatch) => ({
         ...bindActionCreators(Object.assign(
             {},
-            combinedActions,
-            { setHasResults }
+            combinedActions
         ),
         dispatch)
     })

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -30,15 +30,13 @@ import ResultsTableSection from 'components/search/table/ResultsTableSection';
 
 import searchActions from 'redux/actions/searchActions';
 import * as appliedFilterActions from 'redux/actions/search/appliedFilterActions';
-import { setHasResults } from "../../../redux/actions/search/titleBarFilterActions";
 
 const propTypes = {
     filters: PropTypes.object,
     setAppliedFilterCompletion: PropTypes.func,
     noApplied: PropTypes.bool,
     subaward: PropTypes.bool,
-    subAwardIdClicked: PropTypes.func,
-    setHasResults: PropTypes.func
+    subAwardIdClicked: PropTypes.func
 };
 export const tableTypes = [
     {
@@ -220,14 +218,6 @@ const ResultsTableContainer = (props) => {
                 setInFlight(newState.inFlight);
                 setTableInstance(newState.tableInstance);
                 setResults(newState.results);
-
-                if (newState.results.length > 0) {
-                    props.setHasResults(true);
-                }
-                else {
-                    props.setHasResults(false);
-                }
-
                 setPage(newState.page);
                 setLastPage(newState.lastPage);
 
@@ -537,8 +527,7 @@ export default connect(
     (state) => ({
         filters: state.appliedFilters.filters,
         noApplied: state.appliedFilters._empty,
-        subaward: state.searchView.subaward,
-        hasResults: state.titleBarFilter.hasResults
+        subaward: state.searchView.subaward
     }),
     (dispatch) => bindActionCreators(
         // access multiple redux actions
@@ -546,7 +535,6 @@ export default connect(
             {},
             searchActions,
             appliedFilterActions,
-            { setHasResults },
             { subAwardIdClicked }
         ),
         dispatch


### PR DESCRIPTION
**High level description:**

just undoing some of the title filter bar work that i did

**JIRA Ticket:**
[DEV-10984](https://federal-spending-transparency.atlassian.net/browse/DEV-10984)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
