### PR TITLE
Mod/10022 hyperlink style update-2

### DIFF
--- a/src/_scss/pages/explorer/detail/visualization/table/_table.scss
+++ b/src/_scss/pages/explorer/detail/visualization/table/_table.scss
@@ -72,7 +72,7 @@
                     .cell-content {
                         .go-deeper-link {
                             @include button-unstyled;
-                            color: $color-primary;
+                            color: $blue-50;
                             font-size: $font-size-16;
                             line-height: $base-line-height;
                         }

--- a/src/_scss/pages/state/_contentWrap.scss
+++ b/src/_scss/pages/state/_contentWrap.scss
@@ -86,14 +86,14 @@
 					@include flex(0 0 auto);
 					@include align-items(center);
 					@include button-unstyled;
-					color: $color-primary;
+					color: $blue-50;
 					margin-top: rem(16);
 					font-size: rem(14);
 					width: fit-content;
 					&:hover {
-						color: $color-primary-darker;
+						color: $blue-70v;
 						svg {
-							fill: $color-primary-darker;
+							fill: $blue-70v;
 						}
 					}
 				}


### PR DESCRIPTION
**High level description:**
Found two instances of links that needed updating.

**Technical details:**
On spending explorer, the links on the table needed changing. On the state profile, the link 'View awards to this state' needed it's color and hover color updated.

**JIRA Ticket:**
[DEV-10022](https://federal-spending-transparency.atlassian.net/browse/DEV-10022)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
