### PR TITLE
DEV-12046 : "1 selected" is displayed for selecting more than one TAS filter

### DIFF
--- a/src/js/components/search/collapsibleSidebar/SearchSidebarDrilldown.jsx
+++ b/src/js/components/search/collapsibleSidebar/SearchSidebarDrilldown.jsx
@@ -93,7 +93,7 @@ const SearchSidebarDrilldown = ({
         Recipient: selectedRecipients.size,
         'Recipient Type': recipientType.size,
         Agency: selectedAwardingAgencies.size + selectedFundingAgencies.size,
-        'Treasury Account Symbol (TAS)': tasCodes.counts.length,
+        'Treasury Account Symbol (TAS)': generateCount(tasCodes),
         'COVID-19 Spending': covidDefCode.size,
         'Infrastructure Spending': infraDefCode.size
     };

--- a/src/js/helpers/search/filterCheckboxHelper.js
+++ b/src/js/helpers/search/filterCheckboxHelper.js
@@ -399,6 +399,6 @@ export const sourcesCount = ({
     infraDefCode
 }) => selectedAwardingAgencies.size +
     selectedFundingAgencies.size +
-    tasCodes.counts.length +
+    generateCount(tasCodes) +
     covidDefCode.size +
     infraDefCode.size;


### PR DESCRIPTION
**High level description:**

DEV-12046 : "1 selected" is displayed for selecting more than one TAS filter

**Technical details:**

Utilize helper function "generateCount" for tasCodes.

**JIRA Ticket:**
[DEV-12046](https://federal-spending-transparency.atlassian.net/browse/DEV-12046)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
