### PR TITLE
12433 - Adjust sidebar height after closing the notification banner

### DIFF
--- a/src/js/components/search/collapsibleSidebar/SidebarWrapper.jsx
+++ b/src/js/components/search/collapsibleSidebar/SidebarWrapper.jsx
@@ -257,13 +257,13 @@ const SidebarWrapper = React.memo(({
 
         handleResize();
 
-        window.addEventListener('resize', (e) => handleResize(e));
-        window.addEventListener('scroll', (e) => handleScroll(e));
+        window.addEventListener('resize', () => handleResize());
+        window.addEventListener('scroll', () => handleScroll());
         window.addEventListener('scrollend', (e) => handleScrollEnd(e));
 
         return () => {
-            window.removeEventListener('resize', (e) => handleResize(e));
-            window.removeEventListener('scroll', (e) => handleScroll(e));
+            window.removeEventListener('resize', () => handleResize());
+            window.removeEventListener('scroll', () => handleScroll());
             window.removeEventListener('scrollend', (e) => handleScrollEnd(e));
 
             mainContentResizeObserver.unobserve(mainContent);


### PR DESCRIPTION
**Description:**

Added an additional resize listener to adjust the height of the sidebar after closing the notification banner

**JIRA Ticket:**
[DEV-12433](https://federal-spending-transparency.atlassian.net/browse/DEV-12433)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`

