### PR TITLE
11951 -  Fixed DEFC filter label layout and the filter's layout within the v2.0 side panel

### DIFF
--- a/src/_scss/pages/search/_collapsibleSidebar.scss
+++ b/src/_scss/pages/search/_collapsibleSidebar.scss
@@ -1,4 +1,4 @@
-@import '_searchFilter';
+@import "searchFilter";
 
 @keyframes collapsible-sidebar-slideopen {
   0% {
@@ -34,6 +34,8 @@
 }
 
 .search-collapsible-sidebar-container {
+  @import './filters/otherFilters/defCheckboxV2';
+
   position: fixed;
   background-color: $color-white;
   box-shadow: unset;

--- a/src/_scss/pages/search/filters/otherFilters/_defCheckboxV2.scss
+++ b/src/_scss/pages/search/filters/otherFilters/_defCheckboxV2.scss
@@ -2,10 +2,9 @@
     margin-bottom: rem(16);
     padding: unset !important; // TODO remove after search 2.0 is released
       li {
-        margin-bottom: rem(14) !important;
+        margin-bottom: rem(12) !important; // TODO remove after search 2.0 is released
       }
       .checkbox-tree-label {
-        width: auto;
         .checkbox-tree-label__value-container {
           background: $gray-cool-5;
           border-radius: rem(2);
@@ -22,7 +21,7 @@
       }
       .checkbox-tree-label .checkbox-tree-label__label {
         &.multiple-label {
-          padding-bottom: rem(10);
+          padding-bottom: rem(8);
           &:last-of-type {
             padding-bottom: 0;
           }

--- a/src/_scss/pages/search/filters/otherFilters/_defCheckboxV2.scss
+++ b/src/_scss/pages/search/filters/otherFilters/_defCheckboxV2.scss
@@ -4,15 +4,18 @@
       li {
         margin-bottom: rem(12) !important; // TODO remove after search 2.0 is released
       }
+      .checkbox-filter__header {
+        margin-bottom: rem(16) !important; // TODO remove after search 2.0 is released
+      }
       .checkbox-tree-label {
         .checkbox-tree-label__value-container {
           background: $gray-cool-5;
           border-radius: rem(2);
-          display: inline;
+          display: inline-block;
           padding: rem(2.5);
+          height: rem(18);
 
           .checkbox-tree-label__value-container-value {
-            display: inline;
             color: $gray-90;
             font-weight: $font-semibold;
             font-size: $font-size-10;

--- a/src/_scss/pages/search/filters/otherFilters/_defCheckboxV2.scss
+++ b/src/_scss/pages/search/filters/otherFilters/_defCheckboxV2.scss
@@ -1,0 +1,37 @@
+.def-code-filter {
+    margin-bottom: rem(16);
+    padding: unset !important; // TODO remove after search 2.0 is released
+      li {
+        margin-bottom: rem(14) !important;
+      }
+      .checkbox-tree-label {
+        width: auto;
+        .checkbox-tree-label__value-container {
+          background: $gray-cool-5;
+          border-radius: rem(2);
+          display: inline;
+          padding: rem(2.5);
+
+          .checkbox-tree-label__value-container-value {
+            display: inline;
+            color: $gray-90;
+            font-weight: $font-semibold;
+            font-size: $font-size-10;
+          }
+        }
+      }
+      .checkbox-tree-label .checkbox-tree-label__label {
+        &.multiple-label {
+          padding-bottom: rem(10);
+          &:last-of-type {
+            padding-bottom: 0;
+          }
+        }
+        span {
+          font-size: $font-size-10;
+          font-style: italic;
+          line-height: rem(1.8);
+          color: $gray-60;
+        }
+      }
+}

--- a/src/_scss/pages/search/searchPage.scss
+++ b/src/_scss/pages/search/searchPage.scss
@@ -15,6 +15,7 @@
 
     @import "resultsView/resultsView";
     @import "resultsView/dtuiOverrides";
+    @import "filters";
     @import "collapsibleSidebar";
 
 

--- a/src/js/components/search/filters/defc/DEFCheckboxTreeLabelv2.jsx
+++ b/src/js/components/search/filters/defc/DEFCheckboxTreeLabelv2.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { uniqueId } from 'lodash';
+
+const parseAcronym = (str) => {
+    const parsedStr = str.replace("P.L.", "Public Law");
+    if (parsedStr.includes("P.L.")) return parseAcronym(parsedStr);
+    return parsedStr;
+};
+
+const DEFCheckboxTreeLabel = ({
+    label,
+    subLabel,
+    value
+}) => {
+    const cssLabel = label === 'COVID-19 Spending' ? 'covid' : 'notCovid';
+    if (label.includes('|')) {
+        const labels = label.split('|');
+        const subLabels = subLabel.split('|');
+        return (
+            <div className="checkbox-tree-label">
+                <div className="checkbox-tree-label__value-container">
+                    <div className="checkbox-tree-label__value-container-value">
+                        {value}
+                    </div>
+                </div>
+                {labels.map((lbl, i) => (
+                    <div key={uniqueId(i)} className="checkbox-tree-label__label multiple-label">
+                        {lbl}
+                        <>
+                            <br />
+                            <span>{parseAcronym(subLabels[i])}</span>
+                            <br />
+                        </>
+                    </div>
+                ))}
+            </div>
+        );
+    }
+    return (
+        <div className="checkbox-tree-label">
+            <div className="checkbox-tree-label__value-container">
+                <div className="checkbox-tree-label__value-container-value">
+                    {value}
+                </div>
+            </div>
+            <div className={`checkbox-tree-label__label def-checkbox-tree-label__${cssLabel}`}>
+                {label}
+                {subLabel && (
+                    <>
+                        <br />
+                        <span>{parseAcronym(subLabel)}</span>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+};
+
+DEFCheckboxTreeLabel.propTypes = {
+    label: PropTypes.string,
+    subLabel: PropTypes.string,
+    value: PropTypes.string
+};
+
+export default DEFCheckboxTreeLabel;

--- a/src/js/components/search/filters/defc/DEFCheckboxTreeLabelv2.jsx
+++ b/src/js/components/search/filters/defc/DEFCheckboxTreeLabelv2.jsx
@@ -13,7 +13,6 @@ const DEFCheckboxTreeLabel = ({
     subLabel,
     value
 }) => {
-    const cssLabel = label === 'COVID-19 Spending' ? 'covid' : 'notCovid';
     if (label.includes('|')) {
         const labels = label.split('|');
         const subLabels = subLabel.split('|');
@@ -44,7 +43,7 @@ const DEFCheckboxTreeLabel = ({
                     {value}
                 </div>
             </div>
-            <div className={`checkbox-tree-label__label def-checkbox-tree-label__${cssLabel}`}>
+            <div className="checkbox-tree-label__label">
                 {label}
                 {subLabel && (
                     <>

--- a/src/js/components/sharedComponents/checkbox/AccordionCheckbox.jsx
+++ b/src/js/components/sharedComponents/checkbox/AccordionCheckbox.jsx
@@ -27,11 +27,12 @@ const propTypes = {
     filterCategoryMapping: PropTypes.arrayOf(PropTypes.object),
     selectedFilters: PropTypes.object,
     singleFilterChange: PropTypes.func,
-    bulkFilterChange: PropTypes.func
+    bulkFilterChange: PropTypes.func,
+    customLabels: PropTypes.object
 };
 
 const AccordionCheckbox = ({
-    filters, filterCategoryMapping = [], selectedFilters, singleFilterChange, bulkFilterChange, selectedCategory, isExpanded
+    filters, customLabels, filterCategoryMapping = [], selectedFilters, singleFilterChange, bulkFilterChange, selectedCategory, isExpanded
 }) => {
     const [searchString, setSearchString] = useState('');
     const [filterCategory, setFilterCategory] = useState(filterCategoryMapping);
@@ -106,6 +107,7 @@ const AccordionCheckbox = ({
             singleFilterChange={singleFilterChange}
             filters={filters}
             selectedFilters={selectedFilters}
+            customLabels={customLabels}
             expandedCategories={expandedCategories}
             toggleExpanded={toggleExpanded}
             bulkFilterChange={bulkFilterChange}

--- a/src/js/components/sharedComponents/checkbox/AccordionCheckboxPrimary.jsx
+++ b/src/js/components/sharedComponents/checkbox/AccordionCheckboxPrimary.jsx
@@ -19,7 +19,8 @@ const propTypes = {
     singleFilterChange: PropTypes.func,
     filters: PropTypes.object,
     bulkFilterChange: PropTypes.func,
-    enableAnalytics: PropTypes.bool
+    enableAnalytics: PropTypes.bool,
+    customLabels: PropTypes.object
 };
 
 const AccordionCheckboxPrimary = ({
@@ -29,6 +30,7 @@ const AccordionCheckboxPrimary = ({
     selectedFilters,
     singleFilterChange,
     filters,
+    customLabels,
     bulkFilterChange,
     enableAnalytics = false
 }) => {
@@ -158,7 +160,8 @@ const AccordionCheckboxPrimary = ({
                 selectedFilters={selectedFilters}
                 category={category}
                 singleFilterChange={singleFilterChange}
-                filters={filters} />
+                filters={filters}
+                customLabels={customLabels} />
         </div>);
 };
 

--- a/src/js/components/sharedComponents/checkbox/AccordionCheckboxSecondary.jsx
+++ b/src/js/components/sharedComponents/checkbox/AccordionCheckboxSecondary.jsx
@@ -29,8 +29,6 @@ const AccordionCheckboxSecondary = ({
         singleFilterChange(selection);
     };
 
-    console.log(customLabels);
-
     const items = category.filters?.map((filter, index) => (
         <li className={`checkbox-filter__item ${filter === excludedSubFilters ? 'hidden' : ''}`} key={filters[filter]}>
             <input

--- a/src/js/components/sharedComponents/checkbox/AccordionCheckboxSecondary.jsx
+++ b/src/js/components/sharedComponents/checkbox/AccordionCheckboxSecondary.jsx
@@ -11,6 +11,7 @@ const propTypes = {
     selectedFilters: PropTypes.object,
     singleFilterChange: PropTypes.func,
     filters: PropTypes.object,
+    customLabels: PropTypes.object,
     expanded: PropTypes.bool
 };
 
@@ -18,7 +19,7 @@ const propTypes = {
 const excludedSubFilters = "IDV_B";
 
 const AccordionCheckboxSecondary = ({
-    category, selectedFilters, singleFilterChange, filters, expanded
+    category, selectedFilters, singleFilterChange, filters, customLabels, expanded
 }) => {
     const selectFilter = (filter) => {
         const selection = {
@@ -28,6 +29,8 @@ const AccordionCheckboxSecondary = ({
         singleFilterChange(selection);
     };
 
+    console.log(customLabels);
+
     const items = category.filters?.map((filter, index) => (
         <li className={`checkbox-filter__item ${filter === excludedSubFilters ? 'hidden' : ''}`} key={filters[filter]}>
             <input
@@ -36,7 +39,11 @@ const AccordionCheckboxSecondary = ({
                 value={filter}
                 checked={selectedFilters?.has(filter)}
                 onChange={() => selectFilter(filter)} />
-            <div className="checkbox-filter__item-label">{filters[filter]}</div>
+            {customLabels && customLabels[filter] ?
+                <div className="checkbox-filter__item-label">{customLabels[filter]}</div>
+                :
+                <div className="checkbox-filter__item-label">{filters[filter]}</div>
+            }
         </li>
     ));
 

--- a/src/js/containers/search/filters/def/DEFCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/def/DEFCheckboxTreeContainer.jsx
@@ -41,6 +41,17 @@ const DEFCheckboxTreeContainer = ({ defcType }) => {
         return obj;
     }, {});
 
+    const detailsDisplay = (codes) => codes.filter(((code) => code.disaster === defcType)).reduce((obj, item) => {
+        // eslint-disable-next-line no-param-reassign
+        obj[item.code] = (
+            <div>
+                <span>{item.code}</span>
+                <span>{item.title}</span>
+                <span>{item.public_law}</span>
+            </div>);
+        return obj;
+    }, {});
+
     const defcDataByType = (codes) => {
         if (defcType === "covid_19") {
             return [{
@@ -79,11 +90,14 @@ const DEFCheckboxTreeContainer = ({ defcType }) => {
         }
     };
 
+    console.log(detailsDisplay(defCodes));
+
     return (
         <div className="def-code-filter">
             {defCodes?.length > 0 && !isLoading && !errorMsg && <AccordionCheckbox
                 filterCategoryMapping={defcDataByType(defCodes)}
                 filters={titlesByCode(defCodes)}
+                customLabels={detailsDisplay(defCodes)}
                 selectedFilters={selectedDefCodes}
                 selectedCategory={category}
                 singleFilterChange={toggleDefc}

--- a/src/js/containers/search/filters/def/DEFCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/def/DEFCheckboxTreeContainer.jsx
@@ -46,9 +46,9 @@ const DEFCheckboxTreeContainer = ({ defcType }) => {
         // eslint-disable-next-line no-param-reassign
         obj[item.code] = (
             <DEFCheckboxTreeLabelv2
-                label={item.code}
-                subLabel={item.title}
-                value={item.public_law} />);
+                label={item.title}
+                subLabel={item.public_law}
+                value={item.code} />);
         return obj;
     }, {});
 

--- a/src/js/containers/search/filters/def/DEFCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/def/DEFCheckboxTreeContainer.jsx
@@ -9,6 +9,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { bulkCovidDefCodeChange, toggleCovidDefCode, bulkInfraDefCodeChange, toggleInfraDefCode } from 'redux/actions/search/searchFilterActions';
 import { useDefCodes } from 'containers/covid19/WithDefCodes';
 import AccordionCheckbox from "../../../../components/sharedComponents/checkbox/AccordionCheckbox";
+import DEFCheckboxTreeLabelv2 from "../../../../components/search/filters/defc/DEFCheckboxTreeLabelv2";
 
 const propTypes = {
     defcType: PropTypes.string
@@ -44,11 +45,10 @@ const DEFCheckboxTreeContainer = ({ defcType }) => {
     const detailsDisplay = (codes) => codes.filter(((code) => code.disaster === defcType)).reduce((obj, item) => {
         // eslint-disable-next-line no-param-reassign
         obj[item.code] = (
-            <div>
-                <span>{item.code}</span>
-                <span>{item.title}</span>
-                <span>{item.public_law}</span>
-            </div>);
+            <DEFCheckboxTreeLabelv2
+                label={item.code}
+                subLabel={item.title}
+                value={item.public_law} />);
         return obj;
     }, {});
 

--- a/src/js/containers/search/filters/def/DEFCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/def/DEFCheckboxTreeContainer.jsx
@@ -90,8 +90,6 @@ const DEFCheckboxTreeContainer = ({ defcType }) => {
         }
     };
 
-    console.log(detailsDisplay(defCodes));
-
     return (
         <div className="def-code-filter">
             {defCodes?.length > 0 && !isLoading && !errorMsg && <AccordionCheckbox


### PR DESCRIPTION
**High level description:**

Fixed DEFC filter label layout and layout within the v2.0 side panel

**Technical details:**

Adopted the old component for the DEFC filter labels and updated per the mock.

**JIRA Ticket:**
[DEV-11951](https://federal-spending-transparency.atlassian.net/browse/DEV-11951)

**Mockup:**
https://app.zeplin.io/project/61f8076f4ef77f11fcc37f55/screen/66e4a1d1f5ac7ffb6fdab185

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Code review complete
