### PR TITLE
11014 - logic and css for making the right edge fade appear and disap…

### DIFF
--- a/src/_scss/elements/_table.scss
+++ b/src/_scss/elements/_table.scss
@@ -16,7 +16,7 @@ table {
             tbody.usda-table__body {
                 .usda-table__row {
                     td.usda-table__cell:last-of-type {
-                        // this is the right border on the Table, since the fade effect is not in yet
+                        // this is the right border on the dtui Table
                         border-right: rem(1) solid $gray-cool-10;
                     }
                 }

--- a/src/_scss/pages/search/results/table/resultsTable.scss
+++ b/src/_scss/pages/search/results/table/resultsTable.scss
@@ -55,6 +55,10 @@
     .advanced-search__table-wrapper {
         width: auto;
         overflow-x: scroll;
+
+        &.activate-right-fade {
+            mask-image: linear-gradient(to left, transparent, rgba(0, 0, 0, 1) 16px);
+        }
     }
 
     .results-table-message {

--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -40,14 +40,17 @@ export default class ResultsTable extends React.Component {
 
         this.state = {
             currentRows: [],
-            cols: this.prepareDTUIColumns()
+            cols: this.prepareDTUIColumns(),
+            activateRightFade: false
         };
         this.headerCellRender = this.headerCellRender.bind(this);
         this.bodyCellRender = this.bodyCellRender.bind(this);
         this.prepareDTUIColumns = this.prepareDTUIColumns.bind(this);
         this.prepareDTUIRows = this.prepareDTUIRows.bind(this);
         this.prepareTable = this.prepareTable.bind(this);
+        this.checkToAddRightFade = this.checkToAddRightFade.bind(this);
     }
+
     componentDidUpdate(prevProps) {
         if (prevProps.tableInstance !== this.props.tableInstance) {
             // table type has changed, reset the scroll
@@ -252,7 +255,8 @@ export default class ResultsTable extends React.Component {
                     return value;
                 });
                 return values;
-            } else if (this.props.currentType === "direct_payments") {
+            }
+            else if (this.props.currentType === "direct_payments") {
                 values = arrayOfObjects.map((obj) => {
                     const value = [];
                     value.push(
@@ -329,19 +333,29 @@ export default class ResultsTable extends React.Component {
         return values;
     }
 
-    render() {
-        if (this.props.results.length === 0) {
-            // replace with no results component not a class
+    checkToAddRightFade(isScrolledLeft, isScrolledRight) {
+        if (!isScrolledLeft) {
+            this.setState({
+                activateRightFade: true
+            });
         }
+        if (isScrolledRight) {
+            this.setState({
+                activateRightFade: false
+            });
+        }
+    }
 
+    render() {
         const cols = this.prepareDTUIColumns();
         const limitedRows = this.prepareDTUIRows();
         return (
             <>
-                <div className="advanced-search__table-wrapper">
+                <div className={`advanced-search__table-wrapper  ${this.state.activateRightFade ? 'activate-right-fade' : ''} `}>
                     <Table
                         classNames="table-for-new-search-page award-results-table-dtui"
                         stickyFirstColumn
+                        checkToAddRightFade={this.checkToAddRightFade}
                         columns={cols}
                         rows={limitedRows}
                         rowHeight={58}


### PR DESCRIPTION
…pear

**High level description:**

Make the box-shadow on the stickyColumn only appear when user has scrolled right, and disappear if they scroll all the way left again; make the right edge fade only appear when user has scolled right, and make it disappear when all the way to the right

**Technical details:**

Added listener in dtui Table to get scroll positions, and use those to set state vars for right and left there. Had to add a function in usas ResultsTable to see if the fade effect shoudl be applied. This css has to happen in usas because the fade has to be on the table-wrapper, 

**JIRA Ticket:**
[DEV-11014](https://federal-spending-transparency.atlassian.net/browse/DEV-11014)

**Mockup:**


The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
