### PR TITLE
12941 - Removed last two sentences of park atd

### DIFF
--- a/src/content/about-the-data/park.mdx
+++ b/src/content/about-the-data/park.mdx
@@ -11,7 +11,3 @@ PARK codes play a significant role in mapping records to the USAspending display
 they are organized by OMB Fund Families. This structured approach ensures that
 PARK codes correspond to specific activities or projects detailed in the program
 and financing schedules of the annual United States Government budget.
-
-After October 1, 2025 (Fiscal Year 2026), PARK will be associated with specific
-program activity names on USAspending.gov. However, users will still be able to
-view PAC and PAN codes related to activities before Fiscal Year 2026.


### PR DESCRIPTION
**Description:**

New request from PO - there was an ask if we can remove the last two sentences from the PARK About the data entry for DEV-12941 "After October 1, 2025 (Fiscal Year 2026), PARK will be associated with specific program activity names on [USAspending.gov](http://usaspending.gov/). However, users will still be able to view PAC and PAN codes related to activities before Fiscal Year 2026."

**JIRA Ticket:**
[DEV-12941](https://federal-spending-transparency.atlassian.net/browse/DEV-12941)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-12941]: https://federal-spending-transparency.atlassian.net/browse/DEV-12941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ