### PR TITLE
11298 - updated ds&m link to route to medicare 'about the data' page

### DIFF
--- a/src/js/components/search/newResultsView/map/MapDsm.jsx
+++ b/src/js/components/search/newResultsView/map/MapDsm.jsx
@@ -1,12 +1,27 @@
 import React from "react";
 import { useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { Link } from "react-router-dom";
 import { getAtdDefcText } from "helpers/aboutTheDataSidebarHelper";
 import GlossaryLink from "../../../sharedComponents/GlossaryLink";
+import {
+    setAboutTheDataTermFromUrl,
+    showAboutTheData
+} from "../../../../redux/actions/aboutTheDataSidebar/aboutTheDataActions";
+import { setLastOpenedSlideout } from "../../../../redux/actions/slideouts/slideoutActions";
 
 const MapDsm = ({ subaward }) => {
     const reduxFilters = useSelector((state) => state.appliedFilters.filters);
     const isDefCodeInFilter = reduxFilters?.defCodes?.counts;
+
+    const dispatch = useDispatch();
+
+    const openAboutTheDataSidebar = (e) => {
+        dispatch(setAboutTheDataTermFromUrl('medicare-location-data'));
+        dispatch(showAboutTheData());
+        dispatch(setLastOpenedSlideout('atd'));
+        e.preventDefault();
+    };
 
     return (
         <>
@@ -65,8 +80,12 @@ const MapDsm = ({ subaward }) => {
                 <span className="award-search__glossary-term">NOTE: </span>
                 Data reported by the Department of Health and Human Services (HHS) related
                 to Medicare payments does not reflect the place where "the majority of the work" occurs, as
-                required by USAspending's data model specifications. For more information, visit our&nbsp;
-                <Link target="_blank" rel="noopener noreferrer" to="/about?section=data-quality">About Page</Link>.
+                required by USAspending's data model specifications. &nbsp;
+                <Link
+                    to=""
+                    aria-label="Open the About the Data"
+                    onClick={(e) => openAboutTheDataSidebar(e)}>Learn about Medicare Location Data
+                </Link>
             </p>
         </>
     );

--- a/src/js/components/search/newResultsView/map/MapDsm.jsx
+++ b/src/js/components/search/newResultsView/map/MapDsm.jsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { useSelector } from "react-redux";
-import { useDispatch } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { Link } from "react-router-dom";
 import { getAtdDefcText } from "helpers/aboutTheDataSidebarHelper";
 import GlossaryLink from "../../../sharedComponents/GlossaryLink";
@@ -84,7 +83,7 @@ const MapDsm = ({ subaward }) => {
                 <Link
                     to=""
                     aria-label="Open the About the Data"
-                    onClick={(e) => openAboutTheDataSidebar(e)}>Learn about Medicare Location Data
+                    onClick={(e) => openAboutTheDataSidebar(e)}>Learn about Medicare Location Data.
                 </Link>
             </p>
         </>


### PR DESCRIPTION
**High level description:**
Updated link and replaced it with the Medicare Location Data from 'About the Data'.

**Technical details:**
Added useDispatch to help render the About the Data page.

**JIRA Ticket:**
[DEV-11298](https://federal-spending-transparency.atlassian.net/browse/DEV-11298)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
