### PR TITLE
DEV-11508 change active tab for time period depending on active filters (search hash)

### DIFF
--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -62,7 +62,6 @@ export default class TimePeriod extends React.Component {
             selectedFY: new Set(),
             allFY: false,
             clearHint: false,
-            activeTab: 'dr',
             dateRangeChipRemoved: false
         };
 
@@ -324,11 +323,10 @@ export default class TimePeriod extends React.Component {
 
         const toggleTab = (e) => {
             this.setState({ dateRangeChipRemoved: false }, () => {
-                if ((this.state.activeTab === 'fy' && e.target.textContent.trim() !== 'Fiscal years') || (this.state.activeTab === 'dr' && e.target.textContent.trim() !== 'Custom dates')) {
-                    const nextTab = this.state.activeTab === 'fy' ? 'dr' : 'fy';
-                    this.setState({ ...this.state, activeTab: nextTab });
-                    this.clearHint(true);
+                if ((this.props.activeTab === 'fy' && e.target.textContent.trim() !== 'Fiscal years') || (this.props.activeTab === 'dr' && e.target.textContent.trim() !== 'Custom dates')) {
+                    const nextTab = this.props.activeTab === 'fy' ? 'dr' : 'fy';
                     this.props.changeTab(nextTab);
+                    this.clearHint(true);
                 }
             });
         };
@@ -339,7 +337,7 @@ export default class TimePeriod extends React.Component {
                     <FilterTabs
                         labels={tabLabels}
                         switchTab={toggleTab}
-                        active={this.state.activeTab} />
+                        active={this.props.activeTab} />
                     { showFilter }
                     { errorDetails }
                     { !this.props.federalAccountPage && newAwardsFilter }

--- a/src/js/containers/search/filters/TimePeriodContainer.jsx
+++ b/src/js/containers/search/filters/TimePeriodContainer.jsx
@@ -47,6 +47,11 @@ export class TimePeriodContainer extends React.Component {
     }
 
     componentDidMount() {
+        if (this.props.appliedFilters.timePeriodType === 'fy') {
+            this.changeTab('fy');
+        } else {
+            this.changeTab('dr');
+        }
         this.generateTimePeriods();
     }
 

--- a/src/js/models/v1/search/SearchAwardsOperation.js
+++ b/src/js/models/v1/search/SearchAwardsOperation.js
@@ -17,7 +17,7 @@ class SearchAwardsOperation {
     constructor() {
         this.keyword = [];
 
-        this.timePeriodType = 'fy';
+        this.timePeriodType = 'dr';
         this.timePeriodFY = [];
         this.timePeriodRange = [];
 

--- a/src/js/redux/reducers/search/searchFiltersReducer.js
+++ b/src/js/redux/reducers/search/searchFiltersReducer.js
@@ -50,7 +50,7 @@ export const requiredTypes = {
 
 export const initialState = {
     keyword: OrderedMap(),
-    timePeriodType: 'fy',
+    timePeriodType: 'dr',
     timePeriodFY: Set(),
     timePeriodStart: null,
     timePeriodEnd: null,

--- a/tests/redux/reducers/search/searchFiltersReducer-test.js
+++ b/tests/redux/reducers/search/searchFiltersReducer-test.js
@@ -840,7 +840,7 @@ describe('searchFiltersReducer', () => {
                 };
 
                 const expectedSecond = {
-                    timePeriodType: 'fy',
+                    timePeriodType: 'dr',
                     timePeriodFY: new Set(),
                     timePeriodStart: null,
                     timePeriodEnd: null
@@ -886,7 +886,7 @@ describe('searchFiltersReducer', () => {
                 };
 
                 const expectedSecond = {
-                    timePeriodType: 'fy',
+                    timePeriodType: 'dr',
                     timePeriodFY: new Set(),
                     timePeriodStart: null,
                     timePeriodEnd: null

--- a/tests/testResources/defaultReduxFilters.js
+++ b/tests/testResources/defaultReduxFilters.js
@@ -14,7 +14,7 @@ import * as FiscalYearHelper from '../../src/js/helpers/fiscalYearHelper';
 export const defaultFilters = {
     keyword: new OrderedMap(),
     awardType: new Set(),
-    timePeriodType: 'fy',
+    timePeriodType: 'dr',
     timePeriodFY: new Set([`${FiscalYearHelper.currentFiscalYear()}`]),
     timePeriodStart: null,
     timePeriodEnd: null,


### PR DESCRIPTION
**High level description:**

change the active tab for time period depending on what you've searched, not sure why timeperiod was keeping track of the active tab while also getting it as a prop from timeperiodcontainer seemed duplicative

**JIRA Ticket:**
[DEV-11508](https://federal-spending-transparency.atlassian.net/browse/DEV-11508)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
