### PR TITLE
hotfix - removed css that was preventing stickyColumn hover change; a…

### DIFF
--- a/src/_scss/pages/search/results/searchResults.scss
+++ b/src/_scss/pages/search/results/searchResults.scss
@@ -22,19 +22,29 @@
         @import "./screens/screens";
     }
 
-    .table-for-new-search-page {
-        &.activate-right-fade {
-            mask-image: linear-gradient(to left, transparent, rgba(0, 0, 0, 1) 16px);
-        }
+    // temp fix for the box shadow on stickyColumn for awards table
+    table.usda-table {
+        &.table-for-new-search-page {
+            &.award-results-table-dtui {
 
-        .usda-table__cell.stickyColumn {
-            background-color: $color-white;
-        }
+                tbody.usda-table__body {
+                    td.usda-table__cell.stickyColumn {
+                        &.add-box-shadow {
+                            border-right: solid 1px $gray-cool-10;
+                            // same as $shadow-sm, but only on right side
+                            box-shadow: 4px 0 8px -2px rgba(0, 0, 0, 0.1);
+                        }
+                    }
+                }
 
-        .stickyColumn {
-            border-right: solid 1px $gray-cool-10;
-            -webkit-box-shadow: 0 4px 8px rgba(0, 0, 0, .1);
-            box-shadow: 0 4px 8px rgba(0, 0, 0, .1);
+                th.table-header.stickyColumn {
+                    &.add-box-shadow {
+                        border-right: solid 1px $gray-cool-10;
+                        // same as $shadow-sm, but only on right side
+                        box-shadow: 4px 0 8px -2px rgba(0, 0, 0, 0.1);
+                    }
+                }
+            }
         }
     }
 

--- a/src/_scss/pages/search/resultsView/_resultsView.scss
+++ b/src/_scss/pages/search/resultsView/_resultsView.scss
@@ -244,6 +244,10 @@
         }
       }
     }
+
+    .usa-dt-pagination {
+      margin-top: $global-margin;
+    }
   }
 }
 


### PR DESCRIPTION
…dded margin top to pagination; added code to make the awards table box shadow appear on scroll; changed shape of box-shadow to only be on right side

**High level description:**



**Technical details:**

I added back the fade effect on the awards table - the width problem with the Map table at mobile is no longer happening, and the stickyColumn box shadow on scroll is happening on that table now, but the right side fade effect is not. 

**JIRA Ticket:**
[DEV-1234](https://federal-spending-transparency.atlassian.net/browse/DEV-1234)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
