### PR TITLE
11544 - made new component and small scss file for this message; had …

### DIFF
--- a/src/_scss/core/_variables.scss
+++ b/src/_scss/core/_variables.scss
@@ -70,6 +70,7 @@ $blue-50: #2378C3;
 $blue-60v: #005ea2;
 $blue-70v: #0B4778;
 $blue-80v: #112f4e;
+$blue-cool-5v: #e1f3f8;
 $blue-cool-60v: #07648d;
 $blue-cool-80v: #002d3f;
 $blue-vivid-5v: #e8f5ff;

--- a/src/_scss/pages/search/filters/programSource/programSource.scss
+++ b/src/_scss/pages/search/filters/programSource/programSource.scss
@@ -5,6 +5,9 @@
     @import "mixins/selectedFilterWrap";
     @import "../../tooltips";
 
+    // temporary; remove import and delete the scss file when TASDeprecationNotice is removed
+    @import "./tasDeprecationNotice.scss";
+
     padding: 0 $global-padding * 2 rem(20);
 
     .program-source-components {

--- a/src/_scss/pages/search/filters/programSource/tasDeprecationNotice.scss
+++ b/src/_scss/pages/search/filters/programSource/tasDeprecationNotice.scss
@@ -1,5 +1,7 @@
 .tas-deprecation-notice__container {
   background-color: $blue-cool-5v;
+  border-radius: 3px;
+  border: solid 1px $card-outline-color;
   padding: $global-spacing-unit * 2;
   margin-bottom: $global-spacing-unit * 2;
 

--- a/src/_scss/pages/search/filters/programSource/tasDeprecationNotice.scss
+++ b/src/_scss/pages/search/filters/programSource/tasDeprecationNotice.scss
@@ -16,5 +16,6 @@
     font-size: $font-size-14;
     color: $theme-color-body;
     line-height: 1.5;
+    margin-top: $global-spacing-unit;
   }
 }

--- a/src/_scss/pages/search/filters/programSource/tasDeprecationNotice.scss
+++ b/src/_scss/pages/search/filters/programSource/tasDeprecationNotice.scss
@@ -1,0 +1,18 @@
+.tas-deprecation-notice__container {
+  background-color: $blue-cool-5v;
+  padding: $global-spacing-unit * 2;
+  margin-bottom: $global-spacing-unit * 2;
+
+  .tas-deprecation-notice__heading {
+    font-size: $font-size-14;
+    color: $theme-color-headline;
+    font-weight: $font-semibold;
+    line-height: 1.5;
+  }
+
+  .tas-deprecation-notice__text {
+    font-size: $font-size-14;
+    color: $theme-color-body;
+    line-height: 1.5;
+  }
+}

--- a/src/js/components/search/filters/programSource/TASDeprecationNotice.jsx
+++ b/src/js/components/search/filters/programSource/TASDeprecationNotice.jsx
@@ -1,0 +1,24 @@
+/**
+ * TASDeprecationNotice.jsx
+ * Created by Brian Petway 10/30/2024
+ */
+
+import React from 'react';
+
+const TASDeprecationNotice = () => (
+    <div className="tas-deprecation-notice__container">
+        <div className="tas-deprecation-notice__heading">
+                The TAS Components filter will be removed
+        </div>
+        <br />
+        <div className="tas-deprecation-notice__text">
+                You can still search for a specific TAS or Federal Account in the search text field within the Treasury Account tab.
+        </div>
+        <br />
+        <div className="tas-deprecation-notice__text">
+                The API endpoint for this filter will still be available.
+        </div>
+    </div>
+);
+
+export default TASDeprecationNotice;

--- a/src/js/components/search/filters/programSource/TASDeprecationNotice.jsx
+++ b/src/js/components/search/filters/programSource/TASDeprecationNotice.jsx
@@ -10,11 +10,9 @@ const TASDeprecationNotice = () => (
         <div className="tas-deprecation-notice__heading">
                 The TAS Components filter will be removed
         </div>
-        <br />
         <div className="tas-deprecation-notice__text">
                 You can still search for a specific TAS or Federal Account in the search text field within the Treasury Account tab.
         </div>
-        <br />
         <div className="tas-deprecation-notice__text">
                 The API endpoint for this filter will still be available.
         </div>

--- a/src/js/components/search/filters/programSource/TreasuryAccountFilters.jsx
+++ b/src/js/components/search/filters/programSource/TreasuryAccountFilters.jsx
@@ -10,6 +10,7 @@ import EntityWarning from 'components/search/filters/location/EntityWarning';
 import ProgramSourceAutocompleteContainer from 'containers/search/filters/programSource/ProgramSourceAutocompleteContainer';
 import TASCheckboxTree from 'containers/search/filters/programSource/TASCheckboxTreeContainer';
 import { treasuryAccountComponents } from 'dataMapping/search/programSourceComponents';
+import TASDeprecationNotice from "./TASDeprecationNotice";
 
 const propTypes = {
     updateComponent: PropTypes.func,
@@ -77,9 +78,12 @@ export default class TreasuryAccountFilters extends React.Component {
             <div className="program-source-tab">
                 <div className="program-source-components">
                     {activeTab === 2 && (
-                        <div className="program-source-components__heading">
+                        <>
+                            <div className="program-source-components__heading">
                             Treasury Account Components
-                        </div>
+                            </div>
+                            <TASDeprecationNotice />
+                        </>
                     )}
                     {this.generateFilters()}
                     <div


### PR DESCRIPTION
…to add another color var too

**High level description:**

Add notice to the TAS Components tab.

**Technical details:**

I made a new component for it, and a small css file. I figured it would be easier to remove that way.

**JIRA Ticket:**
[DEV-11544](https://federal-spending-transparency.atlassian.net/browse/DEV-11544)

**Mockup:**
https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55/screen/66fc643bd984bccd79c594f1

The following are ALL required for the PR to be merged:

Author:
- [ x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
