### PR TITLE
Fix/dev 15334 Adv Search Downloads: Update logic when over 500k prime awards or transactions are present

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3309,9 +3309,9 @@
       }
     },
     "node_modules/babel-plugin-module-resolver/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -24594,9 +24594,9 @@
       }
     },
     "node_modules/css-minimizer-webpack-plugin/node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "version": "0.34.50",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.50.tgz",
+      "integrity": "sha512-ydBWw0G6WFwWHzh9RK4B5c690UkreOG0llq0r+DaI7LgKgxigf8mhHzIPI3S0850g1BPkq/zpuCfrq4QFgUlTQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -26480,9 +26480,9 @@
       "dev": true
     },
     "node_modules/jest-environment-jsdom/node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "version": "0.34.50",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.50.tgz",
+      "integrity": "sha512-ydBWw0G6WFwWHzh9RK4B5c690UkreOG0llq0r+DaI7LgKgxigf8mhHzIPI3S0850g1BPkq/zpuCfrq4QFgUlTQ==",
       "license": "MIT"
     },
     "node_modules/zod": {

--- a/src/js/containers/search/SearchContainer.jsx
+++ b/src/js/containers/search/SearchContainer.jsx
@@ -89,9 +89,9 @@ const SearchContainer = () => {
             filters: appliedFilters,
             _empty: areAppliedFiltersEmpty
         },
-        // eslint-disable-next-line camelcase
         spending_level
     } = useSelector((state) => state);
+    const spendingLevel = useSelector((state) => state.searchView.spendingLevel);
     const [downloadInFlight, setDownloadInFlight] = useState(false);
     const [generateHashInFlight, setGenerateHashInFlight] = useState(false);
 
@@ -181,18 +181,30 @@ const SearchContainer = () => {
             });
     }, [stagedFilters]);
 
+    useEffect(() => {
+        areAppliedFiltersEmptyRef.current = areAppliedFiltersEmpty;
+        prevAppliedFiltersRef.current = appliedFilters;
+    }, [areAppliedFiltersEmpty, appliedFilters]);
+
     const downloadButtonEnabled = useCallback(() => {
         if (
             (awardsCount === 0 || awardsCount >= 500000) &&
             (transactionsCount === 0 || transactionsCount >= 500000) &&
-            (subawardsCount === 0 || subawardsCount >= 500000)
+            (
+                spendingLevel === 'awards' ||
+                (subawardsCount === 0 || subawardsCount >= 500000)
+            )
         ) {
             setDownloadAvailable(false);
         }
-        else if (awardsCount !== 0 || transactionsCount !== 0 || subawardsCount !== 0) {
+        else if (
+            awardsCount !== 0 ||
+            transactionsCount !== 0 ||
+            (spendingLevel === 'subawards' && subawardsCount !== 0)
+        ) {
             setDownloadAvailable(true);
         }
-    }, [transactionsCount, awardsCount, subawardsCount]);
+    }, [transactionsCount, awardsCount, subawardsCount, spendingLevel]);
 
     useEffect(() => {
         areAppliedFiltersEmptyRef.current = areAppliedFiltersEmpty;
@@ -231,7 +243,7 @@ const SearchContainer = () => {
                 })
                 .catch((err) => {
                     if (!isCancel(err)) {
-                        // eslint-disable-next-line no-console
+
                         console.error('Error fetching filters from hash: ', err);
                         // remove hash since corresponding filter selections aren't retrievable.
                         searchURLParams.delete("hash");
@@ -356,7 +368,7 @@ const SearchContainer = () => {
             transactionsCount={transactionsCount}
             subawardsCount={subawardsCount}
             queryParam={location.state}
-            // eslint-disable-next-line camelcase
+
             spending_level={spending_level} />
     );
 };


### PR DESCRIPTION
**Description:**
The download button is now disabled if the spending level is set to 'Prime Awards and Transactions' and there are too many awards and transactions available to download, regardless of how many subawards are available (i.e., even if it's less than 500,000 and more than 0). The download button should still work exactly the same if the spending level is set to 'Subawards'.

**JIRA Ticket:**
[DEV-15334 ](https://federal-spending-transparency.atlassian.net/browse/DEV-15334 )

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`

