### PR TITLE
DEV-10097 fix for 1366x768 screens

### DIFF
--- a/src/_scss/pages/interactiveDataSources/_dataSourcesTitles.scss
+++ b/src/_scss/pages/interactiveDataSources/_dataSourcesTitles.scss
@@ -29,6 +29,9 @@
             transform: translate(24px,280px);
         }
         @media(min-width: 1200px) {
+            @media(max-height: 892px) {
+                transform: translate(80px,200px);
+            }
             transform: translate(80px,296px);
         }
         @media(min-width: 1400px) {


### PR DESCRIPTION
**High level description:**

adjust text location on data sources page for 1366x768 screen widths
**JIRA Ticket:**
[DEV-10097](https://federal-spending-transparency.atlassian.net/browse/DEV-10097)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
