### PR TITLE
11458 - adjusted width of table section

### DIFF
--- a/src/_scss/pages/aboutTheData/aboutTheData.scss
+++ b/src/_scss/pages/aboutTheData/aboutTheData.scss
@@ -2,13 +2,14 @@
     @import 'all';
     @import 'layouts/default/default';
     @import 'layouts/default/stickyHeader/header';
+
     .main-content {
         @import '../../mixins/fullSectionWrap';
         @include fullSectionWrap(0,0);
         @include display(flex);
         @include flex-wrap(wrap);
         @include flex-direction(column);
-        width: 100%;
+        width: 94%;
         max-width: 160rem;
         border-radius: rem(5) rem(5) 0 0;
         background: $color-white;
@@ -24,13 +25,17 @@
             }
         }
     }
+
     &.about-the-data_agencies-page {
         @import './_agenciesPage';
     }
+
     &.about-the-data_agency-details-page {
         @import './_agencyDetailsPage';
     }
+
     @import 'components/Note';
+
     .default-note {
         font-style: italic;
         margin-top: 0;
@@ -45,19 +50,24 @@
         }
         @import 'components/externalLink';
     }
+
     .table-container {
         max-width: 100%;
     }
+
     .usda-message {
         background-color: $color-white;
         width: 100vw;
     }
+
     @import 'components/stickyTable';
+
     .agency-table-download {
         svg {
             margin-right: rem(5);
         }
     }
+
     .usda-table {
         thead {
             th {


### PR DESCRIPTION
**High level description:**

The table on this page appeared to be running off the right edge of the page.

**Technical details:**

Changed the width for the main-content class to make it look more centered. It still isn't perfect, but the css for this page is weird and confusing and this at least makes it no longer appear broken.

**JIRA Ticket:**
[DEV-11458](https://federal-spending-transparency.atlassian.net/browse/DEV-11458)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
