### PR TITLE
have to comment out this change UNTIL we deploy search v2, setting to previous value

### DIFF
--- a/src/js/components/sharedComponents/checkbox/AccordionCheckbox.jsx
+++ b/src/js/components/sharedComponents/checkbox/AccordionCheckbox.jsx
@@ -153,7 +153,10 @@ const AccordionCheckbox = ({
             {noResults ?
                 <div className="no-results">No results found.</div>
                 :
-                <div className="checkbox-categories-wrapper" style={{ height: innerDivHeight }}>{checkboxCategories}</div>
+                <div className="checkbox-categories-wrapper" style={{ height: "400px" }}>
+                    {/* style={{ height: innerDivHeight }} */}
+                    {checkboxCategories}
+                </div>
             }
         </div>
     );

--- a/src/js/components/sharedComponents/checkbox/ListCheckbox.jsx
+++ b/src/js/components/sharedComponents/checkbox/ListCheckbox.jsx
@@ -119,7 +119,8 @@ const ListCheckbox = ({
             {noResults ?
                 <div className="no-results">No results found.</div>
                 :
-                <div className="filter-item-wrap" style={{ height: innerDivHeight }}>
+                <div className="filter-item-wrap" style={{ height: "400px" }}>
+                    {/* style={{ height: innerDivHeight }} */}
                     {checkboxCategories}
                     <SubmitHint selectedFilters={selectedFilters} />
                 </div>

--- a/src/js/containers/search/filters/recipient/RecipientSearchContainer.jsx
+++ b/src/js/containers/search/filters/recipient/RecipientSearchContainer.jsx
@@ -248,7 +248,8 @@ const RecipientSearchContainer = ({ updateSelectedRecipients, selectedRecipients
                     </button>
                 </div>
                 {isLoading ? loadingIndicator :
-                    <div className="recipient-results__container" style={{ height: innerDivHeight }}>
+                    <div className="recipient-results__container" style={{ height: "400px" }}>
+                        {/* style={{ height: innerDivHeight }} */}
                         <div className={`checkbox-type-filter ${maxRecipients ? 'bottom-fade' : ''}`}>
                             {recipients.toSorted((a, b) => (a.name?.toUpperCase() < b.name?.toUpperCase() ? -1 : 1))
                                 .map((recipient) => (


### PR DESCRIPTION
**High level description:**

in order to not break existing search have to put a hard cap on the height of the containers until we deploy search v2

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
