### PR TITLE
11385 - added logic to handle negative values, and put the label to t…

### DIFF
--- a/src/js/components/search/newResultsView/categories/SpendingByCategoriesChart.jsx
+++ b/src/js/components/search/newResultsView/categories/SpendingByCategoriesChart.jsx
@@ -101,10 +101,20 @@ const SpendingByCategoriesChart = (props) => {
 
         const translateX = isSmMobile ? 2 : 8;
 
+        let anchorString = 'start';
+        let negativeOffset = 0;
+
+        // for negative values we want the label to be at the left end of the
+        // bar, so we change the textAnchor value and add a small offset
+        if (value[0] === '-') {
+            anchorString = 'end';
+            negativeOffset = -16;
+        }
+
         return (
-            <g transform={`translate(${x + width + translateX}, ${y + 14})`}>
+            <g transform={`translate(${x + width + translateX + negativeOffset}, ${y + 15})`}>
                 <Text
-                    textAnchor="left"
+                    textAnchor={anchorString}
                     fontSize={14}
                     fontWeight={600}
                     fill="#07648D"


### PR DESCRIPTION
…he left of the bar; also centered the labels vertically

**High level description:**

Categories chart wasn't showing labels for some negative values.

**Technical details:**

The labels needed to be moved for negative values, so i added logic to change a prop and add a small offset when negative

**JIRA Ticket:**
[DEV-11385](https://federal-spending-transparency.atlassian.net/browse/DEV-11385)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
