### PR TITLE
11605 - added ternary to change the sectionTitle when subawards is true

### DIFF
--- a/src/js/components/search/newResultsView/table/TableSection.jsx
+++ b/src/js/components/search/newResultsView/table/TableSection.jsx
@@ -14,7 +14,7 @@ const propTypes = {
 
 const TableSection = ({ subaward }) => {
     const wrapperProps = {
-        sectionTitle: 'Prime Award Results',
+        sectionTitle: subaward ? 'Subaward Results' : 'Prime Award Results',
         dsmContent: <TableDsm subaward={subaward} />,
         sectionName: 'table'
     };


### PR DESCRIPTION
**High level description:**

Chnage the table section heading when subawards is true

**Technical details:**

Added a ternary in the wrapper props being sent to the section wrapper

**JIRA Ticket:**
[DEV-11605](https://federal-spending-transparency.atlassian.net/browse/DEV-11605)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
