### PR TITLE
Remove buttons in time period filter and replace with tabs

### DIFF
--- a/src/js/components/search/filters/location/LocationSection.jsx
+++ b/src/js/components/search/filters/location/LocationSection.jsx
@@ -64,11 +64,13 @@ const LocationSection = ({ selectedRecipientLocations, selectedLocations, dirtyF
     const tabLabels = [
         {
             internal: 'pop',
-            label: 'Place of Performance'
+            label: 'Place of Performance',
+            title: 'Place of Performance'
         },
         {
             internal: 'recipient',
-            label: 'Recipient Location'
+            label: 'Recipient Location',
+            title: 'Recipient Location'
         }
     ];
 

--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -277,11 +277,13 @@ export default class TimePeriod extends React.Component {
     render() {
         let errorDetails;
         let showFilter;
+        let activeClassDR;
 
         if (this.state.showError && this.props.activeTab === 'dr') {
             errorDetails = (<DateRangeError
                 header={this.state.header}
                 message={this.state.errorMessage} />);
+            activeClassDR = 'inactive';
         }
 
         if (this.props.activeTab === 'fy') {
@@ -304,10 +306,15 @@ export default class TimePeriod extends React.Component {
                 hideError={this.hideError}
                 applyDateRange={this.validateDates}
                 removeDateRange={this.removeDateRange} />);
+            activeClassDR = '';
+        }
+
+        if (this.props.disableDateRange) {
+            activeClassDR = 'hidden';
         }
 
         const newAwardsFilter = (
-            <div className="new-awards-wrapper">
+            <div className={`new-awards-wrapper ${activeClassDR}`}>
                 <label
                     htmlFor="new-awards-checkbox">
                     <input

--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -350,11 +350,13 @@ export default class TimePeriod extends React.Component {
             }
         ];
 
-        const toggleTab = () => {
-            const nextTab = this.state.activeTab === 'fy' ? 'dr' : 'fy';
-            this.setState({ ...this.state, activeTab: nextTab });
-            this.clearHint(true);
-            this.props.changeTab(nextTab);
+        const toggleTab = (e) => {
+            if ((this.state.activeTab === 'fy' && e.target.textContent.trim() !== 'Fiscal Year') || (this.state.activeTab === 'dr' && e.target.textContent.trim() !== 'Date Range')) {
+                const nextTab = this.state.activeTab === 'fy' ? 'dr' : 'fy';
+                this.setState({ ...this.state, activeTab: nextTab });
+                this.clearHint(true);
+                this.props.changeTab(nextTab);
+            }
         };
 
         return (

--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -342,11 +342,13 @@ export default class TimePeriod extends React.Component {
                     <div>
                         Fiscal Year &nbsp; <GlossaryLink term="fiscal-year-fy" />
                     </div>
-                )
+                ),
+                title: 'Fiscal Year'
             },
             {
                 internal: 'dr',
-                label: 'Date Range'
+                label: 'Date Range',
+                title: 'Date Range'
             }
         ];
 

--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -14,6 +14,7 @@ import DateRange from './DateRange';
 import AllFiscalYears from './AllFiscalYears';
 import DateRangeError from './DateRangeError';
 import GlossaryLink from "../../../sharedComponents/GlossaryLink";
+import FilterTabs from '../../../sharedComponents/filterSidebar/FilterTabs';
 
 const dayjs = require('dayjs');
 const isSameOrAfter = require('dayjs/plugin/isSameOrAfter');
@@ -60,14 +61,14 @@ export default class TimePeriod extends React.Component {
             isActive: false,
             selectedFY: new Set(),
             allFY: false,
-            clearHint: false
+            clearHint: false,
+            activeTab: 'fy'
         };
 
         // bind functions
         this.handleDateChange = this.handleDateChange.bind(this);
         this.showError = this.showError.bind(this);
         this.hideError = this.hideError.bind(this);
-        this.toggleFilters = this.toggleFilters.bind(this);
         this.validateDates = this.validateDates.bind(this);
         this.removeDateRange = this.removeDateRange.bind(this);
         this.clearHint = this.clearHint.bind(this);
@@ -174,11 +175,6 @@ export default class TimePeriod extends React.Component {
         if (datesChanged) {
             this.setState(newState);
         }
-    }
-
-    toggleFilters(e) {
-        this.clearHint(true);
-        this.props.changeTab(e.target.value);
     }
 
     handleDateChange(date, dateType) {
@@ -342,39 +338,35 @@ export default class TimePeriod extends React.Component {
             </div>
         );
 
+        const tabLabels = [
+            {
+                internal: 'fy',
+                label: (
+                    <div>
+                        Fiscal Year &nbsp; <GlossaryLink term="fiscal-year-fy" />
+                    </div>
+                )
+            },
+            {
+                internal: 'dr',
+                label: 'Date Range'
+            }
+        ];
+
+        const toggleTab = () => {
+            const nextTab = this.state.activeTab === 'fy' ? 'dr' : 'fy';
+            this.setState({ ...this.state, activeTab: nextTab });
+            this.clearHint(true);
+            this.props.changeTab(nextTab);
+        };
+
         return (
             <div className="tab-filter-wrap">
-                <div className="filter-item-wrap">
-                    <ul
-                        className="toggle-buttons"
-                        role="tablist">
-                        <li>
-                            <button
-                                className={`tab-toggle ${activeClassFY}`}
-                                value="fy"
-                                role="tab"
-                                aria-selected={this.props.activeTab === 'fy'}
-                                aria-label="Fiscal Year"
-                                title="Fiscal Year"
-                                onClick={this.toggleFilters}>
-                                Fiscal Year<GlossaryLink term="fiscal-year-fy" />
-                            </button>
-                        </li>
-                        <li>
-                            <button
-                                className={`tab-toggle ${activeClassDR}`}
-                                id="filter-date-range-tab"
-                                value="dr"
-                                role="tab"
-                                aria-selected={this.props.activeTab === 'dr'}
-                                aria-label="Date Range"
-                                title="Date Range"
-                                onClick={this.toggleFilters}
-                                disabled={this.props.disableDateRange}>
-                                Date Range
-                            </button>
-                        </li>
-                    </ul>
+                <div className="filter-item-wrap location-filter">
+                    <FilterTabs
+                        labels={tabLabels}
+                        switchTab={toggleTab}
+                        active={this.state.activeTab} />
                     { showFilter }
                     { errorDetails }
                     { !this.props.federalAccountPage && newAwardsFilter }

--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -277,8 +277,6 @@ export default class TimePeriod extends React.Component {
     render() {
         let errorDetails;
         let showFilter;
-        let activeClassFY;
-        let activeClassDR;
 
         if (this.state.showError && this.props.activeTab === 'dr') {
             errorDetails = (<DateRangeError
@@ -291,8 +289,6 @@ export default class TimePeriod extends React.Component {
                 updateFilter={this.props.updateFilter}
                 timePeriods={this.props.timePeriods}
                 selectedFY={this.props.filterTimePeriodFY} />);
-            activeClassFY = '';
-            activeClassDR = 'inactive';
         }
         else {
             showFilter = (<DateRange
@@ -308,16 +304,10 @@ export default class TimePeriod extends React.Component {
                 hideError={this.hideError}
                 applyDateRange={this.validateDates}
                 removeDateRange={this.removeDateRange} />);
-            activeClassFY = 'inactive';
-            activeClassDR = '';
-        }
-
-        if (this.props.disableDateRange) {
-            activeClassDR = 'hidden';
         }
 
         const newAwardsFilter = (
-            <div className={`new-awards-wrapper ${activeClassDR}`}>
+            <div className="new-awards-wrapper">
                 <label
                     htmlFor="new-awards-checkbox">
                     <input

--- a/src/js/components/sharedComponents/filterSidebar/FilterTab.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterTab.jsx
@@ -8,18 +8,21 @@ import PropTypes from 'prop-types';
 
 const propTypes = {
     label: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
     active: PropTypes.bool.isRequired,
     switchTab: PropTypes.func.isRequired
 };
 
-const FilterTab = ({ label, active, switchTab }) => (
+const FilterTab = ({
+    label, title, active, switchTab
+}) => (
     <div
         className={`filter-tabs__tab ${active ? 'active' : ''}`}
         role="tab"
         onClick={switchTab}
         onKeyDown={switchTab}
-        title={`Show ${label.label}`}
-        aria-label={`Show ${label.label}`}
+        title={`Show ${title}`}
+        aria-label={`Show ${label}`}
         tabIndex={0}>
         <div className="filter-tabs__label">
             {label}

--- a/src/js/components/sharedComponents/filterSidebar/FilterTab.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterTab.jsx
@@ -22,7 +22,7 @@ const FilterTab = ({
         onClick={switchTab}
         onKeyDown={switchTab}
         title={`Show ${title}`}
-        aria-label={`Show ${label}`}
+        aria-label={`Show ${title}`}
         tabIndex={0}>
         <div className="filter-tabs__label">
             {label}

--- a/src/js/components/sharedComponents/filterSidebar/FilterTabs.jsx
+++ b/src/js/components/sharedComponents/filterSidebar/FilterTabs.jsx
@@ -17,6 +17,7 @@ const FilterTabs = ({ labels, active, switchTab }) => {
     const tabs = labels.map((label) => (
         <FilterTab
             label={label.label}
+            title={label.title}
             active={active === label.internal}
             switchTab={switchTab}
             key={`filter-tab-${label.internal}`} />


### PR DESCRIPTION
**High level description:**

Replace time period buttons with tabs from LocationSection

**Technical details:**

Technical details for the knowledge of other developers.

**JIRA Ticket:**
[DEV-11304](https://federal-spending-transparency.atlassian.net/browse/DEV-11304)

**Mockup:**
https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55/screen/663942629f0e7d977ea7eb9e

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
