### PR TITLE
Ftr/11959 clear all button

### DIFF
--- a/src/_scss/pages/search/filters/recipient/recipient.scss
+++ b/src/_scss/pages/search/filters/recipient/recipient.scss
@@ -11,13 +11,18 @@
             @include selected-filter-wrap;
         }
 
-        .placeholder {
-            background: none;
-            color: $theme-color-1;
-            margin: 0 0 ($global-margin * 2) 0;
-            padding: 0;
-            font-size: $smallest-font-size;
-            line-height: 1.5;
+        .clear-all__container {
+            display: flex;
+            justify-content: right;
+
+            .clear-all__button {
+                background: none;
+                color: $theme-color-1;
+                margin: ($global-margin * 2) 0 0 0;
+                padding: 0;
+                font-size: $smallest-font-size;
+                line-height: 1.5;
+            }
         }
     }
 

--- a/src/_scss/pages/search/filters/recipient/recipient.scss
+++ b/src/_scss/pages/search/filters/recipient/recipient.scss
@@ -10,6 +10,15 @@
         .selected-filters {
             @include selected-filter-wrap;
         }
+
+        .placeholder {
+            background: none;
+            color: $theme-color-1;
+            margin: 0 0 ($global-margin * 2) 0;
+            padding: 0;
+            font-size: $smallest-font-size;
+            line-height: 1.5;
+        }
     }
 
     .recipient-results__container {

--- a/src/js/containers/search/filters/recipient/RecipientSearchContainer.jsx
+++ b/src/js/containers/search/filters/recipient/RecipientSearchContainer.jsx
@@ -15,6 +15,7 @@ import SubmitHint from "../../../../components/sharedComponents/filterSidebar/Su
 import EntityDropdownAutocomplete from "../../../../components/search/filters/location/EntityDropdownAutocomplete";
 import PrimaryCheckboxType from "../../../../components/sharedComponents/checkbox/PrimaryCheckboxType";
 import SelectedRecipients from "../../../../components/search/filters/recipient/SelectedRecipients";
+import Button from "../../../../components/sharedComponents/buttons/Button";
 
 const propTypes = {
     updateSelectedRecipients: PropTypes.func,
@@ -178,6 +179,15 @@ const RecipientSearchContainer = ({ updateSelectedRecipients, selectedRecipients
         );
     }
 
+    const handleClearRecipients = () => {
+        console.log('selectedRecipients: ', selectedRecipients);
+        const currentRecipients = selectedRecipients;
+
+        currentRecipients.forEach((recipient) => {
+            updateSelectedRecipients(recipient);
+        });
+    };
+
     useEffect(() => {
         if (searchString.length >= 3) {
             setNewSearch(false);
@@ -208,6 +218,14 @@ const RecipientSearchContainer = ({ updateSelectedRecipients, selectedRecipients
                     context={{}}
                     loading={false}
                     searchIcon />
+                <Button
+                    copy="Clear all Recipient filters"
+                    buttonTitle="Clear all Recipient filters"
+                    buttonSize="sm"
+                    onClick={handleClearRecipients}
+                    buttonType="text"
+                    backgroundColor="light"
+                    textAlignment="center" />
                 {isLoading ? loadingIndicator :
                     <div className="recipient-results__container">
                         <div className={`checkbox-type-filter ${maxRecipients ? 'bottom-fade' : ''}`}>

--- a/src/js/containers/search/filters/recipient/RecipientSearchContainer.jsx
+++ b/src/js/containers/search/filters/recipient/RecipientSearchContainer.jsx
@@ -216,14 +216,16 @@ const RecipientSearchContainer = ({ updateSelectedRecipients, selectedRecipients
                     context={{}}
                     loading={false}
                     searchIcon />
-                <button
-                    type="button"
-                    aria-label="Clear all Recipient filters"
-                    className="placeholder"
-                    tabIndex="0"
-                    onClick={handleClearRecipients} >
-                    Clear all Recipient filters
-                </button>
+                <div className="clear-all__container">
+                    <button
+                        type="button"
+                        aria-label="Clear all Recipient filters"
+                        className="clear-all__button"
+                        tabIndex="0"
+                        onClick={handleClearRecipients} >
+                        Clear all Recipient filters
+                    </button>
+                </div>
                 {isLoading ? loadingIndicator :
                     <div className="recipient-results__container">
                         <div className={`checkbox-type-filter ${maxRecipients ? 'bottom-fade' : ''}`}>

--- a/src/js/containers/search/filters/recipient/RecipientSearchContainer.jsx
+++ b/src/js/containers/search/filters/recipient/RecipientSearchContainer.jsx
@@ -15,7 +15,6 @@ import SubmitHint from "../../../../components/sharedComponents/filterSidebar/Su
 import EntityDropdownAutocomplete from "../../../../components/search/filters/location/EntityDropdownAutocomplete";
 import PrimaryCheckboxType from "../../../../components/sharedComponents/checkbox/PrimaryCheckboxType";
 import SelectedRecipients from "../../../../components/search/filters/recipient/SelectedRecipients";
-import Button from "../../../../components/sharedComponents/buttons/Button";
 
 const propTypes = {
     updateSelectedRecipients: PropTypes.func,
@@ -180,7 +179,6 @@ const RecipientSearchContainer = ({ updateSelectedRecipients, selectedRecipients
     }
 
     const handleClearRecipients = () => {
-        console.log('selectedRecipients: ', selectedRecipients);
         const currentRecipients = selectedRecipients;
 
         currentRecipients.forEach((recipient) => {
@@ -218,14 +216,14 @@ const RecipientSearchContainer = ({ updateSelectedRecipients, selectedRecipients
                     context={{}}
                     loading={false}
                     searchIcon />
-                <Button
-                    copy="Clear all Recipient filters"
-                    buttonTitle="Clear all Recipient filters"
-                    buttonSize="sm"
-                    onClick={handleClearRecipients}
-                    buttonType="text"
-                    backgroundColor="light"
-                    textAlignment="center" />
+                <button
+                    type="button"
+                    aria-label="Clear all Recipient filters"
+                    className="placeholder"
+                    tabIndex="0"
+                    onClick={handleClearRecipients} >
+                    Clear all Recipient filters
+                </button>
                 {isLoading ? loadingIndicator :
                     <div className="recipient-results__container">
                         <div className={`checkbox-type-filter ${maxRecipients ? 'bottom-fade' : ''}`}>


### PR DESCRIPTION
**High level description:**
Added a clear all button for the recipients filter

Testing Note: In conversations with testing, it was decided to change the margin below the ‘Clear all Recipient filters’ button to be 20px (instead of 16px as in the mocks) in order to align with other filter headers. 

**JIRA Ticket:**
[DEV-11959](https://federal-spending-transparency.atlassian.net/browse/DEV-11959)

**Mockup:**
[Zeplin](https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55/screen/66c7387f9edd5064a09eb761)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
