### PR TITLE
DEV-13786 display dashes instead of blank spaces on keyword search

### DIFF
--- a/src/js/components/keyword/table/ResultsTable.jsx
+++ b/src/js/components/keyword/table/ResultsTable.jsx
@@ -75,7 +75,7 @@ export default class ResultsTable extends React.Component {
         const props = {
             rowIndex,
             columnIndex,
-            value: this.props.results[rowIndex][columnId],
+            value: this.props.results[rowIndex][columnId] || '--',
             dataType: keywordTableColumnTypes[columnId]
         };
 


### PR DESCRIPTION
**Description:**
keyword search table is displaying blank spaces instead of two dashes

**JIRA Ticket:**
[DEV-13786](https://federal-spending-transparency.atlassian.net/browse/DEV-13786)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-13786]: https://federal-spending-transparency.atlassian.net/browse/DEV-13786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ