### PR TITLE
Mod/dev 15035 Restyle Several Custom Award Download Filters

### DIFF
--- a/src/_scss/core/_variables.scss
+++ b/src/_scss/core/_variables.scss
@@ -118,6 +118,7 @@ $gray-2: #f9f9f9;
 $gray-10: #e6e6e6;
 $gray-20: #c9c9c9;
 $gray-cool-30: #a9aeb1;
+$gray-70: #454545;
 $gray-80: #2e2e2e;
 $gray-90: #1b1b1b;
 $gray-cool-50: #71767a;

--- a/src/_scss/pages/bulkDownload/form/downloadForm.scss
+++ b/src/_scss/pages/bulkDownload/form/downloadForm.scss
@@ -282,11 +282,17 @@
         &:last-of-type {
           width: stretch;
         }
+
+        label {
+          display: flex;
+        }
       }
 
       input[type="checkbox"] {
         @include usa-input-checkbox;
 
+        height: rem(16);
+        width: rem(16);
         margin-right: $global-margin;
         border: rem(2) solid $gray-70;
         border-radius: rem(4);

--- a/src/_scss/pages/bulkDownload/form/downloadForm.scss
+++ b/src/_scss/pages/bulkDownload/form/downloadForm.scss
@@ -167,11 +167,22 @@
 
     .download-filter__unordered-list {
       list-style-type: none;
-      margin-top: 0;
       color: $gray-90;
+      display: flex;
+      margin: 0;
+      padding: 0;
 
       li {
         list-style-type: none;
+
+        &:first-of-type {
+          // 3 of 8 columns available to the form
+          min-width: 37.5%;
+        }
+
+        &:last-of-type {
+          width: stretch;
+        }
       }
 
       input {

--- a/src/_scss/pages/bulkDownload/form/downloadForm.scss
+++ b/src/_scss/pages/bulkDownload/form/downloadForm.scss
@@ -104,13 +104,13 @@
             color: $gray-90;
 
             input {
-              margin: 0 $global-margin 0 0;
-              height: rem(24);
-              min-width: rem(24);
+              margin: rem(2) $global-margin 0 0;
+              height: rem(20);
+              min-width: rem(20);
 
               &:before {
-                height: rem(18);
-                width: rem(18);
+                height: rem(14);
+                width: rem(14);
               }
 
               &:checked {
@@ -150,13 +150,13 @@
             color: $gray-90;
 
             input {
-              margin: 0 $global-margin 0 0;
-              height: rem(24);
-              min-width: rem(24);
+              margin: rem(2) $global-margin 0 0;
+              height: rem(20);
+              min-width: rem(20);
 
               &:before {
-                height: rem(18);
-                width: rem(18);
+                height: rem(14);
+                width: rem(14);
               }
 
               &:checked {

--- a/src/_scss/pages/bulkDownload/form/downloadForm.scss
+++ b/src/_scss/pages/bulkDownload/form/downloadForm.scss
@@ -127,6 +127,34 @@
         }
       }
 
+      &.file-type {
+        display: flex;
+        padding: 0;
+
+        .radio {
+          padding: 0;
+          margin: 0 ($global-margin * 3) 0 0;
+
+          label {
+            display: flex;
+            font-size: $base-font-size;
+            line-height: 1.5;
+            color: $gray-90;
+
+            input {
+              margin: 0 $global-margin 0 0;
+              height: rem(24);
+              min-width: rem(24);
+
+              &:before {
+                height: rem(18);
+                width: rem(18);
+              }
+            }
+          }
+        }
+      }
+
       input[type="checkbox"] {
         @include usa-input-checkbox;
       }

--- a/src/_scss/pages/bulkDownload/form/downloadForm.scss
+++ b/src/_scss/pages/bulkDownload/form/downloadForm.scss
@@ -271,6 +271,17 @@
 
         border: rem(2) solid $gray-70;
         border-radius: rem(4);
+
+        &:indeterminate {
+          background-color: $blue-50;
+          border-color: $blue-50;
+        }
+
+        &:indeterminate:before {
+          width: rem(10);
+          margin: rem(6) auto;
+          border-bottom: rem(2) solid #fff;
+        }
       }
     }
     @import "agencyPicker";

--- a/src/_scss/pages/bulkDownload/form/downloadForm.scss
+++ b/src/_scss/pages/bulkDownload/form/downloadForm.scss
@@ -73,11 +73,58 @@
         padding-left: rem(30);
         width: 96%;
       }
+
       .radio {
         input[type="radio"] {
           @include usa-input-radio;
         }
       }
+
+      &.date-type {
+        display: flex;
+        padding: 0;
+
+        .radio {
+          padding: 0;
+
+          &:first-of-type {
+            // 3 of 8 columns available to the form
+            min-width: 37.5%;
+          }
+
+          &:last-of-type {
+            width: stretch;
+          }
+
+          label {
+            display: flex;
+            font-size: $base-font-size;
+            font-weight: $font-semibold;
+            line-height: 1.5;
+            color: $gray-90;
+
+            input {
+              margin: 0 $global-margin 0 0;
+              height: rem(24);
+              min-width: rem(24);
+
+              &:before {
+                height: rem(18);
+                width: rem(18);
+              }
+            }
+
+            .radio-description {
+              font-size: $base-font-size;
+              font-weight: normal;
+              color: $gray-60;
+              font-style: normal;
+              margin: 0;
+            }
+          }
+        }
+      }
+
       input[type="checkbox"] {
         @include usa-input-checkbox;
       }

--- a/src/_scss/pages/bulkDownload/form/downloadForm.scss
+++ b/src/_scss/pages/bulkDownload/form/downloadForm.scss
@@ -251,6 +251,12 @@
 
       li {
         list-style-type: none;
+        margin-bottom: rem(12);
+
+        ul {
+          margin: rem(12) 0 0 rem(32);
+          padding: 0;
+        }
 
         &:first-of-type {
           // 3 of 8 columns available to the form
@@ -262,13 +268,10 @@
         }
       }
 
-      input {
-        margin-right: $global-margin;
-      }
-
       input[type="checkbox"] {
         @include usa-input-checkbox;
 
+        margin-right: $global-margin;
         border: rem(2) solid $gray-70;
         border-radius: rem(4);
 

--- a/src/_scss/pages/bulkDownload/form/downloadForm.scss
+++ b/src/_scss/pages/bulkDownload/form/downloadForm.scss
@@ -112,6 +112,14 @@
                 height: rem(18);
                 width: rem(18);
               }
+
+              &:checked {
+                border-color: $blue-60v;
+
+                &:before {
+                  background-color: $blue-60v;
+                }
+              }
             }
 
             .radio-description {
@@ -149,6 +157,14 @@
               &:before {
                 height: rem(18);
                 width: rem(18);
+              }
+
+              &:checked {
+                  border-color: $blue-60v;
+
+                &:before {
+                  background-color: $blue-60v;
+                }
               }
             }
           }
@@ -276,8 +292,13 @@
         border-radius: rem(4);
 
         &:indeterminate {
-          background-color: $blue-50;
-          border-color: $blue-50;
+          background-color: $blue-60v;
+          border-color: $blue-60v;
+        }
+
+        &:checked {
+          background-color: $blue-60v;
+          border-color: $blue-60v;
         }
 
         &:indeterminate:before {

--- a/src/_scss/pages/bulkDownload/form/downloadForm.scss
+++ b/src/_scss/pages/bulkDownload/form/downloadForm.scss
@@ -164,17 +164,25 @@
         margin-right: rem(5);
       }
     }
+
     .download-filter__unordered-list {
       list-style-type: none;
       margin-top: 0;
+      color: $gray-90;
+
       li {
         list-style-type: none;
       }
+
       input {
-        margin-right: rem(5);
+        margin-right: $global-margin;
       }
+
       input[type="checkbox"] {
         @include usa-input-checkbox;
+
+        border: rem(2) solid $gray-70;
+        border-radius: rem(4);
       }
     }
     @import "agencyPicker";

--- a/src/_scss/pages/bulkDownload/form/downloadForm.scss
+++ b/src/_scss/pages/bulkDownload/form/downloadForm.scss
@@ -120,6 +120,8 @@
               color: $gray-60;
               font-style: normal;
               margin: 0;
+              width: 100%;
+              padding-right: rem(24);
             }
           }
         }

--- a/src/js/components/bulkDownload/awards/AwardDataContent.jsx
+++ b/src/js/components/bulkDownload/awards/AwardDataContent.jsx
@@ -126,11 +126,7 @@ const AwardDataContent = ({
                         currentLocation={awards.location}
                         updateFilter={updateFilter}
                         currentLocationType={awards.locationType} />
-                    <DateTypeFilter
-                        dateTypes={awardDownloadOptions.dateTypes}
-                        currentDateType={awards.dateType}
-                        updateFilter={updateFilter}
-                        valid={awards.dateType !== ''} />
+                    <DateTypeFilter updateFilter={updateFilter} />
                     <TimePeriodFilter
                         updateStartDate={updateStartDate}
                         updateEndDate={updateEndDate}

--- a/src/js/components/bulkDownload/awards/AwardDataContent.jsx
+++ b/src/js/components/bulkDownload/awards/AwardDataContent.jsx
@@ -90,13 +90,6 @@ const AwardDataContent = ({
         agency: awards.agency,
         subAgency: awards.subAgency
     };
-
-    const awardTypeLabels = Object.assign(
-        {},
-        ...Object.entries(awardDownloadOptions.awardTypeLookups)
-            .map(([key, value]) => ({ [key]: value.label }))
-    );
-
     return (
         <div className="download-center">
             <div className="download-center__filters">
@@ -122,9 +115,6 @@ const AwardDataContent = ({
                     className="download-center-form"
                     onSubmit={handleSubmit}>
                     <AwardLevelAndTypeFilter
-                        awardLevels={awardDownloadOptions.awardLevels}
-                        awardTypeLabels={awardTypeLabels}
-                        currentAwardTypes={awards.awardTypes}
                         bulkAwardTypeChange={bulkAwardTypeChange}
                         toggleAwardTypeChange={toggleAwardTypeChange} />
                     <AgencyFilter

--- a/src/js/components/bulkDownload/awards/AwardDataContent.jsx
+++ b/src/js/components/bulkDownload/awards/AwardDataContent.jsx
@@ -134,11 +134,7 @@ const AwardDataContent = ({
                         setValidDates={setValidDates}
                         filterTimePeriodStart={awards.dateRange.startDate}
                         filterTimePeriodEnd={awards.dateRange.endDate} />
-                    <FileFormatFilter
-                        fileFormats={awardDownloadOptions.fileFormats}
-                        currentFileFormat={awards.fileFormat}
-                        updateFilter={updateFilter}
-                        valid={awards.fileFormat !== ''} />
+                    <FileFormatFilter updateFilter={updateFilter} />
                     { isTablet && <AwardsUserSelections />}
                     <SubmitButton
                         filters={awards}

--- a/src/js/components/bulkDownload/awards/AwardDataContent.jsx
+++ b/src/js/components/bulkDownload/awards/AwardDataContent.jsx
@@ -31,9 +31,7 @@ const propTypes = {
     subAgencies: PropTypes.array,
     setSubAgencyList: PropTypes.func,
     states: PropTypes.array,
-    clickedDownload: PropTypes.func,
-    bulkAwardTypeChange: PropTypes.func,
-    toggleAwardTypeChange: PropTypes.func
+    clickedDownload: PropTypes.func
 };
 
 const AwardDataContent = ({
@@ -46,9 +44,7 @@ const AwardDataContent = ({
     subAgencies,
     setSubAgencyList,
     states,
-    clickedDownload,
-    bulkAwardTypeChange,
-    toggleAwardTypeChange
+    clickedDownload
 }) => {
     const { isTablet } = useContext(IsMobileContext);
     const [validDates, setValidDates] = useState(false);
@@ -114,9 +110,7 @@ const AwardDataContent = ({
                 <form
                     className="download-center-form"
                     onSubmit={handleSubmit}>
-                    <AwardLevelAndTypeFilter
-                        bulkAwardTypeChange={bulkAwardTypeChange}
-                        toggleAwardTypeChange={toggleAwardTypeChange} />
+                    <AwardLevelAndTypeFilter />
                     <AgencyFilter
                         currentAgencyType={awards.agencyType}
                         agencyTypes={awardDownloadOptions.agencyTypes}

--- a/src/js/components/bulkDownload/awards/filters/AwardLevelAndTypeFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/AwardLevelAndTypeFilter.jsx
@@ -3,23 +3,34 @@
  * Created by Seth Stoudenmier 03/01/20
  */
 
-import React from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from "react-redux";
 import { CheckCircle, ExclamationCircle } from 'components/sharedComponents/icons/Icons';
-import PrimaryCheckboxType from '../../../sharedComponents/checkbox/PrimaryCheckboxType';
+import { awardDownloadOptions } from 'dataMapping/bulkDownload/bulkDownloadOptions';
+import PrimaryCheckboxType from 'components/sharedComponents/checkbox/PrimaryCheckboxType';
+
+const awardTypeLabels = Object.assign(
+    {},
+    ...Object.entries(awardDownloadOptions.awardTypeLookups)
+        .map(([key, value]) => ({ [key]: value.label }))
+);
 
 const propTypes = {
-    awardLevels: PropTypes.array,
-    awardTypeLabels: PropTypes.object,
-    currentAwardTypes: PropTypes.object,
     bulkAwardTypeChange: PropTypes.func,
     toggleAwardTypeChange: PropTypes.func
 };
 
-const AwardLevelAndTypeFilter = (props) => {
+// eslint-disable-next-line prefer-arrow-callback
+const AwardLevelAndTypeFilter = memo(function AwardLevelAndTypeFilter({
+    bulkAwardTypeChange,
+    toggleAwardTypeChange
+}) {
+    const currentAwardTypes = useSelector((state) => state.bulkDownload.awards.awardTypes);
+
     const isValid = (
-        props.currentAwardTypes.primeAwards.size > 0 ||
-        props.currentAwardTypes.subAwards.size > 0
+        currentAwardTypes.primeAwards.size > 0 ||
+        currentAwardTypes.subAwards.size > 0
     );
 
     let icon = (
@@ -36,26 +47,34 @@ const AwardLevelAndTypeFilter = (props) => {
         );
     }
 
-    const awardLevelCheckboxes = props.awardLevels
-        .map((type, index) => {
-            const selectedAwardTypes = props.currentAwardTypes[type.lookupName];
+    const awardLevelCheckboxes = awardDownloadOptions.awardLevels
+        .map(({
+            id, name, lookupName, filters
+        }) => {
+            const selectedAwardTypes = currentAwardTypes[lookupName];
 
-            return (<PrimaryCheckboxType
-                {...type}
-                {...props}
-                key={index}
-                types={props.awardTypeLabels}
-                filterType="BulkDownload"
-                isCollapsable={false}
-                arrowState="expanded"
-                selectedCheckboxes={selectedAwardTypes}
-                bulkTypeChange={props.bulkAwardTypeChange}
-                toggleCheckboxType={props.toggleAwardTypeChange} />);
+            return (
+                <PrimaryCheckboxType
+                    id={id}
+                    name={name}
+                    lookupName={lookupName}
+                    filters={filters}
+                    filterType="BulkDownload"
+                    types={awardTypeLabels}
+                    arrowState="expanded"
+                    selectedCheckboxes={selectedAwardTypes}
+                    isCollapsable={false}
+                    bulkTypeChange={bulkAwardTypeChange}
+                    toggleCheckboxType={toggleAwardTypeChange}
+                    key={`award-type__${id}`} />
+            );
         });
     return (
         <div className="download-filter">
             <h3 className="download-filter__title">
-                {icon} Select the <span className="download-filter__title_em">award types</span> to include.
+                {icon} Select the
+                <span className="download-filter__title_em"> award types </span>
+                to include.
             </h3>
             <div className="checkbox-type-filter">
                 <div className="filter-item-wrap">
@@ -66,7 +85,7 @@ const AwardLevelAndTypeFilter = (props) => {
             </div>
         </div>
     );
-};
+});
 
 AwardLevelAndTypeFilter.propTypes = propTypes;
 export default AwardLevelAndTypeFilter;

--- a/src/js/components/bulkDownload/awards/filters/AwardLevelAndTypeFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/AwardLevelAndTypeFilter.jsx
@@ -4,7 +4,6 @@
  */
 
 import React, { memo } from 'react';
-import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from "react-redux";
 
 import { awardDownloadOptions } from 'dataMapping/bulkDownload/bulkDownloadOptions';
@@ -19,11 +18,6 @@ const awardTypeLabels = Object.assign(
     ...Object.entries(awardDownloadOptions.awardTypeLookups)
         .map(([key, value]) => ({ [key]: value.label }))
 );
-
-const propTypes = {
-    bulkAwardTypeChange: PropTypes.func,
-    toggleAwardTypeChange: PropTypes.func
-};
 
 // eslint-disable-next-line prefer-arrow-callback
 const AwardLevelAndTypeFilter = memo(function AwardLevelAndTypeFilter() {
@@ -92,5 +86,4 @@ const AwardLevelAndTypeFilter = memo(function AwardLevelAndTypeFilter() {
     );
 });
 
-AwardLevelAndTypeFilter.propTypes = propTypes;
 export default AwardLevelAndTypeFilter;

--- a/src/js/components/bulkDownload/awards/filters/AwardLevelAndTypeFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/AwardLevelAndTypeFilter.jsx
@@ -5,9 +5,13 @@
 
 import React, { memo } from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from "react-redux";
-import { CheckCircle, ExclamationCircle } from 'components/sharedComponents/icons/Icons';
+import { useDispatch, useSelector } from "react-redux";
+
 import { awardDownloadOptions } from 'dataMapping/bulkDownload/bulkDownloadOptions';
+import {
+    bulkAwardTypeChange, toggleAwardTypeChange
+} from "redux/actions/bulkDownload/bulkDownloadActions";
+import { CheckCircle, ExclamationCircle } from 'components/sharedComponents/icons/Icons';
 import PrimaryCheckboxType from 'components/sharedComponents/checkbox/PrimaryCheckboxType';
 
 const awardTypeLabels = Object.assign(
@@ -22,11 +26,12 @@ const propTypes = {
 };
 
 // eslint-disable-next-line prefer-arrow-callback
-const AwardLevelAndTypeFilter = memo(function AwardLevelAndTypeFilter({
-    bulkAwardTypeChange,
-    toggleAwardTypeChange
-}) {
+const AwardLevelAndTypeFilter = memo(function AwardLevelAndTypeFilter() {
     const currentAwardTypes = useSelector((state) => state.bulkDownload.awards.awardTypes);
+    const dispatch = useDispatch();
+
+    const bulkTypeChange = (selection) => dispatch(bulkAwardTypeChange(selection));
+    const toggleCheckboxType = (selection) => dispatch(toggleAwardTypeChange(selection));
 
     const isValid = (
         currentAwardTypes.primeAwards.size > 0 ||
@@ -64,8 +69,8 @@ const AwardLevelAndTypeFilter = memo(function AwardLevelAndTypeFilter({
                     arrowState="expanded"
                     selectedCheckboxes={selectedAwardTypes}
                     isCollapsable={false}
-                    bulkTypeChange={bulkAwardTypeChange}
-                    toggleCheckboxType={toggleAwardTypeChange}
+                    bulkTypeChange={bulkTypeChange}
+                    toggleCheckboxType={toggleCheckboxType}
                     key={`award-type__${id}`} />
             );
         });

--- a/src/js/components/bulkDownload/awards/filters/DateTypeFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/DateTypeFilter.jsx
@@ -3,71 +3,73 @@
  * Created by Lizzie Salita 11/2/17
  */
 
-import React from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 
+import { awardDownloadOptions } from 'dataMapping/bulkDownload/bulkDownloadOptions';
 import { CheckCircle, ExclamationCircle } from 'components/sharedComponents/icons/Icons';
+import { useSelector } from "react-redux";
 
-const propTypes = {
-    dateTypes: PropTypes.array,
-    currentDateType: PropTypes.string,
-    updateFilter: PropTypes.func,
-    valid: PropTypes.bool
-};
+const propTypes = { updateFilter: PropTypes.func };
 
-export default class DateTypeFilter extends React.Component {
-    constructor(props) {
-        super(props);
+// eslint-disable-next-line prefer-arrow-callback
+const DateTypeFilter = memo(function DateTypeFilter({
+    updateFilter
+}) {
+    const currentDateType = useSelector((state) => state.bulkDownload.awards.dateType);
 
-        this.onChange = this.onChange.bind(this);
-    }
+    const valid = currentDateType !== '';
 
-    onChange(e) {
+    const onChange = (e) => {
         const target = e.target;
-        this.props.updateFilter('dateType', target.value);
-    }
+        updateFilter('dateType', target.value);
+    };
 
-    render() {
-        let icon = (
-            <div className="icon valid">
-                <CheckCircle />
-            </div>
-        );
-        if (!this.props.valid) {
-            icon = (
-                <div className="icon invalid">
-                    <ExclamationCircle />
-                </div>
-            );
-        }
-        const dateTypes = this.props.dateTypes.map((dateType) => (
-            <div
-                className="radio"
-                key={dateType.name}>
-                <input
-                    type="radio"
-                    aria-label={dateType.name}
-                    value={dateType.name}
-                    name="dateType"
-                    checked={this.props.currentDateType === dateType.name}
-                    onChange={this.onChange} />
-                <label className="radio-label" htmlFor="dateType">{dateType.label}</label>
-                <div className="radio-description">
-                    {dateType.description}
-                </div>
-            </div>
-        ));
-        return (
-            <div className="download-filter">
-                <h3 className="download-filter__title">
-                    {icon} Select a <span className="download-filter__title_em">date type</span> for the date range below.
-                </h3>
-                <div className="download-filter__content">
-                    {dateTypes}
-                </div>
+    let icon = (
+        <div className="icon valid">
+            <CheckCircle />
+        </div>
+    );
+    if (!valid) {
+        icon = (
+            <div className="icon invalid">
+                <ExclamationCircle />
             </div>
         );
     }
-}
+    const dateTypes = awardDownloadOptions.dateTypes.map((dateType) => (
+        <div
+            className="radio"
+            key={dateType.name}>
+            <input
+                type="radio"
+                aria-label={dateType.name}
+                value={dateType.name}
+                name="dateType"
+                checked={currentDateType === dateType.name}
+                onChange={onChange} />
+            <label className="radio-label" htmlFor="dateType">
+                {dateType.label}
+            </label>
+            <div className="radio-description">
+                {dateType.description}
+            </div>
+        </div>
+    ));
+
+    return (
+        <div className="download-filter">
+            <h3 className="download-filter__title">
+                {icon} Select a
+                <span className="download-filter__title_em"> date type </span>
+                for the date range below.
+            </h3>
+            <div className="download-filter__content">
+                {dateTypes}
+            </div>
+        </div>
+    );
+});
 
 DateTypeFilter.propTypes = propTypes;
+export default DateTypeFilter;

--- a/src/js/components/bulkDownload/awards/filters/DateTypeFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/DateTypeFilter.jsx
@@ -5,10 +5,10 @@
 
 import React, { memo } from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from "react-redux";
 
 import { awardDownloadOptions } from 'dataMapping/bulkDownload/bulkDownloadOptions';
 import { CheckCircle, ExclamationCircle } from 'components/sharedComponents/icons/Icons';
-import { useSelector } from "react-redux";
 
 const propTypes = { updateFilter: PropTypes.func };
 
@@ -41,19 +41,21 @@ const DateTypeFilter = memo(function DateTypeFilter({
         <div
             className="radio"
             key={dateType.name}>
-            <input
-                type="radio"
-                aria-label={dateType.name}
-                value={dateType.name}
-                name="dateType"
-                checked={currentDateType === dateType.name}
-                onChange={onChange} />
             <label className="radio-label" htmlFor="dateType">
-                {dateType.label}
+                <input
+                    type="radio"
+                    aria-label={dateType.name}
+                    value={dateType.name}
+                    name="dateType"
+                    checked={currentDateType === dateType.name}
+                    onChange={onChange} />
+                <div className="text-container">
+                    {dateType.label}
+                    <div className="radio-description">
+                        {dateType.description}
+                    </div>
+                </div>
             </label>
-            <div className="radio-description">
-                {dateType.description}
-            </div>
         </div>
     ));
 
@@ -64,7 +66,7 @@ const DateTypeFilter = memo(function DateTypeFilter({
                 <span className="download-filter__title_em"> date type </span>
                 for the date range below.
             </h3>
-            <div className="download-filter__content">
+            <div className="download-filter__content date-type">
                 {dateTypes}
             </div>
         </div>

--- a/src/js/components/bulkDownload/awards/filters/DateTypeFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/DateTypeFilter.jsx
@@ -13,9 +13,7 @@ import { CheckCircle, ExclamationCircle } from 'components/sharedComponents/icon
 const propTypes = { updateFilter: PropTypes.func };
 
 // eslint-disable-next-line prefer-arrow-callback
-const DateTypeFilter = memo(function DateTypeFilter({
-    updateFilter
-}) {
+const DateTypeFilter = memo(function DateTypeFilter({ updateFilter }) {
     const currentDateType = useSelector((state) => state.bulkDownload.awards.dateType);
 
     const valid = currentDateType !== '';

--- a/src/js/components/bulkDownload/awards/filters/FileFormatFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/FileFormatFilter.jsx
@@ -3,76 +3,70 @@
  * Created by Lizzie Salita 11/3/17
  */
 
-import React from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
-
+import { useSelector } from "react-redux";
+import { awardDownloadOptions } from 'dataMapping/bulkDownload/bulkDownloadOptions';
 import { CheckCircle, ExclamationCircle } from 'components/sharedComponents/icons/Icons';
 
-const propTypes = {
-    fileFormats: PropTypes.array,
-    currentFileFormat: PropTypes.string,
-    updateFilter: PropTypes.func,
-    valid: PropTypes.bool
-};
+const propTypes = { updateFilter: PropTypes.func };
 
-export default class FileFormatFilter extends React.Component {
-    constructor(props) {
-        super(props);
+// eslint-disable-next-line prefer-arrow-callback
+const FileFormatFilter = memo(function FileFormatFilter({ updateFilter }) {
+    const currentFileFormat = useSelector((state) => state.bulkDownload.awards.fileFormat);
 
-        this.onChange = this.onChange.bind(this);
-    }
+    const valid = currentFileFormat !== '';
 
-    onChange(e) {
+    const onChange = (e) => {
         const target = e.target;
-        this.props.updateFilter('fileFormat', target.value);
-    }
+        updateFilter('fileFormat', target.value);
+    };
 
-    render() {
-        let icon = (
-            <div className="icon valid">
-                <CheckCircle />
-            </div>
-        );
+    let icon = (
+        <div className="icon valid">
+            <CheckCircle />
+        </div>
+    );
 
-        if (!this.props.valid) {
-            icon = (
-                <div className="icon invalid">
-                    <ExclamationCircle />
-                </div>
-            );
-        }
-
-        const fileFormats = this.props.fileFormats.map((fileFormat) => (
-            <div
-                className="radio"
-                key={fileFormat.name}>
-                <input
-                    type="radio"
-                    aria-label={fileFormat.name}
-                    value={fileFormat.name}
-                    name="fileFormat"
-                    checked={this.props.currentFileFormat === fileFormat.name}
-                    onChange={this.onChange}
-                    disabled={fileFormat.disabled} />
-                <label
-                    className={`radio-label ${fileFormat.disabled ? 'disabled' : ''}`}
-                    htmlFor="fileFormat">
-                    {fileFormat.label}
-                </label>
-            </div>
-        ));
-
-        return (
-            <div className="download-filter">
-                <h3 className="download-filter__title">
-                    {icon} Select a <span className="download-filter__title_em">file format</span>.
-                </h3>
-                <div className="download-filter__content">
-                    {fileFormats}
-                </div>
+    if (!valid) {
+        icon = (
+            <div className="icon invalid">
+                <ExclamationCircle />
             </div>
         );
     }
-}
+
+    const fileFormats = awardDownloadOptions.fileFormats.map((fileFormat) => (
+        <div
+            className="radio"
+            key={fileFormat.name}>
+            <input
+                type="radio"
+                aria-label={fileFormat.name}
+                value={fileFormat.name}
+                name="fileFormat"
+                checked={currentFileFormat === fileFormat.name}
+                onChange={onChange}
+                disabled={fileFormat.disabled} />
+            <label
+                className={`radio-label ${fileFormat.disabled ? 'disabled' : ''}`}
+                htmlFor="fileFormat">
+                {fileFormat.label}
+            </label>
+        </div>
+    ));
+
+    return (
+        <div className="download-filter">
+            <h3 className="download-filter__title">
+                {icon} Select a <span className="download-filter__title_em">file format</span>.
+            </h3>
+            <div className="download-filter__content">
+                {fileFormats}
+            </div>
+        </div>
+    );
+});
 
 FileFormatFilter.propTypes = propTypes;
+export default FileFormatFilter;

--- a/src/js/components/bulkDownload/awards/filters/FileFormatFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/FileFormatFilter.jsx
@@ -40,17 +40,17 @@ const FileFormatFilter = memo(function FileFormatFilter({ updateFilter }) {
         <div
             className="radio"
             key={fileFormat.name}>
-            <input
-                type="radio"
-                aria-label={fileFormat.name}
-                value={fileFormat.name}
-                name="fileFormat"
-                checked={currentFileFormat === fileFormat.name}
-                onChange={onChange}
-                disabled={fileFormat.disabled} />
             <label
                 className={`radio-label ${fileFormat.disabled ? 'disabled' : ''}`}
                 htmlFor="fileFormat">
+                <input
+                    type="radio"
+                    aria-label={fileFormat.name}
+                    value={fileFormat.name}
+                    name="fileFormat"
+                    checked={currentFileFormat === fileFormat.name}
+                    onChange={onChange}
+                    disabled={fileFormat.disabled} />
                 {fileFormat.label}
             </label>
         </div>
@@ -61,7 +61,7 @@ const FileFormatFilter = memo(function FileFormatFilter({ updateFilter }) {
             <h3 className="download-filter__title">
                 {icon} Select a <span className="download-filter__title_em">file format</span>.
             </h3>
-            <div className="download-filter__content">
+            <div className="download-filter__content file-type">
                 {fileFormats}
             </div>
         </div>

--- a/src/js/components/sharedComponents/checkbox/CollapsedCheckboxType.jsx
+++ b/src/js/components/sharedComponents/checkbox/CollapsedCheckboxType.jsx
@@ -3,9 +3,8 @@
  * Created by michaelbray on 5/18/17.
  */
 
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
-import { uniqueId } from 'lodash-es';
 import CheckboxExpandButton from './CheckboxExpandButton';
 
 const propTypes = {
@@ -15,7 +14,9 @@ const propTypes = {
     selected: PropTypes.bool,
     hideArrow: PropTypes.bool,
     arrowState: PropTypes.string,
-    isCollapsable: PropTypes.bool
+    isCollapsable: PropTypes.bool,
+    id: PropTypes.string,
+    indeterminate: PropTypes.bool
 };
 
 const CollapsedCheckboxType = ({
@@ -25,9 +26,15 @@ const CollapsedCheckboxType = ({
     selected = false,
     hideArrow = true,
     arrowState = 'collapsed',
-    isCollapsable = true
+    isCollapsable = true,
+    id,
+    indeterminate
 }) => {
-    const elementId = `checkbox-${uniqueId()}`;
+    const ref = useRef(null);
+    const inputId = `collapsed-checkbox__${id}`;
+
+    if (ref.current) ref.current.indeterminate = indeterminate;
+
     return (
         <div className="primary-checkbox-type">
             <div className="checkbox-type-item-wrapper">
@@ -40,13 +47,14 @@ const CollapsedCheckboxType = ({
                 }
                 <label
                     className="checkbox-item-wrapper"
-                    htmlFor={elementId}>
+                    htmlFor={inputId}>
                     <input
                         type="checkbox"
-                        id={elementId}
+                        id={inputId}
                         value={name}
                         checked={selected}
-                        onChange={toggleChildren} />
+                        onChange={toggleChildren}
+                        ref={ref} />
                     <span className="checkbox-item-label">
                         {name}
                     </span>

--- a/src/js/components/sharedComponents/checkbox/PrimaryCheckboxType.jsx
+++ b/src/js/components/sharedComponents/checkbox/PrimaryCheckboxType.jsx
@@ -138,14 +138,21 @@ const PrimaryCheckboxType = ({
         }
     };
 
-    let primaryTypes = (<CollapsedCheckboxType
-        toggleExpand={toggleSubItems}
-        toggleChildren={toggleChildren}
-        name={name}
-        selected={allChildren}
-        hideArrow={selectedChildren || restrictChildren}
-        arrowState={arrowState}
-        isCollapsable={isCollapsable} />);
+    const indeterminate = filters.length !== selectedCheckboxes.size &&
+        selectedCheckboxes.size !== 0;
+
+    let primaryTypes = (
+        <CollapsedCheckboxType
+            toggleExpand={toggleSubItems}
+            toggleChildren={toggleChildren}
+            name={name}
+            selected={allChildren}
+            hideArrow={selectedChildren || restrictChildren}
+            arrowState={arrowState}
+            isCollapsable={isCollapsable}
+            id={id}
+            indeterminate={indeterminate} />
+    );
 
     let secondaryTypes = null;
 

--- a/src/js/containers/bulkDownload/awards/AwardDataContainer.jsx
+++ b/src/js/containers/bulkDownload/awards/AwardDataContainer.jsx
@@ -19,9 +19,7 @@ const propTypes = {
     clearDownloadFilters: PropTypes.func,
     updateAwardDateRange: PropTypes.func,
     bulkDownload: PropTypes.object,
-    clickedDownload: PropTypes.func,
-    bulkAwardTypeChange: PropTypes.func,
-    toggleAwardTypeChange: PropTypes.func
+    clickedDownload: PropTypes.func
 };
 
 export class AwardDataContainer extends React.Component {
@@ -48,8 +46,6 @@ export class AwardDataContainer extends React.Component {
         this.setAgencyList = this.setAgencyList.bind(this);
         this.setSubAgencyList = this.setSubAgencyList.bind(this);
         this.loadStates = this.loadStates.bind(this);
-        this.bulkAwardTypeChange = this.bulkAwardTypeChange.bind(this);
-        this.toggleAwardTypeChange = this.toggleAwardTypeChange.bind(this);
     }
 
     componentDidMount() {
@@ -195,14 +191,6 @@ export class AwardDataContainer extends React.Component {
         this.props.clearDownloadFilters('awards');
     }
 
-    bulkAwardTypeChange(selection) {
-        this.props.bulkAwardTypeChange(selection);
-    }
-
-    toggleAwardTypeChange(selection) {
-        this.props.toggleAwardTypeChange(selection);
-    }
-
     render() {
         return (
             <AwardDataContent
@@ -215,9 +203,7 @@ export class AwardDataContainer extends React.Component {
                 subAgencies={this.state.subAgencies}
                 setSubAgencyList={this.setSubAgencyList}
                 states={this.state.states}
-                clickedDownload={this.props.clickedDownload}
-                bulkAwardTypeChange={this.bulkAwardTypeChange}
-                toggleAwardTypeChange={this.toggleAwardTypeChange} />
+                clickedDownload={this.props.clickedDownload} />
         );
     }
 }


### PR DESCRIPTION
**Description:**
Updated the styling for the Award Types, Date Types, and File Format filters on the awards download page. This includes adding an indeterminate state to the Award Type filter. I also converted the components to functions and memoized them.

**JIRA Ticket:**
[DEV-15035](https://federal-spending-transparency.atlassian.net/browse/DEV-15035)

**Mockup:**
[FigGov](https://figma-gov.com/design/pYhsiDOkUTlcv9Z2Y15A4L/Download-the-Data?node-id=485-5634&m=dev)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-15035]: https://federal-spending-transparency.atlassian.net/browse/DEV-15035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ