### PR TITLE
DEV-12857 : Adv Search: Expand Keyword Search Accordion on default

### DIFF
--- a/src/js/components/search/SearchSidebar.jsx
+++ b/src/js/components/search/SearchSidebar.jsx
@@ -183,7 +183,7 @@ const SearchSidebar = ({
 
     releasedFilters.options.forEach((filter) => {
     // Collapse all by default, unless the filter has a selection made
-        if (filter.title === 'Time Period') {
+        if (filter.title === 'Time Period' || filter.title === 'Keyword') {
             // time period is always expanded
             expanded.push(true);
         }


### PR DESCRIPTION
**Description:**
set Keyword section in legacy search filters to be defaulted open on page load

**JIRA Ticket:**
[DEV-12857](https://federal-spending-transparency.atlassian.net/browse/DEV-12857)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness



[DEV-12857]: https://federal-spending-transparency.atlassian.net/browse/DEV-12857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ