### PR TITLE
DEV-11396 fix end problem on not typing in dates

### DIFF
--- a/src/js/components/search/filters/timePeriod/DateRange.jsx
+++ b/src/js/components/search/filters/timePeriod/DateRange.jsx
@@ -69,7 +69,8 @@ const DateRange = (props) => {
             if (start) {
                 startValue = start.format('YYYY-MM-DD');
             }
-            else {
+
+            if (end) {
                 endValue = end.format('YYYY-MM-DD');
             }
 


### PR DESCRIPTION
**High level description:**

fix issue mentioned here https://data-transparency-bfs.slack.com/archives/CE5P5AWE8/p1726073360975559
wasn't caught before bc I had been typing in dates, this problem only occurs when clicking on the calendar icon and selecting dates


**JIRA Ticket:**
[DEV-11396](https://federal-spending-transparency.atlassian.net/browse/DEV-11396)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [x] Code review complete
