### PR TITLE
15056 - State Profile, updating top five and spending over time tanstack query code

### DIFF
--- a/src/js/features/state/topFive/containers/TopFiveContainer.jsx
+++ b/src/js/features/state/topFive/containers/TopFiveContainer.jsx
@@ -3,12 +3,10 @@
  * Created by Kevin Li 5/15/18
  */
 
-import React, { useCallback, useMemo, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from "prop-types";
 
-import { getTrailingTwelveMonths, convertFYToDateRange } from 'helpers/fiscalYearHelper';
-import { awardTypeGroups } from 'dataMapping/search/awardType';
 import TopFive from "components/sharedComponents/TopFive";
 import useFetchSpendingBy from "./useFetchSpendingBy";
 
@@ -25,74 +23,9 @@ const TopFiveContainer = ({ category, type, agencyData }) => {
 
     const { code, _totalAmount: total } = overview;
 
-    const getDataParams = useCallback(() => {
-        let timePeriod = null;
-        if (fy === 'latest') {
-            const trailing = getTrailingTwelveMonths();
-            timePeriod = {
-                start_date: trailing[0],
-                end_date: trailing[1]
-            };
-        }
-        else if (fy !== 'all' && fy) {
-            const range = convertFYToDateRange(parseInt(fy, 10));
-            timePeriod = {
-                start_date: range[0],
-                end_date: range[1]
-            };
-        }
-
-        const filters = {
-            place_of_performance_scope: 'domestic',
-            place_of_performance_locations: [
-                {
-                    country: 'USA',
-                    state: code
-                }
-            ]
-        };
-
-        if (timePeriod) {
-            filters.time_period = [timePeriod];
-        }
-
-        // Tab selection
-        if (type !== 'all' && awardTypeGroups[type]) {
-            filters.award_type_codes = awardTypeGroups[type];
-        }
-
-        const params = {
-            filters,
-            category,
-            limit: 5,
-            page: 1
-        };
-
-        if (category === 'awards') {
-            filters.award_type_codes = ['A', 'B', 'C', 'D'];
-            params.fields = ['Award ID', 'Award Amount', 'generated_internal_id'];
-            params.order = 'desc';
-            params.sort = 'Award Amount';
-            params.spending_level = 'awards';
-        }
-
-        if (category === 'defc') {
-            params.spending_level = 'award_financial';
-            params.filters = {
-                def_codes: ["L", "M", "N", "O", "P", "U", "V", "Z", "1"],
-                ...filters
-            };
-        }
-
-        return params;
-    }, [category, code, fy, type]);
-
-    const dataParams = useMemo(() => getDataParams(), [getDataParams]);
-
-
     const {
-        parsedData, noResults, isSuccess, isLoading, error
-    } = useFetchSpendingBy(dataParams, category, code, fy);
+        parsedData, noResults, isSuccess, isLoading, error, dataParams
+    } = useFetchSpendingBy(category, code, fy, type);
 
     useEffect(() => {
         if (isSuccess && (noResults || parsedData?.length > 0)) {

--- a/src/js/features/state/topFive/containers/useFetchSpendingBy.jsx
+++ b/src/js/features/state/topFive/containers/useFetchSpendingBy.jsx
@@ -3,14 +3,80 @@
  * Created by Andrea Blackwell 03/19/26
  */
 
-import { useState, useEffect } from "react";
-import { useMutation } from '@tanstack/react-query';
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useQuery } from '@tanstack/react-query';
 import { performSpendingByAwardSearch, performSpendingByCategorySearch } from "helpers/searchHelper";
 import BaseStateCategoryResult from "models/v2/state/BaseStateCategoryResult";
+import { convertFYToDateRange, getTrailingTwelveMonths } from "../../../../helpers/fiscalYearHelper";
+import { awardTypeGroups } from "../../../../dataMapping/search/awardType";
 
-export const useFetchSpendingBy = (apiParams, category, code, fy) => {
+export const useFetchSpendingBy = (category, code, fy, type) => {
     const [parsedData, setParsedData] = useState(null);
     const [noResults, setNoResults] = useState(false);
+
+    const getDataParams = useCallback(() => {
+        let timePeriod = null;
+        if (fy === 'latest') {
+            const trailing = getTrailingTwelveMonths();
+            timePeriod = {
+                start_date: trailing[0],
+                end_date: trailing[1]
+            };
+        }
+        else if (fy !== 'all' && fy) {
+            const range = convertFYToDateRange(parseInt(fy, 10));
+            timePeriod = {
+                start_date: range[0],
+                end_date: range[1]
+            };
+        }
+
+        const filters = {
+            place_of_performance_scope: 'domestic',
+            place_of_performance_locations: [
+                {
+                    country: 'USA',
+                    state: code
+                }
+            ]
+        };
+
+        if (timePeriod) {
+            filters.time_period = [timePeriod];
+        }
+
+        // Tab selection
+        if (type !== 'all' && awardTypeGroups[type]) {
+            filters.award_type_codes = awardTypeGroups[type];
+        }
+
+        const params = {
+            filters,
+            category,
+            limit: 5,
+            page: 1
+        };
+
+        if (category === 'awards') {
+            filters.award_type_codes = ['A', 'B', 'C', 'D'];
+            params.fields = ['Award ID', 'Award Amount', 'generated_internal_id'];
+            params.order = 'desc';
+            params.sort = 'Award Amount';
+            params.spending_level = 'awards';
+        }
+
+        if (category === 'defc') {
+            params.spending_level = 'award_financial';
+            params.filters = {
+                def_codes: ["L", "M", "N", "O", "P", "U", "V", "Z", "1"],
+                ...filters
+            };
+        }
+
+        return params;
+    }, [category, code, fy, type]);
+
+    const dataParams = useMemo(() => getDataParams(), [getDataParams]);
 
     const parseData = (res) => {
         if (!res) {
@@ -58,29 +124,26 @@ export const useFetchSpendingBy = (apiParams, category, code, fy) => {
     };
 
     const {
-        mutate, isSuccess, isPending, error
-    } = useMutation({
-        mutationKey: [`spendingBy${category}${code}${fy}`],
-        mutationFn: () => {
+        data, isSuccess, isLoading, error
+    } = useQuery({
+        queryKey: [`spendingBy${category}${type}${code}${fy}`],
+        queryFn: () => {
             if (category === 'awards') {
-                return performSpendingByAwardSearch(apiParams).promise;
+                return performSpendingByAwardSearch(dataParams).promise;
             }
-            return performSpendingByCategorySearch(apiParams).promise;
-        },
-        onSuccess: (data) => {
-            parseData(data?.data);
+            return performSpendingByCategorySearch(dataParams).promise;
         },
         staleTime: 60000
     });
 
     useEffect(() => {
-        if (code && category) {
-            mutate();
+        if (isSuccess && Object.keys(data?.data).length > 0) {
+            parseData(data?.data);
         }
-    }, [code, mutate, category, apiParams]);
+    }, [data, isSuccess]);
 
     return {
-        parsedData, noResults, isSuccess, isLoading: isPending, error
+        parsedData, noResults, isSuccess, isLoading, error, dataParams
     };
 };
 

--- a/src/js/features/state/topFive/containers/useFetchSpendingBy.jsx
+++ b/src/js/features/state/topFive/containers/useFetchSpendingBy.jsx
@@ -133,6 +133,7 @@ export const useFetchSpendingBy = (category, code, fy, type) => {
             }
             return performSpendingByCategorySearch(dataParams).promise;
         },
+        enabled: !!(dataParams && code && type && fy),
         staleTime: 60000
     });
 

--- a/src/js/features/state/transactionsOverTime/containers/StateTimeVisualizationSectionContainer.jsx
+++ b/src/js/features/state/transactionsOverTime/containers/StateTimeVisualizationSectionContainer.jsx
@@ -7,7 +7,6 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import StateTimeVisualizationSection from '../StateTimeVisualizationSection';
 import useFetchSpendingOverTime from "./useFetchSpendingOverTime";
-import { createApiParams } from "../../stateHelper";
 
 const StateTimeVisualizationSectionContainer = () => {
     const { code } = useSelector((state) => state.stateProfile.overview);
@@ -18,22 +17,14 @@ const StateTimeVisualizationSectionContainer = () => {
     const [combined, setCombined] = useState([]);
     const [combinedOutlay, setCombinedOutlay] = useState();
     const [ySeriesOutlay, setYSeriesOutlay] = useState([]);
-    const [apiSearchParams, setApiSearchParams] = useState(null);
 
     const {
         parsedData, isSuccess, isLoading, error
-    } = useFetchSpendingOverTime(apiSearchParams, visualizationPeriod, code);
+    } = useFetchSpendingOverTime(visualizationPeriod, code);
 
     const updateVisualizationPeriod = (newVizPeriod) => {
         setVisualizationPeriod(newVizPeriod);
     };
-
-    useEffect(() => {
-        // don't run fetch unless we have a state code
-        if (code && visualizationPeriod) {
-            setApiSearchParams(createApiParams(code, visualizationPeriod));
-        }
-    }, [code, visualizationPeriod]);
 
     useEffect(() => {
         if (isSuccess && parsedData && Object.keys(parsedData).length > 0) {
@@ -45,7 +36,7 @@ const StateTimeVisualizationSectionContainer = () => {
             setYSeries(parsedData.ySeriesLocal);
             setYSeriesOutlay(parsedData.ySeriesOutlayLocal);
         }
-    }, [parsedData]);
+    }, [isSuccess, parsedData]);
 
     return (
         <StateTimeVisualizationSection

--- a/src/js/features/state/transactionsOverTime/containers/useFetchSpendingOverTime.jsx
+++ b/src/js/features/state/transactionsOverTime/containers/useFetchSpendingOverTime.jsx
@@ -79,7 +79,8 @@ export const useFetchSpendingOverTime = (visualizationPeriod, code) => {
         if (isSuccess && Object.keys(data?.data).length > 0) {
             parseData(data?.data);
         }
-    }, [data, isSuccess, parseData]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [data, isSuccess]);
 
     return {
         parsedData, isSuccess, isLoading, error

--- a/src/js/features/state/transactionsOverTime/containers/useFetchSpendingOverTime.jsx
+++ b/src/js/features/state/transactionsOverTime/containers/useFetchSpendingOverTime.jsx
@@ -7,20 +7,13 @@ import { useCallback, useState, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { performSpendingOverTimeSearch } from "helpers/searchHelper";
 import { convertMonthToFY, convertNumToShortMonth } from "helpers/monthHelper";
+import { createApiParams } from "../../stateHelper";
 
-export const useFetchSpendingOverTime = (apiParams, visualizationPeriod, code) => {
+export const useFetchSpendingOverTime = (visualizationPeriod, code) => {
     const [parsedData, setParsedData] = useState(null);
 
-    const {
-        data, isSuccess, isLoading, error
-    } = useQuery({
-        queryKey: [`spendingOverTimeSearch${code}${visualizationPeriod}`],
-        queryFn: () => performSpendingOverTimeSearch(apiParams).promise,
-        enabled: !!apiParams,
-        staleTime: 60000
-    });
 
-    const generateTime = (group, timePeriod, type) => {
+    const generateTime = useCallback((group, timePeriod, type) => {
         const month = convertNumToShortMonth(timePeriod.month);
         const year = convertMonthToFY(timePeriod.month, timePeriod.fiscal_year);
 
@@ -35,7 +28,7 @@ export const useFetchSpendingOverTime = (apiParams, visualizationPeriod, code) =
                 { period: `Q${timePeriod.quarter}`, year: `${timePeriod.fiscal_year}` };
         }
         return type === 'label' ? `${month} ${year}` : { period: `${month}`, year: `${year}` };
-    };
+    });
 
     const parseData = useCallback((res) => {
         const groupsLocal = [];
@@ -71,7 +64,16 @@ export const useFetchSpendingOverTime = (apiParams, visualizationPeriod, code) =
             combinedOutlayLocal,
             ySeriesOutlayLocal
         });
-    }, [visualizationPeriod]);
+    }, [generateTime, visualizationPeriod]);
+
+    const {
+        data, isSuccess, isLoading, error
+    } = useQuery({
+        queryKey: [`spendingOverTimeSearch${code}${visualizationPeriod}`],
+        queryFn: () => performSpendingOverTimeSearch(createApiParams(code, visualizationPeriod)).promise,
+        enabled: !!(code && visualizationPeriod),
+        staleTime: 60000
+    });
 
     useEffect(() => {
         if (isSuccess && Object.keys(data?.data).length > 0) {


### PR DESCRIPTION
**Description:**

Fixed issue with change the time period on the State Profile Transaction over Time chart.  Issue was found while testing.   Also switched top five container component from Tanstack useMutation to useQuery.  useMutation doesn't cache according to the mutationKey like queryKey.  useQuery ended up being the better choice.

**JIRA Ticket:**
[DEV-15056](https://federal-spending-transparency.atlassian.net/browse/DEV-15056)

**Mockup:**
https://figma-gov.com/

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-15056]: https://federal-spending-transparency.atlassian.net/browse/DEV-15056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ