### PR TITLE
11637 Adopting new time_period field

### DIFF
--- a/src/js/components/search/filters/timePeriod/DateRange.jsx
+++ b/src/js/components/search/filters/timePeriod/DateRange.jsx
@@ -206,12 +206,12 @@ const DateRange = (props) => {
 
     const startDateDisabledDays = generateStartDateDisabledDays(earliestDate);
     const endDateDisabledDays = generateEndDateDisabledDays(earliestDate);
+    const lastInTimePeriod = props.timePeriod[props.timePeriod.length - 1];
 
     let dateLabel = '';
     let hideTags = 'hide';
-    if (props.timePeriod.length > 0) {
-        const lastInTimePeriod = props.timePeriod[props.timePeriod.length - 1];
 
+    if (props.timePeriod.length > 0) {
         hideTags = '';
         let start = null;
         let end = null;
@@ -228,8 +228,11 @@ const DateRange = (props) => {
         else if (start) {
             dateLabel = `${start} to present`;
         }
-        else {
+        else if (end) {
             dateLabel = `... to ${end}`;
+        }
+        else {
+            hideTags = 'hide';
         }
     }
 

--- a/src/js/components/search/filters/timePeriod/DateRange.jsx
+++ b/src/js/components/search/filters/timePeriod/DateRange.jsx
@@ -23,6 +23,7 @@ const propTypes = {
     onDateChange: PropTypes.func,
     startDate: PropTypes.object,
     endDate: PropTypes.object,
+    timePeriod: PropTypes.array,
     selectedStart: PropTypes.string,
     selectedEnd: PropTypes.string,
     showError: PropTypes.func,
@@ -208,15 +209,18 @@ const DateRange = (props) => {
 
     let dateLabel = '';
     let hideTags = 'hide';
-    if (props.selectedStart || props.selectedEnd) {
+    if (props.timePeriod.length > 0) {
+        const lastInTimePeriod = props.timePeriod[props.timePeriod.length - 1];
+
         hideTags = '';
         let start = null;
         let end = null;
-        if (props.selectedStart) {
-            start = dayjs(props.selectedStart, 'YYYY-MM-DD').format('MM/DD/YYYY');
+
+        if (lastInTimePeriod.start_date) {
+            start = dayjs(lastInTimePeriod.start_date, 'YYYY-MM-DD').format('MM/DD/YYYY');
         }
-        if (props.selectedEnd) {
-            end = dayjs(props.selectedEnd, 'YYYY-MM-DD').format('MM/DD/YYYY');
+        if (lastInTimePeriod.end_date) {
+            end = dayjs(lastInTimePeriod.end_date, 'YYYY-MM-DD').format('MM/DD/YYYY');
         }
         if (start && end) {
             dateLabel = `${start} to ${end}`;

--- a/src/js/components/search/filters/timePeriod/TimePeriod.jsx
+++ b/src/js/components/search/filters/timePeriod/TimePeriod.jsx
@@ -31,6 +31,7 @@ const propTypes = {
     filterTimePeriodStart: PropTypes.string,
     filterTimePeriodEnd: PropTypes.string,
     filterTimePeriodType: PropTypes.string,
+    filterTime_Period: PropTypes.array,
     label: PropTypes.string,
     timePeriods: PropTypes.array,
     activeTab: PropTypes.string,
@@ -265,6 +266,7 @@ export default class TimePeriod extends React.Component {
                 startingTab={1}
                 startDate={this.state.startDateUI}
                 endDate={this.state.endDateUI}
+                timePeriod={this.props.filterTime_Period}
                 selectedStart={this.props.filterTimePeriodStart}
                 selectedEnd={this.props.filterTimePeriodEnd}
                 onDateChange={this.handleDateChange}

--- a/src/js/containers/search/SearchContainer.jsx
+++ b/src/js/containers/search/SearchContainer.jsx
@@ -43,9 +43,9 @@ export const parseRemoteFilters = (data) => {
     const version = data.version;
 
     if (version !== filterStoreVersion) {
-    // versions don't match, don't populate the filters
-    // TODO: Kevin Li - figure out how we want to deal with Redux structure changes when
-    // a URL hash contains data that no longer applies to the current site
+        // versions don't match, don't populate the filters
+        // TODO: Kevin Li - figure out how we want to deal with Redux structure changes when
+        // a URL hash contains data that no longer applies to the current site
         console.info("version mismatch");
         return null;
     }

--- a/src/js/containers/search/filters/TimePeriodContainer.jsx
+++ b/src/js/containers/search/filters/TimePeriodContainer.jsx
@@ -81,12 +81,14 @@ const TimePeriodContainer = (props) => {
         const appliedFields = [
             'timePeriodFY',
             'timePeriodStart',
-            'timePeriodEnd'
+            'timePeriodEnd',
+            'time_period'
         ];
         const activeFields = [
             'filterTimePeriodFY',
             'filterTimePeriodStart',
-            'filterTimePeriodEnd'
+            'filterTimePeriodEnd',
+            'filterTime_Period'
         ];
 
         const noChanges = appliedFields.every((appliedField, index) => {

--- a/src/js/containers/search/filters/TimePeriodContainer.jsx
+++ b/src/js/containers/search/filters/TimePeriodContainer.jsx
@@ -71,7 +71,7 @@ const TimePeriodContainer = (props) => {
             newFilters.fy = [];
         }
 
-        props.updateTimePeriod(newFilters);
+        // props.updateTimePeriod(newFilters);
 
         // here is where the time_period array gets updated
         props.updateTimePeriodArray(newFilters);

--- a/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
+++ b/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
@@ -82,7 +82,6 @@ const TopFilterBarContainer = (props) => {
             const lastInTimePeriod = props.filters.time_period[props.filters.time_period.length - 1];
             // check to see if any date ranges are selected
             if (lastInTimePeriod?.start_date || lastInTimePeriod?.end_date) {
-                console.log('fire:', lastInTimePeriod);
                 // start and end dates are provided
                 selected = true;
                 filter.code = 'timePeriodDR';

--- a/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
+++ b/src/js/containers/search/topFilterBar/TopFilterBarContainer.jsx
@@ -79,23 +79,25 @@ const TopFilterBarContainer = (props) => {
             }
         }
         else if (props.filters?.timePeriodType === 'dr') {
+            const lastInTimePeriod = props.filters.time_period[props.filters.time_period.length - 1];
             // check to see if any date ranges are selected
-            if (props.filters.timePeriodStart || props.filters.timePeriodEnd) {
+            if (lastInTimePeriod?.start_date || lastInTimePeriod?.end_date) {
+                console.log('fire:', lastInTimePeriod);
                 // start and end dates are provided
                 selected = true;
                 filter.code = 'timePeriodDR';
                 filter.name = 'Time Period';
 
-                const startString = dayjs(props.filters.timePeriodStart, 'YYYY-MM-DD')
+                const startString = dayjs(lastInTimePeriod.start_date, 'YYYY-MM-DD')
                     .format('MM/DD/YYYY');
-                const endString = dayjs(props.filters.timePeriodEnd, 'YYYY-MM-DD').format('MM/DD/YYYY');
+                const endString = dayjs(lastInTimePeriod.end_date, 'YYYY-MM-DD').format('MM/DD/YYYY');
                 filter.values = [`${startString} to ${endString}`];
 
-                if (!props.filters.timePeriodStart) {
+                if (!lastInTimePeriod.start_date) {
                     // open-ended start date
                     filter.values = [`... to ${endString}`];
                 }
-                else if (!props.filters.timePeriodEnd) {
+                else if (!lastInTimePeriod.end_date) {
                     // open-ended end date
                     filter.values = [`${startString} to present`];
                 }

--- a/src/js/models/v1/search/SearchAwardsOperation.js
+++ b/src/js/models/v1/search/SearchAwardsOperation.js
@@ -55,7 +55,7 @@ class SearchAwardsOperation {
 
     fromState(state) {
         this.keyword = state.keyword.toArray();
-        this.time_period = state.time_period;
+        this.time_period = state.selectedAwardIDs.toArray();
         this.timePeriodFY = state.timePeriodFY.toArray();
         this.timePeriodRange = [];
         this.timePeriodType = state.timePeriodType;

--- a/src/js/models/v1/search/SearchAwardsOperation.js
+++ b/src/js/models/v1/search/SearchAwardsOperation.js
@@ -55,7 +55,7 @@ class SearchAwardsOperation {
 
     fromState(state) {
         this.keyword = state.keyword.toArray();
-        this.time_period = state.selectedAwardIDs.toArray();
+        this.time_period = state.time_period;
         this.timePeriodFY = state.timePeriodFY.toArray();
         this.timePeriodRange = [];
         this.timePeriodType = state.timePeriodType;

--- a/src/js/models/v1/search/SearchAwardsOperation.js
+++ b/src/js/models/v1/search/SearchAwardsOperation.js
@@ -122,7 +122,7 @@ class SearchAwardsOperation {
         }
 
         // Add Time Period
-        if (this.timePeriodFY?.length > 0 || this.timePeriodRange?.length === 2) {
+        if (this.timePeriodFY?.length > 0 || this.time_period?.length > 0) {
             if (this.timePeriodType === 'fy' && this.timePeriodFY?.length > 0) {
                 filters[rootKeys.timePeriod] = this.timePeriodFY.map((fy) => {
                     const dates = FiscalYearHelper.convertFYToDateRange(fy);
@@ -133,9 +133,11 @@ class SearchAwardsOperation {
                     };
                 });
             }
-            else if (this.timePeriodType === 'dr' && this.timePeriodRange?.length > 0) {
-                let start = this.timePeriodRange[0];
-                let end = this.timePeriodRange[1];
+            else if (this.timePeriodType === 'dr' && this.time_period?.length > 0) {
+                const lastInTimePeriod = this.time_period[this.time_period?.length - 1];
+
+                let start = lastInTimePeriod.start_date;
+                let end = lastInTimePeriod.end_date;
 
                 // if no start or end date is provided, use the 2008-present date range to fill out
                 // the missing dates
@@ -159,7 +161,7 @@ class SearchAwardsOperation {
         }
 
         if ((this.timePeriodType === 'fy' && this.timePeriodFY?.length === 0) ||
-        (this.timePeriodType === 'dr' && this.timePeriodRange?.length === 0)) {
+        (this.timePeriodType === 'dr' && this.time_period?.length === 0)) {
             // the user selected fiscal years but did not specify any years OR
             // the user has selected the date range type but has not entered any dates yet
             // this should default to a period of time from FY 2008 to present

--- a/src/js/redux/reducers/search/filters/timePeriodFilterFunctions.js
+++ b/src/js/redux/reducers/search/filters/timePeriodFilterFunctions.js
@@ -1,0 +1,20 @@
+/**
+ * timePeriodFilterFunctions.js
+ * Created by Nick Torres 11/7/2024
+ */
+
+/* eslint-disable import/prefer-default-export */
+// We only have one export but want to maintain consistency with other query modules
+export const updateSelectedDates = (currentDates, date) => {
+    let updatedSet = currentDates;
+
+    if (date.start || date.end) {
+        currentDates.push({
+            start_date: date.start,
+            end_date: date.end
+        });
+    }
+
+    return currentDates;
+};
+/* eslint-enable import/prefer-default-export */

--- a/src/js/redux/reducers/search/filters/timePeriodFilterFunctions.js
+++ b/src/js/redux/reducers/search/filters/timePeriodFilterFunctions.js
@@ -6,8 +6,6 @@
 /* eslint-disable import/prefer-default-export */
 // We only have one export but want to maintain consistency with other query modules
 export const updateSelectedDates = (currentDates, date) => {
-    let updatedSet = currentDates;
-
     if (date.start || date.end) {
         currentDates.push({
             start_date: date.start,

--- a/src/js/redux/reducers/search/searchFiltersReducer.js
+++ b/src/js/redux/reducers/search/searchFiltersReducer.js
@@ -14,6 +14,7 @@ import * as AwardAmountFilterFunctions from './filters/awardAmountFilterFunction
 import * as OtherFilterFunctions from './filters/OtherFilterFunctions';
 import * as ContractFilterFunctions from './filters/contractFilterFunctions';
 import * as ProgramSourceFilterFunctions from './filters/programSourceFilterFunctions';
+import * as TimePeriodFilterFunctions from './filters/timePeriodFilterFunctions';
 
 // update this version when changes to the reducer structure are made
 // frontend will reject inbound hashed search filter sets with different versions because the
@@ -28,7 +29,7 @@ export const CheckboxTreeSelections = Record(defaultCheckboxTreeSelections);
 export const requiredTypes = {
     keyword: OrderedMap,
     timePeriodFY: Set,
-    time_period: OrderedMap,
+    time_period: [],
     selectedLocations: OrderedMap,
     selectedFundingAgencies: OrderedMap,
     selectedAwardingAgencies: OrderedMap,
@@ -53,7 +54,7 @@ export const initialState = {
     keyword: OrderedMap(),
     timePeriodType: 'dr',
     timePeriodFY: Set(),
-    time_period: OrderedMap(),
+    time_period: [],
     timePeriodStart: null,
     timePeriodEnd: null,
     filterNewAwardsOnlySelected: false,
@@ -104,11 +105,15 @@ const searchFiltersReducer = (state = initialState, action) => {
 
         // New Time Period Filter Array
         case 'ADD_TIME_PERIOD_OBJECT': {
+            // return Object.assign({}, state, {
+            //     time_period: state.time_period.concat({
+            //         start_date: action.start,
+            //         end_date: action.end
+            //     })
+            // });
+
             return Object.assign({}, state, {
-                time_period: state.time_period.concat({
-                    start_date: action.start,
-                    end_date: action.end
-                })
+                time_period: TimePeriodFilterFunctions.updateSelectedDates(state.time_period, action)
             });
         }
 

--- a/src/js/redux/reducers/search/searchFiltersReducer.js
+++ b/src/js/redux/reducers/search/searchFiltersReducer.js
@@ -28,6 +28,7 @@ export const CheckboxTreeSelections = Record(defaultCheckboxTreeSelections);
 export const requiredTypes = {
     keyword: OrderedMap,
     timePeriodFY: Set,
+    time_period: OrderedMap,
     selectedLocations: OrderedMap,
     selectedFundingAgencies: OrderedMap,
     selectedAwardingAgencies: OrderedMap,
@@ -52,7 +53,7 @@ export const initialState = {
     keyword: OrderedMap(),
     timePeriodType: 'dr',
     timePeriodFY: Set(),
-    time_period: [],
+    time_period: OrderedMap(),
     timePeriodStart: null,
     timePeriodEnd: null,
     filterNewAwardsOnlySelected: false,

--- a/src/js/redux/reducers/search/searchFiltersReducer.js
+++ b/src/js/redux/reducers/search/searchFiltersReducer.js
@@ -29,7 +29,6 @@ export const CheckboxTreeSelections = Record(defaultCheckboxTreeSelections);
 export const requiredTypes = {
     keyword: OrderedMap,
     timePeriodFY: Set,
-    time_period: [],
     selectedLocations: OrderedMap,
     selectedFundingAgencies: OrderedMap,
     selectedAwardingAgencies: OrderedMap,

--- a/src/js/redux/reducers/search/searchFiltersReducer.js
+++ b/src/js/redux/reducers/search/searchFiltersReducer.js
@@ -14,7 +14,7 @@ import * as AwardAmountFilterFunctions from './filters/awardAmountFilterFunction
 import * as OtherFilterFunctions from './filters/OtherFilterFunctions';
 import * as ContractFilterFunctions from './filters/contractFilterFunctions';
 import * as ProgramSourceFilterFunctions from './filters/programSourceFilterFunctions';
-import * as TimePeriodFilterFunctions from './filters/timePeriodFilterFunctions';
+// import * as TimePeriodFilterFunctions from './filters/timePeriodFilterFunctions';
 
 // update this version when changes to the reducer structure are made
 // frontend will reject inbound hashed search filter sets with different versions because the
@@ -105,15 +105,11 @@ const searchFiltersReducer = (state = initialState, action) => {
 
         // New Time Period Filter Array
         case 'ADD_TIME_PERIOD_OBJECT': {
-            // return Object.assign({}, state, {
-            //     time_period: state.time_period.concat({
-            //         start_date: action.start,
-            //         end_date: action.end
-            //     })
-            // });
-
             return Object.assign({}, state, {
-                time_period: TimePeriodFilterFunctions.updateSelectedDates(state.time_period, action)
+                time_period: state.time_period.concat({
+                    start_date: action.start,
+                    end_date: action.end
+                })
             });
         }
 

--- a/tests/testResources/defaultReduxFilters.js
+++ b/tests/testResources/defaultReduxFilters.js
@@ -14,7 +14,7 @@ import * as FiscalYearHelper from '../../src/js/helpers/fiscalYearHelper';
 export const defaultFilters = {
     keyword: new OrderedMap(),
     awardType: new Set(),
-    time_period: new OrderedMap(),
+    time_period: [],
     timePeriodType: 'dr',
     timePeriodFY: new Set([`${FiscalYearHelper.currentFiscalYear()}`]),
     timePeriodStart: null,

--- a/tests/testResources/defaultReduxFilters.js
+++ b/tests/testResources/defaultReduxFilters.js
@@ -14,7 +14,7 @@ import * as FiscalYearHelper from '../../src/js/helpers/fiscalYearHelper';
 export const defaultFilters = {
     keyword: new OrderedMap(),
     awardType: new Set(),
-    time_period: [],
+    time_period: new OrderedMap(),
     timePeriodType: 'dr',
     timePeriodFY: new Set([`${FiscalYearHelper.currentFiscalYear()}`]),
     timePeriodStart: null,


### PR DESCRIPTION
**High level description:**
Adopted new 'time_period' field to be used in place of timePeriodStart and timePeriodEnd

**Technical details:**
Adopted the code to read time_period, but only the final submission into the time_period array, to maintain functionality before UI updates. The full array is still being pushed, but as an 'undefined' field as to not impact search results yet. Date range tags, search results tags, dirty filter hints, and reading the hash on load have all been updated to read time_period.

**JIRA Ticket:**
[DEV-11637](https://federal-spending-transparency.atlassian.net/browse/DEV-11637)

**Mockup:**
n/a 

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
