### PR TITLE
Dev- 15366: Advanced Search: Error in award table when new award only and subawards are both selected

### DIFF
--- a/src/_scss/pages/interactiveDataSources/index.scss
+++ b/src/_scss/pages/interactiveDataSources/index.scss
@@ -79,7 +79,7 @@
             overflow-x: auto;
           }
         }
-        
+
         .body-padded__content {
           @import "./_scrollerOverlayCard.scss";
           margin-top: 0;

--- a/src/js/components/search/FilterAwardToggle.jsx
+++ b/src/js/components/search/FilterAwardToggle.jsx
@@ -44,8 +44,8 @@ const FilterAwardToggle = memo(function FilterAwardToggle({
     }, [dispatch, queryParam, selected, setSearchParams]);
 
     const onToggle = useCallback((type) => {
-        dispatch(setSearchViewSubaward(type === 'subawards'));
         dispatch(setSpendingLevel(type));
+        dispatch(setSearchViewSubaward(type === 'subawards'));
         setSelected(type);
 
         if (type === 'subawards') {

--- a/src/js/components/search/topFilterBar/filterGroups/useNewAwardsOnly.jsx
+++ b/src/js/components/search/topFilterBar/filterGroups/useNewAwardsOnly.jsx
@@ -10,6 +10,7 @@ const propTypes = { name: PropTypes.string };
 
 const useNewAwardsOnly = () => {
     const dispatch = useDispatch();
+    const spendingLevel = useSelector((state) => state.searchView.spendingLevel);
     const newAwards = useSelector((state) => state.filters.filterNewAwardsOnlySelected);
     const newAwardsApplied = useSelector(
         (state) => state.appliedFilters.filters.filterNewAwardsOnlySelected
@@ -18,6 +19,11 @@ const useNewAwardsOnly = () => {
     const toggleFilter = (value) => {
         dispatch(updateNewAwardsOnlySelected(!value));
     };
+
+    // if subawards is true, newAwardsOnly cannot be true, so we remove
+    if (spendingLevel === "subawards") {
+        return null;
+    }
 
     return newAwardsApplied && {
         value: newAwards,

--- a/src/js/containers/search/resultsView/useResultsTableSearch.jsx
+++ b/src/js/containers/search/resultsView/useResultsTableSearch.jsx
@@ -90,7 +90,7 @@ const useResultsTableSearch = (
 
     // if subawards is true, newAwardsOnly cannot be true, so we remove
     // dateType for this request; also has to be done for the tabCounts request
-    if (spendingLevel === "subaward" && filtersTemp.dateType) {
+    if (spendingLevel === "subawards" && filtersTemp.dateType) {
         delete filtersTemp.dateType;
     }
 


### PR DESCRIPTION
**Description:**
Fix typo and remove filter toggle if spendingLevel === "subawards"

**JIRA Ticket:**
[DEV-15366](https://federal-spending-transparency.atlassian.net/browse/DEV-15366)

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-15366]: https://federal-spending-transparency.atlassian.net/browse/DEV-15366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ