### PR TITLE
DEV - 13114:  Active sort indicator is not working for Subaward Action Date column in Group By table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@storybook/addon-webpack5-compiler-babel": "^3.0.6",
         "react-hot-loader": "^4.8.2",
         "core-js": "^3.43.0",
-        "axios": "1.8.4",
+        "axios": "^1.8.4",
         "clean-webpack-plugin": "^4.0.0",
         "tunnel": "^0.0.6",
         "react-helmet": "^6.1.0",
@@ -37,7 +37,7 @@
         "streamx": "^2.17.0",
         "swiper": "^8.3.2",
         "react-copy-to-clipboard": "^5.0.1",
-        "postcss": "8.4.31",
+        "postcss": "^8.4.31",
         "file-loader": "^6.2.0",
         "d3": "^7.6.1",
         "date-fns": "^2.16.1",
@@ -62,7 +62,7 @@
         "react-router-dom": "^7.5.2",
         "history": "^4.6.1",
         "@fortawesome/fontawesome-svg-core": "^1.2.15",
-        "dompurify": "3.2.4",
+        "dompurify": "^3.2.4",
         "redux-perf-middleware": "^1.2.2",
         "react-frame-component": "^5.2.7",
         "bourbon": "^4.3.4",
@@ -148,7 +148,7 @@
         "webidl-conversions": "^6.1.0",
         "eslint-plugin-import": "^2.1.0",
         "is-extendable": "^1.0.1",
-        "trim-newlines": "4.0.2",
+        "trim-newlines": "^4.0.2",
         "storybook": "^8.6.14",
         "webpack-dev-server": "^5.2.0",
         "jest-util": "^29.7.0",
@@ -165,8 +165,8 @@
         "querystring-es3": "^0.2.1",
         "webpack-cli": "^5.1.4",
         "kind-of": "^6.0.3",
-        "browserify-sign": "4.2.2",
-        "glob-parent": "6.0.2",
+        "browserify-sign": "^4.2.2",
+        "glob-parent": "^6.0.2",
         "webpack-merge": "^6.0.1",
         "@babel/node": "^7.10.5",
         "@mdx-js/loader": "^2.1.5",
@@ -2333,7 +2333,7 @@
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "1.1.12"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"

--- a/src/js/components/search/table/tanStackTable/NestedTanStackTable.jsx
+++ b/src/js/components/search/table/tanStackTable/NestedTanStackTable.jsx
@@ -83,12 +83,17 @@ const NestedTanStackTable = (props) => {
         }
         newFilters.selectedAwardIDs.push(props.awardId);
 
+        let subSortField = subSort.field;
+        if (subSortField === 'Action Date' && props.columnType === "subawards") {
+            subSortField = 'Sub-Award Date';
+        }
+
         const params = {
             filters: newFilters.toParams(),
             fields: requestFields,
             page: subPage,
             limit: subResultsLimit,
-            sort: subSort.field,
+            sort: subSortField,
             order: subSort.direction,
             subawards: true,
             auditTrail: 'Results Table - Spending by award search'
@@ -175,6 +180,15 @@ const NestedTanStackTable = (props) => {
         }
     };
 
+    const formattedSubSort = () => {
+        const formattedSort = subSort;
+        if (formattedSort?.field === 'Sub-Award Date') {
+            formattedSort.field = "Action Date";
+        }
+
+        return formattedSort;
+    };
+
     useEffect(throttle(() => {
         // need to pull out of here to helper or up to Container lv
         if (props.columnType === "subawards") {
@@ -223,7 +237,7 @@ const NestedTanStackTable = (props) => {
                 error={error}
                 resultsCount={props.resultsCount}
                 updateSort={updateSort}
-                sort={subSort}
+                sort={formattedSubSort()}
                 page={subPage}
                 setPage={setSubPage}
                 resultsLimit={subResultsLimit}


### PR DESCRIPTION
**Description:**

Fix bug with Sub-award Date sort button highlight not displaying like all other sort indicator buttons with sub table.

**JIRA Ticket:**
[DEV-13114](https://federal-spending-transparency.atlassian.net/browse/DEV-13114)

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`

