### PR TITLE
DEV-10012 able to click back

### DIFF
--- a/src/js/components/sharedComponents/header/mobile/MobileTop.jsx
+++ b/src/js/components/sharedComponents/header/mobile/MobileTop.jsx
@@ -65,6 +65,7 @@ const MobileTop = (props) => {
                         className={props.detailMobileNavIsHidden ? "mobile-nav-header__close-button" : "mobile-nav-header__close-button-section"}
                         title="Close menu"
                         aria-label="Close menu"
+                        tabIndex="0"
                         onClick={(e) => props.hideMobileNav(e)}>
                         <FontAwesomeIcon size="lg" alt="close button" icon="times" />
                     </button>


### PR DESCRIPTION
**High level description:**

tab to back button in mobile screen size, just a testing note though
if you click through some items on the menu and then try to hit tab it'll be on one of the menu items, just hit shift + tab and you can indeed navigate to the back button

**JIRA Ticket:**
[DEV-10012](https://federal-spending-transparency.atlassian.net/browse/DEV-10012)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
