### PR TITLE
11395 - make time period new awards only checkbox filter keyboard accessible

### DIFF
--- a/src/_scss/pages/search/filters/timePeriod/timePeriod.scss
+++ b/src/_scss/pages/search/filters/timePeriod/timePeriod.scss
@@ -34,6 +34,10 @@
                     opacity: 0.5;
                     cursor: default;
                 }
+
+                &:focus-visible {
+                    outline: 1px solid $color-focus;
+                }
             }
 
             .new-awards-label {

--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -277,10 +277,23 @@ export default class TimePeriod extends React.Component {
         }
     }
 
+    enterKeyToggleHandler(e) {
+        if (e.key === 'Enter') {
+            let isSelected = false;
+            if (!this.props.newAwardsOnlySelected) {
+                isSelected = true;
+            }
+            else {
+                isSelected = false;
+            }
+            this.props.updateNewAwardsOnlySelected(isSelected);
+        }
+    }
+
     render() {
         let errorDetails;
         let showFilter;
-        let activeClassDR;
+        let activeClassDR = '';
 
         if (this.state.showError && this.props.activeTab === 'dr') {
             errorDetails = (<DateRangeError
@@ -331,9 +344,10 @@ export default class TimePeriod extends React.Component {
                         value="new-awards-checkbox"
                         disabled={this.props.subaward || !this.props.newAwardsOnlyActive}
                         checked={this.props.newAwardsOnlySelected}
-                        onChange={this.newAwardsClick} />
+                        onChange={this.newAwardsClick}
+                        onKeyUp={(e) => this.enterKeyToggleHandler(e)} />
                     <span className={`new-awards-label ${this.props.subaward || !this.props.newAwardsOnlyActive ? 'not-active' : ''}`}>
-                    Show New Awards Only
+                        Show New Awards Only
                     </span>
                 </label>
                 <TooltipWrapper


### PR DESCRIPTION
**High level description:**

Addresses keyboard accessibility for the Show New Awards Only checkbox under the Time Period Fiscal Year filter.

**Technical details:**

Used the onKeyUp event handler and conditionals to toggle selecting and unselecting the New Awards Only filter.

**JIRA Ticket:**
[DEV-11395](https://federal-spending-transparency.atlassian.net/browse/DEV-11395)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
