### PR TITLE
DEV-11702 loading indicator for recipient + 100 results

### DIFF
--- a/src/_scss/pages/search/filters/recipient/recipient.scss
+++ b/src/_scss/pages/search/filters/recipient/recipient.scss
@@ -97,6 +97,16 @@
         }
     }
 
+    .recipient-filter-message-container {
+        font-size: rem(30);
+        text-align: center;
+        margin-top: $global-margin;
+        .recipient-filter-message-container__text {
+          font-size: 2rem;
+          padding-bottom: 2rem;
+        }
+    }
+
     .recipient-filter-item-wrap {
         padding: 0;
 

--- a/src/js/components/search/filters/recipient/RecipientResultsContainer.jsx
+++ b/src/js/components/search/filters/recipient/RecipientResultsContainer.jsx
@@ -5,6 +5,7 @@
 
 import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from "prop-types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as SearchHelper from 'helpers/searchHelper';
 import { EntityDropdownAutocomplete } from "../location/EntityDropdownAutocomplete";
 import PrimaryCheckboxType from "../../../sharedComponents/checkbox/PrimaryCheckboxType";
@@ -17,6 +18,7 @@ const propTypes = {
 const RecipientResultsContainer = ({ selectedRecipients, updateSelectedRecipients }) => {
     const [recipients, setRecipients] = useState([]);
     const [searchString, setSearchString] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
 
     const recipientRequest = useRef();
 
@@ -44,10 +46,11 @@ const RecipientResultsContainer = ({ selectedRecipients, updateSelectedRecipient
         }
 
         recipientRequest.current = SearchHelper.fetchRecipients();
-
+        setIsLoading(true);
         recipientRequest.current.promise
             .then((res) => {
                 setRecipients(res.data.results);
+                setIsLoading(false);
             });
     };
 
@@ -62,10 +65,11 @@ const RecipientResultsContainer = ({ selectedRecipients, updateSelectedRecipient
         };
 
         recipientRequest.current = SearchHelper.fetchRecipientsAutocomplete(paramObj);
-
+        setIsLoading(true);
         recipientRequest.current.promise
             .then((res) => {
                 setRecipients(res.data.results);
+                setIsLoading(false);
             });
     };
 
@@ -83,6 +87,13 @@ const RecipientResultsContainer = ({ selectedRecipients, updateSelectedRecipient
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [searchString]);
 
+    const loadingIndicator = (
+        <div className="recipient-filter-message-container">
+            <FontAwesomeIcon icon="spinner" spin />
+            <div className="recipient-filter-message-container__text">Loading your data...</div>
+        </div>
+    );
+
     return (
         <>
             <EntityDropdownAutocomplete
@@ -92,31 +103,32 @@ const RecipientResultsContainer = ({ selectedRecipients, updateSelectedRecipient
                 context={{}}
                 loading={false}
                 searchIcon />
-            <div className="recipient-results__container">
-                <div className="checkbox-type-filter">
-                    { recipients.toSorted((a, b) => (a.name?.toUpperCase() < b.name?.toUpperCase() ? -1 : 1)).map((recipient) => (
-                        <div className="recipient-label__container">
-                            <PrimaryCheckboxType
-                                name={(<div className="recipient-checkbox__uei"> <span>UEI:</span> {recipient.uei ? recipient.uei : 'Not provided'}</div>)}
-                                value={{
-                                    name: recipient.name ? recipient.name : recipient.recipient_name,
-                                    uei: recipient.uei,
-                                    duns: recipient.duns ? recipient.duns : null
-                                }}
-                                key={recipient.uei}
-                                toggleCheckboxType={toggleRecipient}
-                                selectedCheckboxes={selectedRecipients} />
-                            <div className="recipient-label__lower-container">
-                                <div className="recipient-label__legacy-duns">Legacy DUNS: {recipient.duns ? recipient.duns : 'Not provided'}</div>
-                                <div className="recipient-label__name-container">
-                                    <span className="recipient-label__recipient-name">{recipient.name || recipient.recipient_name}</span>
-                                    <span className="recipient-label__recipient-level">{levelMapping[recipient.recipient_level]}</span>
+            {isLoading ? loadingIndicator :
+                <div className="recipient-results__container">
+                    <div className="checkbox-type-filter">
+                        { recipients.toSorted((a, b) => (a.name?.toUpperCase() < b.name?.toUpperCase() ? -1 : 1)).map((recipient) => (
+                            <div className="recipient-label__container">
+                                <PrimaryCheckboxType
+                                    name={(<div className="recipient-checkbox__uei"> <span>UEI:</span> {recipient.uei ? recipient.uei : 'Not provided'}</div>)}
+                                    value={{
+                                        name: recipient.name ? recipient.name : recipient.recipient_name,
+                                        uei: recipient.uei,
+                                        duns: recipient.duns ? recipient.duns : null
+                                    }}
+                                    key={recipient.uei}
+                                    toggleCheckboxType={toggleRecipient}
+                                    selectedCheckboxes={selectedRecipients} />
+                                <div className="recipient-label__lower-container">
+                                    <div className="recipient-label__legacy-duns">Legacy DUNS: {recipient.duns ? recipient.duns : 'Not provided'}</div>
+                                    <div className="recipient-label__name-container">
+                                        <span className="recipient-label__recipient-name">{recipient.name || recipient.recipient_name}</span>
+                                        <span className="recipient-label__recipient-level">{levelMapping[recipient.recipient_level]}</span>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                    ))}
-                </div>
-            </div>
+                        ))}
+                    </div>
+                </div>}
         </>
     );
 };

--- a/src/js/components/search/filters/recipient/RecipientResultsContainer.jsx
+++ b/src/js/components/search/filters/recipient/RecipientResultsContainer.jsx
@@ -45,7 +45,10 @@ const RecipientResultsContainer = ({ selectedRecipients, updateSelectedRecipient
             recipientRequest.current.cancel();
         }
 
-        recipientRequest.current = SearchHelper.fetchRecipients();
+        const paramObj = {
+            limit: 100
+        };
+        recipientRequest.current = SearchHelper.fetchRecipients(paramObj);
         setIsLoading(true);
         recipientRequest.current.promise
             .then((res) => {
@@ -61,7 +64,7 @@ const RecipientResultsContainer = ({ selectedRecipients, updateSelectedRecipient
 
         const paramObj = {
             search_text: term,
-            limit: 50
+            limit: 100
         };
 
         recipientRequest.current = SearchHelper.fetchRecipientsAutocomplete(paramObj);

--- a/src/js/helpers/searchHelper.js
+++ b/src/js/helpers/searchHelper.js
@@ -82,9 +82,10 @@ export const fetchAwardV2 = (awardId) => apiRequest({
     url: `v2/awards/${awardId}/`
 });
 
-export const fetchRecipients = () => apiRequest({
+export const fetchRecipients = (req) => apiRequest({
     url: 'v2/recipient/',
-    method: 'post'
+    method: 'post',
+    data: req
 });
 
 // Recipient search for autocomplete


### PR DESCRIPTION
**High level description:**

add loading spinner and change request to be 100 results by default

**JIRA Ticket:**
[DEV-11702](https://federal-spending-transparency.atlassian.net/browse/DEV-11702)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
