### PR TITLE
DEV-13133 add in X (close button)

### DIFF
--- a/src/_scss/pages/search/_collapsibleSidebar.scss
+++ b/src/_scss/pages/search/_collapsibleSidebar.scss
@@ -116,14 +116,12 @@
     }
 
     .collapsible-sidebar--header {
-      padding: rem(16) rem(32);
-      font-size: 16px;
-      font-weight: $font-semibold;
+      padding: rem(20) rem(20) 0 rem(32);
       line-height: 1.5;
       color: $gray-90;
-      border-bottom: $gray-cool-10 1px solid;
       background-color: unset;
-
+      display: flex;
+      justify-content: flex-end;
       #collapsible-mobile-close-button {
         @media(min-width: $medium-screen) {
           display: none;
@@ -132,10 +130,9 @@
         width: rem(10);
         height: rem(10);
         background-color: white;
+        margin: 0;
+        stroke-width: rem(2);
         padding: 0;
-        right: 0;
-        position: absolute;
-
         svg {
           width: rem(10);
           height: rem(10);

--- a/src/js/components/search/collapsibleSidebar/SidebarContent.jsx
+++ b/src/js/components/search/collapsibleSidebar/SidebarContent.jsx
@@ -55,7 +55,7 @@ const SidebarContent = ({
         "COVID-19 Spending": false,
         "Infrastructure Spending": false
     });
-    const [isTablet, setIsTablet] = useState(window.innerWidth < mediumScreen);
+    const [isSmall, setIsSmall] = useState(window.innerWidth < mediumScreen);
     const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
     const filters = useSelector((state) => state.filters);
@@ -89,7 +89,7 @@ const SidebarContent = ({
         if (windowWidth !== windowWidthTemp) {
             // width changed, update the visualization width
             setWindowWidth(window.innerWidth);
-            setIsTablet(window.innerWidth < mediumScreen);
+            setIsSmall(window.innerWidth < mediumScreen);
         }
     }, [windowWidth]);
 
@@ -125,7 +125,7 @@ const SidebarContent = ({
     return (
         <>
             <div className="collapsible-sidebar--main-menu search-filters-wrapper opened">
-                {isTablet &&
+                {isSmall &&
                 <div className="collapsible-sidebar--header">
                     <button
                         className="close-button"

--- a/src/js/components/search/collapsibleSidebar/SidebarContent.jsx
+++ b/src/js/components/search/collapsibleSidebar/SidebarContent.jsx
@@ -3,7 +3,7 @@
  * Created by Andrea Blackwell 1/10/2025
  **/
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useSelector } from "react-redux";
@@ -14,6 +14,8 @@ import Accordion from "../../sharedComponents/accordion/Accordion";
 import DsmSlider from "./DsmSlider";
 import { excludeIDVB, generateCount } from "../../../helpers/search/filterCheckboxHelper";
 import KeywordContainer from "../../../containers/search/filters/KeywordContainer";
+import * as Icons from '../../../components/sharedComponents/icons/Icons';
+import { mediumScreen } from '../../../dataMapping/shared/mobileBreakpoints';
 
 const propTypes = {
     sidebarContentHeight: PropTypes.number,
@@ -53,6 +55,8 @@ const SidebarContent = ({
         "COVID-19 Spending": false,
         "Infrastructure Spending": false
     });
+    const [isTablet, setIsTablet] = useState(window.innerWidth < mediumScreen);
+    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
     const filters = useSelector((state) => state.filters);
 
@@ -78,6 +82,16 @@ const SidebarContent = ({
         'COVID-19 Spending': filters.covidDefCode.size,
         'Infrastructure Spending': filters.infraDefCode.size
     };
+
+    useEffect(() => {
+    // determine if the width changed
+        const windowWidthTemp = window.innerWidth;
+        if (windowWidth !== windowWidthTemp) {
+            // width changed, update the visualization width
+            setWindowWidth(window.innerWidth);
+            setIsTablet(window.innerWidth < mediumScreen);
+        }
+    }, [windowWidth]);
 
     const dsmElHeight = sidebarContentHeight + 51;
 
@@ -111,6 +125,19 @@ const SidebarContent = ({
     return (
         <>
             <div className="collapsible-sidebar--main-menu search-filters-wrapper opened">
+                {isTablet &&
+                <div className="collapsible-sidebar--header">
+                    <button
+                        className="close-button"
+                        id="collapsible-mobile-close-button"
+                        aria-label="Close Mobile Filters"
+                        title="Close Mobile Filters"
+                        onClick={() => {
+                            setShowMobileFilters(false);
+                        }}>
+                        <Icons.Close alt="Close About The Data" />
+                    </button>
+                </div>}
                 {!isDsmOpened && (
                     <div
                         className="collapsible-sidebar--search-filters-list"


### PR DESCRIPTION
**Description:**

add close button back on mobile/tablet for search 2.0 sidebar

**JIRA Ticket:**
[DEV-13133](https://federal-spending-transparency.atlassian.net/browse/DEV-13133)

**Mockup:**
https://figma-gov.com/design/s8rgQ5B6Rd3snAgGATNvXl/Design-Tickets?node-id=532-5477&m=dev
(on the side there is a mobile mock with a close button)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-13133]: https://federal-spending-transparency.atlassian.net/browse/DEV-13133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ