### PR TITLE
fix - adjusted css for error, loading, and no results screens for pre…

### DIFF
--- a/src/_scss/pages/search/results/visualizations/time/timeVisualization.scss
+++ b/src/_scss/pages/search/results/visualizations/time/timeVisualization.scss
@@ -22,7 +22,7 @@
         .download {
             float: right;
             padding-top: rem(20);
-            
+
             svg {
               font-size: rem(17);
             }

--- a/src/_scss/pages/search/resultsView/_resultsView.scss
+++ b/src/_scss/pages/search/resultsView/_resultsView.scss
@@ -237,3 +237,18 @@
 .usda-message_no-results, .usda-message_error, .usda-message_loading {
   padding: rem(200) 0;
 }
+
+// TODO: REMOVE BELOW ONCE NEW SEARCH GOES TO PROD
+.recharts-time-visualization-container {
+  .usda-message_no-results {
+    padding: rem(142.5) 0;
+  }
+
+ .usda-message_error {
+   padding: rem(120.1) 0;
+ }
+
+ .usda-message_loading {
+   padding: rem(127.5) 0;
+ }
+}


### PR DESCRIPTION
**High level description:**
Fixed the sizing on the no results, error, and loading screens for the time chart.

**Technical details:**
CSS changes made just for the current advanced search.

**JIRA Ticket:**
n/a

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
