### PR TITLE
11644 - added ternary for the duns field too

### DIFF
--- a/src/js/components/search/filters/recipient/RecipientResults.jsx
+++ b/src/js/components/search/filters/recipient/RecipientResults.jsx
@@ -52,7 +52,7 @@ const RecipientResults = ({ toggleRecipient }) => {
                             key={recipient.uei}
                             toggleCheckboxType={toggleRecipient} />
                         <div className="recipient-label__lower-container">
-                            <div className="recipient-label__legacy-duns">Legacy DUNS: {recipient.duns}</div>
+                            <div className="recipient-label__legacy-duns">Legacy DUNS: {recipient.duns ? recipient.duns : 'Not provided'}</div>
                             <div className="recipient-label__name-container">
                                 <span className="recipient-label__recipient-name">{recipient.name}</span>
                                 <span className="recipient-label__recipient-level">{levelMapping[recipient.recipient_level]}</span>


### PR DESCRIPTION
**High level description:**

QA pointed out that the duns field was not showing the 'Not provided' string when the data field was null, so I added that. It's part of AC1.


**JIRA Ticket:**
[DEV-11644](https://federal-spending-transparency.atlassian.net/browse/DEV-11644)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
