### PR TITLE
DEV-11790 tabbing search v2

### DIFF
--- a/src/js/components/search/collapsibleSidebar/CollapsibleSidebar.jsx
+++ b/src/js/components/search/collapsibleSidebar/CollapsibleSidebar.jsx
@@ -145,7 +145,6 @@ const CollapsibleSidebar = () => {
     }, 50);
 
     const keyHandler = (e, func) => {
-        e.preventDefault();
         if (e.key === "Enter") {
             func(e);
         }
@@ -185,7 +184,8 @@ const CollapsibleSidebar = () => {
                     onClick={(e) => toggleOpened(e)}
                     onKeyDown={(e) => keyHandler(e, toggleOpened)}
                     role="button"
-                    tabIndex="0">
+                    focusable="true"
+                    tabIndex={0}>
                     {isOpened ?
                         <FontAwesomeIcon className="chevron" icon="chevron-left" />
                         :


### PR DESCRIPTION
**High level description:**

tabbing no longer stuck on sidebar opening - this was caused by calling e.preventDefault twice

**JIRA Ticket:**
[DEV-11790](https://federal-spending-transparency.atlassian.net/browse/DEV-11790)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
