### PR TITLE
11180 - centered text in explore the data section buttons

### DIFF
--- a/src/_scss/pages/homepageUpdate/_awardSearch.scss
+++ b/src/_scss/pages/homepageUpdate/_awardSearch.scss
@@ -257,6 +257,9 @@
           .card__button {
             margin-bottom: 0;
 
+              button {
+                margin-right: 0;
+              }
 
             .card__button--primary {
               white-space: normal;

--- a/src/_scss/pages/homepageUpdate/_awardSearch.scss
+++ b/src/_scss/pages/homepageUpdate/_awardSearch.scss
@@ -257,10 +257,6 @@
           .card__button {
             margin-bottom: 0;
 
-              button {
-                margin-right: 0;
-              }
-
             .card__button--primary {
               white-space: normal;
               text-align: center;

--- a/src/_scss/pages/homepageUpdate/_awardSearch.scss
+++ b/src/_scss/pages/homepageUpdate/_awardSearch.scss
@@ -10,6 +10,7 @@
       display:flex;
     }
   }
+
   .grid-content {
     margin-top: 0;
     margin-bottom: 96px;
@@ -19,8 +20,10 @@
     @media (min-width: 1400px) {
       align-items: center;
     }
+
     .award-search__col1 {
       align-items: center;
+
       @media (max-width:1400px) {
         width: 100%;
       }
@@ -213,7 +216,6 @@
             @media (max-width: $tablet-screen) {
               margin-bottom: $global-margin;
             }
-
           }
         }
 

--- a/src/_scss/pages/homepageUpdate/_exploreTheData.scss
+++ b/src/_scss/pages/homepageUpdate/_exploreTheData.scss
@@ -73,7 +73,9 @@
           }
           .button-type__secondary-light{
             margin-top: 0;
-            padding-top: 0;
+            padding: rem(4) $global-padding * 2;
+            //padding-top: 0;
+            //padding-bottom: 0;
             justify-content: center;
             width: 100%;
             font-size: $font-size-16;

--- a/src/_scss/pages/homepageUpdate/_exploreTheData.scss
+++ b/src/_scss/pages/homepageUpdate/_exploreTheData.scss
@@ -74,8 +74,6 @@
           .button-type__secondary-light{
             margin-top: 0;
             padding: rem(4) $global-padding * 2;
-            //padding-top: 0;
-            //padding-bottom: 0;
             justify-content: center;
             width: 100%;
             font-size: $font-size-16;


### PR DESCRIPTION


**High level description:**

Center button text in the Explore the Data section

**Technical details:**

Did that by changing padding in the buttons; also noticed that in the Award Search carousel the buttons had margin right that wasn't needed and was making them slightly not centered horizontally, so I removed that

**JIRA Ticket:**
[DEV-11180](https://federal-spending-transparency.atlassian.net/browse/DEV-11180)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
