### PR TITLE
Bug/11534 recipient details table

### DIFF
--- a/src/_scss/pages/recipient/_contentWrap.scss
+++ b/src/_scss/pages/recipient/_contentWrap.scss
@@ -80,6 +80,37 @@
 					@include flex(1 1 50%);
 				}
 
+				.recipient-section__details-table {
+					border-collapse: unset !important;
+					//border-spacing: 0;
+
+					th, td {
+						//border: 0;
+						border: solid 1px $color-gray-border;
+					}
+
+					.recipient-section__details-table-first-th {
+						border-top-left-radius: 5px;
+					}
+
+					.recipient-section__details-table-first-td {
+						border-top-right-radius: 5px;
+					}
+
+					.recipient-section__details-table-last-th {
+						border-bottom-left-radius: 5px;
+					}
+
+					.recipient-section__details-table-last-td {
+						border-bottom-right-radius: 5px;
+					}
+
+					.details__table-cd-row {
+						display: flex;
+						flex-direction: row;
+					}
+				}
+
 				.recipient-section__award-button {
 					@include display(flex);
 					@include flex(0 0 auto);

--- a/src/_scss/pages/recipient/_contentWrap.scss
+++ b/src/_scss/pages/recipient/_contentWrap.scss
@@ -85,15 +85,18 @@
 				.recipient-section__details-table {
 					border-collapse: unset !important;
 
-					th {
-						border: solid 1px $color-gray-border;
-						border-right: 0;
-						border-bottom: 0;
+					tr {
+						height: rem(39);
 					}
 
-					td {
+					th, td {
 						border: solid 1px $color-gray-border;
 						border-bottom: 0;
+						padding: rem(10) rem(15);
+					}
+
+					th {
+						border-right: 0;
 					}
 
 					.recipient-section__details-table-first-th {

--- a/src/_scss/pages/recipient/_contentWrap.scss
+++ b/src/_scss/pages/recipient/_contentWrap.scss
@@ -80,13 +80,20 @@
 					@include flex(1 1 50%);
 				}
 
+				// this is all to make the borders gray and not doubled
+				// it's not ideal, but here we are
 				.recipient-section__details-table {
 					border-collapse: unset !important;
-					//border-spacing: 0;
 
-					th, td {
-						//border: 0;
+					th {
 						border: solid 1px $color-gray-border;
+						border-right: 0;
+						border-bottom: 0;
+					}
+
+					td {
+						border: solid 1px $color-gray-border;
+						border-bottom: 0;
 					}
 
 					.recipient-section__details-table-first-th {
@@ -99,10 +106,12 @@
 
 					.recipient-section__details-table-last-th {
 						border-bottom-left-radius: 5px;
+						border-bottom: solid 1px $color-gray-border;
 					}
 
 					.recipient-section__details-table-last-td {
 						border-bottom-right-radius: 5px;
+						border-bottom: solid 1px $color-gray-border;
 					}
 
 					.details__table-cd-row {

--- a/src/js/components/recipient/RecipientOverview.jsx
+++ b/src/js/components/recipient/RecipientOverview.jsx
@@ -109,7 +109,7 @@ const RecipientOverview = (props) => {
     );
     if (recipient.businessTypes.length > 0) {
         businessTypes = (
-            <td>
+            <td className="recipient-section__details-table-last-td">
                 {recipient.businessTypes.map((type, i) =>
                     <div key={i}>{type}</div>)}
             </td>
@@ -217,11 +217,11 @@ const RecipientOverview = (props) => {
                         <h3 className="recipient-overview__heading">
                             Details
                         </h3>
-                        <table className="details__table">
+                        <table className="recipient-section__details-table">
                             <tbody>
                                 <tr>
-                                    <th>Recipient Identifier</th>
-                                    <td>{idList(recipient.duns, recipient.uei).map((i) => <>{i}<br /></>)}</td>
+                                    <th className="recipient-section__details-table-first-th">Recipient Identifier</th>
+                                    <td className="recipient-section__details-table-first-td">{idList(recipient.duns, recipient.uei).map((i) => <>{i}<br /></>)}</td>
                                 </tr>
                                 <tr>
                                     <th>Address</th>
@@ -229,24 +229,22 @@ const RecipientOverview = (props) => {
                                 </tr>
                                 <tr>
                                     <th className="details__table-cd-row">
-                                        <div className="details__table-cd-text">
+                                        <div className="`details__table-cd-text`">
                                             Congressional District
                                         </div>
-                                        <FeatureFlag>
-                                            <TooltipWrapper
-                                                className="congressional-district__tt"
-                                                icon="info"
-                                                tooltipPosition="bottom"
-                                                styles={{
-                                                    position: 'relative'
-                                                }}
-                                                tooltipComponent={<CondensedCDTooltip title="Congressional District" />} />
-                                        </FeatureFlag>
+                                        <TooltipWrapper
+                                            className="congressional-district__tt"
+                                            icon="info"
+                                            tooltipPosition="left"
+                                            styles={{
+                                                position: 'relative'
+                                            }}
+                                            tooltipComponent={<CondensedCDTooltip title="Congressional District" />} />
                                     </th>
                                     {congressionalDistrict}
                                 </tr>
                                 <tr>
-                                    <th>Business Types</th>
+                                    <th className="recipient-section__details-table-last-th">Business Types</th>
                                     {businessTypes}
                                 </tr>
                             </tbody>

--- a/src/js/components/recipient/RecipientOverview.jsx
+++ b/src/js/components/recipient/RecipientOverview.jsx
@@ -18,7 +18,6 @@ import { generateUrlHash } from "../../helpers/searchHelper";
 import FaceValueOfLoans from '../sharedComponents/FaceValueOfLoans';
 import RecipientMultiParentCollapse from './RecipientMultiParentCollapse';
 import { REQUEST_VERSION } from "../../GlobalConstants";
-import FeatureFlag from "../sharedComponents/FeatureFlag";
 import { CondensedCDTooltip } from '../../components/award/shared/InfoTooltipContent';
 
 const propTypes = {


### PR DESCRIPTION
**High level description:**

Make the Recipient page details table look more like the top five tables

**Technical details:**

Added some hyper-specific css rules to the details table to accomplish this, for border colors, border radius, row height, and the padding within the cells

**JIRA Ticket:**
[DEV-11534](https://federal-spending-transparency.atlassian.net/browse/DEV-11534)

**Mockup:**


The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
