### PR TITLE
changed all chips to be shownValue

### DIFF
--- a/src/_scss/pages/search/filters/naics/naics.scss
+++ b/src/_scss/pages/search/filters/naics/naics.scss
@@ -46,6 +46,8 @@
         line-height: rem(15);
         font-size: rem(12);
         color: $color-gray;
+        width: fit-content;
+        max-width: fit-content;
         .close {
           color: $color-gray;
         }

--- a/src/_scss/pages/search/filters/otherFilters/_defCheckbox.scss
+++ b/src/_scss/pages/search/filters/otherFilters/_defCheckbox.scss
@@ -72,6 +72,8 @@
         line-height: rem(15);
         font-size: rem(12);
         color: $color-gray;
+        width: fit-content;
+        max-width: fit-content;
         .close {
           color: $color-gray;
         }

--- a/src/_scss/pages/search/filters/otherFilters/_pscCheckbox.scss
+++ b/src/_scss/pages/search/filters/otherFilters/_pscCheckbox.scss
@@ -35,6 +35,8 @@
       .shown-filter-button {
         line-height: rem(15);
         font-size: rem(12);
+        width: fit-content;
+        max-width: fit-content;
         color: $color-gray;
         .close {
           color: $color-gray;

--- a/src/_scss/pages/search/filters/otherFilters/_tasCheckbox.scss
+++ b/src/_scss/pages/search/filters/otherFilters/_tasCheckbox.scss
@@ -49,6 +49,8 @@
         line-height: rem(15);
         font-size: rem(12);
         color: $color-gray;
+        width: fit-content;
+        max-width: fit-content;
         .close {
           color: $color-gray;
         }

--- a/src/js/components/search/filters/agency/ShownAgency.jsx
+++ b/src/js/components/search/filters/agency/ShownAgency.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import ShownValue from '../otherFilters/ShownValue';
 
 const propTypes = {
     agency: PropTypes.object,
@@ -27,17 +27,7 @@ export default class ShownAgency extends React.Component {
 
     render() {
         return (
-            <button
-                className="shown-filter-button"
-                value={this.props.label}
-                onClick={this.toggleAgency}
-                title="Click to remove."
-                aria-label={`Applied filter: ${this.props.label}`}>
-                {this.props.label}
-                <span className="close">
-                    <FontAwesomeIcon icon="times" />
-                </span>
-            </button>
+            <ShownValue label={this.props.label} removeValue={this.toggleAgency} />
         );
     }
 }

--- a/src/js/components/search/filters/awardAmount/SelectedAwardAmountBound.jsx
+++ b/src/js/components/search/filters/awardAmount/SelectedAwardAmountBound.jsx
@@ -5,8 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-
+import ShownValue from '../otherFilters/ShownValue';
 
 const propTypes = {
     label: PropTypes.string,
@@ -22,17 +21,7 @@ const SelectedAwardAmountBound = (props) => {
 
     const { label } = props;
     return (
-        <button
-            className="shown-filter-button"
-            value={label}
-            onClick={removeFilterFn}
-            title="Click to remove."
-            aria-label={`Applied filter: ${label}`}>
-            {label}
-            <span className="close">
-                <FontAwesomeIcon icon="times" />
-            </span>
-        </button>
+        <ShownValue label={label} removeValue={removeFilterFn} />
     );
 };
 

--- a/src/js/components/search/filters/awardID/ShownAwardID.jsx
+++ b/src/js/components/search/filters/awardID/ShownAwardID.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import ShownValue from '../otherFilters/ShownValue';
 
 const propTypes = {
     toggleAwardID: PropTypes.func,
@@ -16,17 +16,7 @@ const ShownAwardID = (props) => {
     const { toggleAwardID, label } = props;
 
     return (
-        <button
-            className="shown-filter-button"
-            value={label}
-            onClick={toggleAwardID}
-            title="Click to remove filter."
-            aria-label={`Applied filter: ${label}`}>
-            {label}
-            <span className="close">
-                <FontAwesomeIcon icon="times" />
-            </span>
-        </button>
+        <ShownValue label={label} removeValue={toggleAwardID} />
     );
 };
 

--- a/src/js/components/search/filters/location/ShownLocation.jsx
+++ b/src/js/components/search/filters/location/ShownLocation.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import ShownValue from '../otherFilters/ShownValue';
 
 const propTypes = {
     removeLocation: PropTypes.func,
@@ -15,17 +15,7 @@ const propTypes = {
 export default class ShownLocation extends React.Component {
     render() {
         return (
-            <button
-                className="shown-filter-button"
-                value={this.props.label}
-                onClick={this.props.removeLocation}
-                title="Click to remove."
-                aria-label={`Applied filter: ${this.props.label}`}>
-                {this.props.label}
-                <span className="close">
-                    <FontAwesomeIcon icon="times" />
-                </span>
-            </button>
+            <ShownValue label={this.props.label} removeValue={this.props.removeLocation} />
         );
     }
 }

--- a/src/js/components/search/filters/recipient/ShownRecipient.jsx
+++ b/src/js/components/search/filters/recipient/ShownRecipient.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import ShownValue from '../otherFilters/ShownValue';
 
 const propTypes = {
     toggleRecipient: PropTypes.func,
@@ -13,17 +13,7 @@ const propTypes = {
 };
 
 const ShownRecipient = ({ toggleRecipient, label }) => (
-    <button
-        className="shown-filter-button"
-        value={label}
-        onClick={toggleRecipient}
-        title="Click to remove filter."
-        aria-label={`Applied filter: ${label}`}>
-        {label}
-        <span className="close">
-            <FontAwesomeIcon icon="times" />
-        </span>
-    </button>
+    <ShownValue label={label} removeValue={toggleRecipient} />
 );
 
 ShownRecipient.propTypes = propTypes;

--- a/src/js/containers/search/filters/def/DEFCheckboxTree.jsx
+++ b/src/js/containers/search/filters/def/DEFCheckboxTree.jsx
@@ -1,8 +1,7 @@
 import React, { useRef } from 'react';
 import PropTypes from "prop-types";
 import { connect } from 'react-redux';
-import { uniqueId, flowRight } from 'lodash';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { flowRight } from 'lodash';
 
 import withDefCodes from 'containers/covid19/WithDefCodes';
 
@@ -10,6 +9,7 @@ import CheckboxTree from 'components/sharedComponents/CheckboxTree';
 import { updateDefCodes } from 'redux/actions/search/searchFilterActions';
 import SubmitHint from 'components/sharedComponents/filterSidebar/SubmitHint';
 import DEFCheckboxTreeLabel from 'components/search/filters/defc/DEFCheckboxTreeLabel';
+import ShownValue from '../../../../components/search/filters/otherFilters/ShownValue';
 
 export const NewBadge = () => (
     <div className="new-badge">NEW</div>
@@ -137,18 +137,7 @@ const DEFCheckboxTree = (props) => {
                     {props.counts.map((node) => {
                         const label = `${node.label} (${node.count})`;
                         return (
-                            <button
-                                key={uniqueId()}
-                                className="shown-filter-button"
-                                value={label}
-                                onClick={(e) => removeSelectedFilter(e, node)}
-                                title="Click to remove."
-                                aria-label={`Applied filter: ${label}`}>
-                                {label}
-                                <span className="close">
-                                    <FontAwesomeIcon icon="times" />
-                                </span>
-                            </button>
+                            <ShownValue label={label} removeValue={(e) => removeSelectedFilter(e, node)} />
                         );
                     })}
                 </div>

--- a/src/js/containers/search/filters/naics/NAICSCheckboxTree.jsx
+++ b/src/js/containers/search/filters/naics/NAICSCheckboxTree.jsx
@@ -6,9 +6,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { debounce, uniqueId } from 'lodash';
+import { debounce } from 'lodash';
 import { isCancel } from 'axios';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { CSSOnlyTooltip } from 'components/search/filters/tooltips/AdvancedSearchTooltip';
 
@@ -44,6 +43,7 @@ import { updateNaics } from 'redux/actions/search/searchFilterActions';
 import CheckboxTree from 'components/sharedComponents/CheckboxTree';
 import EntityDropdownAutocomplete from 'components/search/filters/location/EntityDropdownAutocomplete';
 import SubmitHint from 'components/sharedComponents/filterSidebar/SubmitHint';
+import ShownValue from '../../../../components/search/filters/otherFilters/ShownValue';
 
 const propTypes = {
     stageNaics: PropTypes.func,
@@ -470,18 +470,7 @@ export class NAICSCheckboxTree extends React.Component {
                             {counts.map((node) => {
                                 const label = `${node.value} - ${node.label} (${node.count})`;
                                 return (
-                                    <button
-                                        key={uniqueId()}
-                                        className="shown-filter-button"
-                                        value={label}
-                                        onClick={() => this.removeStagedNaics(node)}
-                                        title="Click to remove."
-                                        aria-label={`Applied filter: ${label}`}>
-                                        {label}
-                                        <span className="close">
-                                            <FontAwesomeIcon icon="times" />
-                                        </span>
-                                    </button>
+                                    <ShownValue label={label} removeValue={() => this.removeStagedNaics(node)} />
                                 );
                             })}
                         </div>

--- a/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/programSource/TASCheckboxTreeContainer.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { isCancel } from 'axios';
-import { debounce, get, uniqueId, flattenDeep } from 'lodash';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { debounce, get, flattenDeep } from 'lodash';
 import { connect } from 'react-redux';
 
 import {
@@ -40,6 +39,7 @@ import CheckboxTree from 'components/sharedComponents/CheckboxTree';
 import SubmitHint from 'components/sharedComponents/filterSidebar/SubmitHint';
 import EntityDropdownAutocomplete from 'components/search/filters/location/EntityDropdownAutocomplete';
 import { CSSOnlyTooltip } from 'components/search/filters/tooltips/AdvancedSearchTooltip';
+import ShownValue from '../../../../components/search/filters/otherFilters/ShownValue';
 
 const propTypes = {
     setTasNodes: PropTypes.func,
@@ -429,18 +429,7 @@ export class TASCheckboxTree extends React.Component {
                         {counts.map((node) => {
                             const label = `${node.value} - ${node.label} (${node.count})`;
                             return (
-                                <button
-                                    key={uniqueId()}
-                                    className="shown-filter-button"
-                                    value={label}
-                                    onClick={(e) => this.removeSelectedFilter(e, node)}
-                                    title="Click to remove."
-                                    aria-label={`Applied filter: ${label}`}>
-                                    {label}
-                                    <span className="close">
-                                        <FontAwesomeIcon icon="times" />
-                                    </span>
-                                </button>
+                                <ShownValue label={label} removeValue={(e) => this.removeSelectedFilter(e, node)} />
                             );
                         })}
                     </div>

--- a/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
+++ b/src/js/containers/search/filters/psc/PSCCheckboxTreeContainer.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { isCancel } from 'axios';
-import { debounce, get, flattenDeep, uniqueId } from 'lodash';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { debounce, get, flattenDeep } from 'lodash';
 import { connect } from 'react-redux';
 
 import {
@@ -39,6 +38,7 @@ import CheckboxTree from 'components/sharedComponents/CheckboxTree';
 import SubmitHint from 'components/sharedComponents/filterSidebar/SubmitHint';
 import EntityDropdownAutocomplete from 'components/search/filters/location/EntityDropdownAutocomplete';
 import { CSSOnlyTooltip } from 'components/search/filters/tooltips/AdvancedSearchTooltip';
+import ShownValue from '../../../../components/search/filters/otherFilters/ShownValue';
 
 const propTypes = {
     setPscNodes: PropTypes.func,
@@ -415,18 +415,7 @@ export class PSCCheckboxTreeContainer extends React.Component {
                         {counts.map((node) => {
                             const label = `${node.value} - ${node.label} (${node.count})`;
                             return (
-                                <button
-                                    key={uniqueId()}
-                                    className="shown-filter-button"
-                                    value={label}
-                                    onClick={(e) => this.removeSelectedFilter(e, node)}
-                                    title="Click to remove."
-                                    aria-label={`Applied filter: ${label}`}>
-                                    {label}
-                                    <span className="close">
-                                        <FontAwesomeIcon icon="times" />
-                                    </span>
-                                </button>
+                                <ShownValue label={label} removeValue={(e) => this.removeSelectedFilter(e, node)} />
                             );
                         })}
                     </div>


### PR DESCRIPTION
**High level description:**
changed chips to be icon closed instead of whole button in all instance but DateRange as that will take more refactoring. Josue message about it: https://data-transparency-bfs.slack.com/archives/C038E9G7S4D/p1738364766233509

**Technical details:**
refactor so that shownValue compenent was used in all chip filter instances

**JIRA Ticket:**
https://federal-spending-transparency.atlassian.net/jira/software/c/projects/DEV/boards/25?selectedIssue=DEV-11869

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
