### PR TITLE
Mod/11134 state top five section

### DIFF
--- a/src/js/containers/state/topFive/TopFiveContainer.jsx
+++ b/src/js/containers/state/topFive/TopFiveContainer.jsx
@@ -95,7 +95,7 @@ export class TopFiveContainer extends React.Component {
 
         if (this.props.category === 'awards') {
             filters.award_type_codes = ['A', 'B', 'C', 'D'];
-            params.fields = ['Award ID', 'Award Amount'];
+            params.fields = ['Award ID', 'Award Amount', 'generated_internal_id'];
             params.order = 'desc';
             params.sort = 'Award Amount';
             params.subawards = false;
@@ -150,11 +150,13 @@ export class TopFiveContainer extends React.Component {
             if (this.props.category === 'awards') {
                 result.populate({
                     name: item['Award ID'],
-                    amount: item['Award Amount']
+                    amount: item['Award Amount'],
+                    agency_slug: item.generated_internal_id,
+                    category: this.props.category
                 }, index + 1);
             }
             else {
-                result.populate(item, index + 1);
+                result.populate({ ...item, category: this.props.category }, index + 1);
             }
 
             if (type === 'awarding_agency' || type === 'awarding_subagency') {

--- a/src/js/containers/state/topFive/TopFiveContainer.jsx
+++ b/src/js/containers/state/topFive/TopFiveContainer.jsx
@@ -132,7 +132,6 @@ export class TopFiveContainer extends React.Component {
         this.request.promise
             .then((res) => {
                 this.parseResults(res.data.results, res.data.category);
-                console.log(`res ${this.props.category}: `, res);
             })
             .catch((err) => {
                 if (!isCancel(err)) {

--- a/src/js/dataMapping/state/topCategories.js
+++ b/src/js/dataMapping/state/topCategories.js
@@ -7,6 +7,7 @@ export const categories = {
     all: [
         'awarding_agency',
         'recipient',
+        'awards',
         'cfda',
         'naics',
         'county',
@@ -16,6 +17,7 @@ export const categories = {
         'awarding_agency',
         'awarding_subagency',
         'recipient',
+        'awards',
         'naics',
         'county',
         'district'
@@ -24,6 +26,7 @@ export const categories = {
         'awarding_agency',
         'awarding_subagency',
         'recipient',
+        'awards',
         'cfda',
         'county',
         'district'
@@ -32,6 +35,7 @@ export const categories = {
         'awarding_agency',
         'awarding_subagency',
         'recipient',
+        'awards',
         'cfda',
         'county',
         'district'
@@ -40,6 +44,7 @@ export const categories = {
         'awarding_agency',
         'awarding_subagency',
         'recipient',
+        'awards',
         'cfda',
         'county',
         'district'
@@ -48,6 +53,7 @@ export const categories = {
         'awarding_agency',
         'awarding_subagency',
         'recipient',
+        'awards',
         'cfda',
         'county',
         'district'
@@ -58,6 +64,7 @@ export const categoryTitles = {
     awarding_agency: 'Awarding Agencies',
     awarding_subagency: 'Awarding Sub-Agencies',
     recipient: 'Recipients',
+    awards: 'Awards',
     cfda: 'Assistance Listings (CFDA Programs)',
     naics: 'NAICS Codes',
     county: 'Counties',

--- a/src/js/models/v2/state/BaseStateCategoryResult.jsx
+++ b/src/js/models/v2/state/BaseStateCategoryResult.jsx
@@ -21,6 +21,7 @@ const BaseStateCategoryResult = {
         this._code = data.code || '';
         this._slug = data.agency_slug;
         this._amount = data.amount || 0;
+        this._category = data.category || '';
 
         this._nameTemplate = defaultNameTemplate;
     },
@@ -41,6 +42,10 @@ const BaseStateCategoryResult = {
         return `${this.index}. ${this.combinedName}`;
     },
     get linkedName() {
+        if (this._category === 'awards') {
+            return <a href={`/award/${this._slug}`}>{this.name}</a>;
+        }
+
         return <a href={`/agency/${this._slug}`}>{this.name}</a>;
     }
 };


### PR DESCRIPTION
**High level description:**
Added new awards section to the Top Five section on the State Profile Page.

**Technical details:**
Adjustments to data params, parse results, and BaseStateCategoryResult to accommodate the new api call. New image added for icon in awards section header.

**JIRA Ticket:**
[DEV-11134](https://federal-spending-transparency.atlassian.net/browse/DEV-11134)

**Mockup:**
https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
