### PR TITLE
11814 - In searchv2 side panel, remove tooltips from NAICS and PSC filters

### DIFF
--- a/src/_scss/pages/search/_collapsibleSidebar.scss
+++ b/src/_scss/pages/search/_collapsibleSidebar.scss
@@ -225,6 +225,7 @@
       width: 100%;
     }
   }
+
 }
 
 .search-contents.v2 {
@@ -255,6 +256,11 @@
   .search-results-view-container {
     width: 100%;
     min-width: 0;
+  }
+
+  // TODO remove when search v2 is released and remove tooltips from filter code
+  .tooltip-popover-container {
+    display: none !important;
   }
 }
 


### PR DESCRIPTION
**High level description:**

 In searchv2 side panel, remove tooltips from NAICS and PSC filters

**Technical details:**
Used css to hide tooltips

**JIRA Ticket:**
[DEV-11814](https://federal-spending-transparency.atlassian.net/browse/DEV-11814)

**Mockup:**
See ticket

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
- [ ] Code review complete
