### PR TITLE
DEV-12564: Fixed issue with loading fed account pages

### DIFF
--- a/src/js/containers/account/AccountContainer.jsx
+++ b/src/js/containers/account/AccountContainer.jsx
@@ -98,7 +98,7 @@ const AccountContainer = (props) => {
         const account = new FederalAccount(data);
         props.setSelectedAccount(account);
         if (props.latestPeriod.year) {
-            loadFiscalYearSnapshot(account.id);
+            loadFiscalYearSnapshot(page.account.id);
         }
     };
 

--- a/src/js/containers/account/AccountContainer.jsx
+++ b/src/js/containers/account/AccountContainer.jsx
@@ -98,7 +98,7 @@ const AccountContainer = (props) => {
         const account = new FederalAccount(data);
         props.setSelectedAccount(account);
         if (props.latestPeriod.year) {
-            loadFiscalYearSnapshot(page.account.id);
+            loadFiscalYearSnapshot(props.account.id);
         }
     };
 


### PR DESCRIPTION
**Description:**

Noticed that the fed account table does load correctly when the filters are changed on the left.  The original fix was correct

**JIRA Ticket:**
[DEV-12564](https://federal-spending-transparency.atlassian.net/browse/DEV-12564)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`

