### PR TITLE
DEV-11371 minimize jumping

### DIFF
--- a/src/js/components/search/newResultsView/SearchSectionWrapper.jsx
+++ b/src/js/components/search/newResultsView/SearchSectionWrapper.jsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from "prop-types";
+import { throttle } from "lodash";
 import { useHistory } from "react-router-dom";
 import { useQueryParams, combineQueryParams, getQueryParamString } from 'helpers/queryParams';
 import Analytics from 'helpers/analytics/Analytics';
@@ -69,6 +70,10 @@ const SearchSectionWrapper = ({
     const wrapperWidth = document.querySelector('.search__section-wrapper-content')?.clientWidth;
 
     const history = useHistory();
+
+    const params = history.location.search.split("&");
+    params.shift();
+    const sectionValue = params[0].substring(8);
     const sortFn = () => dropdownOptions;
 
     const changeView = (label) => {
@@ -80,7 +85,7 @@ const SearchSectionWrapper = ({
         }
     };
 
-    const jumpToSection = (section = '') => {
+    const jumpToSection = (section) => {
         const sections = ['map', 'time', 'categories', 'awards'];
         // we've been provided a section to jump to
         // check if it's a valid section
@@ -114,25 +119,24 @@ const SearchSectionWrapper = ({
             rectTopOffset = 2240;
         }
 
-        window.scrollTo({
-            top: rectTopOffset,
-            behavior: 'smooth'
-        });
-    };
-
-    const parseSection = () => {
-        const params = history.location.search.split("&");
-        params.shift();
-        if ((params.length === 1 || params.length === 2) && params[0].substring(0, 8) === "section=") {
-            jumpToSection(params[0].substring(8));
+        if (section === sectionValue) {
+            window.scrollTo({
+                top: rectTopOffset,
+                behavior: 'smooth'
+            });
         }
     };
 
-    useEffect(() => {
+    const parseSection = () => {
+        if ((params.length === 1 || params.length === 2) && params[0].substring(0, 8) === "section=") {
+            jumpToSection(sectionValue);
+        }
+    };
+    useEffect(throttle(() => {
         setContentHeight(content);
         parseSection();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [content, sectionName]);
+    }, 500), [content, sectionName]);
 
     useEffect(() => {
         if (gaRef.current) {


### PR DESCRIPTION
**High level description:**

there is still a small amount of jumping which i think can be chalked up to the table finishing loading bc that is the biggest section on the search page

**JIRA Ticket:**
[DEV-11371](https://federal-spending-transparency.atlassian.net/browse/DEV-11371)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
