### PR TITLE
12067 - Remove drilldown animation for MVP

### DIFF
--- a/src/_scss/pages/search/_collapsibleSidebar.scss
+++ b/src/_scss/pages/search/_collapsibleSidebar.scss
@@ -1,18 +1,5 @@
 @import "searchFilter";
 
-@keyframes drilldown-slidein {
-  0% {
-    display: block;
-    transform: translateX(24px);
-    visibility: hidden;
-  }
-
-  100% {
-    transform: translateX(0);
-    visibility: visible;
-  }
-}
-
 // .usda-page-header style is a DTUI override that's specific to the search 2.0 page
 &.v2 {
   .site-header, .usda-page-header:not(.usda-page-header--sticky) {
@@ -200,8 +187,6 @@
 
       &.opened {
         display: block;
-        -webkit-animation: drilldown-slidein 0.2s forwards;
-        animation: drilldown-slidein 0.2s forwards;
       }
 
       .collapsible-sidebar--back-btn {


### PR DESCRIPTION
**High level description:**

After discussion with the designers on 2/26, removing this animation from the MVP on the Adv Search 2.0 Phase 2 release

**JIRA Ticket:**
[DEV-12067](https://federal-spending-transparency.atlassian.net/browse/DEV-12067)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`

