### PR TITLE
Fix/dev 13008 side panel reopening

### DIFF
--- a/src/js/components/search/collapsibleSidebar/SidebarContent.jsx
+++ b/src/js/components/search/collapsibleSidebar/SidebarContent.jsx
@@ -102,7 +102,7 @@ const SidebarContent = ({
                     openIcon="chevron-up"
                     contentClassName={open[filter.title] ? '' : 'hidden'}
                     selectedChipCount={filterCount[filter.title]}>
-                    {renderSidebarContent && filter.component}
+                    {renderSidebarContent && open[filter.title] && filter.component}
                 </Accordion>
             ))}
         </div>

--- a/src/js/components/search/collapsibleSidebar/SidebarContent.jsx
+++ b/src/js/components/search/collapsibleSidebar/SidebarContent.jsx
@@ -17,11 +17,17 @@ const propTypes = {
     setShowMobileFilters: PropTypes.func,
     isDsmOpened: PropTypes.bool,
     setIsDsmOpened: PropTypes.func,
-    timerRef: PropTypes.object
+    timerRef: PropTypes.object,
+    renderSidebarContent: PropTypes.bool
 };
 
 const SidebarContent = ({
-    sidebarContentHeight, setShowMobileFilters, isDsmOpened, setIsDsmOpened, timerRef
+    sidebarContentHeight,
+    setShowMobileFilters,
+    isDsmOpened,
+    setIsDsmOpened,
+    timerRef,
+    renderSidebarContent
 }) => {
     const [open, setOpen] = useState({
         Location: false,
@@ -77,7 +83,7 @@ const SidebarContent = ({
                     closedIcon="chevron-down"
                     openIcon="chevron-up"
                     contentClassName={open[filter.title] ? '' : 'hidden'}>
-                    {filter.component}
+                    {renderSidebarContent && filter.component}
                 </Accordion>
             ))}
         </div>

--- a/src/js/components/search/collapsibleSidebar/SidebarWrapper.jsx
+++ b/src/js/components/search/collapsibleSidebar/SidebarWrapper.jsx
@@ -337,7 +337,7 @@ const SidebarWrapper = React.memo(({
                         isDsmOpened={isDsmOpened}
                         setIsDsmOpened={setIsDsmOpened}
                         timerRef={timerRef}
-                        renderSidebarContent={renderSidebarContent} />
+                        renderSidebarContent={isMobile || renderSidebarContent} />
                 }
             </div>
         </div>

--- a/src/js/components/search/collapsibleSidebar/SidebarWrapper.jsx
+++ b/src/js/components/search/collapsibleSidebar/SidebarWrapper.jsx
@@ -152,7 +152,6 @@ const SidebarWrapper = React.memo(({
         document.querySelector(".full-search-sidebar").style.flexBasis = `${width}px`;
         document.querySelector(".collapsible-sidebar").style.width = `${width}px`;
         document.querySelector(".collapsible-sidebar").style.transition = 'width 300ms cubic-bezier(0.2, 0, 0, 1)';
-        // document.querySelector(".sidebar-submit").style.display = "block";
         const allDsmSlidersToOpen = document.querySelectorAll(".collapsible-sidebar--dsm-slider");
         if (allDsmSlidersToOpen.length) {
             for (const slider of allDsmSlidersToOpen.values()) {
@@ -168,7 +167,6 @@ const SidebarWrapper = React.memo(({
         document.querySelector(".collapsible-sidebar").style.transition = 'width 300ms cubic-bezier(0.2, 0, 0, 1)';
         document.querySelector(".mobile-search-sidebar-v2").style.flexBasis = "0";
         document.querySelector(".collapsible-sidebar").style.width = "0";
-        // document.querySelector(".sidebar-submit").style.display = "none";
         const allDsmSlidersToClose = document.querySelectorAll(".collapsible-sidebar--dsm-slider");
         if (allDsmSlidersToClose.length) {
             for (const slider of allDsmSlidersToClose.values()) {

--- a/src/js/components/search/collapsibleSidebar/SidebarWrapper.jsx
+++ b/src/js/components/search/collapsibleSidebar/SidebarWrapper.jsx
@@ -34,6 +34,7 @@ const SidebarWrapper = React.memo(({
     const [isFooterVisible, setIsFooterVisible] = useState();
     const [isDsmOpened, setIsDsmOpened] = useState(false);
     const [headerHeight, setHeaderHeight] = useState();
+    const [renderSidebarContent, setRenderSidebarContent] = useState(true);
 
     const mainContentEl = document.querySelector("#main-content");
     const footerEl = document.querySelector("footer");
@@ -151,7 +152,7 @@ const SidebarWrapper = React.memo(({
         document.querySelector(".full-search-sidebar").style.flexBasis = `${width}px`;
         document.querySelector(".collapsible-sidebar").style.width = `${width}px`;
         document.querySelector(".collapsible-sidebar").style.transition = 'width 300ms cubic-bezier(0.2, 0, 0, 1)';
-        document.querySelector(".sidebar-submit").style.display = "block";
+        // document.querySelector(".sidebar-submit").style.display = "block";
         const allDsmSlidersToOpen = document.querySelectorAll(".collapsible-sidebar--dsm-slider");
         if (allDsmSlidersToOpen.length) {
             for (const slider of allDsmSlidersToOpen.values()) {
@@ -167,7 +168,7 @@ const SidebarWrapper = React.memo(({
         document.querySelector(".collapsible-sidebar").style.transition = 'width 300ms cubic-bezier(0.2, 0, 0, 1)';
         document.querySelector(".mobile-search-sidebar-v2").style.flexBasis = "0";
         document.querySelector(".collapsible-sidebar").style.width = "0";
-        document.querySelector(".sidebar-submit").style.display = "none";
+        // document.querySelector(".sidebar-submit").style.display = "none";
         const allDsmSlidersToClose = document.querySelectorAll(".collapsible-sidebar--dsm-slider");
         if (allDsmSlidersToClose.length) {
             for (const slider of allDsmSlidersToClose.values()) {
@@ -247,11 +248,27 @@ const SidebarWrapper = React.memo(({
             setHeaderHeight(entries[0].target?.clientHeight);
         });
 
+        // eslint-disable-next-line no-undef
+        const sidebarResizeObserver = new ResizeObserver((entries) => {
+            if (
+                (entries[0].contentRect.width === sideBarDesktopWidth - 2) ||
+                (entries[0].contentRect.width === sideBarXlDesktopWidth - 2)
+            ) {
+                setRenderSidebarContent(true);
+            }
+            else {
+                setRenderSidebarContent(false);
+            }
+        });
+
         const mainContent = document.querySelector("#main-content");
         mainContentResizeObserver.observe(mainContent);
 
         const siteHeader = document.querySelector(".site-header");
         headerResizeObserver.observe(siteHeader);
+
+        const sidebar = document.querySelector(".collapsible-sidebar");
+        sidebarResizeObserver.observe(sidebar);
 
         handleResize();
 
@@ -265,8 +282,8 @@ const SidebarWrapper = React.memo(({
             window.removeEventListener('scrollend', (e) => handleScrollEnd(e));
 
             mainContentResizeObserver?.unobserve(mainContent);
-
             headerResizeObserver?.unobserve(siteHeader);
+            sidebarResizeObserver?.unobserve(sidebar);
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
@@ -315,12 +332,15 @@ const SidebarWrapper = React.memo(({
                         <FontAwesomeIcon className="chevron" icon="chevron-right" />
                     }
                 </div>
-                <SidebarContent
-                    sidebarContentHeight={sidebarContentHeight}
-                    setShowMobileFilters={setShowMobileFilters}
-                    isDsmOpened={isDsmOpened}
-                    setIsDsmOpened={setIsDsmOpened}
-                    timerRef={timerRef} />
+                { isOpened &&
+                    <SidebarContent
+                        sidebarContentHeight={sidebarContentHeight}
+                        setShowMobileFilters={setShowMobileFilters}
+                        isDsmOpened={isDsmOpened}
+                        setIsDsmOpened={setIsDsmOpened}
+                        timerRef={timerRef}
+                        renderSidebarContent={renderSidebarContent} />
+                }
             </div>
         </div>
     );


### PR DESCRIPTION
**Description:**
The filter components now don't render until the opening animation is complete AND their accordion is opened. Additionally, the Sidebar component unmounts as soon as the isOpen state is false, also slightly speeding up that animation as well.

**JIRA Ticket:**
[DEV-13008](https://federal-spending-transparency.atlassian.net/browse/DEV-13008)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled and completed design review 
- [x] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-13008]: https://federal-spending-transparency.atlassian.net/browse/DEV-13008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ