### PR TITLE
DEV-13231: Adv Search 2.0: Style updates to filter menu close button and update bottom submit bar on mobil

### DIFF
--- a/src/_scss/pages/search/_collapsibleSidebar.scss
+++ b/src/_scss/pages/search/_collapsibleSidebar.scss
@@ -133,6 +133,7 @@
         margin: 0;
         stroke-width: rem(2);
         padding: 0;
+        padding-bottom: 20px;
         svg {
           width: rem(10);
           height: rem(10);
@@ -468,6 +469,7 @@
 
     .dsm-opened {
       display: block !important;
+      padding-bottom: 20px;
     }
 
   }

--- a/src/js/components/search/collapsibleSidebar/SidebarContent.jsx
+++ b/src/js/components/search/collapsibleSidebar/SidebarContent.jsx
@@ -93,7 +93,7 @@ const SidebarContent = ({
         }
     }, [windowWidth]);
 
-    const dsmElHeight = sidebarContentHeight + 51;
+    const dsmElHeight = sidebarContentHeight;
 
     const filtersArray = searchFilterCategoryTree.map((category) => (
         <div className="search-filters-list">

--- a/src/js/components/search/collapsibleSidebar/SidebarWrapper.jsx
+++ b/src/js/components/search/collapsibleSidebar/SidebarWrapper.jsx
@@ -38,7 +38,7 @@ const SidebarWrapper = React.memo(({
 
     const mainContentEl = document.querySelector("#main-content");
     const footerEl = document.querySelector("footer");
-    const sidebarStaticEls = 175;
+    const sidebarStaticEls = 190;
     const footerMargin = 0;
     const topStickyBarHeight = 60;
     const minContentHeight = 124;

--- a/src/js/components/search/collapsibleSidebar/SidebarWrapper.jsx
+++ b/src/js/components/search/collapsibleSidebar/SidebarWrapper.jsx
@@ -38,7 +38,7 @@ const SidebarWrapper = React.memo(({
 
     const mainContentEl = document.querySelector("#main-content");
     const footerEl = document.querySelector("footer");
-    const sidebarStaticEls = 155;
+    const sidebarStaticEls = 175;
     const footerMargin = 0;
     const topStickyBarHeight = 60;
     const minContentHeight = 124;


### PR DESCRIPTION
**Description:**
add 20px bottom padding to close button (x) and sidebar content height to ensure submit bottom bar fully shows on mobile.

**JIRA Ticket:**
[DEV-13231](https://federal-spending-transparency.atlassian.net/browse/DEV-13231)


The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`

