### PR TITLE
Ftr/11355 date range dropdown

### DIFF
--- a/src/_scss/pages/search/filters/timePeriod/timePeriodNew.scss
+++ b/src/_scss/pages/search/filters/timePeriod/timePeriodNew.scss
@@ -245,6 +245,9 @@
                       white-space: nowrap;
                       overflow: hidden;
                       text-overflow: ellipsis;
+                      cursor: pointer;
+                      width: 100%;
+                      height: 100%;
                     }
                   }
 

--- a/src/_scss/pages/search/filters/timePeriod/timePeriodNew.scss
+++ b/src/_scss/pages/search/filters/timePeriod/timePeriodNew.scss
@@ -230,6 +230,8 @@
                   transform: translate(0px, 0px);
                   width: max-content;
                   min-width: 100%;
+                  height: rem(224);
+                  overflow-y: scroll;
 
                   .filter__dropdown-list-item {
                     padding-left: $global-margin;

--- a/src/_scss/pages/search/filters/timePeriod/timePeriodNew.scss
+++ b/src/_scss/pages/search/filters/timePeriod/timePeriodNew.scss
@@ -51,7 +51,7 @@
       display: flex;
       align-items: baseline;
       justify-content: center;
-      margin: rem(20) 0 0 0;
+      margin: rem(42) 0 0 0;
 
       // this inactive class refers to the 'activeClassDR' var in TimePeriod.jsx; used here to left-align the new awards only checkbox in both Time Period and Date Range tabs
       &.inactive {
@@ -158,6 +158,105 @@
 
         button {
           margin: 0;
+        }
+      }
+
+      .date-range-option__dropdown-section {
+        margin-top: $global-margin * 3;
+
+        .date-range-option__dropdown-section-label {
+          text-transform: uppercase;
+          font-size: $font-size-10;
+          font-weight: $font-semibold;
+          line-height: 1.5;
+          color: $gray-60;
+        }
+
+        .date-range-option__dropdown-section-bottom {
+          display: flex;
+          flex-wrap: nowrap;
+          justify-content: space-between;
+          align-items: center;
+          width: auto;
+          height: rem(32);
+          margin-top: $global-margin;
+
+          .date-range-option__dropdown-section-picker-wrapper {
+            width: 100%;
+            margin-right: $global-margin * .5;
+
+            .filter__dropdown-container {
+              height: rem(32);
+
+              .filter__dropdown-button-list-container {
+                width: 100%;
+
+                button {
+                  width: 100%;
+                }
+
+                [class*="filter__dropdown-button"] {
+                  margin: 0;
+                  border-color: $gray-cool-10;
+                  justify-content: space-between;
+
+                  .filter__dropdown-button-text {
+                    margin-right: rem(8);
+                    font-size: $font-size-12;
+                    line-height: 1.5;
+                    color: $gray-cool-60;
+                    opacity: 1;
+                    white-space: nowrap;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                  }
+
+                  .filter__dropdown-chevron {
+                    padding-top: 0;
+                    svg {
+                      color: $theme-color-1;
+                      opacity: 1;
+                      vertical-align: middle;
+                      width: rem(10);
+                    }
+                  }
+                }
+
+                ul[class^='filter__dropdown-list'] {
+                  background-color: $color-white;
+                  border: rem(2) solid $gray-cool-10;
+                  border-radius: rem(4);
+                  box-shadow: 0 rem(1) rem(4) 0 rgba(0, 0, 0, 0.1);
+                  transform: translate(0px, 0px);
+                  width: max-content;
+                  min-width: 100%;
+
+                  .filter__dropdown-list-item {
+                    padding-left: $global-margin;
+                    padding-right: $global-margin;
+
+                    button {
+                      font-size: $font-size-12;
+                      line-height: 1.5;
+                      color: $gray-cool-60;
+                      opacity: 1;
+                      white-space: nowrap;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                    }
+                  }
+
+                  .filter__dropdown-list-item.active:hover {
+                    background-color: $gray-cool-10;
+                  }
+                }
+              }
+            }
+          }
+
+          button {
+            margin: 0;
+          }
         }
       }
     }

--- a/src/js/components/search/SearchSidebarSubmit.jsx
+++ b/src/js/components/search/SearchSidebarSubmit.jsx
@@ -32,8 +32,24 @@ const SearchSidebarSubmit = (props) => {
             className="sidebar-submit"
             role="region"
             aria-label="Submit">
-            <Button additionalClassnames="submit-button" copy="Submit" buttonTitle={title} buttonSize="md" buttonType="primary" backgroundColor="light" disabled={disabled} onClick={props.applyStagedFilters} />
-            <Button additionalClassnames="reset-button" copy="Reset filters" buttonTitle="Reset filters" buttonSize="md" buttonType="text" backgroundColor="light" disabled={!props.requestsComplete} onClick={props.resetFilters} />
+            <Button
+                additionalClassnames="submit-button"
+                copy="Submit"
+                buttonTitle={title}
+                buttonSize="md"
+                buttonType="primary"
+                backgroundColor="light"
+                disabled={disabled}
+                onClick={props.applyStagedFilters} />
+            <Button
+                additionalClassnames="reset-button"
+                copy="Reset filters"
+                buttonTitle="Reset filters"
+                buttonSize="md"
+                buttonType="text"
+                backgroundColor="light"
+                disabled={!props.requestsComplete}
+                onClick={props.resetFilters} />
         </div>
     );
 };

--- a/src/js/components/search/filters/timePeriod/DateRange.jsx
+++ b/src/js/components/search/filters/timePeriod/DateRange.jsx
@@ -146,13 +146,9 @@ const DateRange = (props) => {
     const sortFn = () => dropdownOptions;
 
     const submitDates = () => {
-        // validate that dates are provided for both fields and the end dates
-        // don't come before the start dates
-        // validate the date ranges
         const start = props.startDate;
         const end = props.endDate;
         if (!props.errorState && (start || end)) {
-            // open-ended date range
             let startValue = null;
             let endValue = null;
             if (start) {
@@ -180,14 +176,14 @@ const DateRange = (props) => {
     };
 
     const submitRange = (e) => {
-    // allow the user to change date ranges by keyboard and pressing enter
+        // allow the user to change date ranges by keyboard and pressing enter
         e.preventDefault();
         submitDates();
     };
 
     const generateStartDateDisabledDays = (earliestDate) => {
-    // handle the cutoff dates (preventing end dates from coming before
-    // start dates or vice versa)
+        // handle the cutoff dates (preventing end dates from coming before
+        // start dates or vice versa)
         const disabledDays = [earliestDate];
 
         if (props.endDate) {

--- a/src/js/components/search/filters/timePeriod/DateRange.jsx
+++ b/src/js/components/search/filters/timePeriod/DateRange.jsx
@@ -328,22 +328,6 @@ const DateRange = (props) => {
                     disabled={disabled}
                     onClick={submitRange} />
             </form>
-            <div
-                className={`selected-filters ${hideTags}`}
-                id="selected-date-range"
-                aria-hidden={noDates}
-                role="status">
-                <button
-                    className="shown-filter-button"
-                    title="Click to remove filter."
-                    aria-label={`Applied date range: ${dateLabel}`}
-                    onClick={props.removeDateRange}>
-                    {dateLabel}
-                    <span className="close">
-                        <FontAwesomeIcon icon="times" />
-                    </span>
-                </button>
-            </div>
             <FeatureFlag>
                 <div className="date-range-option__dropdown-section">
                     <div className="date-range-option__dropdown-section-top">
@@ -373,6 +357,22 @@ const DateRange = (props) => {
                     </div>
                 </div>
             </FeatureFlag>
+            <div
+                className={`selected-filters ${hideTags}`}
+                id="selected-date-range"
+                aria-hidden={noDates}
+                role="status">
+                <button
+                    className="shown-filter-button"
+                    title="Click to remove filter."
+                    aria-label={`Applied date range: ${dateLabel}`}
+                    onClick={props.removeDateRange}>
+                    {dateLabel}
+                    <span className="close">
+                        <FontAwesomeIcon icon="times" />
+                    </span>
+                </button>
+            </div>
         </div>
     );
 };

--- a/src/js/components/search/filters/timePeriod/DateRange.jsx
+++ b/src/js/components/search/filters/timePeriod/DateRange.jsx
@@ -388,6 +388,5 @@ const DateRange = (props) => {
     );
 };
 
-// DateRange.defaultProps = defaultProps;
 DateRange.propTypes = propTypes;
 export default DateRange;

--- a/src/js/components/search/filters/timePeriod/DateRange.jsx
+++ b/src/js/components/search/filters/timePeriod/DateRange.jsx
@@ -28,7 +28,6 @@ const propTypes = {
     selectedEnd: PropTypes.string,
     showError: PropTypes.func,
     hideError: PropTypes.func,
-    applyDateRange: PropTypes.func,
     removeDateRange: PropTypes.func,
     updateFilter: PropTypes.func,
     errorState: PropTypes.bool,
@@ -47,33 +46,45 @@ const DateRange = (props) => {
 
     const onClick = (e) => {
         setSelectedDropdownOption(e);
-        setDropdownOptionSelected(true);
 
-        Analytics.event({
-            category: 'Date Range Dropdown',
-            action: `View ${e}`
-        });
+        if (e === 'select') {
+            setDropdownOptionSelected(false);
+        }
+        else {
+            setDropdownOptionSelected(true);
 
-        dateRangeDropdownTimePeriods.find((obj) => {
-            if (obj.value === e) {
-                props.onDateChange(obj.startDate, 'startDate');
-                props.onDateChange(obj.endDate, 'endDate');
-                return true;
-            }
-            return false;
-        });
+            Analytics.event({
+                category: 'Date Range Dropdown',
+                action: `View ${e}`
+            });
+
+            dateRangeDropdownTimePeriods.find((obj) => {
+                if (obj.value === e) {
+                    props.onDateChange(obj.startDate, 'startDate');
+                    props.onDateChange(obj.endDate, 'endDate');
+                    return true;
+                }
+                return false;
+            });
+        }
     };
 
-    const clearDropdownOption = () => {
+    // const clearDropdownOption = () => {
+    //     setSelectedDropdownOption('select');
+    //     setDropdownOptionSelected(false);
+    // };
+
+    const localRemoveDateRange = () => {
         setSelectedDropdownOption('select');
         setDropdownOptionSelected(false);
+        props.removeDateRange();
     };
 
     const dropdownOptions = [
         {
             name: 'Select a date range',
             value: 'select',
-            onClick: clearDropdownOption
+            onClick
         },
         {
             name: 'Yesterday',
@@ -377,7 +388,7 @@ const DateRange = (props) => {
                     className="shown-filter-button"
                     title="Click to remove filter."
                     aria-label={`Applied date range: ${dateLabel}`}
-                    onClick={props.removeDateRange}>
+                    onClick={localRemoveDateRange}>
                     {dateLabel}
                     <span className="close">
                         <FontAwesomeIcon icon="times" />

--- a/src/js/components/search/filters/timePeriod/DateRange.jsx
+++ b/src/js/components/search/filters/timePeriod/DateRange.jsx
@@ -5,11 +5,13 @@
 
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import Analytics from 'helpers/analytics/Analytics';
 import { Button } from "data-transparency-ui";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import DatePicker from 'components/sharedComponents/DatePicker';
 import * as FiscalYearHelper from 'helpers/fiscalYearHelper';
 import { usePrevious } from "../../../../helpers/";
+import NewPicker from "../../../sharedComponents/dropdowns/NewPicker";
 
 const dayjs = require('dayjs');
 const isSameOrAfter = require('dayjs/plugin/isSameOrAfter');
@@ -41,7 +43,85 @@ const DateRange = (props) => {
     const [startPicker, setStartPicker] = useState(null);
     const [endPicker, setEndPicker] = useState(null);
     const [disabled, setDisabled] = useState(true);
+    const [selectedDropdownOption, setSelectedDropdownOption] = useState('select');
     const prevProps = usePrevious(props);
+
+    const onClick = (e) => {
+        setSelectedDropdownOption(e);
+        Analytics.event({
+            category: 'Date Range Dropdown',
+            action: `View ${e}`
+        });
+    };
+
+    const clearDropdownOption = () => {
+        setSelectedDropdownOption('');
+    };
+
+    const dropdownOptions = [
+        {
+            name: 'Select a date range',
+            value: 'select',
+            onClick: clearDropdownOption
+        },
+        {
+            name: 'Yesterday',
+            value: 'yesterday',
+            onClick
+        },
+        {
+            name: 'Last 7 days',
+            value: 'last-seven-days',
+            onClick
+        },
+        {
+            name: 'Last 15 days',
+            value: 'last-fifteen-days',
+            onClick
+        },
+        {
+            name: 'Last 30 days',
+            value: 'last-thirty-days',
+            onClick
+        },
+        {
+            name: 'Last 60 days',
+            value: 'last-sixty-days',
+            onClick
+        },
+        {
+            name: 'This month',
+            value: 'current-month',
+            onClick
+        },
+        {
+            name: 'Last 3 months',
+            value: 'last-three-months',
+            onClick
+        },
+        {
+            name: 'Last 6 months',
+            value: 'last-six-months',
+            onClick
+        },
+        {
+            name: 'Last 12 months',
+            value: 'last-twelve-months',
+            onClick
+        },
+        {
+            name: 'Last year (Jan - Dec)',
+            value: 'last-calendar-year',
+            onClick
+        },
+        {
+            name: 'Year-to-date (Jan - today)',
+            value: 'year-to-date',
+            onClick
+        }
+    ];
+
+    const sortFn = () => dropdownOptions;
 
     useEffect(() => {
         if (prevProps?.startDate !== props?.startDate && !props?.startDate) {
@@ -201,7 +281,7 @@ const DateRange = (props) => {
                 <div className="date-range-column">
                     <DatePicker
                         type="startDate"
-                        title="START DATE"
+                        title="start date"
                         onDateChange={props.onDateChange}
                         value={props.startDate}
                         opposite={props.endDate}
@@ -218,7 +298,7 @@ const DateRange = (props) => {
                 <div className="date-range-column">
                     <DatePicker
                         type="endDate"
-                        title="END DATE"
+                        title="end date"
                         onDateChange={props.onDateChange}
                         value={props.endDate}
                         opposite={props.startDate}
@@ -257,9 +337,38 @@ const DateRange = (props) => {
                     </span>
                 </button>
             </div>
+            <div className="date-range-option__dropdown-section">
+                <div className="date-range-option__dropdown-section-top">
+                    <div className="date-range-option__dropdown-section-label">
+                    Date Ranges
+                    </div>
+                </div>
+                <div className="date-range-option__dropdown-section-bottom">
+                    <div className="date-range-option__dropdown-section-picker-wrapper">
+                        <NewPicker
+                            leftIcon=""
+                            size="sm"
+                            options={dropdownOptions}
+                            enabled
+                            selectedOption={dropdownOptions?.length
+                                ? dropdownOptions?.find((obj) => obj.value === selectedDropdownOption)?.name
+                                : `${selectedDropdownOption}`}
+                            sortFn={sortFn} />
+                    </div>
+                    <Button
+                        copy="Add"
+                        buttonTitle="Add"
+                        buttonSize="sm"
+                        buttonType="primary"
+                        backgroundColor="light" />
+                    {/* // disabled={disabled}*/}
+                    {/* // onClick={submitRange} />*/}
+                </div>
+            </div>
         </div>
     );
 };
+
 DateRange.defaultProps = defaultProps;
 DateRange.propTypes = propTypes;
 export default DateRange;

--- a/src/js/components/search/filters/timePeriod/DateRange.jsx
+++ b/src/js/components/search/filters/timePeriod/DateRange.jsx
@@ -12,6 +12,7 @@ import DatePicker from 'components/sharedComponents/DatePicker';
 import * as FiscalYearHelper from 'helpers/fiscalYearHelper';
 import { usePrevious } from "../../../../helpers/";
 import NewPicker from "../../../sharedComponents/dropdowns/NewPicker";
+import FeatureFlag from "../../../sharedComponents/FeatureFlag";
 
 const dayjs = require('dayjs');
 const isSameOrAfter = require('dayjs/plugin/isSameOrAfter');
@@ -337,34 +338,36 @@ const DateRange = (props) => {
                     </span>
                 </button>
             </div>
-            <div className="date-range-option__dropdown-section">
-                <div className="date-range-option__dropdown-section-top">
-                    <div className="date-range-option__dropdown-section-label">
+            <FeatureFlag>
+                <div className="date-range-option__dropdown-section">
+                    <div className="date-range-option__dropdown-section-top">
+                        <div className="date-range-option__dropdown-section-label">
                     Date Ranges
+                        </div>
+                    </div>
+                    <div className="date-range-option__dropdown-section-bottom">
+                        <div className="date-range-option__dropdown-section-picker-wrapper">
+                            <NewPicker
+                                leftIcon=""
+                                size="sm"
+                                options={dropdownOptions}
+                                enabled
+                                selectedOption={dropdownOptions?.length
+                                    ? dropdownOptions?.find((obj) => obj.value === selectedDropdownOption)?.name
+                                    : `${selectedDropdownOption}`}
+                                sortFn={sortFn} />
+                        </div>
+                        <Button
+                            copy="Add"
+                            buttonTitle="Add"
+                            buttonSize="sm"
+                            buttonType="primary"
+                            backgroundColor="light" />
+                        {/* // disabled={disabled}*/}
+                        {/* // onClick={submitRange} />*/}
                     </div>
                 </div>
-                <div className="date-range-option__dropdown-section-bottom">
-                    <div className="date-range-option__dropdown-section-picker-wrapper">
-                        <NewPicker
-                            leftIcon=""
-                            size="sm"
-                            options={dropdownOptions}
-                            enabled
-                            selectedOption={dropdownOptions?.length
-                                ? dropdownOptions?.find((obj) => obj.value === selectedDropdownOption)?.name
-                                : `${selectedDropdownOption}`}
-                            sortFn={sortFn} />
-                    </div>
-                    <Button
-                        copy="Add"
-                        buttonTitle="Add"
-                        buttonSize="sm"
-                        buttonType="primary"
-                        backgroundColor="light" />
-                    {/* // disabled={disabled}*/}
-                    {/* // onClick={submitRange} />*/}
-                </div>
-            </div>
+            </FeatureFlag>
         </div>
     );
 };

--- a/src/js/components/search/filters/timePeriod/DateRange.jsx
+++ b/src/js/components/search/filters/timePeriod/DateRange.jsx
@@ -13,20 +13,15 @@ import * as FiscalYearHelper from 'helpers/fiscalYearHelper';
 import { usePrevious } from "../../../../helpers/";
 import NewPicker from "../../../sharedComponents/dropdowns/NewPicker";
 import FeatureFlag from "../../../sharedComponents/FeatureFlag";
+import dateRangeDropdownTimePeriods from '../../../../helpers/search/dateRangeDropdownHelper';
 
 const dayjs = require('dayjs');
 const isSameOrAfter = require('dayjs/plugin/isSameOrAfter');
 
 dayjs.extend(isSameOrAfter);
 
-const defaultProps = {
-    startDate: '01/01/2016',
-    endDate: '12/31/2016',
-    startingTab: 1
-};
-
 const propTypes = {
-    startingTab: PropTypes.number,
+    // startingTab: PropTypes.number,
     onDateChange: PropTypes.func,
     startDate: PropTypes.object,
     endDate: PropTypes.object,
@@ -49,14 +44,25 @@ const DateRange = (props) => {
 
     const onClick = (e) => {
         setSelectedDropdownOption(e);
+
         Analytics.event({
             category: 'Date Range Dropdown',
             action: `View ${e}`
         });
+
+        dateRangeDropdownTimePeriods.find((obj) => {
+            if (obj.value === e) {
+                // startDate = y.startDate;
+                // endDate = y.endDate;
+                props.onDateChange(obj.startDate, 'startDate');
+                props.onDateChange(obj.endDate, 'endDate');
+                return true;
+            }
+        });
     };
 
     const clearDropdownOption = () => {
-        setSelectedDropdownOption('');
+        setSelectedDropdownOption('select');
     };
 
     const dropdownOptions = [
@@ -362,9 +368,8 @@ const DateRange = (props) => {
                             buttonTitle="Add"
                             buttonSize="sm"
                             buttonType="primary"
-                            backgroundColor="light" />
-                        {/* // disabled={disabled}*/}
-                        {/* // onClick={submitRange} />*/}
+                            backgroundColor="light"
+                            onClick={submitRange} />
                     </div>
                 </div>
             </FeatureFlag>
@@ -372,6 +377,6 @@ const DateRange = (props) => {
     );
 };
 
-DateRange.defaultProps = defaultProps;
+// DateRange.defaultProps = defaultProps;
 DateRange.propTypes = propTypes;
 export default DateRange;

--- a/src/js/components/search/filters/timePeriod/DateRange.jsx
+++ b/src/js/components/search/filters/timePeriod/DateRange.jsx
@@ -354,6 +354,7 @@ const DateRange = (props) => {
                             buttonSize="sm"
                             buttonType="primary"
                             backgroundColor="light"
+                            disabled={disabled}
                             onClick={submitRange} />
                     </div>
                 </div>

--- a/src/js/components/search/filters/timePeriod/DateRange.jsx
+++ b/src/js/components/search/filters/timePeriod/DateRange.jsx
@@ -69,11 +69,6 @@ const DateRange = (props) => {
         }
     };
 
-    // const clearDropdownOption = () => {
-    //     setSelectedDropdownOption('select');
-    //     setDropdownOptionSelected(false);
-    // };
-
     const localRemoveDateRange = () => {
         setSelectedDropdownOption('select');
         setDropdownOptionSelected(false);
@@ -173,12 +168,6 @@ const DateRange = (props) => {
                 endDate: null
             });
         }
-    };
-
-    const submitRange = (e) => {
-        // allow the user to change date ranges by keyboard and pressing enter
-        e.preventDefault();
-        submitDates();
     };
 
     const generateStartDateDisabledDays = (earliestDate) => {
@@ -301,7 +290,7 @@ const DateRange = (props) => {
         <div className="date-range-option">
             <form
                 className="date-range-wrapper"
-                onSubmit={submitRange}>
+                onSubmit={submitDates}>
                 <div className="date-range-column">
                     <DatePicker
                         type="startDate"
@@ -343,7 +332,7 @@ const DateRange = (props) => {
                     buttonType="primary"
                     backgroundColor="light"
                     disabled={disabled}
-                    onClick={submitRange} />
+                    onClick={submitDates} />
             </form>
             <FeatureFlag>
                 <div className="date-range-option__dropdown-section">
@@ -371,7 +360,7 @@ const DateRange = (props) => {
                             buttonType="primary"
                             backgroundColor="light"
                             disabled={disabled}
-                            onClick={submitRange} />
+                            onClick={submitDates} />
                     </div>
                 </div>
             </FeatureFlag>

--- a/src/js/components/search/filters/timePeriod/DateRange.jsx
+++ b/src/js/components/search/filters/timePeriod/DateRange.jsx
@@ -41,10 +41,13 @@ const DateRange = (props) => {
     const [endPicker, setEndPicker] = useState(null);
     const [disabled, setDisabled] = useState(true);
     const [selectedDropdownOption, setSelectedDropdownOption] = useState('select');
+    const [dropdownOptionSelected, setDropdownOptionSelected] = useState(false);
+    const [noDates, setNoDates] = useState(false);
     const prevProps = usePrevious(props);
 
     const onClick = (e) => {
         setSelectedDropdownOption(e);
+        setDropdownOptionSelected(true);
 
         Analytics.event({
             category: 'Date Range Dropdown',
@@ -53,17 +56,17 @@ const DateRange = (props) => {
 
         dateRangeDropdownTimePeriods.find((obj) => {
             if (obj.value === e) {
-                // startDate = y.startDate;
-                // endDate = y.endDate;
                 props.onDateChange(obj.startDate, 'startDate');
                 props.onDateChange(obj.endDate, 'endDate');
                 return true;
             }
+            return false;
         });
     };
 
     const clearDropdownOption = () => {
         setSelectedDropdownOption('select');
+        setDropdownOptionSelected(false);
     };
 
     const dropdownOptions = [
@@ -130,22 +133,6 @@ const DateRange = (props) => {
     ];
 
     const sortFn = () => dropdownOptions;
-
-    useEffect(() => {
-        if (prevProps?.startDate !== props?.startDate && !props?.startDate) {
-            // the start date was reset to null, clear the picker
-            startPicker?.clearValue();
-        }
-        /* eslint-disable-next-line react-hooks/exhaustive-deps */
-    }, [props?.startDate]);
-
-    useEffect(() => {
-        if (prevProps?.endDate !== props?.endDate && !props?.endDate) {
-            // the end date was reset to null, clear the picker
-            endPicker?.clearValue();
-        }
-        /* eslint-disable-next-line react-hooks/exhaustive-deps */
-    }, [props?.endDate]);
 
     const submitDates = () => {
         // validate that dates are provided for both fields and the end dates
@@ -245,11 +232,6 @@ const DateRange = (props) => {
         }
     }
 
-    let noDates = false;
-    if (!props.startDate && !props.endDate) {
-        noDates = true;
-    }
-
     const testDates = () => {
         if (props.startDate === null && props.endDate === null) {
             if (props.errorState) {
@@ -268,6 +250,34 @@ const DateRange = (props) => {
     const onFocus = () => {
         testDates();
     };
+
+    useEffect(() => {
+        if (!props.startDate && !props.endDate && !dropdownOptionSelected) {
+            setNoDates(true);
+        }
+        else {
+            setNoDates(false);
+            // we need this in cases where the error message is showing and the user selects an option from the dropdown
+            props.hideError();
+        }
+        /* eslint-disable-next-line react-hooks/exhaustive-deps */
+    }, [props.endDate, props.startDate, dropdownOptionSelected]);
+
+    useEffect(() => {
+        if (prevProps?.startDate !== props?.startDate && !props?.startDate) {
+            // the start date was reset to null, clear the picker
+            startPicker?.clearValue();
+        }
+        /* eslint-disable-next-line react-hooks/exhaustive-deps */
+    }, [props?.startDate]);
+
+    useEffect(() => {
+        if (prevProps?.endDate !== props?.endDate && !props?.endDate) {
+            // the end date was reset to null, clear the picker
+            endPicker?.clearValue();
+        }
+        /* eslint-disable-next-line react-hooks/exhaustive-deps */
+    }, [props?.endDate]);
 
     useEffect(() => {
         if (noDates || props.errorState) {

--- a/src/js/components/search/filters/timePeriod/DateRange.jsx
+++ b/src/js/components/search/filters/timePeriod/DateRange.jsx
@@ -21,7 +21,6 @@ const isSameOrAfter = require('dayjs/plugin/isSameOrAfter');
 dayjs.extend(isSameOrAfter);
 
 const propTypes = {
-    // startingTab: PropTypes.number,
     onDateChange: PropTypes.func,
     startDate: PropTypes.object,
     endDate: PropTypes.object,

--- a/src/js/components/search/filters/timePeriod/DateRange.jsx
+++ b/src/js/components/search/filters/timePeriod/DateRange.jsx
@@ -342,7 +342,7 @@ const DateRange = (props) => {
                 <div className="date-range-option__dropdown-section">
                     <div className="date-range-option__dropdown-section-top">
                         <div className="date-range-option__dropdown-section-label">
-                    Date Ranges
+                            Date Ranges
                         </div>
                     </div>
                     <div className="date-range-option__dropdown-section-bottom">

--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -180,10 +180,10 @@ export default class TimePeriod extends React.Component {
     }
 
     handleDateChange(date, dateType) {
-    // the component will hold values of the start/end dates for use by the UI only
-    // this is because the start/end range will be incomplete during the time the user has only
-    // picked one date, or if they have picked an invalid range
-    // additional logic is required to keep these values in sync with Redux
+        // the component will hold values of the start/end dates for use by the UI only
+        // this is because the start/end range will be incomplete during the time the user has only
+        // picked one date, or if they have picked an invalid range
+        // additional logic is required to keep these values in sync with Redux
         let value = dayjs(date);
         if (!date) {
             value = null;

--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -201,7 +201,9 @@ export default class TimePeriod extends React.Component {
             endDate: null
         });
         this.setState({
-            dateRangeChipRemoved: true
+            dateRangeChipRemoved: true,
+            startDateUI: null,
+            endDateUI: null
         });
     }
 

--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -212,6 +212,7 @@ export default class TimePeriod extends React.Component {
             errorMessage: message
         });
     }
+
     hideError() {
         this.setState({
             showError: false,

--- a/src/js/containers/search/filters/TimePeriodContainer.jsx
+++ b/src/js/containers/search/filters/TimePeriodContainer.jsx
@@ -25,7 +25,8 @@ const propTypes = {
     filterTimePeriodEnd: PropTypes.string,
     appliedFilters: PropTypes.object,
     newAwardsOnlySelected: PropTypes.bool,
-    newAwardsOnlyActive: PropTypes.bool
+    newAwardsOnlyActive: PropTypes.bool,
+    naoActiveFromFyOrDateRange: PropTypes.bool
 };
 
 export class TimePeriodContainer extends React.Component {
@@ -83,28 +84,18 @@ export class TimePeriodContainer extends React.Component {
     }
 
     updateFilter(params) {
-        // set the state to a clone of the filter subobject merged with the param object
-        const currentFilters = {
-            dateType: this.state.activeTab,
-            fy: this.props.filterTimePeriodFY,
-            startDate: this.props.filterTimePeriodStart,
-            endDate: this.props.filterTimePeriodEnd
-        };
-
-        const newFilters = Object.assign({}, currentFilters, params);
+        const newFilters = Object.assign({}, params);
 
         if (this.state.activeTab === 'fy') {
+            newFilters.dateType = 'fy';
             // reset the date range values
             newFilters.startDate = null;
             newFilters.endDate = null;
         }
         else {
             // reset the fiscal year set
+            // start and end dates and datetype are in params
             newFilters.fy = [];
-
-            if (!newFilters.startDate && !newFilters.endDate) {
-                newFilters.dateType = 'fy';
-            }
         }
 
         this.props.updateTimePeriod(newFilters);

--- a/src/js/helpers/search/dateRangeDropdownHelper.js
+++ b/src/js/helpers/search/dateRangeDropdownHelper.js
@@ -1,0 +1,66 @@
+/**
+ * dateRangeDropdownHelper.js
+ * Created by Brian Petway
+ */
+
+const dayjs = require('dayjs');
+
+export const dateRangeDropdownTimePeriods = [
+    {
+        value: 'yesterday',
+        startDate: dayjs().subtract(1, 'day').format('YYYY-MM-DD'),
+        endDate: dayjs().subtract(1, 'day').format('YYYY-MM-DD')
+    },
+    {
+        value: 'last-seven-days',
+        startDate: dayjs().subtract(1, 'week').format('YYYY-MM-DD'),
+        endDate: dayjs().format('YYYY-MM-DD')
+    },
+    {
+        value: 'last-fifteen-days',
+        startDate: dayjs().subtract(15, 'day').format('YYYY-MM-DD'),
+        endDate: dayjs().format('YYYY-MM-DD')
+    },
+    {
+        value: 'last-thirty-days',
+        startDate: dayjs().subtract(30, 'day').format('YYYY-MM-DD'),
+        endDate: dayjs().format('YYYY-MM-DD')
+    },
+    {
+        value: 'last-sixty-days',
+        startDate: dayjs().subtract(60, 'day').format('YYYY-MM-DD'),
+        endDate: dayjs().format('YYYY-MM-DD')
+    },
+    {
+        value: 'current-month',
+        startDate: dayjs().startOf('month').format('YYYY-MM-DD'),
+        endDate: dayjs().format('YYYY-MM-DD')
+    },
+    {
+        value: 'last-three-months',
+        startDate: dayjs().subtract(3, 'month').format('YYYY-MM-DD'),
+        endDate: dayjs().format('YYYY-MM-DD')
+    },
+    {
+        value: 'last-six-months',
+        startDate: dayjs().subtract(6, 'month').format('YYYY-MM-DD'),
+        endDate: dayjs().format('YYYY-MM-DD')
+    },
+    {
+        value: 'last-twelve-months',
+        startDate: dayjs().subtract(12, 'month').format('YYYY-MM-DD'),
+        endDate: dayjs().format('YYYY-MM-DD')
+    },
+    {
+        value: 'last-calendar-year',
+        startDate: dayjs().subtract(1, 'year').startOf('year').format('YYYY-MM-DD'),
+        endDate: dayjs().subtract(1, 'year').endOf('year').format('YYYY-MM-DD')
+    },
+    {
+        value: 'year-to-date',
+        startDate: dayjs().startOf('year').format('YYYY-MM-DD'),
+        endDate: dayjs().format('YYYY-MM-DD')
+    }
+];
+
+export default dateRangeDropdownTimePeriods;


### PR DESCRIPTION
**High level description:**

Add the date range dropdown, with FeatureFlag

**Technical details:**

Added the dropdown; removed unneeded props from DateRange; added to the error message logic to make it go away if a dropdown option is selected
Also made ticket 11523, to make changes to this UI after the api allows for multiple date ranges

**JIRA Ticket:**
[DEV-11355](https://federal-spending-transparency.atlassian.net/browse/DEV-11355)

**Mockup:**
https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55/screen/66b0dc445bcde94ea1ca3356

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
