### PR TITLE
10897 - switched to grid, adjusted margins, removed unused styling

### DIFF
--- a/src/_scss/pages/state/_contentWrap.scss
+++ b/src/_scss/pages/state/_contentWrap.scss
@@ -3,8 +3,6 @@
     color: $color-base;
 
     .state-section {
-        padding: rem(30);
-
         h3.state-section__title {
             margin: 0;
             font-size: $h3-font-size;

--- a/src/_scss/pages/state/_positioning.scss
+++ b/src/_scss/pages/state/_positioning.scss
@@ -1,23 +1,14 @@
 .state-content-wrapper {
-    @include display(flex);
-    @include align-items(flex-start);
     width: 100%;
+    padding: ($global-spacing-unit * 5) ($global-spacing-unit * 4) ($global-spacing-unit * 4) ($global-spacing-unit * 4);
 
-    .state-sidebar {
-        display: none;
-        margin-top: 0;
-        // Evenly distribute the 30px space between the sidebar & content
-        margin-right: rem(15);
-        @include media($medium-screen) {
-            display: block;
-            @include flex(0 0 25%);
-        }
+    @media (max-width: $tablet-screen) {
+        padding: ($global-spacing-unit * 5) ($global-spacing-unit * 2) ($global-spacing-unit * 2) ($global-spacing-unit * 2);
     }
 
     .state-content {
         width: 100%;
-        @include media($medium-screen) {
-            @include flex(1 1 75%);
-        }
+        max-width: rem(1400);
+        margin: auto;
     }
 }

--- a/src/_scss/pages/state/statePage.scss
+++ b/src/_scss/pages/state/statePage.scss
@@ -26,8 +26,8 @@
     }
 
     .main-content {
-        @import "../../mixins/fullSectionWrap";
-        @include fullSectionWrap(0,0);
+        //@import "../../mixins/fullSectionWrap";
+        //@include fullSectionWrap(0,0);
         padding:  0;
 
         @import "./_positioning";

--- a/src/js/components/state/StateContent.jsx
+++ b/src/js/components/state/StateContent.jsx
@@ -5,6 +5,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FlexGridCol, FlexGridRow } from "data-transparency-ui";
+
 import StateTimeVisualizationSectionContainer from 'containers/state/StateTimeVisualizationSectionContainer';
 import TopFiveSection from './topFive/TopFiveSection';
 import StateOverview from './overview/StateOverview';
@@ -16,16 +18,16 @@ const propTypes = {
 };
 
 const StateContent = ({ stateProfile }) => (
-    <div className="state-content-wrapper">
-        <div className="state-content">
+    <FlexGridRow className="state-content-wrapper">
+        <FlexGridCol className="state-content">
             <StateOverview
                 stateProfile={stateProfile.overview} />
             <StateTimeVisualizationSectionContainer
                 stateProfile={stateProfile.overview} />
             <TopFiveSection />
             <StateFooter />
-        </div>
-    </div>
+        </FlexGridCol>
+    </FlexGridRow>
 );
 
 StateContent.propTypes = propTypes;


### PR DESCRIPTION
**High level description:**
Switched the state profile page to grid layouts, adjusted the page-wide margins, and removed some unused styling.

**JIRA Ticket:**
[DEV-10897](https://federal-spending-transparency.atlassian.net/browse/DEV-10897)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
