### PR TITLE
DEV -15360 : USAspending.gov hyperlink is missing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10696,7 +10696,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",

--- a/src/content/featuredContent/the-story-of-spending-transparency.mdx
+++ b/src/content/featuredContent/the-story-of-spending-transparency.mdx
@@ -14,6 +14,6 @@ The U.S. is one of the few countries worldwide that makes federal spending data 
 ![The USAspending.gov home page in 2014](usaspending2014.png)
 <span className="caption">The USAspending.gov home page in 2014</span>
 
-Today, USAspending.gov continues to evolve as a central source for federal spending data. The site allows anyone to follow how taxpayer dollars move from Congress to agencies, recipients, and communities across the country. From research grants to infrastructure projects, the DATA Act makes this information accessible and consistent, offering a full picture of how public funds are spent.
+Today, [USAspending.gov](https://www.usaspending.gov) continues to evolve as a central source for federal spending data. The site allows anyone to follow how taxpayer dollars move from Congress to agencies, recipients, and communities across the country. From research grants to infrastructure projects, the DATA Act makes this information accessible and consistent, offering a full picture of how public funds are spent.
 
 Want to see where your tax dollars go? Try our [Advanced Search](https://www.usaspending.gov/search) and explore government spending in your community. 


### PR DESCRIPTION
**Description:**
Fix hyperlink

**JIRA Ticket:**
[DEV-15360](https://federal-spending-transparency.atlassian.net/browse/DEV-15360)

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-15360]: https://federal-spending-transparency.atlassian.net/browse/DEV-15360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ