### PR TITLE
DEV -15042 : Mobile - Profile pages breadcrumbs are not left-aligned vertically

### DIFF
--- a/src/_scss/components/_profileBackLink.scss
+++ b/src/_scss/components/_profileBackLink.scss
@@ -6,21 +6,17 @@
     display: flex;
     flex-direction: row;
     list-style-type: none;
-    margin: rem(20) auto;
-    margin-left: rem(4);
+    margin: rem(16) 0 0 rem(20);
     
-    @media(min-width: $tablet-screen) and (max-width: $large-screen - 1) {
-        margin-left: rem(-12);
-    }
     @media(min-width: $large-screen) {
-        padding: rem(8) 0;
-        margin-left: rem(8);
+        padding: rem(16) 0;
+        margin: 0 rem(40);
     }
     @media(min-width: $x-large-screen) {
+        margin: 0 auto;
         width: rem(1600);
-        margin-left: auto;
     }
-
+    
     .usa-profile-back-link__wrapper {
         display: inline-flex;
         gap: rem(4);
@@ -42,5 +38,23 @@
             aspect-ratio: 1/1;
             padding-right: rem(4);
         }
+    }
+
+    &.agency-profile {
+        margin: rem(20) auto;
+        margin-left: rem(4);
+        
+        @media(min-width: $tablet-screen) and (max-width: $large-screen - 1) {
+            margin-left: rem(-12);
+        }
+        @media(min-width: $large-screen) {
+            padding: rem(8) 0;
+            margin-left: rem(8);
+        }
+        @media(min-width: $x-large-screen) {
+            width: rem(1600);
+            margin-left: auto;
+        }
+    
     }
 }

--- a/src/_scss/components/_profileBackLink.scss
+++ b/src/_scss/components/_profileBackLink.scss
@@ -6,17 +6,20 @@
     display: flex;
     flex-direction: row;
     list-style-type: none;
-    margin: rem(16) 0 0 rem(20);
+    margin: rem(20) auto;
+    margin-left: rem(4);
     
+    @media(min-width: $tablet-screen) and (max-width: $large-screen - 1) {
+        margin-left: rem(-12);
+    }
     @media(min-width: $large-screen) {
-        padding: rem(16) 0;
-        margin: 0 rem(40);
+        padding: rem(8) 0;
+        margin-left: rem(8);
     }
     @media(min-width: $x-large-screen) {
-        margin: 0 auto;
         width: rem(1600);
+        margin-left: auto;
     }
-    
 
     .usa-profile-back-link__wrapper {
         display: inline-flex;

--- a/src/js/components/agency/AgencyPage.jsx
+++ b/src/js/components/agency/AgencyPage.jsx
@@ -166,6 +166,7 @@ export const AgencyProfileV2 = ({
             ]}>
             <main id="main-content" className="main-content usda__flex-row">
                 <ProfileBackLink
+                    className="agency-profile"
                     label="Back to Agency Profile Page"
                     url="/agency" />
                 <div className="body usda__flex-col">

--- a/src/js/components/sharedComponents/ProfileBackLink.jsx
+++ b/src/js/components/sharedComponents/ProfileBackLink.jsx
@@ -10,11 +10,12 @@ import PropTypes from 'prop-types';
 
 const propTypes = {
     label: PropTypes.string,
-    url: PropTypes.string
+    url: PropTypes.string,
+    className: PropTypes.string
 };
 
-const ProfileBackLink = ({ label, url }) => (
-    <div className="usa-profile-back-link__container">
+const ProfileBackLink = ({ label, url, className = "" }) => (
+    <div className={`usa-profile-back-link__container ${className}`}>
         <div className="usa-profile-back-link__wrapper">
             <Link
                 to={url}


### PR DESCRIPTION
**Description:**

Update styling to left-align vertically with in-Page Nav for various break-points 

**JIRA Ticket:**
[DEV-15402](https://federal-spending-transparency.atlassian.net/browse/DEV-15402)

**Mockup:**
https://figma-gov.com/design/kISPhhxFlnn8sui2xohJUw/USAS-%E2%80%93-Agency?node-id=449-939&m=dev

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`

