### PR TITLE
Mod/11644 recipient filter UI

### DIFF
--- a/src/_scss/pages/search/filters/recipient/recipient.scss
+++ b/src/_scss/pages/search/filters/recipient/recipient.scss
@@ -12,24 +12,7 @@
         overflow-y: scroll;
         list-style: none;
 
-        >div>div:not(:first-child) {
-            margin-top: $global-margin * 1.5;
-        }
-
         .checkbox-type-filter {
-            p {
-                color: $color-gray;
-                font-size: $small-font-size;
-                margin-top: 0;
-                margin-bottom: rem(5);
-            }
-            span {
-                label {
-                    color: $color-gray;
-                    font-weight: normal;
-                }
-            }
-
             .checkbox-set,
             .secondary-checkbox-type {
                 margin: 0.5rem 0;
@@ -38,6 +21,7 @@
             .recipient-label__container {
                 display: flex;
                 flex-flow: column nowrap;
+                margin-top: $global-margin * 1.5;
 
                 .primary-checkbox-type {
                     padding-left: 0;
@@ -68,7 +52,7 @@
                     padding: rem(2.5) $global-padding * .5;
                     border-radius: 2px;
                     background-color: $gray-cool-5;
-                    line-height: 1.3;
+                    line-height: 1.5;
                     color: $theme-color-headline;
 
                     span {
@@ -82,20 +66,19 @@
                     .recipient-label__legacy-duns {
                         font-size: $font-size-10;
                         font-style: italic;
-                        line-height: 1.3;
+                        line-height: 1.5;
                         color: $gray-60;
                         margin-top: $global-margin * .5;
-                        padding: rem(2.5) 0;
                     }
 
                     .recipient-label__name-container {
-                        margin-right: rem(4);
+                        margin: rem(4) rem(4) 0 0;
 
                         .recipient-label__recipient-name {
                             font-size: $font-size-12;
-                            line-height: 1.1;
+                            font-weight: $font-normal;
+                            line-height: 1.5;
                             color: $gray-90;
-                            margin-top: $global-margin * .5;
                             border-right: 0;
                             margin-right: 0;
                         }
@@ -103,11 +86,9 @@
                         .recipient-label__recipient-level {
                             font-size: $font-size-10;
                             font-style: italic;
-                            line-height: 1.3;
+                            line-height: 1.5;
                             color: $gray-60;
-                            margin-top: $global-margin * .5;
                             margin-left: $global-spacing-unit;
-                            padding: rem(2.5) 0;
                         }
                     }
                 }

--- a/src/_scss/pages/search/filters/recipient/recipient.scss
+++ b/src/_scss/pages/search/filters/recipient/recipient.scss
@@ -73,10 +73,11 @@
                     padding: rem(2.5) $global-padding * .5;
                     border-radius: 2px;
                     background-color: $gray-cool-5;
-                    line-height: 1.5;
+                    line-height: 1.3;
+                    color: $theme-color-headline;
 
                     span {
-                        font-weight: $font-bold;
+                        font-weight: $font-semibold;
                     }
                 }
 
@@ -86,7 +87,7 @@
                     .recipient-label__legacy-duns {
                         font-size: $font-size-10;
                         font-style: italic;
-                        line-height: 1.5;
+                        line-height: 1.3;
                         color: $gray-60;
                         margin-top: $global-margin * .5;
                         padding: rem(2.5) 0;

--- a/src/_scss/pages/search/filters/recipient/recipient.scss
+++ b/src/_scss/pages/search/filters/recipient/recipient.scss
@@ -28,11 +28,6 @@
                     color: $color-gray;
                     font-weight: normal;
                 }
-                &:not(:last-child) {
-                    border-right: rem(1) solid rgba(0, 0, 0, 0.3);
-                    padding-right: rem(10);
-                    margin-right: rem(10);
-                }
             }
 
             .checkbox-set,
@@ -81,7 +76,7 @@
                     }
                 }
 
-                .recipient-label__bottom-section {
+                .recipient-label__lower-container {
                     margin-left: rem(21);
 
                     .recipient-label__legacy-duns {
@@ -93,13 +88,27 @@
                         padding: rem(2.5) 0;
                     }
 
-                    .recipient-label__recipient-name {
-                        font-size: $font-size-12;
-                        line-height: 1.5;
-                        color: $gray-90;
-                        margin-top: $global-margin * .5;
-                        border-right: 0;
-                        margin-right: 0;
+                    .recipient-label__name-container {
+                        margin-right: rem(4);
+
+                        .recipient-label__recipient-name {
+                            font-size: $font-size-12;
+                            line-height: 1.1;
+                            color: $gray-90;
+                            margin-top: $global-margin * .5;
+                            border-right: 0;
+                            margin-right: 0;
+                        }
+
+                        .recipient-label__recipient-level {
+                            font-size: $font-size-10;
+                            font-style: italic;
+                            line-height: 1.3;
+                            color: $gray-60;
+                            margin-top: $global-margin * .5;
+                            margin-left: $global-spacing-unit;
+                            padding: rem(2.5) 0;
+                        }
                     }
                 }
             }

--- a/src/js/components/search/filters/recipient/RecipientResults.jsx
+++ b/src/js/components/search/filters/recipient/RecipientResults.jsx
@@ -64,11 +64,11 @@ const RecipientResults = ({ toggleRecipient }) => {
                             value={`primary-checkbox-${index}`}
                             key={recipient.uei}
                             toggleCheckboxType={toggleRecipient} />
-                        <div className="recipient-label__bottom-section">
+                        <div className="recipient-label__lower-container">
                             <div className="recipient-label__legacy-duns">Legacy DUNS: {recipient.duns}</div>
-                            <div>
+                            <div className="recipient-label__name-container">
                                 <span className="recipient-label__recipient-name">{recipient.name}</span>
-                                <span className="recipient-label__legacy-duns">{levelMapping[recipient.recipient_level]}</span>
+                                <span className="recipient-label__recipient-level">{levelMapping[recipient.recipient_level]}</span>
                             </div>
                         </div>
                     </div>

--- a/src/js/components/search/filters/recipient/RecipientResults.jsx
+++ b/src/js/components/search/filters/recipient/RecipientResults.jsx
@@ -32,19 +32,6 @@ const RecipientResults = ({ toggleRecipient }) => {
 
         recipientRequest.promise
             .then((res) => {
-                // todo - only for testing; remove after design review
-                res.data.results.forEach((r) => {
-                    if (r.name === 'ARIZONA HEALTH CARE COST CONTAINMENT SYSTEM') {
-                        r.uei = '';
-                    }
-                    if (r.name === 'COLORADO DEPARMENT-HEALTH CARE') {
-                        r.uei = false;
-                    }
-                    if (r.name === 'DEPARTMENT OF HEALTH HUMAN SERVICES') {
-                        r.uei = null;
-                    }
-                });
-                console.log('res.data', res.data);
                 setRecipients(res.data.results);
             });
     };

--- a/src/js/components/search/filters/recipient/RecipientResults.jsx
+++ b/src/js/components/search/filters/recipient/RecipientResults.jsx
@@ -32,6 +32,19 @@ const RecipientResults = ({ toggleRecipient }) => {
 
         recipientRequest.promise
             .then((res) => {
+                // todo - only for testing; remove after design review
+                res.data.results.forEach((r) => {
+                    if (r.name === 'ARIZONA HEALTH CARE COST CONTAINMENT SYSTEM') {
+                        r.uei = '';
+                    }
+                    if (r.name === 'COLORADO DEPARMENT-HEALTH CARE') {
+                        r.uei = false;
+                    }
+                    if (r.name === 'DEPARTMENT OF HEALTH HUMAN SERVICES') {
+                        r.uei = null;
+                    }
+                });
+                console.log('res.data', res.data);
                 setRecipients(res.data.results);
             });
     };
@@ -47,7 +60,7 @@ const RecipientResults = ({ toggleRecipient }) => {
                 { recipients.toSorted((a, b) => (a.name?.toUpperCase() < b.name?.toUpperCase() ? -1 : 1)).map((recipient, index) => (
                     <div className="recipient-label__container">
                         <PrimaryCheckboxType
-                            name={(<div className="recipient-checkbox__uei"> <span>UEI:</span> {recipient.uei}</div>)}
+                            name={(<div className="recipient-checkbox__uei"> <span>UEI:</span> {recipient.uei ? recipient.uei : 'Not provided'}</div>)}
                             value={`primary-checkbox-${index}`}
                             key={recipient.uei}
                             toggleCheckboxType={toggleRecipient} />


### PR DESCRIPTION
**High level description:**

Design noticed some small changes needed in this filter

**Technical details:**

Got rid of some unneeded css and changed some classnames; changed font weights and colors where needed; added logic to show 'Not provided' when no uei is in the data. To test this you have to force the data to be blank or false, in order to show the 'Not provided' text, because there are no longer any blank ueis in the data.
This has been thoroughly design reviewed.

**JIRA Ticket:**
[DEV-11644](https://federal-spending-transparency.atlassian.net/browse/DEV-11644)

**Mockup:**
https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55/screen/66c7387f9edd5064a09eb761

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
