### PR TITLE
Repositioned Prime Award Table/Map

### DIFF
--- a/src/js/components/search/newResultsView/SectionsContent.jsx
+++ b/src/js/components/search/newResultsView/SectionsContent.jsx
@@ -90,10 +90,10 @@ const SectionsContent = (props) => {
 
     return (
         <>
-            <MapSection subaward={props.subaward} />
+            <TableSection subaward={props.subaward} awardTableHasLoaded={awardTableHasLoaded} />
             <CategoriesSection subaward={props.subaward} categoriesHasLoaded={categoriesHasLoaded} setSelectedDropdown={setSelectedDropdown} selectedDropdown={selectedDropdown} />
             <TimeSection subaward={props.subaward} timeHasLoaded={timeHasLoaded} />
-            <TableSection subaward={props.subaward} awardTableHasLoaded={awardTableHasLoaded} />
+            <MapSection subaward={props.subaward} />
         </>
     );
 };

--- a/src/js/containers/search/newResultsView/ResultsTableContainer.jsx
+++ b/src/js/containers/search/newResultsView/ResultsTableContainer.jsx
@@ -90,7 +90,7 @@ const ResultsTableContainer = (props) => {
     const [error, setError] = useState(false);
     const [results, setResults] = useState([]);
     const [total, setTotal] = useState(0);
-    const [resultLimit, setResultLimit] = useState(10);
+    const [resultLimit, setResultLimit] = useState(100);
     const [tableInstance, setTableInstance] = useState(`${uniqueId()}`);
     const [isLoadingNextPage, setLoadNextPage] = useState(false);
     const initialRender = useRef(true);


### PR DESCRIPTION
**High level description:**

Moved Prime Award Table to top off Search page and Map to bottom. Changed default from 10 to 100 awards to load upon render of Prime Award Table. 

**Technical details:**

N/A

**JIRA Ticket:**
[DEV-11292](https://federal-spending-transparency.atlassian.net/browse/DEV-11292)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [x] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
