### PR TITLE
Mod/11955 filter header layout

### DIFF
--- a/src/_scss/pages/search/filters/otherFilters/_extentCompeted.scss
+++ b/src/_scss/pages/search/filters/otherFilters/_extentCompeted.scss
@@ -2,7 +2,7 @@
   .autocomplete__input {
     @include display(flex);
     width: 100%;
-    padding: 0 ($global-spacing-unit * 4) rem(20) ($global-spacing-unit * 4);
+    padding: 0 ($global-spacing-unit * 2) rem(20) ($global-spacing-unit * 2);
     position: relative;
 
     input {
@@ -29,7 +29,7 @@
       position: absolute;
       width: rem(16);
       height: rem(16);
-      left: ($global-spacing-unit * 5);
+      left: ($global-spacing-unit * 3);
       top: rem(2);
       padding: rem(2);
     }
@@ -53,5 +53,16 @@
     line-height: 1.5;
     color: $gray-60;
     text-align: center;
+  }
+}
+
+// TODO: replace the relevant padding and left properties above with those below once searchV2 releases
+&.collapsible-sidebar--drilldown {
+  .extent-competed-filter .autocomplete__input {
+    padding: 0 ($global-spacing-unit * 4) rem(20) ($global-spacing-unit * 4);
+
+    .search-icon {
+      left: ($global-spacing-unit * 5);
+    }
   }
 }

--- a/src/_scss/pages/search/filters/otherFilters/_extentCompeted.scss
+++ b/src/_scss/pages/search/filters/otherFilters/_extentCompeted.scss
@@ -56,13 +56,14 @@
   }
 }
 
-// TODO: replace the relevant padding and left properties above with those below once searchV2 releases
+// TODO: replace the relevant padding, left, and top properties above with those below once searchV2 releases
 &.collapsible-sidebar--drilldown {
   .extent-competed-filter .autocomplete__input {
-    padding: 0 ($global-spacing-unit * 4) rem(20) ($global-spacing-unit * 4);
+    padding: $global-spacing-unit ($global-spacing-unit * 4) rem(20) ($global-spacing-unit * 4);
 
     .search-icon {
       left: ($global-spacing-unit * 5);
+      top: rem(10);
     }
   }
 }

--- a/src/_scss/pages/search/filters/otherFilters/_extentCompeted.scss
+++ b/src/_scss/pages/search/filters/otherFilters/_extentCompeted.scss
@@ -2,7 +2,7 @@
   .autocomplete__input {
     @include display(flex);
     width: 100%;
-    padding: 0 ($global-spacing-unit * 2) rem(20) ($global-spacing-unit * 2);
+    padding: 0 ($global-spacing-unit * 4) rem(20) ($global-spacing-unit * 4);
     position: relative;
 
     input {
@@ -29,7 +29,7 @@
       position: absolute;
       width: rem(16);
       height: rem(16);
-      left: ($global-spacing-unit * 3);
+      left: ($global-spacing-unit * 5);
       top: rem(2);
       padding: rem(2);
     }

--- a/src/_scss/pages/search/filters/otherFilters/otherFilters.scss
+++ b/src/_scss/pages/search/filters/otherFilters/otherFilters.scss
@@ -5,7 +5,11 @@
     @import "mixins/selectedFilterWrap";
     @import './pages/award/_moreButton';
 
-    padding-left: rem(32);
+    padding-left: rem(20);
+
+    &.searchV2 {
+        padding-left: rem(32);
+    }
 
     .shown {
         min-height: rem(18);

--- a/src/_scss/pages/search/filters/otherFilters/otherFilters.scss
+++ b/src/_scss/pages/search/filters/otherFilters/otherFilters.scss
@@ -1,11 +1,11 @@
-.cfda-filter, .psc-filter, .naics-filter {
+.cfda-filter {
     @import "elements/filters/_errorMessage";
     @import "elements/filters/_typeahead";
     @import "elements/filters/_selectedFilterBtn";
     @import "mixins/selectedFilterWrap";
     @import './pages/award/_moreButton';
 
-    padding-left: rem(20);
+    padding-left: rem(32);
 
     .shown {
         min-height: rem(18);

--- a/src/js/components/search/filters/cfda/CFDASearch.jsx
+++ b/src/js/components/search/filters/cfda/CFDASearch.jsx
@@ -14,11 +14,12 @@ const propTypes = {
     selectCFDA: PropTypes.func,
     removeCFDA: PropTypes.func,
     selectedCFDA: PropTypes.object,
-    dirtyFilters: PropTypes.symbol
+    dirtyFilters: PropTypes.symbol,
+    searchV2: PropTypes.bool
 };
 
 const CFDASearch = ({
-    selectCFDA, removeCFDA, selectedCFDA, dirtyFilters
+    selectCFDA, removeCFDA, selectedCFDA, dirtyFilters, searchV2
 }) => {
     let CFDAComponent = null;
 
@@ -29,7 +30,7 @@ const CFDASearch = ({
     }
 
     return (
-        <div className="cfda-filter">
+        <div className={`cfda-filter ${searchV2 ? 'searchV2' : ''}`}>
             <div className="filter-item-wrap">
                 <CFDAListContainer
                     selectCFDA={selectCFDA}

--- a/src/js/components/search/filters/cfda/CFDASearch.jsx
+++ b/src/js/components/search/filters/cfda/CFDASearch.jsx
@@ -17,36 +17,30 @@ const propTypes = {
     dirtyFilters: PropTypes.symbol
 };
 
-export default class CFDASearch extends React.Component {
-    componentDidUpdate(prevProps) {
-        if (this.props.dirtyFilters && prevProps.dirtyFilters !== this.props.dirtyFilters) {
-            if (this.hint) {
-                this.hint.showHint();
-            }
-        }
+const CFDASearch = ({
+    selectCFDA, removeCFDA, selectedCFDA, dirtyFilters
+}) => {
+    let CFDAComponent = null;
+
+    if (selectedCFDA.size > 0) {
+        CFDAComponent = (<SelectedCFDA
+            selectedCFDA={selectedCFDA}
+            removeCFDA={removeCFDA} />);
     }
 
-    render() {
-        let selectedCFDA = null;
-        if (this.props.selectedCFDA.size > 0) {
-            selectedCFDA = (<SelectedCFDA
-                selectedCFDA={this.props.selectedCFDA}
-                removeCFDA={this.props.removeCFDA} />);
-        }
-
-        return (
-            <div className="cfda-filter">
-                <div className="filter-item-wrap">
-                    <CFDAListContainer {...this.props} selectCFDA={this.props.selectCFDA} />
-                    {selectedCFDA}
-                    <SubmitHint
-                        ref={(component) => {
-                            this.hint = component;
-                        }} />
-                </div>
+    return (
+        <div className="cfda-filter">
+            <div className="filter-item-wrap">
+                <CFDAListContainer
+                    selectCFDA={selectCFDA}
+                    selectedCFDA={selectedCFDA}
+                    dirtyFilters={dirtyFilters} />
+                {CFDAComponent}
+                <SubmitHint selectedFilters={dirtyFilters} />
             </div>
-        );
-    }
-}
+        </div>
+    );
+};
 
 CFDASearch.propTypes = propTypes;
+export default CFDASearch;

--- a/src/js/components/sharedComponents/autocomplete/Autocomplete.jsx
+++ b/src/js/components/sharedComponents/autocomplete/Autocomplete.jsx
@@ -301,7 +301,9 @@ const Autocomplete = ({
             aria-expanded={shown}
             aria-haspopup="true">
             <div className="usa-da-typeahead">
-                <p>{label}</p>
+                {label &&
+                    <p>{label}</p>
+                }
                 <div className="usa-da-typeahead__input">
                     {icon && <FontAwesomeIcon icon="search" />}
                     <input

--- a/src/js/components/sharedComponents/autocomplete/Autocomplete.jsx
+++ b/src/js/components/sharedComponents/autocomplete/Autocomplete.jsx
@@ -301,9 +301,7 @@ const Autocomplete = ({
             aria-expanded={shown}
             aria-haspopup="true">
             <div className="usa-da-typeahead">
-                {label &&
-                    <p>{label}</p>
-                }
+                {label && <p>{label}</p>}
                 <div className="usa-da-typeahead__input">
                     {icon && <FontAwesomeIcon icon="search" />}
                     <input

--- a/src/js/containers/search/filters/cfda/CFDAListContainer.jsx
+++ b/src/js/containers/search/filters/cfda/CFDAListContainer.jsx
@@ -52,7 +52,6 @@ const CFDAListContainer = ({ selectCFDA, selectedCFDA, dirtyFilters }) => {
             setCfdaSearchString(input);
 
             if (cfdaSearchRequest.current) {
-                console.log('fire');
                 // A request is currently in-flight, cancel it
                 cfdaSearchRequest.current.cancel();
             }

--- a/src/js/containers/search/filters/cfda/CFDASearchContainer.jsx
+++ b/src/js/containers/search/filters/cfda/CFDASearchContainer.jsx
@@ -16,10 +16,13 @@ import CFDASearch from 'components/search/filters/cfda/CFDASearch';
 const propTypes = {
     selectedCFDA: PropTypes.object,
     appliedCFDA: PropTypes.object,
-    updateSelectedCFDA: PropTypes.func
+    updateSelectedCFDA: PropTypes.func,
+    searchV2: PropTypes.bool
 };
 
-const CFDASearchContainer = ({ selectedCFDA, appliedCFDA, updateSelectedCFDA }) => {
+const CFDASearchContainer = ({
+    selectedCFDA, appliedCFDA, updateSelectedCFDA, searchV2 = false
+}) => {
     const selectCFDA = (cfda, isValid) => {
         // If cfda exists and is valid
         if (cfda !== null && isValid) {
@@ -47,7 +50,8 @@ const CFDASearchContainer = ({ selectedCFDA, appliedCFDA, updateSelectedCFDA }) 
             selectedCFDA={selectedCFDA}
             dirtyFilters={dirtyFilters()}
             selectCFDA={selectCFDA}
-            removeCFDA={removeCFDA} />
+            removeCFDA={removeCFDA}
+            searchV2={searchV2} />
     );
 };
 

--- a/src/js/containers/search/filters/cfda/CFDASearchContainer.jsx
+++ b/src/js/containers/search/filters/cfda/CFDASearchContainer.jsx
@@ -19,47 +19,37 @@ const propTypes = {
     updateSelectedCFDA: PropTypes.func
 };
 
-export class CFDASearchContainer extends React.Component {
-    constructor(props) {
-        super(props);
-
-        // Bind functions
-        this.selectCFDA = this.selectCFDA.bind(this);
-        this.removeCFDA = this.removeCFDA.bind(this);
-    }
-
-    selectCFDA(cfda, isValid) {
-    // If cfda exists and is valid
+const CFDASearchContainer = ({ selectedCFDA, appliedCFDA, updateSelectedCFDA }) => {
+    const selectCFDA = (cfda, isValid) => {
+        // If cfda exists and is valid
         if (cfda !== null && isValid) {
             const updateParams = {};
             updateParams.cfda = cfda;
-            this.props.updateSelectedCFDA(updateParams);
+            updateSelectedCFDA(updateParams);
         }
-    }
+    };
 
-    removeCFDA(cfda) {
+    const removeCFDA = (cfda) => {
         const updateParams = {};
         updateParams.cfda = cfda;
-        this.props.updateSelectedCFDA(updateParams);
-    }
+        updateSelectedCFDA(updateParams);
+    };
 
-    dirtyFilters() {
-        if (is(this.props.selectedCFDA, this.props.appliedCFDA)) {
+    const dirtyFilters = () => {
+        if (is(selectedCFDA, appliedCFDA)) {
             return null;
         }
         return Symbol('dirty CFDA');
-    }
+    };
 
-    render() {
-        return (
-            <CFDASearch
-                selectedCFDA={this.props.selectedCFDA}
-                dirtyFilters={this.dirtyFilters()}
-                selectCFDA={this.selectCFDA}
-                removeCFDA={this.removeCFDA} />
-        );
-    }
-}
+    return (
+        <CFDASearch
+            selectedCFDA={selectedCFDA}
+            dirtyFilters={dirtyFilters()}
+            selectCFDA={selectCFDA}
+            removeCFDA={removeCFDA} />
+    );
+};
 
 CFDASearchContainer.propTypes = propTypes;
 

--- a/src/js/dataMapping/search/searchFilterCategories.jsx
+++ b/src/js/dataMapping/search/searchFilterCategories.jsx
@@ -155,7 +155,7 @@ export const FilterCategoryTree = {
                     },
                     {
                         title: 'Assistance Listing',
-                        component: <CFDASearchContainer />,
+                        component: <CFDASearchContainer searchV2 />,
                         titleOnly: true
                     }
                 ]


### PR DESCRIPTION
**High level description:**
Updated the spacing of the contract pricing, set asides, extent competed, and assistance listings filter headers. Converted the  CFDA components to function.

**JIRA Ticket:**
[DEV-11955](https://federal-spending-transparency.atlassian.net/browse/DEV-11955)

**Mockup:**
https://zpl.io/dRR7vZp
https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55/screen/669a8163e991ac796d242ca8
https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55/screen/663e9863f3ee1c2672b19adc

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
