### PR TITLE
Bug/11173 fed acct mobile

### DIFF
--- a/src/_scss/pages/account/results/visualizations/rank/_topSection.scss
+++ b/src/_scss/pages/account/results/visualizations/rank/_topSection.scss
@@ -5,14 +5,18 @@
     @import "../../../../../components/visualizations/_period";
     margin-left: 0;
     width: 100%;
-    @include media($tablet-screen) {
-        @include display(flex);
-        float: none;
+    @include display(flex);
+    flex-direction: column;
+    float: none;
+
+    @media(min-width: $tablet-screen) {
+        flex-direction: row;
     }
+
     .visualization-period {
         .content {
             li {
-                //EDIT THIS DEPENDING ON HOW MANY CHOICES ARE AVAILABLE WITHIN THE TOGGLE (DEFAULT IS 3 = 5.3 COLUMNS) 
+                //EDIT THIS DEPENDING ON HOW MANY CHOICES ARE AVAILABLE WITHIN THE TOGGLE (DEFAULT IS 3 = 5.3 COLUMNS)
                 @include grid-column(5.3);
             }
         }

--- a/src/_scss/pages/account/results/visualizations/time/_topSection.scss
+++ b/src/_scss/pages/account/results/visualizations/time/_topSection.scss
@@ -5,11 +5,15 @@
     @import "../../../../../components/visualizations/_period";
     margin-left: 0;
     width: 100%;
-    @include media($tablet-screen) {
-        @include display(flex);
-        float: none;
+    @include display(flex);
+    flex-direction: column;
+    float: none;
+
+    @media(min-width: $tablet-screen) {
+        flex-direction: row;
     }
-    .visualization-period {
+
+        .visualization-period {
         .content {
             ul {
                 display: flex;


### PR DESCRIPTION
**High level description:**

Bug only at screens < 768, the buttons in the top section of the charts in Time and Categories sections weren't working

**Technical details:**

It was a css issue. A fix was made to these buttons before but only applied to > 768.

**JIRA Ticket:**
[DEV-11173](https://federal-spending-transparency.atlassian.net/browse/DEV-11173)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
