### PR TITLE
DEV-11723 agency and tas filter on searchv2 page

### DIFF
--- a/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
@@ -59,7 +59,12 @@ const propTypes = {
     nodes: PropTypes.arrayOf(PropTypes.object),
     searchExpanded: PropTypes.arrayOf(PropTypes.string),
     counts: PropTypes.arrayOf(PropTypes.shape({})),
-    filters: PropTypes.object
+    filters: PropTypes.object,
+    showInfo: PropTypes.bool
+};
+
+const defaultProps = {
+    showInfo: true
 };
 
 const SearchNote = () => (
@@ -374,7 +379,8 @@ export class TASCheckboxTree extends React.Component {
             checked,
             expanded,
             counts,
-            searchExpanded
+            searchExpanded,
+            showInfo
         } = this.props;
         const {
             isLoading,
@@ -386,12 +392,13 @@ export class TASCheckboxTree extends React.Component {
         } = this.state;
         return (
             <div className="tas-checkbox">
+                {showInfo &&
                 <span className="checkbox-header">
                     Search by Agency, Federal Account, or Treasury Account
                     <CSSOnlyTooltip
                         definition={<SearchNote />}
                         heading="Find a Treasury Account" />
-                </span>
+                </span>}
                 <EntityDropdownAutocomplete
                     placeholder="Type to filter results"
                     searchString={searchString}
@@ -447,6 +454,7 @@ export class TASCheckboxTree extends React.Component {
 }
 
 TASCheckboxTree.propTypes = propTypes;
+TASCheckboxTree.defaultProps = defaultProps;
 
 const mapStateToProps = (state) => ({
     nodes: state.tas.tas.toJS(),

--- a/src/js/dataMapping/search/searchFilterCategories.jsx
+++ b/src/js/dataMapping/search/searchFilterCategories.jsx
@@ -117,7 +117,7 @@ export const FilterCategoryTree = {
             },
             {
                 title: 'Treasury Account Symbol (TAS)',
-                component: <TASCheckboxTreeContainer />
+                component: <TASCheckboxTreeContainer showInfo={false} />
             },
             {
                 title: 'COVID-19 Spending'

--- a/src/js/dataMapping/search/searchFilterCategories.jsx
+++ b/src/js/dataMapping/search/searchFilterCategories.jsx
@@ -7,6 +7,8 @@ import React from 'react';
 import { LocationSectionContainer } from "../../containers/search/filters/location/LocationSectionContainer";
 import TimePeriodContainer from "../../containers/search/filters/TimePeriodContainer";
 import AwardIDSearchContainer from "../../containers/search/filters/awardID/AwardIDSearchContainer";
+import AgencyContainer from "../../containers/search/filters/AgencyContainer";
+import TASCheckboxTreeContainer from "../../containers/search/filters/programSource/TASCheckboxTreeContainer";
 
 export const SearchFilterCategories = [
     {
@@ -110,10 +112,12 @@ export const FilterCategoryTree = {
     sources: {
         children: [
             {
-                title: 'Agency'
+                title: 'Agency',
+                component: <AgencyContainer />
             },
             {
-                title: 'Treasury Account Symbol (TAS)'
+                title: 'Treasury Account Symbol (TAS)',
+                component: <TASCheckboxTreeContainer />
             },
             {
                 title: 'COVID-19 Spending'


### PR DESCRIPTION
**High level description:**

add two filters to search v2 - also add the ability to turn off the info explanation for the tas filter

**JIRA Ticket:**
[DEV-11723](https://federal-spending-transparency.atlassian.net/browse/DEV-11723)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
