### PR TITLE
11238 - enable focus color for covid19 page map filters

### DIFF
--- a/src/_scss/pages/covid19/recipient/recipientContainer.scss
+++ b/src/_scss/pages/covid19/recipient/recipientContainer.scss
@@ -210,11 +210,6 @@
                         border: none;
                       }
 
-                      &:focus {
-                        outline: none;
-                        box-shadow: none;
-                      }
-
                       .usa-dt-picker__button-text {
                         @include flex(0 0 auto);
                         margin-right: 0.3rem;


### PR DESCRIPTION
**High level description:**

Enabled the blue color around the filter dropdown buttons to show. This improves accessibility.

**Technical details:**

Needed to remove the :focus pseudo-class selector which prevented the default box-shadow styles that were configured at a higher level for indicating focused state.

**JIRA Ticket:**
[DEV-11238](https://federal-spending-transparency.atlassian.net/browse/DEV-11238)

**Mockup:**
N/A

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
