### PR TITLE
Mod/9983 replace global mrg

### DIFF
--- a/src/_scss/components/_Note.scss
+++ b/src/_scss/components/_Note.scss
@@ -1,6 +1,6 @@
 .default-note {
   font-size: 14px;
-  padding-top: $global-pad;
+  padding-top: $global-padding * 2;
   width: 100%;
   strong {
     font-weight: 600;

--- a/src/_scss/components/_checkboxes.scss
+++ b/src/_scss/components/_checkboxes.scss
@@ -8,7 +8,7 @@
         @import "./checkbox/secondaryCheckboxType";
         & li {
             &:last-child {
-                margin-bottom: $global-mrg;
+                margin-bottom: $global-margin * 2;
             }
         }
     }

--- a/src/_scss/components/_footerLinkToAdvancedSearch.scss
+++ b/src/_scss/components/_footerLinkToAdvancedSearch.scss
@@ -4,7 +4,7 @@
     @include justify-content(center);
     background-color: $color-primary-darkest;
     color: $color-white;
-    padding: ($global-pad * 4) 0;
+    padding: ($global-padding * 8) 0;
     position: relative;
     width: 100%;
 

--- a/src/_scss/components/tooltips/_customTooltipContent.scss
+++ b/src/_scss/components/tooltips/_customTooltipContent.scss
@@ -73,7 +73,7 @@
     @include align-items(center);
     .tooltip__title {
         width: 100%;
-        margin-bottom: math.div($global-mrg, 2);
+        margin-bottom: math.div($global-margin * 2, 2);
         text-align: center;
     }
     .tooltip__text {

--- a/src/_scss/components/visualizations/_period.scss
+++ b/src/_scss/components/visualizations/_period.scss
@@ -1,7 +1,7 @@
 .visualization-period {
     @include grid-column(16);
     @import "_scope";
-    margin-top: $global-mrg;
+    margin-top: $global-margin * 2;
     margin-left: 0;
     width: 100%;
     @include media($tablet-screen) {

--- a/src/_scss/components/visualizations/tooltip/_tooltip.scss
+++ b/src/_scss/components/visualizations/tooltip/_tooltip.scss
@@ -18,7 +18,7 @@
         color: $gray-90;
         font-size: $font-size-16;
         font-weight: $font-semibold;
-        padding: $global-pad ($global-pad * 2);
+        padding: $global-padding * 2 ($global-padding * 4);
         text-align: center;
         z-index: 9;
     }
@@ -26,7 +26,7 @@
         @include display(flex);
         @include flex-flow(row wrap);
         @include justify-content(space-between);
-        padding: rem(15) ($global-pad * 2);
+        padding: rem(15) ($global-padding * 4);
         &.center {
             width: 100%;
         }

--- a/src/_scss/core/_variables.scss
+++ b/src/_scss/core/_variables.scss
@@ -245,7 +245,7 @@ $shadow-lg: 0 12px 24px rgba(0, 0, 0, 0.1);
 // (example usage {padding: ($global-pad * 4);} = 60px of padding.)
 $global-pad-mrg: rem(15);
 $global-pad: $global-pad-mrg;
-$global-mrg: $global-pad-mrg;
+//$global-mrg: $global-pad-mrg;
 
 // Global Padding and Margins (new units for 2022 homepage redesign)
 // (example usage {padding: ($global-padding * 4);} = 32px of padding.)

--- a/src/_scss/core/_variables.scss
+++ b/src/_scss/core/_variables.scss
@@ -243,8 +243,8 @@ $shadow-lg: 0 12px 24px rgba(0, 0, 0, 0.1);
 
 // Global Padding and Margins
 // (example usage {padding: ($global-pad * 4);} = 60px of padding.)
-$global-pad-mrg: rem(15);
-$global-pad: $global-pad-mrg;
+//$global-pad-mrg: rem(15);
+//$global-pad: $global-pad-mrg;
 //$global-mrg: $global-pad-mrg;
 
 // Global Padding and Margins (new units for 2022 homepage redesign)

--- a/src/_scss/core/_variables.scss
+++ b/src/_scss/core/_variables.scss
@@ -240,13 +240,6 @@ $shadow-sm: 0 4px 8px rgba(0, 0, 0, 0.1);
 $shadow-md: 0 8px 16px rgba(0, 0, 0, 0.1);
 $shadow-lg: 0 12px 24px rgba(0, 0, 0, 0.1);
 
-
-// Global Padding and Margins
-// (example usage {padding: ($global-pad * 4);} = 60px of padding.)
-//$global-pad-mrg: rem(15);
-//$global-pad: $global-pad-mrg;
-//$global-mrg: $global-pad-mrg;
-
 // Global Padding and Margins (new units for 2022 homepage redesign)
 // (example usage {padding: ($global-padding * 4);} = 32px of padding.)
 $global-spacing-unit: rem(8);

--- a/src/_scss/elements/filters/_errorMessage.scss
+++ b/src/_scss/elements/filters/_errorMessage.scss
@@ -2,7 +2,7 @@
     @import "mixins/setText";
     @include usa-input-error-message;
     border: 1px solid $color-secondary-dark;
-    padding: $global-pad;
+    padding: $global-padding * 2;
     margin: $global-margin * 2 0;
     .error-title {
         @include display(flex);

--- a/src/_scss/elements/filters/_errorMessage.scss
+++ b/src/_scss/elements/filters/_errorMessage.scss
@@ -3,7 +3,7 @@
     @include usa-input-error-message;
     border: 1px solid $color-secondary-dark;
     padding: $global-pad;
-    margin: $global-mrg 0;
+    margin: $global-margin * 2 0;
     .error-title {
         @include display(flex);
         @include justify-content(flex-start);

--- a/src/_scss/layouts/article/aboutArticle.scss
+++ b/src/_scss/layouts/article/aboutArticle.scss
@@ -16,7 +16,7 @@
         }
         & svg:not(:root) {
             fill: $color-gray-medium;
-            padding: 0 $global-pad;
+            padding: 0 $global-padding * 2;
         }
         & .breadcrumb-arrow {
             display: inline-block;

--- a/src/_scss/layouts/article/aboutArticle.scss
+++ b/src/_scss/layouts/article/aboutArticle.scss
@@ -31,7 +31,7 @@
             float: none;
             & ul {
                 padding-left: 0;
-                margin: ($global-mrg * 2) 0 0 0;
+                margin: ($global-margin * 4) 0 0 0;
             }
         }
         @include media($large-screen) {
@@ -40,7 +40,7 @@
             float: none;
             & ul {
                 padding-left: 0;
-                margin: ($global-mrg * 2) 0 0 0;
+                margin: ($global-margin * 4) 0 0 0;
             }
         }
         @include media($x-large-screen) {
@@ -56,20 +56,14 @@
         }
     }
     .article-wrapper {
+        margin-top: $global-margin * 2;
+
         h1 {
-            margin: ($global-pad * 2) 0 ($global-pad) 0;
+            margin: ($global-margin * 4) 0 ($global-margin * 2) 0;
         }
+
         hr.results-divider {
-            margin: 0 0 ($global-pad * 3) 0;
-        }
-        @include media($small-screen) {
-            margin-top: $global-mrg;
-        }
-        @include media($tablet-screen) {
-            margin-top: $global-mrg;
-        }
-        @include media($medium-screen) {
-            margin-top: $global-mrg;
+            margin: 0 0 ($global-margin * 6) 0;
         }
     }
 }

--- a/src/_scss/layouts/article/article.scss
+++ b/src/_scss/layouts/article/article.scss
@@ -3,7 +3,7 @@
 
 .main-content {
     @import "../../mixins/fullSectionWrap";
-    @include fullSectionWrap(($global-mrg * 2), ($global-mrg * 2));
+    @include fullSectionWrap(($global-margin * 4), ($global-margin * 4));
 
     .article-wrapper {
         @import "elements/_divider";
@@ -12,11 +12,11 @@
 
         h1 {
             @include setText($h3-font-size);
-            margin: ($global-pad * 2) 0;
+            margin: ($global-margin * 4) 0;
         }
 
         p {
-            margin: ($global-pad * 2) 0;
+            margin: ($global-margin * 4) 0;
         }
 
         @include media($tablet-screen) {
@@ -30,7 +30,6 @@
             @include grid-shift(3);
             float: none;
             left: unset;
-            float: none;
             margin: auto;
         }
 

--- a/src/_scss/layouts/landingPage/landingPage.scss
+++ b/src/_scss/layouts/landingPage/landingPage.scss
@@ -1,7 +1,7 @@
 @import "../summary/summary";
 
 .landing-page {
-    padding: $global-pad;
+    padding: $global-padding * 2;
     .landing-page__overview {
         text-align: center;
         h2.landing-page__title {

--- a/src/_scss/mixins/selectedFilterWrap.scss
+++ b/src/_scss/mixins/selectedFilterWrap.scss
@@ -6,7 +6,7 @@
     @include flex-flow(row wrap);
     background-color: #E4E4E4;
     padding: rem(5);
-    margin-top: $global-mrg;
+    margin-top: $global-margin * 2;
     margin-bottom: rem(10);
     &:empty {
         display: none;

--- a/src/_scss/pages/about/aboutPage.scss
+++ b/src/_scss/pages/about/aboutPage.scss
@@ -8,7 +8,7 @@
 
     .main-content {
         @import "../../mixins/fullSectionWrap";
-        @include fullSectionWrap(($global-mrg * 2), ($global-mrg * 2));
+        @include fullSectionWrap(($global-margin * 4), ($global-margin * 4));
         padding:  0;
 
         @import "./_contentWrap";

--- a/src/_scss/pages/account/accountPage.scss
+++ b/src/_scss/pages/account/accountPage.scss
@@ -8,7 +8,7 @@
 
     .main-content {
         @import "../../mixins/fullSectionWrap";
-        @include fullSectionWrap(0, ($global-mrg * 4));
+        @include fullSectionWrap(0, ($global-margin * 8));
         padding: 0;
         @import "./overview/overview";
         @import "./results/searchResults";

--- a/src/_scss/pages/account/header/_options.scss
+++ b/src/_scss/pages/account/header/_options.scss
@@ -80,7 +80,7 @@
                     @include flex-direction(column);
                     @include flex(1 0 rem(180));
 
-                    padding: 0 $global-pad * 2;
+                    padding: 0 $global-padding * 4;
                     .item-label {
                         text-align: center;
                         width: 100%;

--- a/src/_scss/pages/account/overview/overview.scss
+++ b/src/_scss/pages/account/overview/overview.scss
@@ -38,7 +38,7 @@
     }
 
     .account-overview__content {
-        margin: 0 auto ($global-mrg * 2) auto;
+        margin: 0 auto ($global-margin * 4) auto;
         font-size: $small-font-size;
 
         .account-overview__heading {

--- a/src/_scss/pages/account/results/visualizations/rank/rank.scss
+++ b/src/_scss/pages/account/results/visualizations/rank/rank.scss
@@ -1,5 +1,5 @@
 .results-visualization-rank-section {
-    margin-top: ($global-mrg * 4);
+    margin-top: ($global-margin * 8);
     @import "./_topSection";
     .results-visualization-rank-container {
         position: relative;

--- a/src/_scss/pages/award/awardFinancialAssistance.scss
+++ b/src/_scss/pages/award/awardFinancialAssistance.scss
@@ -104,7 +104,7 @@
                   .tooltip-subtitle {
                     text-align: center;
                     background-color: #f8f8f8;
-                    padding: $global-pad ($global-pad * 2);
+                    padding: $global-padding * 2 ($global-padding * 4);
                   }
                   .disclaimer-total {
                       margin-bottom: rem(15);

--- a/src/_scss/pages/award/awardPage.scss
+++ b/src/_scss/pages/award/awardPage.scss
@@ -29,7 +29,7 @@
   }
   .award-content {
       @import "mixins/fullSectionWrap";
-      @include fullSectionWrap(($global-mrg * 2), ($global-mrg * 2));
+      @include fullSectionWrap(($global-margin * 4), ($global-margin * 4));
       background-color: $color-white;
 
       // Shared award summary styles

--- a/src/_scss/pages/award/shared/_awardHistorySection.scss
+++ b/src/_scss/pages/award/shared/_awardHistorySection.scss
@@ -1,6 +1,6 @@
 .award-history {
     padding: rem(40) 0 rem(60);
-    width: 100%; 
+    width: 100%;
     @import "../table/_tablesSection";
     .table-types {
       .table-type-toggle {
@@ -11,7 +11,7 @@
         @include display(flex);
         justify-content: center;
         .total-item {
-            padding: $global-pad;
+            padding: $global-padding * 2;
             .total-value {
                 font-weight: bold;
             }

--- a/src/_scss/pages/award/shared/_expandableAwardSection.scss
+++ b/src/_scss/pages/award/shared/_expandableAwardSection.scss
@@ -4,12 +4,12 @@
         @include button-unstyled;
         @include display(flex);
         color: $color-link;
-        margin-top: $global-mrg;
+        margin-top: $global-margin * 2;
         .award-description__button-icon {
-            padding-left: rem(5);
+            padding-left: rem(4);
             svg {
-                height: rem(15);
-                width: rem(15);
+                height: rem(16);
+                width: rem(16);
                 fill: $color-link;
             }
         }
@@ -17,6 +17,6 @@
 }
 .award-expandable-section__primary {
     .primary-btn {
-        margin-top: 30px;
+        margin-top: $global-margin * 4;
     }
 }

--- a/src/_scss/pages/award/table/_tablesSection.scss
+++ b/src/_scss/pages/award/table/_tablesSection.scss
@@ -61,7 +61,7 @@
         .table-type-toggle {
             @include display(flex);
             .tab-content span {
-                margin-right: math.div($global-mrg, 3);
+                margin-right: math.div($global-margin * 2, 3);
             }
         }
     }

--- a/src/_scss/pages/award/visualizations/_awardFundingSummary.scss
+++ b/src/_scss/pages/award/visualizations/_awardFundingSummary.scss
@@ -16,7 +16,7 @@
       .tooltip-subtitle {
         text-align: center;
         background-color: #f8f8f8;
-        padding: $global-pad ($global-pad * 2);
+        padding: $global-padding * 2 ($global-padding * 4);
       }
       .disclaimer-total {
           margin-bottom: rem(15);

--- a/src/_scss/pages/bulkDownload/bulkDownloadPage.scss
+++ b/src/_scss/pages/bulkDownload/bulkDownloadPage.scss
@@ -6,7 +6,7 @@
 
     .bulk-download {
         @import "../../mixins/fullSectionWrap";
-        @include fullSectionWrap(($global-mrg * 2), ($global-mrg * 2));
+        @include fullSectionWrap(($global-margin * 4), ($global-margin * 4));
         padding: 0;
 
         @media(max-width: $medium-screen) {

--- a/src/_scss/pages/bulkDownload/form/_fyPicker.scss
+++ b/src/_scss/pages/bulkDownload/form/_fyPicker.scss
@@ -40,7 +40,7 @@
                         font-weight: 300;
                         line-height: rem(34);
                         svg {
-                            margin-left: $global-mrg;
+                            margin-left: $global-margin * 2;
                         }
                     }
 

--- a/src/_scss/pages/covid19/recipient/recipientContainer.scss
+++ b/src/_scss/pages/covid19/recipient/recipientContainer.scss
@@ -273,7 +273,7 @@
 
             .tooltip {
               .tooltip-body {
-                padding: 0 ($global-pad * 2);
+                padding: 0 ($global-padding * 4);
               }
 
               .tooltip-left {

--- a/src/_scss/pages/data-sources/index.scss
+++ b/src/_scss/pages/data-sources/index.scss
@@ -7,7 +7,7 @@
 
     .main-content {
         @import "../../mixins/fullSectionWrap";
-        @include fullSectionWrap(($global-mrg * 2), ($global-mrg * 2));
+        @include fullSectionWrap(($global-margin * 4), ($global-margin * 4));
         padding:  0;
 
         @import "../about/_contentWrap";

--- a/src/_scss/pages/explorer/detail/sidebar/_fyPicker.scss
+++ b/src/_scss/pages/explorer/detail/sidebar/_fyPicker.scss
@@ -41,7 +41,7 @@
             font-size: $font-size-20;
             line-height: $heading-line-height;
             svg {
-                margin-left: $global-mrg;
+                margin-left: $global-margin * 2;
             }
         }
 

--- a/src/_scss/pages/keyword/keywordPage.scss
+++ b/src/_scss/pages/keyword/keywordPage.scss
@@ -6,8 +6,8 @@
 
     .keyword-content {
         @import "../../mixins/fullSectionWrap";
-        @include fullSectionWrap(($global-mrg * 2), ($global-mrg * 2));
-        padding:  rem(25);
+        @include fullSectionWrap(($global-margin * 4), ($global-margin * 4));
+        padding:  $global-padding * 3;
         background-color: $color-white;
         box-shadow: $container-shadow;
         color: $color-base;

--- a/src/_scss/pages/search/_searchOption.scss
+++ b/src/_scss/pages/search/_searchOption.scss
@@ -5,7 +5,7 @@
         padding: 0.1rem 0;
     }
     .filter-item-wrap {
-        padding: 0 $global-pad rem(20);
+        padding: 0 $global-padding * 2 rem(20);
         @include clearfix;
         &:last-child {
             margin-bottom: 0;

--- a/src/_scss/pages/search/filters/awardAmount/_awardAmountItem.scss
+++ b/src/_scss/pages/search/filters/awardAmount/_awardAmountItem.scss
@@ -1,5 +1,5 @@
 li.award-amount-set {
     &:last-of-type {
-        margin-bottom: $global-mrg;
+        margin-bottom: $global-margin * 2;
     }
 }

--- a/src/_scss/pages/search/filters/location/location.scss
+++ b/src/_scss/pages/search/filters/location/location.scss
@@ -7,7 +7,7 @@
     @import "./_warning";
     @import "components/_filterTabs.scss";
 
-    padding: 0 $global-pad rem(20);
+    padding: 0 $global-padding * 2 rem(20);
 
     .location-picker-divider {
         border: none;

--- a/src/_scss/pages/search/filters/programSource/programSource.scss
+++ b/src/_scss/pages/search/filters/programSource/programSource.scss
@@ -5,7 +5,7 @@
     @import "mixins/selectedFilterWrap";
     @import "../../tooltips";
 
-    padding: 0 $global-pad rem(20);
+    padding: 0 $global-padding * 2 rem(20);
 
     .program-source-components {
         .program-source-components__heading {

--- a/src/_scss/pages/search/filters/timePeriod/timePeriod.scss
+++ b/src/_scss/pages/search/filters/timePeriod/timePeriod.scss
@@ -75,7 +75,7 @@
                         float: left;
                         width: 42.3%;
                     }
-            
+
                 }
 
             li {
@@ -143,7 +143,7 @@
             }
         }
         .error-message {
-            margin: $global-mrg
+            margin: $global-margin * 2
         }
 
         .selected-filters {

--- a/src/_scss/pages/search/filters/timePeriod/timePeriod.scss
+++ b/src/_scss/pages/search/filters/timePeriod/timePeriod.scss
@@ -10,7 +10,7 @@
         @import "mixins/selectedFilterWrap";
         @import "../_singleSubmit";
 
-        padding: 0 $global-pad rem(20);
+        padding: 0 $global-padding * 2 rem(20);
 
         .new-awards-wrapper {
             display: flex;
@@ -66,7 +66,7 @@
         ul.fiscal-years {
             @include clearfix;
             list-style-type: none;
-            padding: $global-pad $global-pad 0;
+            padding: $global-padding * 2 $global-padding * 2 0;
             margin: -1px 0 0;
             .fy-columns-container {
                 display: flex;

--- a/src/_scss/pages/search/filters/timePeriod/timePeriodNew.scss
+++ b/src/_scss/pages/search/filters/timePeriod/timePeriodNew.scss
@@ -10,7 +10,7 @@
     @import "mixins/selectedFilterWrap";
     @import "../_singleSubmit";
 
-    padding: 0 $global-pad rem(20);
+    padding: 0 $global-padding * 2 rem(20);
 
     .fiscal-years-with-chips {
       display: flex;
@@ -148,7 +148,7 @@
         .date-range-column {
           margin-right: .5 * $global-margin;
           width: 100%;
-          
+
           .generate-datepicker-wrap {
             width: 100%;
 

--- a/src/_scss/pages/search/results/visualizations/geo/map/_legend.scss
+++ b/src/_scss/pages/search/results/visualizations/geo/map/_legend.scss
@@ -8,7 +8,7 @@
   border: solid 1px $gray-cool-10;
 
   .map-legend-header {
-    padding: $global-padding*2 $global-padding*2 0 $global-padding*2;
+    padding: $global-padding * 2 $global-padding * 2 0 $global-padding * 2;
     border-bottom: 2px solid $color-gray-lightest;
 
     .map-legend-header__title {
@@ -73,7 +73,7 @@
         border-radius: 4px;
         float: left;
         height: rem(12);
-        margin: 2px 6px 2px 0; 
+        margin: 2px 6px 2px 0;
         width: rem(12);
       }
 
@@ -90,7 +90,7 @@
   .map-legend-body-covid19 {
     text-align: center;
     @include unstyled-list;
-    padding: 0.65rem $global-pad;
+    padding: 0.65rem $global-padding * 2;
 
     .map-legend-gradient {
       background: linear-gradient(rgba(1, 43, 58, 1), #FFF);

--- a/src/_scss/pages/state/footer/footer.scss
+++ b/src/_scss/pages/state/footer/footer.scss
@@ -4,7 +4,7 @@
     @include justify-content(center);
     background-color: $color-primary-darkest;
     color: $color-white;
-    padding: ($global-pad * 4) 0;
+    padding: ($global-padding * 8) 0;
     position: relative;
     width: 100%;
     .footer-content {

--- a/src/_scss/pages/state/visualizations/treemaps/treemapSection.scss
+++ b/src/_scss/pages/state/visualizations/treemaps/treemapSection.scss
@@ -27,7 +27,7 @@
         .function-desc {
             padding-left: 10%;
             padding-right: 10%;
-            margin-top: ($global-mrg * 2);
+            margin-top: ($global-margin * 4);
             .function-title {
                 @include h1;
                 text-align: center;
@@ -164,7 +164,7 @@
             height: rem(642);
             &.large {
                 height: rem(20);
-                margin-bottom: $global-mrg;
+                margin-bottom: $global-margin * 2;
                 width: 100%;
             }
         }


### PR DESCRIPTION
**High level description:**

Replace the old vars for margin and padding with the new ones.

**Technical details:**

The old ones were 15px, the new ones are 8px, so some math had to be done, and the new ones may be 1-4px larger than the old ones to make them consistent with our new system using multiples of 4.
A lot of files were changed here, and these older vars were only used on the older pages.

**JIRA Ticket:**
[DEV-9983](https://federal-spending-transparency.atlassian.net/browse/DEV-9983)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
