### PR TITLE
11628 - added a set page to useEffect

### DIFF
--- a/src/js/containers/award/table/AwardHistoryTableContainer.jsx
+++ b/src/js/containers/award/table/AwardHistoryTableContainer.jsx
@@ -341,6 +341,7 @@ const AwardHistoryTableContainer = ({
     }, [page]);
 
     useEffect(() => {
+        setPage(1);
         if (activeTab === 'transaction') {
             setSort({
                 field: 'modification_number',


### PR DESCRIPTION
**Technical details:**
Added a set state to reset pagination on tab change

**JIRA Ticket:**
[DEV-11628](https://federal-spending-transparency.atlassian.net/browse/DEV-11628)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
