### PR TITLE
Mod/11628 add rows per page dropdown

### DIFF
--- a/src/js/containers/award/table/AwardHistoryTableContainer.jsx
+++ b/src/js/containers/award/table/AwardHistoryTableContainer.jsx
@@ -35,11 +35,11 @@ const AwardHistoryTableContainer = ({
     const [rows, setRows] = useState();
     const [totalItems, setTotalItems] = useState(0);
     const [activateRightFade, setActivateRightFade] = useState(false);
+    const [pageLimit, setPageLimit] = useState(10);
 
     const tabCounts = useRef({});
 
     let request = null;
-    const pageLimit = 15;
     const totalSubAwardLabel = 'Number of Sub-Award Transactions';
     const totalSubAwardAmountLabel = 'Sub-Award Obligations';
 
@@ -332,7 +332,7 @@ const AwardHistoryTableContainer = ({
     useEffect(() => {
         fetchData(1);
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [award.id, sort]);
+    }, [award.id, sort, pageLimit]);
 
     useEffect(() => {
         fetchData(page);
@@ -421,9 +421,11 @@ const AwardHistoryTableContainer = ({
             </div>
             <Pagination
                 resultsText
+                limitSelector
                 currentPage={page}
                 changePage={setPage}
                 pageSize={pageLimit}
+                changeLimit={setPageLimit}
                 totalItems={totalItems}
                 hideLast={totalItems >= 50000} />
         </>

--- a/src/js/containers/award/table/AwardHistoryTableContainer.jsx
+++ b/src/js/containers/award/table/AwardHistoryTableContainer.jsx
@@ -13,6 +13,7 @@ import BaseFederalAccountFunding, { AwardHistoryTransactionsTableRow } from "mod
 import BaseSubawardRow from "models/v2/award/subawards/BaseSubawardRow";
 import { fetchFederalAccountFunding } from "helpers/awardHistoryHelper";
 import { fetchAwardFedAccountFunding } from 'helpers/idvHelper';
+import { formatMoney } from 'helpers/moneyFormatter';
 
 const propTypes = {
     award: PropTypes.object,
@@ -242,7 +243,7 @@ const AwardHistoryTableContainer = ({
                     text={obj.recipient || '--'}
                     limit={50} />,
                 obj.date || '--',
-                obj._amount || '--',
+                formatMoney(obj._amount) || '--',
                 <ReadMore
                     text={obj.description || '--'}
                     limit={50} />

--- a/src/js/dataMapping/award/transactionHistoryTable/tableMapping.js
+++ b/src/js/dataMapping/award/transactionHistoryTable/tableMapping.js
@@ -63,7 +63,7 @@ export const transactionsTableMapping = {
             title: 'original_loan_subsidy_cost'
         },
         {
-            columnWidth: 200,
+            columnWidth: 250,
             displayName: 'Action Type',
             right: false,
             title: 'action_type'

--- a/src/js/dataMapping/award/transactionHistoryTable/tableMapping.js
+++ b/src/js/dataMapping/award/transactionHistoryTable/tableMapping.js
@@ -1,25 +1,25 @@
 export const transactionsTableMapping = {
     idv: [
         {
-            columnWidth: 300,
+            columnWidth: 150,
             displayName: 'Modification Number',
             right: false,
             title: 'modification_number'
         },
         {
-            columnWidth: 300,
+            columnWidth: 150,
             displayName: 'Action Date',
             right: false,
             title: 'action_date'
         },
         {
-            columnWidth: 300,
+            columnWidth: 150,
             displayName: 'Amount',
-            right: false,
+            right: true,
             title: 'federal_action_obligation'
         },
         {
-            columnWidth: 300,
+            columnWidth: 250,
             displayName: 'Action Type',
             right: false,
             title: 'action_type'
@@ -33,37 +33,37 @@ export const transactionsTableMapping = {
     ],
     loan: [
         {
-            columnWidth: 300,
+            columnWidth: 150,
             displayName: 'Modification Number',
             right: false,
             title: 'modification_number'
         },
         {
-            columnWidth: 300,
+            columnWidth: 150,
             displayName: 'CFDA Number',
             right: false,
             title: 'cfda_number'
         },
         {
-            columnWidth: 300,
+            columnWidth: 150,
             displayName: 'Action Date',
             right: false,
             title: 'action_date'
         },
         {
-            columnWidth: 300,
+            columnWidth: 150,
             displayName: 'Loan Face Value',
-            right: false,
+            right: true,
             title: 'face_value_loan_guarantee'
         },
         {
-            columnWidth: 300,
+            columnWidth: 250,
             displayName: 'Loan Subsidy Cost (Total Obligations To Date)',
-            right: false,
+            right: true,
             title: 'original_loan_subsidy_cost'
         },
         {
-            columnWidth: 300,
+            columnWidth: 200,
             displayName: 'Action Type',
             right: false,
             title: 'action_type'
@@ -77,25 +77,25 @@ export const transactionsTableMapping = {
     ],
     contract: [
         {
-            columnWidth: 300,
+            columnWidth: 150,
             displayName: 'Modification Number',
             right: false,
             title: 'modification_number'
         },
         {
-            columnWidth: 300,
+            columnWidth: 150,
             displayName: 'Action Date',
             right: false,
             title: 'action_date'
         },
         {
-            columnWidth: 300,
+            columnWidth: 150,
             displayName: 'Amount',
             right: false,
             title: 'federal_action_obligation'
         },
         {
-            columnWidth: 300,
+            columnWidth: 250,
             displayName: 'Action Type',
             right: false,
             title: 'action_type'
@@ -109,31 +109,31 @@ export const transactionsTableMapping = {
     ],
     assistance: [
         {
-            columnWidth: 300,
+            columnWidth: 150,
             displayName: 'Modification Number',
             right: false,
             title: 'modification_number'
         },
         {
-            columnWidth: 300,
+            columnWidth: 150,
             displayName: 'Assistance Listing',
             right: false,
             title: 'cfda_number'
         },
         {
-            columnWidth: 300,
+            columnWidth: 150,
             displayName: 'Action Date',
             right: false,
             title: 'action_date'
         },
         {
-            columnWidth: 300,
+            columnWidth: 150,
             displayName: 'Amount',
-            right: false,
+            right: true,
             title: 'federal_action_obligation'
         },
         {
-            columnWidth: 300,
+            columnWidth: 250,
             displayName: 'Action Type',
             right: false,
             title: 'action_type'
@@ -150,13 +150,13 @@ export const transactionsTableMapping = {
 export const federalAccountsTableMapping = {
     idv: [
         {
-            columnWidth: 300,
+            columnWidth: 150,
             displayName: 'Submission Period',
             right: false,
             title: 'reporting_fiscal_date'
         },
         {
-            columnWidth: 300,
+            columnWidth: 150,
             displayName: 'Award ID',
             right: false,
             title: 'piid'
@@ -174,13 +174,13 @@ export const federalAccountsTableMapping = {
             title: 'awarding_agency_name'
         },
         {
-            columnWidth: 300,
+            columnWidth: 100,
             displayName: 'DEFC',
             right: false,
             title: 'disaster_emergency_fund_code'
         },
         {
-            columnWidth: 300,
+            columnWidth: 500,
             displayName: 'Federal Account Name',
             right: false,
             title: 'account_title'
@@ -198,27 +198,27 @@ export const federalAccountsTableMapping = {
             title: 'object_class'
         },
         {
-            columnWidth: 300,
+            columnWidth: 250,
             displayName: 'Funding Obligated',
-            right: false,
+            right: true,
             title: 'transaction_obligated_amount'
         },
         {
-            columnWidth: 300,
+            columnWidth: 250,
             displayName: 'Outlayed Amount (Beginning of FY to Period End)',
-            right: false,
+            right: true,
             title: 'gross_outlay_amount'
         }
     ],
     otherFunding: [
         {
-            columnWidth: 300,
+            columnWidth: 150,
             displayName: 'Submission Period',
             right: false,
             title: 'reporting_fiscal_date'
         },
         {
-            columnWidth: 300,
+            columnWidth: 500,
             displayName: 'Federal Account',
             right: false,
             title: 'account_title'
@@ -236,7 +236,7 @@ export const federalAccountsTableMapping = {
             title: 'awarding_agency_name'
         },
         {
-            columnWidth: 300,
+            columnWidth: 100,
             displayName: 'DEFC',
             right: false,
             title: 'disaster_emergency_fund_code'
@@ -254,15 +254,15 @@ export const federalAccountsTableMapping = {
             title: 'object_class'
         },
         {
-            columnWidth: 300,
+            columnWidth: 250,
             displayName: 'Funding Obligated',
-            right: false,
+            right: true,
             title: 'transaction_obligated_amount'
         },
         {
-            columnWidth: 300,
+            columnWidth: 250,
             displayName: 'Outlayed Amount (Beginning of FY to Period End)',
-            right: false,
+            right: true,
             title: 'gross_outlay_amount'
         }
     ]
@@ -270,7 +270,7 @@ export const federalAccountsTableMapping = {
 
 export const subawardTableMapping = [
     {
-        columnWidth: 300,
+        columnWidth: 150,
         displayName: 'Sub-Award ID',
         right: false,
         title: 'subaward_number'
@@ -282,15 +282,16 @@ export const subawardTableMapping = [
         title: 'recipient_name'
     },
     {
-        columnWidth: 300,
+        columnWidth: 150,
         displayName: 'Action Date',
         right: false,
         title: 'action_date'
     },
+    // TODO: REFORMAT DOLLAR AMOUNT
     {
-        columnWidth: 300,
+        columnWidth: 150,
         displayName: 'Amount',
-        right: false,
+        right: true,
         title: 'amount'
     },
     {

--- a/src/js/dataMapping/award/transactionHistoryTable/tableMapping.js
+++ b/src/js/dataMapping/award/transactionHistoryTable/tableMapping.js
@@ -287,7 +287,6 @@ export const subawardTableMapping = [
         right: false,
         title: 'action_date'
     },
-    // TODO: REFORMAT DOLLAR AMOUNT
     {
         columnWidth: 150,
         displayName: 'Amount',


### PR DESCRIPTION
**High level description:**
Fine tuning to Award Profile Award History Tables.

**Technical details:**
Added per page dropdown with 10 rows as default, column widths adjusted per Marcy's request, no adjustment at this time to 'read more' character count.

**JIRA Ticket:**
[DEV-11628](https://federal-spending-transparency.atlassian.net/browse/DEV-11628)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
