### PR TITLE
11743 / 11710 - Added sticky behavior to filter side panel

### DIFF
--- a/src/_scss/pages/search/_collapsibleSidebar.scss
+++ b/src/_scss/pages/search/_collapsibleSidebar.scss
@@ -69,13 +69,13 @@
     border-radius: unset;
 
     &.opened:not(.is-initial-loaded) {
-      -webkit-animation: collapsible-sidebar-slideopen 0.25s forwards;
-      animation: collapsible-sidebar-slideopen 0.25s forwards;
+      //-webkit-animation: collapsible-sidebar-slideopen 0.25s forwards;
+      //animation: collapsible-sidebar-slideopen 0.25s forwards;
     }
 
     &:not(.opened) {
-      animation: collapsible-sidebar-slideclose 0.25s forwards;
-      -webkit-animation: collapsible-sidebar-slideclose 0.25s forwards;
+      //animation: collapsible-sidebar-slideclose 0.25s forwards;
+      //-webkit-animation: collapsible-sidebar-slideclose 0.25s forwards;
 
       .sidebar-bottom-submit, .search-filter__container, .collapsible-sidebar--header, .collapsible-sidebar--drilldown, .collapsible-sidebar--main-menu {
         display: none;
@@ -124,6 +124,7 @@
       .collapsible-sidebar--back-btn {
         color: $blue-50;
         cursor: pointer;
+
         .chevron {
           width: 6px;
           height: 10px;
@@ -179,9 +180,23 @@
   }
 }
 
-.full-search-sidebar {
-  width: 300px !important;
-  @media(min-width: $large-screen) {
-    width: 350px !important;
+.search-contents.v2 {
+  .full-search-sidebar {
+    display: none;
+    @media(min-width: $large-screen) {
+      display: flex;
+      flex-basis: 350px;
+    }
+
+    @media(min-width: $medium-screen) {
+      display: flex;
+      flex-basis: 300px;
+    }
+  }
+
+  .search-results-view-container {
+    width: 100%;
+    min-width: 0;
   }
 }
+

--- a/src/_scss/pages/search/_collapsibleSidebar.scss
+++ b/src/_scss/pages/search/_collapsibleSidebar.scss
@@ -36,10 +36,6 @@
   box-shadow: unset;
   border-radius: unset;
 
-  &.fixed {
-    position: fixed;
-  }
-
   .chevron {
     margin: auto;
     color: $blue-50;

--- a/src/_scss/pages/search/_collapsibleSidebar.scss
+++ b/src/_scss/pages/search/_collapsibleSidebar.scss
@@ -193,6 +193,7 @@
 
   .full-search-sidebar {
     display: none;
+    margin-right: rem(16) !important;
     @media(min-width: $large-screen) {
       display: flex;
       flex-basis: 350px;

--- a/src/_scss/pages/search/_collapsibleSidebar.scss
+++ b/src/_scss/pages/search/_collapsibleSidebar.scss
@@ -31,7 +31,7 @@
 }
 
 .search-collapsible-sidebar-container {
-  position: relative;
+  position: fixed;
   background-color: $color-white;
   box-shadow: unset;
   border-radius: unset;
@@ -173,7 +173,7 @@
     }
 
     .sidebar-bottom-submit {
-      position: relative;
+      position: absolute;
       bottom: 0;
       width: 100%;
     }
@@ -181,6 +181,16 @@
 }
 
 .search-contents.v2 {
+  .collapsible-sidebar {
+    @media(min-width: $large-screen) {
+      width: 350px;
+    }
+
+    @media(min-width: $medium-screen) and (max-width: $large-screen - 1) {
+      width: 300px;
+    }
+  }
+
   .full-search-sidebar {
     display: none;
     @media(min-width: $large-screen) {
@@ -188,7 +198,7 @@
       flex-basis: 350px;
     }
 
-    @media(min-width: $medium-screen) {
+    @media(min-width: $medium-screen) and (max-width: $large-screen - 1) {
       display: flex;
       flex-basis: 300px;
     }

--- a/src/_scss/pages/search/_collapsibleSidebar.scss
+++ b/src/_scss/pages/search/_collapsibleSidebar.scss
@@ -69,15 +69,16 @@
     margin-top: -40px !important; // TODO Keep here until we remove the legacy panel
     border: 1px solid $gray-cool-10;
     box-shadow: none;
-    box-shadow: none;
     border-radius: unset;
 
     &.opened:not(.is-initial-loaded) {
+      // TODO: Adjust animations next sprint
       //-webkit-animation: collapsible-sidebar-slideopen 0.25s forwards;
       //animation: collapsible-sidebar-slideopen 0.25s forwards;
     }
 
     &:not(.opened) {
+      // TODO: Adjust animations next sprint
       //animation: collapsible-sidebar-slideclose 0.25s forwards;
       //-webkit-animation: collapsible-sidebar-slideclose 0.25s forwards;
 
@@ -167,10 +168,6 @@
         overflow-y: auto;
       }
 
-      .search-filter__content {
-        margin: unset;
-      }
-
       .location-filter {
         padding: 0 0 2rem 0;
       }
@@ -197,7 +194,7 @@
 
   .full-search-sidebar {
     display: none;
-    margin-right: rem(16) !important;
+    margin-right: rem(16);
     @media(min-width: $large-screen) {
       display: flex;
       flex-basis: 350px;

--- a/src/_scss/pages/search/_collapsibleSidebar.scss
+++ b/src/_scss/pages/search/_collapsibleSidebar.scss
@@ -36,6 +36,10 @@
   box-shadow: unset;
   border-radius: unset;
 
+  &.fixed {
+    position: fixed;
+  }
+
   .chevron {
     margin: auto;
     color: $blue-50;

--- a/src/_scss/pages/search/_collapsibleSidebar.scss
+++ b/src/_scss/pages/search/_collapsibleSidebar.scss
@@ -32,7 +32,6 @@
 
 .search-collapsible-sidebar-container {
   position: relative;
-  //top: 188px;
   background-color: $color-white;
   box-shadow: unset;
   border-radius: unset;
@@ -65,6 +64,7 @@
   .collapsible-sidebar {
     margin-top: -40px !important; // TODO Keep here until we remove the legacy panel
     border: 1px solid $gray-cool-10;
+    box-shadow: none;
     box-shadow: none;
     border-radius: unset;
 
@@ -176,5 +176,12 @@
       bottom: 0;
       width: 100%;
     }
+  }
+}
+
+.full-search-sidebar {
+  width: 300px !important;
+  @media(min-width: $large-screen) {
+    width: 350px !important;
   }
 }

--- a/src/_scss/pages/search/_searchFilter.scss
+++ b/src/_scss/pages/search/_searchFilter.scss
@@ -6,7 +6,6 @@
   padding: $global-margin * 2 $global-margin * 4;
 
   .search-filter__content {
-    margin: $global-margin * 2 0;
     height: rem(91);
 
     .search-filter__top-row {

--- a/src/_scss/pages/search/_searchSubmit.scss
+++ b/src/_scss/pages/search/_searchSubmit.scss
@@ -1,5 +1,5 @@
 .sidebar-submit {
-    padding: rem(15) rem(25);
+    padding: rem(8) rem(32);
 
     .screen-reader-submit-header {
         position:absolute;

--- a/src/_scss/pages/search/_searchv2.scss
+++ b/src/_scss/pages/search/_searchv2.scss
@@ -1,5 +1,4 @@
 .usa-da-search-page.v2 #main-content .search-contents {
-  width: 1600px !important; //TODO: Remove after search 2.0 is released
   max-width: 1600px !important; //TODO: Remove after search 2.0 is released
 
 }

--- a/src/js/components/search/collapsibleSidebar/CollapsibleSidebar.jsx
+++ b/src/js/components/search/collapsibleSidebar/CollapsibleSidebar.jsx
@@ -97,7 +97,7 @@ const CollapsibleSidebar = () => {
         return (intersection.bottom - intersection.top);
     };
 
-    const resizeSidebarWithFullHeader = (footerInView, headingInView, headingPadding, inPanelNonScrollableEls) => {
+    const resizeSidebarWithStickyBar = (footerInView, headingInView, headingPadding, inPanelNonScrollableEls) => {
         if (footerInView < 0) {
             setWindowHeight((window.innerHeight - headingInView) + headingPadding);
             setSidebarHeight(((window.innerHeight - headingInView) - inPanelNonScrollableEls) + headingPadding);
@@ -117,7 +117,7 @@ const CollapsibleSidebar = () => {
         }
     };
 
-    const resizeSidebarWithStickyBar = (fullHeader, inPanelNonScrollableEls) => {
+    const resizeSidebarWithFullHeader = (fullHeader, inPanelNonScrollableEls) => {
         setWindowHeight((window.innerHeight - fullHeader) + window.scrollY);
         setSidebarHeight(((window.innerHeight - fullHeader) - inPanelNonScrollableEls) + window.scrollY);
     };
@@ -137,10 +137,10 @@ const CollapsibleSidebar = () => {
         document.querySelector(".search-collapsible-sidebar-container").style.top = `${headingInView}px`;
 
         if (topStickyBarEl?.classList?.contains("usda-page-header--sticky")) {
-            resizeSidebarWithFullHeader(footerInView, headingInView, headingPadding, inPanelNonScrollableEls);
+            resizeSidebarWithStickyBar(footerInView, headingInView, headingPadding, inPanelNonScrollableEls);
         }
         else if (top !== 0) {
-            resizeSidebarWithStickyBar(fullHeader, inPanelNonScrollableEls);
+            resizeSidebarWithFullHeader(fullHeader, inPanelNonScrollableEls);
         }
     }, 50);
 

--- a/src/js/components/search/collapsibleSidebar/CollapsibleSidebar.jsx
+++ b/src/js/components/search/collapsibleSidebar/CollapsibleSidebar.jsx
@@ -90,38 +90,59 @@ const CollapsibleSidebar = () => {
         return !(rect.bottom < 0 || rect.top - viewHeight >= 0);
     };
 
-    const handleScroll = () => {
-        // 581.63 is the height of the footer at 1839 px browser width
-        const stayInTouch = document.querySelector("footer");
-        const box = stayInTouch.getBoundingClientRect();
-        // Calculate the intersection between the element and the viewport
+    const checkInView = (el) => {
+        const bbox = el.getBoundingClientRect();
+
         const intersection = {
-            top: Math.max(0, box.top),
-            left: Math.max(0, box.left),
-            bottom: Math.min(window.innerHeight, box.bottom),
-            right: Math.min(window.innerWidth, box.right)
+            top: Math.max(0, bbox.top),
+            left: Math.max(0, bbox.left),
+            bottom: Math.min(window.innerHeight, bbox.bottom),
+            right: Math.min(window.innerWidth, bbox.right)
         };
 
-        const amountInView = intersection.bottom - (intersection.top + 48);
+        return (intersection.bottom - intersection.top);
+    };
+
+    const handleScroll = () => {
+        // 581.63 is the height of the footer at 1839 px browser width
+        const footer = document.querySelector("footer");
+        const footerInView = checkInView(footer) + 48;
+
+        const header1 = document.querySelector(".usda-page-header");
+        const bbox = header1.getBoundingClientRect();
+
+        const siteHeader = document.querySelector(".site-header__wrapper");
+        const top = checkInView(header1) < 0 ? 0 : bbox.bottom;
+        const padding = 40;
+        const headingInView = top + padding;
 
         const element = document.querySelector(".usda-page-header");
-        const header = 60;
+
+        console.log("header in view", top, padding, checkInView(header1), checkInView(siteHeader));
+
+        const header = headingInView;
         const stickyHeader = 148;
         const nonScrollableElements = 172;
+        document.querySelector(".search-collapsible-sidebar-container").style.top = `${top + padding}px`;
 
         if (element?.classList?.contains("usda-page-header--sticky")) {
-            if (amountInView < 0) {
-                document.querySelector(".search-collapsible-sidebar-container").style.top = `100px`;
-                setWindowHeight(window.innerHeight - header);
-                setSidebarHeight(window.innerHeight - header - nonScrollableElements);
+            if (footerInView < 0) {
+                setWindowHeight(window.innerHeight - header + padding);
+                setSidebarHeight(window.innerHeight - header - nonScrollableElements + padding);
             }
             else {
-                setWindowHeight(window.innerHeight - header - amountInView);
-                setSidebarHeight(window.innerHeight - header - nonScrollableElements - amountInView);
+                const newSidebarHeight = window.innerHeight - header - nonScrollableElements - footerInView + padding;
+                if (newSidebarHeight < 1) {
+                    document.querySelector(".collapsible-sidebar--header").style.display = "none";
+                } else {
+                    document.querySelector(".collapsible-sidebar--header").style.display = "block";
+                }
+                setWindowHeight(window.innerHeight - header - footerInView + padding);
+                setSidebarHeight(newSidebarHeight);
             }
         }
         else {
-            document.querySelector(".search-collapsible-sidebar-container").style.top = `188px`;
+            // document.querySelector(".search-collapsible-sidebar-container").style.top = `188px`;
             setWindowHeight((window.innerHeight - stickyHeader) + window.scrollY);
             setSidebarHeight(((window.innerHeight - stickyHeader) - nonScrollableElements) + window.scrollY);
         }

--- a/src/js/components/search/collapsibleSidebar/CollapsibleSidebar.jsx
+++ b/src/js/components/search/collapsibleSidebar/CollapsibleSidebar.jsx
@@ -123,7 +123,7 @@ const CollapsibleSidebar = () => {
     };
 
     const handleScroll = throttle(() => {
-        // 581.63 is the height of the footer at 1839 px browser width
+        // TODO:  Remove upon completion of sidepanel - 581.63 is the height of the footer at 1839 px browser width
         const footerEl = document.querySelector("footer");
         const footerInView = checkInView(footerEl) + 48;
         const topStickyBarEl = document.querySelector(".usda-page-header");

--- a/src/js/components/search/collapsibleSidebar/CollapsibleSidebar.jsx
+++ b/src/js/components/search/collapsibleSidebar/CollapsibleSidebar.jsx
@@ -57,22 +57,22 @@ const CollapsibleSidebar = () => {
     };
 
     useEffect(() => {
-        if (isOpened) {
-            if (document.querySelector(".full-search-sidebar")) {
-                document.querySelector(".full-search-sidebar").style.width = "25%";
-            }
-            if (document.querySelector(".search-results")) {
-                document.querySelector(".search-results").style.width = "75%";
-            }
-        }
-        else {
-            if (document.querySelector(".full-search-sidebar")) {
-                document.querySelector(".full-search-sidebar").style.width = "0%";
-            }
-            if (document.querySelector(".search-results")) {
-                document.querySelector(".search-results").style.width = "99%";
-            }
-        }
+        // if (isOpened) {
+        //     if (document.querySelector(".full-search-sidebar")) {
+        //         document.querySelector(".full-search-sidebar").style.width = "25%";
+        //     }
+        //     if (document.querySelector(".search-results")) {
+        //         document.querySelector(".search-results").style.width = "75%";
+        //     }
+        // }
+        // else {
+        //     if (document.querySelector(".full-search-sidebar")) {
+        //         document.querySelector(".full-search-sidebar").style.width = "0%";
+        //     }
+        //     if (document.querySelector(".search-results")) {
+        //         document.querySelector(".search-results").style.width = "99%";
+        //     }
+        // }
     }, [isOpened]);
 
     useEffect(() => {

--- a/src/js/components/search/collapsibleSidebar/CollapsibleSidebar.jsx
+++ b/src/js/components/search/collapsibleSidebar/CollapsibleSidebar.jsx
@@ -84,28 +84,44 @@ const CollapsibleSidebar = () => {
         }
     }, [initialPageLoad, isOpened]);
 
+    const checkVisible = (el) => {
+        const rect = el.getBoundingClientRect();
+        const viewHeight = Math.max(document.documentElement.clientHeight, window.innerHeight);
+        return !(rect.bottom < 0 || rect.top - viewHeight >= 0);
+    };
+
     const handleScroll = () => {
         // 581.63 is the height of the footer at 1839 px browser width
+        const stayInTouch = document.querySelector("footer");
+        const box = stayInTouch.getBoundingClientRect();
+        // Calculate the intersection between the element and the viewport
+        const intersection = {
+            top: Math.max(0, box.top),
+            left: Math.max(0, box.left),
+            bottom: Math.min(window.innerHeight, box.bottom),
+            right: Math.min(window.innerWidth, box.right)
+        };
+
+        const amountInView = intersection.bottom - (intersection.top + 48);
 
         const element = document.querySelector(".usda-page-header");
         const header = 60;
         const stickyHeader = 148;
         const nonScrollableElements = 172;
 
-        const stickyEnd = document.querySelector(".stay-in-touch__section").offsetTop;
-        const scrollbarHeight = document.querySelector(".search-collapsible-sidebar-container").offsetHeight;
-
-        if (window.scrollY + scrollbarHeight > stickyEnd) {
-            // document.querySelector(".search-collapsible-sidebar-container").style.top = window.scrollY + scrollbarHeight;
-        }
-
         if (element?.classList?.contains("usda-page-header--sticky")) {
-            // document.querySelector(".search-collapsible-sidebar-container").style.top = `${window.scrollY - 30}px`;
-            setWindowHeight(window.innerHeight - header);
-            setSidebarHeight(window.innerHeight - header - nonScrollableElements);
+            if (amountInView < 0) {
+                document.querySelector(".search-collapsible-sidebar-container").style.top = `100px`;
+                setWindowHeight(window.innerHeight - header);
+                setSidebarHeight(window.innerHeight - header - nonScrollableElements);
+            }
+            else {
+                setWindowHeight(window.innerHeight - header - amountInView);
+                setSidebarHeight(window.innerHeight - header - nonScrollableElements - amountInView);
+            }
         }
         else {
-            // document.querySelector(".search-collapsible-sidebar-container").style.top = `${188 - window.scrollY}px`;
+            document.querySelector(".search-collapsible-sidebar-container").style.top = `188px`;
             setWindowHeight((window.innerHeight - stickyHeader) + window.scrollY);
             setSidebarHeight(((window.innerHeight - stickyHeader) - nonScrollableElements) + window.scrollY);
         }

--- a/src/js/components/search/collapsibleSidebar/CollapsibleSidebar.jsx
+++ b/src/js/components/search/collapsibleSidebar/CollapsibleSidebar.jsx
@@ -57,23 +57,26 @@ const CollapsibleSidebar = () => {
     };
 
     useEffect(() => {
-        // if (isOpened) {
-        //     if (document.querySelector(".full-search-sidebar")) {
-        //         document.querySelector(".full-search-sidebar").style.width = "25%";
-        //     }
-        //     if (document.querySelector(".search-results")) {
-        //         document.querySelector(".search-results").style.width = "75%";
-        //     }
-        // }
-        // else {
-        //     if (document.querySelector(".full-search-sidebar")) {
-        //         document.querySelector(".full-search-sidebar").style.width = "0%";
-        //     }
-        //     if (document.querySelector(".search-results")) {
-        //         document.querySelector(".search-results").style.width = "99%";
-        //     }
-        // }
-    }, [isOpened]);
+        if (isOpened) {
+            if (document.querySelector(".full-search-sidebar")) {
+                if (windowWidth < 991 && windowWidth < 1200) {
+                    document.querySelector(".full-search-sidebar").style.width = "unset";
+                    document.querySelector(".full-search-sidebar").style.flexBasis = "282px";
+                    document.querySelector(".collapsible-sidebar").style.width = "282px";
+                }
+                else if (windowWidth > 1199) {
+                    document.querySelector(".full-search-sidebar").style.width = "unset";
+                    document.querySelector(".full-search-sidebar").style.flexBasis = "332px";
+                    document.querySelector(".collapsible-sidebar").style.width = "332px";
+                }
+            }
+        }
+        else if (document.querySelector(".full-search-sidebar")) {
+            document.querySelector(".full-search-sidebar").style.width = "0";
+            document.querySelector(".full-search-sidebar").style.flexBasis = "0";
+            document.querySelector(".collapsible-sidebar").style.width = "0";
+        }
+    }, [isOpened, windowWidth]);
 
     useEffect(() => {
         if (!isOpened && initialPageLoad) {
@@ -93,11 +96,11 @@ const CollapsibleSidebar = () => {
         const scrollbarHeight = document.querySelector(".search-collapsible-sidebar-container").offsetHeight;
 
         if (window.scrollY + scrollbarHeight > stickyEnd) {
-            document.querySelector(".search-collapsible-sidebar-container").style.top = window.scrollY + scrollbarHeight;
+            // document.querySelector(".search-collapsible-sidebar-container").style.top = window.scrollY + scrollbarHeight;
         }
 
         if (element?.classList?.contains("usda-page-header--sticky")) {
-            document.querySelector(".search-collapsible-sidebar-container").style.top = `${window.scrollY - 30}px`;
+            // document.querySelector(".search-collapsible-sidebar-container").style.top = `${window.scrollY - 30}px`;
             setWindowHeight(window.innerHeight - header);
             setSidebarHeight(window.innerHeight - header - nonScrollableElements);
         }

--- a/src/js/components/search/collapsibleSidebar/SearchPagev2.jsx
+++ b/src/js/components/search/collapsibleSidebar/SearchPagev2.jsx
@@ -6,7 +6,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { throttle } from 'lodash';
-import { DownloadIconButton, ShareIcon, FlexGridRow, FlexGridCol } from 'data-transparency-ui';
+import { DownloadIconButton, ShareIcon, FlexGridCol } from 'data-transparency-ui';
 import { Helmet } from 'react-helmet';
 
 import { handleShareOptionClick, getBaseUrl } from 'helpers/socialShare';
@@ -179,56 +179,56 @@ const SearchPage = ({
                                 <KeywordSearchLink />
                                 : ''}
                         </div>
-                        {/*<div className="mobile-filter-button-wrapper">*/}
-                        {/*    <button*/}
-                        {/*        className="mobile-filter-button"*/}
-                        {/*        onClick={toggleMobileFilters}*/}
-                        {/*        onKeyUp={(e) => {*/}
-                        {/*            if (e.key === "Escape" && showMobileFilters) {*/}
-                        {/*                toggleMobileFilters();*/}
-                        {/*            }*/}
-                        {/*        }}>*/}
-                        {/*        <div className="mobile-filter-button-content">*/}
-                        {/*            <div className={`mobile-filter-button-count ${showCountBadge}`}>*/}
-                        {/*                {filterCount}*/}
-                        {/*            </div>*/}
-                        {/*            <div className="mobile-filter-button-icon">*/}
-                        {/*                <AddFilter alt="Toggle filters" />*/}
-                        {/*            </div>*/}
-                        {/*            <div className="mobile-filter-button-label">*/}
-                        {/*                {pluralizeFilterLabel(filterCount)}*/}
-                        {/*            </div>*/}
-                        {/*        </div>*/}
-                        {/*    </button>*/}
-                        {/*</div>*/}
-                        {/*<div*/}
-                        {/*    className="visualization-tabs__toggle-mobile">*/}
-                        {/*    <Button*/}
-                        {/*        onClick={(e) => {*/}
-                        {/*            e.persist();*/}
-                        {/*            dispatch(showModal(window.location.href, 'filter'));*/}
-                        {/*        }}*/}
-                        {/*        onKeyUp={(e) => {*/}
-                        {/*            e.persist();*/}
-                        {/*            if (e.key === 'Enter') {*/}
-                        {/*                dispatch(showModal(window.location.href, 'filter'));*/}
-                        {/*            }*/}
-                        {/*        }}*/}
-                        {/*        copy="Learn how active filters work"*/}
-                        {/*        buttonTitle="filter modal"*/}
-                        {/*        buttonSize="sm"*/}
-                        {/*        buttonType="text"*/}
-                        {/*        backgroundColor="light"*/}
-                        {/*        imageAlignment="right"*/}
-                        {/*        image={<FontAwesomeIcon icon="window-restore" />} />*/}
-                        {/*</div>*/}
-                        {/*<FlexGridCol className="mobile-search-sidebar">*/}
-                        {/*    <MobileFilters*/}
-                        {/*        filters={filters}*/}
-                        {/*        filterCount={filterCount}*/}
-                        {/*        showMobileFilters={showMobileFilters}*/}
-                        {/*        toggleMobileFilters={toggleMobileFilters} />*/}
-                        {/*</FlexGridCol>*/}
+                        <div className="mobile-filter-button-wrapper">
+                            <button
+                                className="mobile-filter-button"
+                                onClick={toggleMobileFilters}
+                                onKeyUp={(e) => {
+                                    if (e.key === "Escape" && showMobileFilters) {
+                                        toggleMobileFilters();
+                                    }
+                                }}>
+                                <div className="mobile-filter-button-content">
+                                    <div className={`mobile-filter-button-count ${showCountBadge}`}>
+                                        {filterCount}
+                                    </div>
+                                    <div className="mobile-filter-button-icon">
+                                        <AddFilter alt="Toggle filters" />
+                                    </div>
+                                    <div className="mobile-filter-button-label">
+                                        {pluralizeFilterLabel(filterCount)}
+                                    </div>
+                                </div>
+                            </button>
+                        </div>
+                        <div
+                            className="visualization-tabs__toggle-mobile">
+                            <Button
+                                onClick={(e) => {
+                                    e.persist();
+                                    dispatch(showModal(window.location.href, 'filter'));
+                                }}
+                                onKeyUp={(e) => {
+                                    e.persist();
+                                    if (e.key === 'Enter') {
+                                        dispatch(showModal(window.location.href, 'filter'));
+                                    }
+                                }}
+                                copy="Learn how active filters work"
+                                buttonTitle="filter modal"
+                                buttonSize="sm"
+                                buttonType="text"
+                                backgroundColor="light"
+                                imageAlignment="right"
+                                image={<FontAwesomeIcon icon="window-restore" />} />
+                        </div>
+                        <FlexGridCol className="mobile-search-sidebar">
+                            <MobileFilters
+                                filters={filters}
+                                filterCount={filterCount}
+                                showMobileFilters={showMobileFilters}
+                                toggleMobileFilters={toggleMobileFilters} />
+                        </FlexGridCol>
                         <Helmet>
                             <link href="https://api.mapbox.com/mapbox-gl-js/v2.11.1/mapbox-gl.css" rel="stylesheet" />
                         </Helmet>
@@ -244,10 +244,10 @@ const SearchPage = ({
                                 noFiltersApplied={noFiltersApplied} />
                         </div>
                     </div>
-                    {/*<FullDownloadModalContainer*/}
-                    {/*    download={download}*/}
-                    {/*    mounted={showFullDownload}*/}
-                    {/*    hideModal={hideDownloadModal} />*/}
+                    <FullDownloadModalContainer
+                        download={download}
+                        mounted={showFullDownload}
+                        hideModal={hideDownloadModal} />
                 </div>
             </PageFeatureFlag>
         </PageWrapper>

--- a/src/js/components/search/collapsibleSidebar/SearchPagev2.jsx
+++ b/src/js/components/search/collapsibleSidebar/SearchPagev2.jsx
@@ -172,67 +172,67 @@ const SearchPage = ({
             filters={appliedFilters}>
             <PageFeatureFlag>
                 <div id="main-content">
-                    <FlexGridRow className="search-contents">
+                    <div className="search-contents v2">
                         <div className="full-search-sidebar">
                             {fullSidebar}
                             {isMobile === false && searchv2 === false ?
                                 <KeywordSearchLink />
                                 : ''}
                         </div>
-                        <div className="mobile-filter-button-wrapper">
-                            <button
-                                className="mobile-filter-button"
-                                onClick={toggleMobileFilters}
-                                onKeyUp={(e) => {
-                                    if (e.key === "Escape" && showMobileFilters) {
-                                        toggleMobileFilters();
-                                    }
-                                }}>
-                                <div className="mobile-filter-button-content">
-                                    <div className={`mobile-filter-button-count ${showCountBadge}`}>
-                                        {filterCount}
-                                    </div>
-                                    <div className="mobile-filter-button-icon">
-                                        <AddFilter alt="Toggle filters" />
-                                    </div>
-                                    <div className="mobile-filter-button-label">
-                                        {pluralizeFilterLabel(filterCount)}
-                                    </div>
-                                </div>
-                            </button>
-                        </div>
-                        <div
-                            className="visualization-tabs__toggle-mobile">
-                            <Button
-                                onClick={(e) => {
-                                    e.persist();
-                                    dispatch(showModal(window.location.href, 'filter'));
-                                }}
-                                onKeyUp={(e) => {
-                                    e.persist();
-                                    if (e.key === 'Enter') {
-                                        dispatch(showModal(window.location.href, 'filter'));
-                                    }
-                                }}
-                                copy="Learn how active filters work"
-                                buttonTitle="filter modal"
-                                buttonSize="sm"
-                                buttonType="text"
-                                backgroundColor="light"
-                                imageAlignment="right"
-                                image={<FontAwesomeIcon icon="window-restore" />} />
-                        </div>
-                        <FlexGridCol className="mobile-search-sidebar">
-                            <MobileFilters
-                                filters={filters}
-                                filterCount={filterCount}
-                                showMobileFilters={showMobileFilters}
-                                toggleMobileFilters={toggleMobileFilters} />
-                        </FlexGridCol>
+                        {/*<div className="mobile-filter-button-wrapper">*/}
+                        {/*    <button*/}
+                        {/*        className="mobile-filter-button"*/}
+                        {/*        onClick={toggleMobileFilters}*/}
+                        {/*        onKeyUp={(e) => {*/}
+                        {/*            if (e.key === "Escape" && showMobileFilters) {*/}
+                        {/*                toggleMobileFilters();*/}
+                        {/*            }*/}
+                        {/*        }}>*/}
+                        {/*        <div className="mobile-filter-button-content">*/}
+                        {/*            <div className={`mobile-filter-button-count ${showCountBadge}`}>*/}
+                        {/*                {filterCount}*/}
+                        {/*            </div>*/}
+                        {/*            <div className="mobile-filter-button-icon">*/}
+                        {/*                <AddFilter alt="Toggle filters" />*/}
+                        {/*            </div>*/}
+                        {/*            <div className="mobile-filter-button-label">*/}
+                        {/*                {pluralizeFilterLabel(filterCount)}*/}
+                        {/*            </div>*/}
+                        {/*        </div>*/}
+                        {/*    </button>*/}
+                        {/*</div>*/}
+                        {/*<div*/}
+                        {/*    className="visualization-tabs__toggle-mobile">*/}
+                        {/*    <Button*/}
+                        {/*        onClick={(e) => {*/}
+                        {/*            e.persist();*/}
+                        {/*            dispatch(showModal(window.location.href, 'filter'));*/}
+                        {/*        }}*/}
+                        {/*        onKeyUp={(e) => {*/}
+                        {/*            e.persist();*/}
+                        {/*            if (e.key === 'Enter') {*/}
+                        {/*                dispatch(showModal(window.location.href, 'filter'));*/}
+                        {/*            }*/}
+                        {/*        }}*/}
+                        {/*        copy="Learn how active filters work"*/}
+                        {/*        buttonTitle="filter modal"*/}
+                        {/*        buttonSize="sm"*/}
+                        {/*        buttonType="text"*/}
+                        {/*        backgroundColor="light"*/}
+                        {/*        imageAlignment="right"*/}
+                        {/*        image={<FontAwesomeIcon icon="window-restore" />} />*/}
+                        {/*</div>*/}
+                        {/*<FlexGridCol className="mobile-search-sidebar">*/}
+                        {/*    <MobileFilters*/}
+                        {/*        filters={filters}*/}
+                        {/*        filterCount={filterCount}*/}
+                        {/*        showMobileFilters={showMobileFilters}*/}
+                        {/*        toggleMobileFilters={toggleMobileFilters} />*/}
+                        {/*</FlexGridCol>*/}
                         <Helmet>
                             <link href="https://api.mapbox.com/mapbox-gl-js/v2.11.1/mapbox-gl.css" rel="stylesheet" />
                         </Helmet>
-                        <FlexGridCol className="search-results" desktop={12} tablet={12} mobile={12}>
+                        <div className="search-results-view-container">
                             <ResultsView
                                 filters={filters}
                                 isMobile={isMobile}
@@ -242,12 +242,12 @@ const SearchPage = ({
                                 toggleMobileFilters={toggleMobileFilters}
                                 requestsComplete={requestsComplete}
                                 noFiltersApplied={noFiltersApplied} />
-                        </FlexGridCol>
-                    </FlexGridRow>
-                    <FullDownloadModalContainer
-                        download={download}
-                        mounted={showFullDownload}
-                        hideModal={hideDownloadModal} />
+                        </div>
+                    </div>
+                    {/*<FullDownloadModalContainer*/}
+                    {/*    download={download}*/}
+                    {/*    mounted={showFullDownload}*/}
+                    {/*    hideModal={hideDownloadModal} />*/}
                 </div>
             </PageFeatureFlag>
         </PageWrapper>

--- a/src/js/components/search/collapsibleSidebar/SearchPagev2.jsx
+++ b/src/js/components/search/collapsibleSidebar/SearchPagev2.jsx
@@ -173,12 +173,12 @@ const SearchPage = ({
             <PageFeatureFlag>
                 <div id="main-content">
                     <FlexGridRow className="search-contents">
-                        <FlexGridCol className="full-search-sidebar" width={3}>
+                        <div className="full-search-sidebar">
                             {fullSidebar}
                             {isMobile === false && searchv2 === false ?
                                 <KeywordSearchLink />
                                 : ''}
-                        </FlexGridCol>
+                        </div>
                         <div className="mobile-filter-button-wrapper">
                             <button
                                 className="mobile-filter-button"
@@ -232,7 +232,7 @@ const SearchPage = ({
                         <Helmet>
                             <link href="https://api.mapbox.com/mapbox-gl-js/v2.11.1/mapbox-gl.css" rel="stylesheet" />
                         </Helmet>
-                        <FlexGridCol className="search-results" desktop={9} tablet={12} mobile={12}>
+                        <FlexGridCol className="search-results" desktop={12} tablet={12} mobile={12}>
                             <ResultsView
                                 filters={filters}
                                 isMobile={isMobile}


### PR DESCRIPTION
**High level description:**

 Added sticky behavior to filter side panel.  It's best to test with a url that has a hash (ie. so the results view has content and the page is long). Still working through the extremes behavior with the designers including the following cases:
1. The initial page load before the default image loads and the results view loads
2. if you scroll all the way to the bottom of the screen when the viewport is narrow
3. scrolling to the top or bottom quickly
4. when the results view height changes after content is rendered in the sections

**Technical details:**

Technical details for the knowledge of other developers.

**JIRA Ticket:**
[DEV-11743](https://federal-spending-transparency.atlassian.net/browse/DEV-11743)
[DEV-11710](https://federal-spending-transparency.atlassian.net/browse/DEV-11710)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Code review complete
