### PR TITLE
DEV 12792: Mobile View - User has to click "read more" twice on mobile stacked table

### DIFF
--- a/src/js/components/sharedComponents/ReadMore.jsx
+++ b/src/js/components/sharedComponents/ReadMore.jsx
@@ -45,7 +45,8 @@ const ReadMore = ({
             return (
                 <button
                     className="readMoreUpdated__button"
-                    onClick={() => {
+                    onClick={(e) => {
+                        e.stopPropagation();
                         setExpanded(false);
                         if (additionalFunctionality !== null) {
                             additionalFunctionality(expanded);
@@ -57,7 +58,8 @@ const ReadMore = ({
             return (
                 <button
                     className="readMoreUpdated__button"
-                    onClick={() => {
+                    onClick={(e) => {
+                        e.stopPropagation();
                         setExpanded(false);
                         if (additionalFunctionality !== null) {
                             additionalFunctionality(expanded);
@@ -70,7 +72,8 @@ const ReadMore = ({
             return (
                 <button
                     className="readMoreUpdated__button"
-                    onClick={() => {
+                    onClick={(e) => {
+                        e.stopPropagation();
                         setExpanded(false);
                         if (additionalFunctionality !== null) {
                             additionalFunctionality(expanded);
@@ -78,14 +81,15 @@ const ReadMore = ({
                     }}>{closePrompt}
                 </button>);
         }
-        return (<button className="read-more-button" onClick={() => setExpanded(false)}>Read Less</button>);
+        return (<button className="read-more-button" onClick={(e) => { e.stopPropagation(); setExpanded(false); }}>Read Less</button>);
     };
     const readMore = () => {
         if (openPrompt && openIcon) {
             return (
                 <button
                     className="readMoreUpdated__button"
-                    onClick={() => {
+                    onClick={(e) => {
+                        e.stopPropagation();
                         setExpanded(true);
                         if (additionalFunctionality !== null) {
                             additionalFunctionality(expanded);
@@ -97,7 +101,8 @@ const ReadMore = ({
             return (
                 <button
                     className="readMoreUpdated__button"
-                    onClick={() => {
+                    onClick={(e) => {
+                        e.stopPropagation();
                         setExpanded(true);
                         if (additionalFunctionality !== null) {
                             additionalFunctionality(expanded);
@@ -109,7 +114,8 @@ const ReadMore = ({
             return (
                 <button
                     className="readMoreUpdated__button"
-                    onClick={() => {
+                    onClick={(e) => {
+                        e.stopPropagation();
                         setExpanded(true);
                         if (additionalFunctionality !== null) {
                             additionalFunctionality(expanded);
@@ -117,7 +123,7 @@ const ReadMore = ({
                     }}><span className="usa-button-link__icon"><FontAwesomeIcon className="readMoreUpdated__link-icon" icon={openIcon} /></span>
                 </button>);
         }
-        return (<button className="read-more-button" onClick={() => setExpanded(true)}>Read More</button>);
+        return (<button className="read-more-button" onClick={(e) => { e.stopPropagation(); setExpanded(true); }}>Read More</button>);
     };
 
     if (expanded && children) {


### PR DESCRIPTION
**Description:**
"Read More" component onClick functionality was being masked by parent component.  adding e.stopPropagation() stops the bubbling up action to the parent and allows the child functionality to occur. 

**JIRA Ticket:**
[DEV-12792](https://federal-spending-transparency.atlassian.net/browse/DEV-12792)

*Testing**
To test open advanced search, choose a filter, set to mobile view, in the Results Table scroll until you see a "ReadMore"  --> should only require a single click to expand/collapse.  All other links and buttons within each result grouping/row should work with a single click as well.

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness



[DEV-12792]: https://federal-spending-transparency.atlassian.net/browse/DEV-12792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ