### PR TITLE
11194 - fix for table borders on agency page, award spending section

### DIFF
--- a/src/_scss/pages/agency/dtuiOverrides.scss
+++ b/src/_scss/pages/agency/dtuiOverrides.scss
@@ -1,0 +1,24 @@
+.table-wrapper {
+  .usda-table {
+    // this was added after the dtui table styles were changed for the new search page
+    th, td {
+      // we need to get rid of the black borders that will appear
+      border: 0;
+      // and replace them with this gray border
+      border: solid 1px $color-gray-border;
+    }
+
+    tr {
+      td:last-of-type {
+        border: 0;
+
+        border-right: solid 1px $color-gray-border;
+        border-bottom: solid 1px $color-gray-border;
+      }
+    }
+
+    // and we need to add back top and bottom margins
+    margin-top: $global-margin;
+    margin-bottom: $global-margin;
+  }
+}

--- a/src/_scss/pages/agency/index.scss
+++ b/src/_scss/pages/agency/index.scss
@@ -4,6 +4,7 @@
     @import 'components/pageLoading';
     @import 'layouts/default/stickyHeader/header';
     @import 'mixins/profilePage';
+    @import './dtuiOverrides';
 
     @include display(flex);
     @include justify-content(flex-start);

--- a/src/_scss/pages/agency/statusOfFunds/_dtuiOverrides.scss
+++ b/src/_scss/pages/agency/statusOfFunds/_dtuiOverrides.scss
@@ -8,7 +8,6 @@
     .usda-table__row-item {
       border: 1px solid $color-gray-lighter;
       border-top: 2px solid $color-gray-lighter;
-
     }
   }
 }


### PR DESCRIPTION
**High level description:**

This table has black borders instead of gray.

**Technical details:**

Added a dtuiOverrides file to agency/index.scss to make the borders gray again

**JIRA Ticket:**
[DEV-11194](https://federal-spending-transparency.atlassian.net/browse/DEV-11194)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
