### PR TITLE
DEV-12196 dsm slider close on back and toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18590,9 +18590,9 @@
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/src/_scss/pages/search/_collapsibleSidebar.scss
+++ b/src/_scss/pages/search/_collapsibleSidebar.scss
@@ -283,26 +283,30 @@
 
       .collapsible-sidebar--dsm-slider {
         color: $blue-50;
-        cursor: pointer;
         padding: rem(16) rem(32);
         font-size: rem(12);
         font-weight: $font-semibold;
         line-height: 1.5;
         border-top: 1px solid $gray-cool-5;
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-        &:hover {
-          color: $blue-70v;
-        }
+        
+        span {
+          display: flex;
+          flex-direction: row;
+          flex-wrap: wrap;
+          align-items: center;
+          cursor: pointer;
+          &:hover {
+            color: $blue-70v;
+          }
 
-        .chevron {
-          margin: 4px 8px 0 8px;
-          width: 10px;
+          .chevron {
+            margin: 0 8px 0 8px;
+            width: 10px;
+          }
+  
         }
 
         .collapsible-sidebar--dsm-content {
-
           .collapsible-sidebar--dsm-wrapper {
             font-size: $font-size-14;
             color: $gray-60;

--- a/src/js/components/search/collapsibleSidebar/DsmSlider.jsx
+++ b/src/js/components/search/collapsibleSidebar/DsmSlider.jsx
@@ -26,7 +26,8 @@ const DsmSlider = (props) => {
 
         fetchMarkdown();
     }, [props.dsmFile]);
-    const clickHandler = () => {
+    const clickHandler = (e) => {
+        e.preventDefault();
         props.setIsDsmOpened(!props.isDsmOpened);
     };
 
@@ -39,16 +40,17 @@ const DsmSlider = (props) => {
     };
     return (
         <div
-            className={`collapsible-sidebar--dsm-slider ${props?.isDsmOpened ? `dsm-opened` : ''}`}
-            role="button"
-            tabIndex="0"
-            onClick={clickHandler}
-            onKeyUp={(e) => {
-                if (e.key === 'Enter') {
-                    props.setIsDsmOpened(!props.isDsmOpened);
-                }
-            }}>
-            About {adjustFilterLabel()}{props.isDsmOpened ? <FontAwesomeIcon className="chevron" icon="chevron-up" /> : <FontAwesomeIcon className="chevron" icon="chevron-down" />}
+            className={`collapsible-sidebar--dsm-slider ${props?.isDsmOpened ? `dsm-opened` : ''}`}>
+            <span
+                role="button"
+                tabIndex={0}
+                onClick={clickHandler}
+                onKeyUp={(e) => {
+                    if (e.key === 'Enter') {
+                        props.setIsDsmOpened(!props.isDsmOpened);
+                    }
+                }}>About {adjustFilterLabel()}{props.isDsmOpened ? <FontAwesomeIcon className="chevron" icon="chevron-up" /> : <FontAwesomeIcon className="chevron" icon="chevron-down" />}
+            </span>
             {props.isDsmOpened &&
                 <div className="collapsible-sidebar--dsm-content">
                     <div className="collapsible-sidebar--dsm-wrapper" style={{ height: `${props.height - 64}px` }}>

--- a/src/js/components/search/collapsibleSidebar/SearchSidebarDrilldown.jsx
+++ b/src/js/components/search/collapsibleSidebar/SearchSidebarDrilldown.jsx
@@ -3,7 +3,7 @@
  * Created by Andrea Blackwell 11/05/2024
  **/
 
-import React, { useState } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
@@ -26,7 +26,9 @@ const propTypes = {
     titleOnly: PropTypes.bool,
     dsmComponent: PropTypes.bool,
     dsmFile: PropTypes.string,
-    currentLevel: PropTypes.number
+    currentLevel: PropTypes.number,
+    isDsmOpened: PropTypes.bool,
+    setIsDsmOpened: PropTypes.func
 };
 
 const SearchSidebarDrilldown = ({
@@ -43,9 +45,10 @@ const SearchSidebarDrilldown = ({
     titleOnly = false,
     dsmComponent = false,
     dsmFile = '',
-    currentLevel
+    currentLevel,
+    isDsmOpened,
+    setIsDsmOpened
 }) => {
-    const [isDsmOpened, setIsDsmOpened] = useState(false);
     const keyHandler = (e, func) => {
         e.preventDefault();
         if (e.key === "Enter") {
@@ -132,8 +135,14 @@ const SearchSidebarDrilldown = ({
             <div className="collapsible-sidebar--header">
                 <div
                     className="collapsible-sidebar--back-btn"
-                    onClick={(e) => goBack(e)}
-                    onKeyDown={(e) => keyHandler(e, goBack)}
+                    onClick={(e) => {
+                        setIsDsmOpened(false);
+                        goBack(e);
+                    }}
+                    onKeyDown={(e) => {
+                        setIsDsmOpened(false);
+                        keyHandler(e, goBack);
+                    }}
                     role="button"
                     tabIndex="0">
                     <FontAwesomeIcon className="chevron" icon="chevron-left" />Back

--- a/src/js/components/search/collapsibleSidebar/SidebarContent.jsx
+++ b/src/js/components/search/collapsibleSidebar/SidebarContent.jsx
@@ -15,10 +15,14 @@ import { characteristicsCount, sourcesCount } from "../../../helpers/search/filt
 
 const propTypes = {
     sidebarContentHeight: PropTypes.number,
-    setShowMobileFilters: PropTypes.func
+    setShowMobileFilters: PropTypes.func,
+    isDsmOpened: PropTypes.bool,
+    setIsDsmOpened: PropTypes.func
 };
 
-const SidebarContent = ({ sidebarContentHeight, setShowMobileFilters }) => {
+const SidebarContent = ({
+    sidebarContentHeight, setShowMobileFilters, isDsmOpened, setIsDsmOpened
+}) => {
     const [drilldown, setDrilldown] = useState(null);
     const [isDrilldown, setIsDrilldown] = useState(false);
     const [selectedCategory, setSelectedCategory] = useState(null);
@@ -94,7 +98,9 @@ const SidebarContent = ({ sidebarContentHeight, setShowMobileFilters }) => {
             titleOnly={drilldown?.titleOnly}
             dsmComponent={drilldown?.dsmComponent}
             dsmFile={drilldown?.dsmFile}
-            currentLevel={currentLevel} />
+            currentLevel={currentLevel}
+            isDsmOpened={isDsmOpened}
+            setIsDsmOpened={setIsDsmOpened} />
 
         <div className="sidebar-bottom-submit">
             <SearchSidebarSubmitContainer setShowMobileFilters={setShowMobileFilters} />

--- a/src/js/components/search/collapsibleSidebar/SidebarWrapper.jsx
+++ b/src/js/components/search/collapsibleSidebar/SidebarWrapper.jsx
@@ -31,6 +31,7 @@ const SidebarWrapper = React.memo(({
     const [isOpened, setIsOpened] = useState(sidebarOpen);
     const [sidebarIsSticky, setSidebarIsSticky] = useState();
     const [isFooterVisible, setIsFooterVisible] = useState();
+    const [isDsmOpened, setIsDsmOpened] = useState(false);
 
     const mainContentEl = document.querySelector("#main-content");
     const footerEl = document.querySelector("footer");
@@ -263,8 +264,14 @@ const SidebarWrapper = React.memo(({
                 className={`search-sidebar collapsible-sidebar ${initialPageLoad ? "is-initial-loaded" : ""} ${isOpened ? 'opened' : ''}`}>
                 <div
                     className="collapsible-sidebar--toggle"
-                    onClick={(e) => toggleOpened(e)}
-                    onKeyDown={(e) => keyHandler(e, toggleOpened)}
+                    onClick={(e) => {
+                        setIsDsmOpened(false);
+                        toggleOpened(e);
+                    }}
+                    onKeyDown={(e) => {
+                        setIsDsmOpened(false);
+                        keyHandler(e, toggleOpened);
+                    }}
                     role="button"
                     focusable="true"
                     tabIndex={0}>
@@ -274,7 +281,11 @@ const SidebarWrapper = React.memo(({
                         <FontAwesomeIcon className="chevron" icon="chevron-right" />
                     }
                 </div>
-                <SidebarContent sidebarContentHeight={sidebarContentHeight} setShowMobileFilters={setShowMobileFilters} />
+                <SidebarContent
+                    sidebarContentHeight={sidebarContentHeight}
+                    setShowMobileFilters={setShowMobileFilters}
+                    isDsmOpened={isDsmOpened}
+                    setIsDsmOpened={setIsDsmOpened} />
             </div>
         </div>
     );


### PR DESCRIPTION
**High level description:**

close dsm slider when you go back or toggle the sidebar closed/open

**JIRA Ticket:**
[DEV-12196](https://federal-spending-transparency.atlassian.net/browse/DEV-12196)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled demo including Design/Testing/Front-end OR Provided instructions for testing in JIRA and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`
- [ ] [Component Library Integration Status Report](https://github.com/fedspendingtransparency/data-act-documentation/blob/data-transparency-ui/frontend_apps/component-library-integration-status.md) updated `if applicable`

Reviewer(s):
- [ ] Design review complete `if applicable`
- [ ] [API #1234](https://github.com/fedspendingtransparency/usaspending-api/pull/1234) merged concurrently `if applicable`
- [ ] Code review complete
