### PR TITLE
12862 - partially decoupled the logic for the local and redux checked…

### DIFF
--- a/src/js/components/sharedComponents/checkboxTree/TreeNodes.jsx
+++ b/src/js/components/sharedComponents/checkboxTree/TreeNodes.jsx
@@ -34,10 +34,6 @@ const TreeNodes = ({
     const [loadingParentId, setLoadingParentId] = useState();
 
     useEffect(() => {
-        setLocalChecked(checked);
-    }, [checked, nodes]);
-
-    useEffect(() => {
         setLoadingParentId(null);
         setLocalNodes(nodes);
     }, [nodes]);
@@ -68,23 +64,32 @@ const TreeNodes = ({
         }
         return ids;
     };
+
     const handleCheck = (id, children = []) => {
         const isChecked = localChecked.includes(id);
         const descendantIds = getDescendantIds(children);
+        const modifiedNode = findNodeById(id);
         let newChecked;
 
         if (isChecked) {
             // Uncheck node and its descendants
             newChecked = localChecked.filter((cid) => cid !== id && !descendantIds.includes(cid));
+            setLocalChecked(newChecked);
+            if (onCheck) onCheck(newChecked, modifiedNode);
         }
         else {
-            // Check node and its descendants
-            newChecked = [...new Set([...localChecked, id, ...descendantIds])];
-        }
+            if ((descendantIds.length > 0)) {
+                // Check node's descendants
+                newChecked = [...new Set([...localChecked, ...descendantIds])];
+            }
+            else {
+                // Check node
+                newChecked = [...new Set([...localChecked, id])];
+            }
 
-        setLocalChecked(newChecked);
-        const modifiedNode = findNodeById(id);
-        if (onCheck) onCheck(newChecked, modifiedNode);
+            setLocalChecked([...new Set([...localChecked, id, ...descendantIds])]);
+            if (onCheck) onCheck(newChecked, modifiedNode);
+        }
     };
 
     const handleToggle = (id, hasChildren) => {


### PR DESCRIPTION
**Description:**
Partially decoupled the logic for the local and redux check state. This was done to maintain the proper count in the redux logic, while also maintaining the checked logic within the new component.

**JIRA Ticket:**
[DEV-12862](https://federal-spending-transparency.atlassian.net/browse/DEV-12862)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`

