### PR TITLE
Hotfix:  Fixed Advanced Search legacy page charts to use transaction data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3108,9 +3108,9 @@
       }
     },
     "node_modules/lighthouse/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3372,9 +3372,9 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4054,9 +4054,9 @@
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4568,9 +4568,9 @@
       "dev": true
     },
     "node_modules/@babel/plugin-transform-modules-systemjs/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4693,10 +4693,11 @@
       }
     },
     "node_modules/proxy-agent/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -5989,10 +5990,11 @@
       }
     },
     "node_modules/pac-proxy-agent/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -7882,9 +7884,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9650,9 +9652,9 @@
       ]
     },
     "node_modules/@babel/helper-module-imports/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -12723,10 +12725,11 @@
       }
     },
     "node_modules/@lhci/server/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -21020,9 +21023,10 @@
       "dev": true
     },
     "node_modules/@babel/core/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },

--- a/src/js/containers/search/newResultsView/CategoriesVisualizationWrapperContainer.jsx
+++ b/src/js/containers/search/newResultsView/CategoriesVisualizationWrapperContainer.jsx
@@ -8,10 +8,11 @@ import PropTypes, { oneOfType } from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { isCancel } from 'axios';
-import { useSearchParams } from "react-router";
+import { useLocation, useSearchParams } from "react-router";
 import { max, get } from 'lodash-es';
 import * as searchFilterActions from 'redux/actions/search/searchFilterActions';
 import { setAppliedFilterCompletion } from 'redux/actions/search/appliedFilterActions';
+import GlobalConstants from 'GlobalConstants';
 
 import Analytics from 'helpers/analytics/Analytics';
 import * as SearchHelper from 'helpers/searchHelper';
@@ -64,6 +65,9 @@ const CategoriesVisualizationWrapperContainer = (props) => {
     const [tableRows, setTableRows] = useState([]);
     const [searchParams] = useSearchParams();
     let apiRequest;
+
+    const { pathname } = useLocation();
+    const isv2 = pathname === GlobalConstants.SEARCH_V2_PATH;
 
     const childProps = {
         spendingBy,
@@ -347,6 +351,14 @@ const CategoriesVisualizationWrapperContainer = (props) => {
         setError(false);
     };
 
+    // This function is necessary for the legacy search page.  The spending level must be transactions here.
+    const getSpendingLevel = (spendingLevel) => {
+        if (isv2) {
+            return spendingLevel;
+        }
+        return "transactions";
+    };
+
     const fetchData = () => {
         props.setAppliedFilterCompletion(false);
         setLoading(true);
@@ -378,8 +390,7 @@ const CategoriesVisualizationWrapperContainer = (props) => {
             limit: 10,
             page,
             auditTrail,
-            spending_level: props.spendingLevel
-
+            spending_level: getSpendingLevel(props.spendingLevel)
         };
 
         apiRequest = SearchHelper.performSpendingByCategorySearch(apiParams);

--- a/src/js/containers/search/newResultsView/CategoriesVisualizationWrapperContainer.jsx
+++ b/src/js/containers/search/newResultsView/CategoriesVisualizationWrapperContainer.jsx
@@ -353,7 +353,7 @@ const CategoriesVisualizationWrapperContainer = (props) => {
 
     // This function is necessary for the legacy search page.  The spending level must be transactions here.
     const getSpendingLevel = (spendingLevel) => {
-        if (isv2) {
+        if (isv2 || spendingLevel === "subawards") {
             return spendingLevel;
         }
         return "transactions";

--- a/src/js/containers/search/newResultsView/MapSectionWrapper.jsx
+++ b/src/js/containers/search/newResultsView/MapSectionWrapper.jsx
@@ -4,6 +4,8 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { isCancel } from 'axios';
 import { uniqueId, keyBy } from 'lodash-es';
+import { useLocation } from "react-router";
+import GlobalConstants from 'GlobalConstants';
 
 import * as searchFilterActions from 'redux/actions/search/searchFilterActions';
 import { setAppliedFilterCompletion } from 'redux/actions/search/appliedFilterActions';
@@ -84,6 +86,9 @@ const MapSectionWrapper = React.memo((props) => {
         wrapperError: false,
         wrapperNoData: false
     });
+
+    const { pathname } = useLocation();
+    const isv2 = pathname === GlobalConstants.SEARCH_V2_PATH;
 
     const [mapViewType, setMapViewType] = useState('chart');
     let apiRequest = null;
@@ -196,6 +201,14 @@ const MapSectionWrapper = React.memo((props) => {
         return false;
     };
 
+    // This function is necessary for the legacy search page.  The spending level must be transactions here.
+    const getSpendingLevel = (spendingLevel) => {
+        if (isv2) {
+            return spendingLevel;
+        }
+        return "transactions";
+    };
+
     const fetchData = () => {
         // build a new search operation from the Redux state, but create a transaction-based search
         // operation instead of an award-based one
@@ -230,7 +243,7 @@ const MapSectionWrapper = React.memo((props) => {
             geo_layer_filters: visibleEntities,
             filters: searchParams,
             auditTrail: 'Map Visualization',
-            spending_level: props.spendingLevel
+            spending_level: getSpendingLevel(props.spendingLevel)
         };
 
         if (apiRequest) {

--- a/src/js/containers/search/newResultsView/MapSectionWrapper.jsx
+++ b/src/js/containers/search/newResultsView/MapSectionWrapper.jsx
@@ -203,7 +203,7 @@ const MapSectionWrapper = React.memo((props) => {
 
     // This function is necessary for the legacy search page.  The spending level must be transactions here.
     const getSpendingLevel = (spendingLevel) => {
-        if (isv2) {
+        if (isv2 || spendingLevel === "subawards") {
             return spendingLevel;
         }
         return "transactions";

--- a/src/js/containers/search/newResultsView/TimeVisualizationSectionContainer.jsx
+++ b/src/js/containers/search/newResultsView/TimeVisualizationSectionContainer.jsx
@@ -230,6 +230,14 @@ const TimeVisualizationSectionContainer = (props) => {
         createTableRows(updatedTable);
     };
 
+    // This function is necessary for the legacy search page.  The spending level must be transactions here.
+    const getSpendingLevel = (spendingLevel) => {
+        if (isv2) {
+            return spendingLevel;
+        }
+        return "transactions";
+    };
+
     const fetchAwards = (auditTrail = null) => {
         const operation = new SearchAwardsOperation();
         operation.fromState(props.reduxFilters);
@@ -246,12 +254,8 @@ const TimeVisualizationSectionContainer = (props) => {
         const apiParams = {
             group: visualizationPeriod,
             filters: searchParams,
-            spending_level: props.spendingLevel
+            spending_level: getSpendingLevel(props.spendingLevel)
         };
-
-        if (isv2) {
-            apiParams.spending_level = props.spendingLevel;
-        }
 
         if (auditTrail) {
             apiParams.auditTrail = auditTrail;

--- a/src/js/containers/search/newResultsView/TimeVisualizationSectionContainer.jsx
+++ b/src/js/containers/search/newResultsView/TimeVisualizationSectionContainer.jsx
@@ -232,7 +232,7 @@ const TimeVisualizationSectionContainer = (props) => {
 
     // This function is necessary for the legacy search page.  The spending level must be transactions here.
     const getSpendingLevel = (spendingLevel) => {
-        if (isv2) {
+        if (isv2 || spendingLevel === "subawards") {
             return spendingLevel;
         }
         return "transactions";


### PR DESCRIPTION
**Description:**

This is a regression from https://github.com/fedspendingtransparency/usaspending-website/pull/4851.  The legacy advanced search charts must use transaction data when the filter by level is Prime Awards and Transactions.

**JIRA Ticket:**
https://data-transparency-bfs.slack.com/archives/CE892FN21/p1757938158735419
https://federal-spending-transparency.atlassian.net/browse/DEV-13453

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`

