### PR TITLE
Dev - 15026: Download Center: COVID-19 filters selections do not auto remove when going from a B file to an A file

### DIFF
--- a/src/js/components/bulkDownload/DEFCheckboxTreeDownload.jsx
+++ b/src/js/components/bulkDownload/DEFCheckboxTreeDownload.jsx
@@ -87,6 +87,12 @@ const DEFCheckboxTreeDownload = ({
         detailsDisplay(validDefCodes);
     }, [validDefCodes]);
 
+    useEffect(() => {
+        if (isDisabled && defCodes.length){
+            dispatch(setDefCodes(type, []));
+        }
+    }, [defCodes, dispatch, isDisabled, type])
+
     return (
         <div className="def-code-filter-download">
             {isLoading && loadingIndicator }

--- a/src/js/components/sharedComponents/checkbox/AccordionCheckbox.jsx
+++ b/src/js/components/sharedComponents/checkbox/AccordionCheckbox.jsx
@@ -68,12 +68,20 @@ const AccordionCheckbox = ({
     };
 
     useEffect(() => {
-        if (isExpanded) {
+        if (isDisabled && expandedCategories?.length) {
+            // have to check expandeCategories instead of isExpanded.
+            // isExpanded might not be known by parent
+            // collapse expandedCategories
+            expandedCategories.forEach((ec) => toggleExpanded({id: ec}));
+
+        }
+        else if (isExpanded) {
             const category = filterCategoryMapping.find((item) => item.id === selectedCategory);
             toggleExpanded(category);
         }
+
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [filterCategoryMapping, isExpanded, selectedCategory]);
+    }, [filterCategoryMapping, isExpanded, selectedCategory, isDisabled]);
 
     const handleTextInputChange = (e) => {
         setSearchString(e.target.value);


### PR DESCRIPTION
**Description:**
Fixed enabled and expanded states for defCodes checkboxes.

**JIRA Ticket:**
[DEV-15026](https://federal-spending-transparency.atlassian.net/browse/DEV-15026)


The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-15026]: https://federal-spending-transparency.atlassian.net/browse/DEV-15026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ