### PR TITLE
Fix new search pagination

### DIFF
--- a/src/js/containers/search/newResultsView/ResultsTableContainer.jsx
+++ b/src/js/containers/search/newResultsView/ResultsTableContainer.jsx
@@ -304,6 +304,7 @@ const ResultsTableContainer = (props) => {
         if (newState.sort) {
             setSort(Object.assign(newState.sort));
         }
+        setPage(1);
         Analytics.event({
             event: 'search_table_tab',
             category: 'Advanced Search - Table Tab',

--- a/src/js/containers/search/table/ResultsTableContainer.jsx
+++ b/src/js/containers/search/table/ResultsTableContainer.jsx
@@ -303,6 +303,7 @@ const ResultsTableContainer = (props) => {
         if (newState.sort) {
             setSort(Object.assign(newState.sort));
         }
+        setPage(1);
         Analytics.event({
             event: 'search_table_tab',
             category: 'Advanced Search - Table Tab',


### PR DESCRIPTION
**High level description:**

to test - in qat when you do a search click on page 3 then switch tabs in the search table, it will stay on page 3, the fixes ensure that when you switch tabs you go back to page 1

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
