### PR TITLE
Bug/11457 fix prime award table height issue

### DIFF
--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -273,9 +273,6 @@ export default class ResultsTable extends React.Component {
         // (page * limit) - 1 end
         // (page - 1) * limit start
         const arrayOfObjects = this.props.results;
-        console.log("table height:", this.state.tableHeight);
-        console.log("window height:", this.state.windowHeight);
-        console.log("sticky header height:", stickyHeaderHeight);
         let values = null;
         // check for not subaward && loans
         if (!this.props.subaward) {

--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -492,8 +492,7 @@ export default class ResultsTable extends React.Component {
                 <div
                     className={`advanced-search__table-wrapper ${this.state.activateRightFade ? 'activate-right-fade' : ''} `}
                     id="advanced-search__table-wrapper"
-                    style={this.state.tableHeight > this.state.windowHeight ? { height: this.state.windowHeight + stickyHeaderHeight + 16 + 40 + 57 } : null}>
-                    {/* style={{ height: this.state.windowHeight - stickyHeaderHeight - 16 - 40 - 57 }} */}
+                    style={{ height: this.state.windowHeight - stickyHeaderHeight - 16 - 40 - 57 }}>
                     <Table
                         classNames="table-for-new-search-page award-results-table-dtui"
                         stickyFirstColumn={!this.props.isMobile}

--- a/src/js/components/search/table/ResultsTable.jsx
+++ b/src/js/components/search/table/ResultsTable.jsx
@@ -273,6 +273,9 @@ export default class ResultsTable extends React.Component {
         // (page * limit) - 1 end
         // (page - 1) * limit start
         const arrayOfObjects = this.props.results;
+        console.log("table height:", this.state.tableHeight);
+        console.log("window height:", this.state.windowHeight);
+        console.log("sticky header height:", stickyHeaderHeight);
         let values = null;
         // check for not subaward && loans
         if (!this.props.subaward) {
@@ -489,7 +492,8 @@ export default class ResultsTable extends React.Component {
                 <div
                     className={`advanced-search__table-wrapper ${this.state.activateRightFade ? 'activate-right-fade' : ''} `}
                     id="advanced-search__table-wrapper"
-                    style={this.state.tableHeight > this.state.windowHeight ? { height: this.state.windowHeight - stickyHeaderHeight - 16 - 40 - 57 } : null}>
+                    style={this.state.tableHeight > this.state.windowHeight ? { height: this.state.windowHeight + stickyHeaderHeight + 16 + 40 + 57 } : null}>
+                    {/* style={{ height: this.state.windowHeight - stickyHeaderHeight - 16 - 40 - 57 }} */}
                     <Table
                         classNames="table-for-new-search-page award-results-table-dtui"
                         stickyFirstColumn={!this.props.isMobile}


### PR DESCRIPTION
**High level description:**
Fixed the scroll bar being temporarily hidden upon resize of the prime award table.

**Technical details:**
Removed piece of logic that was removing the scroll bar if the window was at a certain height compared to the table.

**JIRA Ticket:**
[DEV-11457](https://federal-spending-transparency.atlassian.net/browse/DEV-11457)

**Mockup:**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
