### PR TITLE
Hotfix 15400 - Fixed location autocomplete to use both original and current cds

### DIFF
--- a/src/js/containers/search/filters/location/LocationAutocompleteContainer.jsx
+++ b/src/js/containers/search/filters/location/LocationAutocompleteContainer.jsx
@@ -105,6 +105,7 @@ const LocationAutocompleteContainer = ({
     ]);
 
     const addLocation = () => {
+        console.log(selectedItem);
         getLocationObject(selectedItem, countriesList, createLocationObjectByType);
         clearAutocompleteSuggestions();
     };

--- a/src/js/containers/search/filters/location/LocationAutocompleteContainer.jsx
+++ b/src/js/containers/search/filters/location/LocationAutocompleteContainer.jsx
@@ -105,7 +105,6 @@ const LocationAutocompleteContainer = ({
     ]);
 
     const addLocation = () => {
-        console.log(selectedItem);
         getLocationObject(selectedItem, countriesList, createLocationObjectByType);
         clearAutocompleteSuggestions();
     };

--- a/src/js/helpers/search/locationAutocompleteHelper.js
+++ b/src/js/helpers/search/locationAutocompleteHelper.js
@@ -91,16 +91,17 @@ export const addCountry = (country, countryAbbreviation) => ({
     }
 });
 
-export const addDistrict = (district, type) => {
+export const addDistrict = (district, category, type) => {
     const districtArray = district.split('-');
     const stateAbbreviation = districtArray[0];
     const districtNumber = districtArray[1];
+    const districtType = category || "district_current";
     return {
         identifier: `USA_${stateAbbreviation}_${districtNumber}`,
         filter: {
             country: "USA",
             state: stateAbbreviation,
-            district_current: districtNumber
+            [districtType]: districtNumber
         },
         display: {
             entity: type,
@@ -261,10 +262,10 @@ export const getLocationObject = (selectedItem, countriesList, createLocationObj
         location = addCountry(item.data.country_name, countryAbbreviation);
     }
     else if (item.category === "current_cd") {
-        location = addDistrict(item.data.current_cd, "Current congressional district");
+        location = addDistrict(item.data.current_cd, "district_current", "Current congressional district");
     }
     else if (item.category === "original_cd") {
-        location = addDistrict(item.data.original_cd, "Original congressional district");
+        location = addDistrict(item.data.original_cd, "district_original", "Original congressional district");
     }
 
     if (item.category !== "county") {


### PR DESCRIPTION
**Description:**

Fixed location autocomplete to use both original and current cds

**JIRA Ticket:**
[DEV-15400](https://federal-spending-transparency.atlassian.net/browse/DEV-15400)

**Mockup:**
https://figma-gov.com/

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-15400]: https://federal-spending-transparency.atlassian.net/browse/DEV-15400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ