### PR TITLE
DEV-11272 fix fed account legend on mobile so it isn't cut off

### DIFF
--- a/src/js/components/account/visualizations/time/TimeVisualization.jsx
+++ b/src/js/components/account/visualizations/time/TimeVisualization.jsx
@@ -106,17 +106,20 @@ export default class TimeVisualization extends React.Component {
                 {
                     color: '#fba302',
                     label: 'Outlay',
-                    offset: 0
+                    offset: 0,
+                    mobileOffset: 0
                 },
                 {
                     color: '#5c7480',
                     label: 'Obligations Incurred',
-                    offset: 84
+                    offset: 84,
+                    mobileOffset: 24
                 },
                 {
                     color: '#a0bac4',
                     label: 'Unobligated Balance',
-                    offset: 220
+                    offset: 220,
+                    mobileOffset: 48
                 }
             ];
         }

--- a/src/js/components/account/visualizations/time/chart/BarChartStacked.jsx
+++ b/src/js/components/account/visualizations/time/chart/BarChartStacked.jsx
@@ -363,7 +363,7 @@ ${xAxis.items[0].label} to ${xAxis.items[xAxis.items.length - 1].label}.`;
                 <svg
                     className="bar-graph"
                     width={this.props.width}
-                    height={this.props.height + 20}>
+                    height={this.props.height + 40}>
 
                     <BarChartYAxis
                         {...this.state.virtualChart.yAxis}

--- a/src/js/components/account/visualizations/time/chart/BarChartStacked.jsx
+++ b/src/js/components/account/visualizations/time/chart/BarChartStacked.jsx
@@ -355,7 +355,7 @@ ${xAxis.items[0].label} to ${xAxis.items[xAxis.items.length - 1].label}.`;
                 toggleTooltip={this.props.toggleTooltip} />
         ));
 
-        // add 20px to the top of the chart to avoid cutting off label text
+        // add 40px to the top of the chart to avoid cutting off label text (especially on mobile)
         // wrap the chart contents in a group and transform it down 20px to avoid impacting
         // positioning calculations
         return (

--- a/src/js/components/sharedComponents/timeChart/chart/BarChartLegendItem.jsx
+++ b/src/js/components/sharedComponents/timeChart/chart/BarChartLegendItem.jsx
@@ -16,7 +16,7 @@ const propTypes = {
 };
 
 const BarChartLegendItem = (props) => {
-    const [windowWidth, setWindowWidth] = useState(0);
+    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
     useEffect(() => {
         const handleResize = throttle(() => {

--- a/src/js/components/sharedComponents/timeChart/chart/BarChartLegendItem.jsx
+++ b/src/js/components/sharedComponents/timeChart/chart/BarChartLegendItem.jsx
@@ -11,7 +11,8 @@ import { smTabletScreen } from "../../../../dataMapping/shared/mobileBreakpoints
 const propTypes = {
     color: PropTypes.string,
     label: PropTypes.string,
-    offset: PropTypes.number
+    offset: PropTypes.number,
+    mobileOffset: PropTypes.number
 };
 
 const BarChartLegendItem = (props) => {
@@ -27,6 +28,7 @@ const BarChartLegendItem = (props) => {
         window.addEventListener('resize', handleResize);
         return () => window.removeEventListener('resize', handleResize);
     }, [windowWidth]);
+
     return (
         <g
             className="chart-legend-item"

--- a/src/js/components/sharedComponents/timeChart/chart/BarChartLegendItem.jsx
+++ b/src/js/components/sharedComponents/timeChart/chart/BarChartLegendItem.jsx
@@ -3,8 +3,10 @@
  * Created by Kevin Li 3/21/17
  */
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { throttle } from "lodash";
+import { smTabletScreen } from "../../../../dataMapping/shared/mobileBreakpoints";
 
 const propTypes = {
     color: PropTypes.string,
@@ -12,27 +14,38 @@ const propTypes = {
     offset: PropTypes.number
 };
 
-export default class BarChartLegendItem extends React.Component {
-    render() {
-        return (
-            <g
-                className="chart-legend-item"
-                transform={`translate(${this.props.offset}, 0)`}>
-                <circle
-                    className="key-color"
-                    fill={this.props.color}
-                    cx="6"
-                    cy="6"
-                    r="6" />
-                <text
-                    className="key-label"
-                    x="20"
-                    y="10">
-                    {this.props.label}
-                </text>
-            </g>
-        );
-    }
-}
+const BarChartLegendItem = (props) => {
+    const [windowWidth, setWindowWidth] = useState(0);
+
+    useEffect(() => {
+        const handleResize = throttle(() => {
+            const newWidth = window.innerWidth;
+            if (windowWidth !== newWidth) {
+                setWindowWidth(newWidth);
+            }
+        }, 50);
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, [windowWidth]);
+    return (
+        <g
+            className="chart-legend-item"
+            transform={windowWidth <= smTabletScreen ? `translate(0, ${props.mobileOffset})` : `translate(${props.offset}, 0)`}>
+            <circle
+                className="key-color"
+                fill={props.color}
+                cx="6"
+                cy="6"
+                r="6" />
+            <text
+                className="key-label"
+                x="20"
+                y="10">
+                {props.label}
+            </text>
+        </g>
+    );
+};
 
 BarChartLegendItem.propTypes = propTypes;
+export default BarChartLegendItem;


### PR DESCRIPTION
**High level description:**

change legend so that it's stacked under 576px
http://localhost:3000/federal_account/020-0500 used as an example

**JIRA Ticket:**
[DEV-11272](https://federal-spending-transparency.atlassian.net/browse/DEV-11272)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
