### PR TITLE
DEV-14382/15122 glossary issues

### DIFF
--- a/src/js/components/glossary/definition/GlossaryDefinition.jsx
+++ b/src/js/components/glossary/definition/GlossaryDefinition.jsx
@@ -36,24 +36,7 @@ const GlossaryDefinition = ({ glossary }) => {
     const handleShareDispatch = (url) => {
         dispatch(showModal(url));
     };
-    // preserving in case it is needed
-    // let copyConfirmation = null;
-
-    // const getCopyFn = () => {
-    //     const separator = window.location.href.includes('?') ? '&' : '?';
-    //     const slug = `${separator}glossary=${props.glossary.term.toJS().slug}`;
-    //     const value = window.location.href.includes("glossary") ? window.location.href : window.location.href + slug;
-    //     if (window.navigator && window.navigator.clipboard && window.navigator.clipboard.writeText) {
-    //         window.navigator.clipboard.writeText(value);
-    //         setShowCopiedConfirmation(true);
-    //         copyConfirmation = window.setTimeout(() => {
-    //             setShowCopiedConfirmation(false);
-    //         }, 1750);
-    //     }
-    // };
-    // useEffect(() => window.clearTimeout(copyConfirmation), []);
-
-
+    
     const checkDefinitions = () => {
         let hasPlainLocal = false;
         let hasOfficialLocal = false;

--- a/src/js/components/sharedComponents/AboutTheDataLink.jsx
+++ b/src/js/components/sharedComponents/AboutTheDataLink.jsx
@@ -33,12 +33,12 @@ const AboutTheDataLink = ({ slug, children }) => {
     // there is already a search query
     if (search && !search.includes('about-the-data')) {
         // url with original search &about-the-data={term}
-        newUrl = `${pathname}${search}&about-the-data=${entry.slug}`;
+        newUrl = `${pathname}${search}`;
     }
     else {
         // url with search term as query
         newUrl = getNewUrlForGlossary(
-            pathname, `?about-the-data=${entry.slug}`, urlSearchParam
+            pathname, urlSearchParam
         );
     }
 

--- a/src/js/components/sharedComponents/GlossaryLink.jsx
+++ b/src/js/components/sharedComponents/GlossaryLink.jsx
@@ -34,9 +34,10 @@ const GlossaryLink = ({
     const { pathname, search } = useLocation();
     const params = new URLSearchParams(search);
     params.set('glossary', term)
-    const glossaryUrl = `${pathname}?${params.toString()}`
+    const glossaryUrl = `${pathname}`
 
     const stopBubble = (e) => {
+        e.preventDefault();
         e.stopPropagation();
         showSlideout('glossary', { url: term });
     };


### PR DESCRIPTION
**Description:**
glossary links cause refresh on featured content
glossary links causing a reset of the fy on the agency page 

**JIRA Ticket:**
[DEV-14382](https://federal-spending-transparency.atlassian.net/browse/DEV-14382)
[DEV-15122](https://federal-spending-transparency.atlassian.net/browse/DEV-15122)

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-14382]: https://federal-spending-transparency.atlassian.net/browse/DEV-14382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-15122]: https://federal-spending-transparency.atlassian.net/browse/DEV-15122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ