### PR TITLE
11283 - Added missing agency_abbreviation field to fix the Subagency top 5 section link to "View Awards"

### DIFF
--- a/src/js/components/state/topFive/TopFive.jsx
+++ b/src/js/components/state/topFive/TopFive.jsx
@@ -126,7 +126,7 @@ const TopFive = (props) => {
                         toptier_flag: false,
                         toptier_agency: {
                             toptier_code: agencySlugs[linkData.agency_slug],
-                            abbreviation: linkData.agency_code,
+                            abbreviation: linkData.agency_abbreviation,
                             name: linkData.agency_name
                         },
                         subtier_agency: {


### PR DESCRIPTION
**High level description:**
Added missing agency_abbreviation field to fix the Subagency top 5 section link to "View Awards"

**Technical details:**
Added the missing field from the backend added with their ticket DEV-11405

**JIRA Ticket:**
[DEV-11283](https://federal-spending-transparency.atlassian.net/browse/DEV-11283)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
- [x] Code review complete
