### PR TITLE
DEV -14939 : In mobile, in-page nav in hidden on State and Recipient profiles after scrolling

### DIFF
--- a/src/_scss/pages/agency/index.scss
+++ b/src/_scss/pages/agency/index.scss
@@ -14,6 +14,11 @@
   min-height: 100vh;
   width: 100%;
 
+  @media (max-width: $medium-screen) {
+    .usda-in-page-nav__container {
+      top: 121px;
+    }
+  }
   .site-header,
   .usda-page__container,
   .main-content,

--- a/src/_scss/pages/data-sources/index.scss
+++ b/src/_scss/pages/data-sources/index.scss
@@ -5,6 +5,12 @@
 
   $color-gray-border: $color-gray-lighter;
 
+  @media (max-width: $medium-screen) {
+    .usda-in-page-nav__container {
+      top: 121px;
+    }
+  }
+  
   .main-content {
     @import "../../mixins/fullSectionWrap";
     @include fullSectionWrap(($global-margin * 4), ($global-margin * 4));

--- a/src/_scss/pages/interactiveDataSources/index.scss
+++ b/src/_scss/pages/interactiveDataSources/index.scss
@@ -21,6 +21,12 @@
     width: 100%;
   }
 
+  @media (max-width: $medium-screen) {
+    .usda-in-page-nav__container {
+      top: 121px;
+    }
+  }
+  
   .main-content {
     justify-content: center;
     margin: auto;

--- a/src/_scss/pages/recipient/recipientPage.scss
+++ b/src/_scss/pages/recipient/recipientPage.scss
@@ -30,6 +30,12 @@
     width: 100%;
   }
 
+  @media (max-width: $medium-screen) {
+    .usda-in-page-nav__container {
+      top: 121px;
+    }
+  }
+
   .topfive .topfive__content .category-table .category-table__title {
     height: unset;
   }

--- a/src/_scss/pages/state/statePage.scss
+++ b/src/_scss/pages/state/statePage.scss
@@ -28,6 +28,13 @@
     width: 100%;
   }
 
+  
+  @media (max-width: $medium-screen) {
+    .usda-in-page-nav__container {
+      top: 121px;
+    }
+  }
+
   .main-content {
     //@import "../../mixins/fullSectionWrap";
     //@include fullSectionWrap(0,0);


### PR DESCRIPTION
**Description:**
update top css for inPage Nav for all pages where the top sticky header changes from 1 line to 2.  

**JIRA Ticket:**
[DEV-14939](https://federal-spending-transparency.atlassian.net/browse/DEV-14939)

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-14939]: https://federal-spending-transparency.atlassian.net/browse/DEV-14939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ