### PR TITLE
11610 - changed font weight to 400 after selection from dropdown is made

### DIFF
--- a/src/js/components/sharedComponents/autocomplete/Autocomplete.jsx
+++ b/src/js/components/sharedComponents/autocomplete/Autocomplete.jsx
@@ -96,7 +96,7 @@ const Autocomplete = (props) => {
 
         if (props.retainValue && isValid) {
             autocompleteInputRef.current.value = selectedItemTitle;
-            autocompleteInputRef.current.style.fontWeight = "600";
+            autocompleteInputRef.current.style.fontWeight = "400";
         }
 
         else {


### PR DESCRIPTION
**High level description:**

In the Location filter, after selecting something from the dropdown, the text in the input box is bold, and stays bold after you clear it and enter a different string there

**Technical details:**

Finally found this fn that was firing after the selection is made from the dropdown. It was applying font weight 600 to the input box text, so I changed it to 400.

**JIRA Ticket:**
[DEV-11610](https://federal-spending-transparency.atlassian.net/browse/DEV-11610)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
