### PR TITLE
Fix/dev 15297 Download Center - Pressing Enter while keyboard is focused on a radio button opens the Download pop-up window

### DIFF
--- a/src/js/components/bulkDownload/accounts/AccountDataContent.jsx
+++ b/src/js/components/bulkDownload/accounts/AccountDataContent.jsx
@@ -51,6 +51,14 @@ const AccountDataContent = ({
     const { isTablet } = useContext(IsMobileContext);
     const [validForm, setValidForm] = useState(false);
 
+    // prevents submission on enter keydown
+    const onKeyDown = (e) => {
+        if (e.keyCode === 13) {
+            e.preventDefault();
+            clearAccountFilters();
+        }
+    };
+
     useEffect(() => {
         setValidForm((
             (accounts.budgetFunction.code !== '')
@@ -110,8 +118,11 @@ const AccountDataContent = ({
                         validDates
                         dataType="accounts" />
                     <div className="download-center__reset-container">
-                        <button className="download-center__reset" onClick={clearAccountFilters}>
-                    Reset form and start over
+                        <button
+                            className="download-center__reset"
+                            onClick={clearAccountFilters}
+                            onKeyDown={onKeyDown}>
+                            Reset form and start over
                         </button>
                     </div>
                 </div>

--- a/src/js/components/bulkDownload/awards/AwardDataContent.jsx
+++ b/src/js/components/bulkDownload/awards/AwardDataContent.jsx
@@ -60,6 +60,14 @@ const AwardDataContent = ({
         setValidDates(false);
     };
 
+    // prevents submission on enter keydown
+    const onKeyDown = (e) => {
+        if (e.keyCode === 13) {
+            e.preventDefault();
+            resetForm();
+        }
+    };
+
     const validateForm = useCallback((award, dates) => {
         const primeAwards = award.awardTypes.primeAwards.size > 0;
         const subAwards = award.awardTypes.subAwards.size > 0;
@@ -121,7 +129,10 @@ const AwardDataContent = ({
                         validDates={validDates}
                         dataType="awards" />
                     <div className="download-center__reset-container">
-                        <button className="download-center__reset" onClick={resetForm}>
+                        <button
+                            className="download-center__reset"
+                            onClick={resetForm}
+                            onKeyDown={onKeyDown}>
                         Reset form and start over
                         </button>
                     </div>

--- a/src/js/components/bulkDownload/awards/filters/AgencyFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/AgencyFilter.jsx
@@ -9,6 +9,7 @@ import { useSelector } from "react-redux";
 import { awardDownloadOptions } from "dataMapping/bulkDownload/bulkDownloadOptions";
 import FilterSectionTitle from 'components/bulkDownload/FilterSelectionTitle';
 import ComboBox from "components/sharedComponents/ComboBox";
+import BulkDownloadRadioButton from "../../../sharedComponents/BulkDownloadRadioButton";
 
 const propTypes = {
     agencies: PropTypes.object,
@@ -25,7 +26,6 @@ const AgencyFilter = memo(function AgencyFilter({
     updateFilter
 }) {
     const currentAgencyType = useSelector((state) => state.bulkDownload.awards.agencyType);
-    const currentAgency = useSelector((state) => state.bulkDownload.awards.agency);
 
     const onChange = (e) => updateFilter('agencyType', e.target.value);
 
@@ -53,26 +53,15 @@ const AgencyFilter = memo(function AgencyFilter({
         });
     };
 
-    const agencyTypesList = awardDownloadOptions.agencyTypes.map((agencyType) => (
-        <div
-            className="radio"
-            key={agencyType.name}>
-            <label className="radio-label" htmlFor="agencyType">
-                <input
-                    type="radio"
-                    aria-label={agencyType.name}
-                    value={agencyType.name}
-                    name="agencyType"
-                    checked={currentAgencyType === agencyType.name}
-                    onChange={onChange} />
-                <div className="radio-container">
-                    {agencyType.label}
-                    <div className="radio-description">
-                        {agencyType.description}
-                    </div>
-                </div>
-            </label>
-        </div>
+    const agencyTypesList = awardDownloadOptions.agencyTypes.map(({ name, label, description }) => (
+        <BulkDownloadRadioButton
+            name="agencyType"
+            value={name}
+            checked={currentAgencyType === name}
+            onChange={onChange}
+            label={label}
+            description={description}
+            key={name} />
     ));
 
     // data manipulation for combo boxes

--- a/src/js/components/bulkDownload/awards/filters/DateTypeFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/DateTypeFilter.jsx
@@ -9,6 +9,7 @@ import { useSelector } from "react-redux";
 
 import { awardDownloadOptions } from 'dataMapping/bulkDownload/bulkDownloadOptions';
 import FilterSectionTitle from 'components/bulkDownload/FilterSelectionTitle';
+import BulkDownloadRadioButton from "../../../sharedComponents/BulkDownloadRadioButton";
 
 const propTypes = { updateFilter: PropTypes.func };
 
@@ -21,26 +22,15 @@ const DateTypeFilter = memo(function DateTypeFilter({ updateFilter }) {
         updateFilter('dateType', target.value);
     };
 
-    const dateTypes = awardDownloadOptions.dateTypes.map((dateType) => (
-        <div
-            className="radio"
-            key={dateType.name}>
-            <label className="radio-label" htmlFor="dateType">
-                <input
-                    type="radio"
-                    aria-label={dateType.name}
-                    value={dateType.name}
-                    name="dateType"
-                    checked={currentDateType === dateType.name}
-                    onChange={onChange} />
-                <div className="text-container">
-                    {dateType.label}
-                    <div className="radio-description">
-                        {dateType.description}
-                    </div>
-                </div>
-            </label>
-        </div>
+    const dateTypes = awardDownloadOptions.dateTypes.map(({ name, label, description }) => (
+        <BulkDownloadRadioButton
+            name="dateType"
+            value={name}
+            checked={currentDateType === name}
+            onChange={onChange}
+            label={label}
+            description={description}
+            key={name} />
     ));
 
     return (

--- a/src/js/components/bulkDownload/awards/filters/FileFormatFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/FileFormatFilter.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { useSelector } from "react-redux";
 import { awardDownloadOptions } from 'dataMapping/bulkDownload/bulkDownloadOptions';
 import FilterSectionTitle from 'components/bulkDownload/FilterSelectionTitle';
+import BulkDownloadRadioButton from "../../../sharedComponents/BulkDownloadRadioButton";
 
 const propTypes = { updateFilter: PropTypes.func };
 
@@ -20,24 +21,15 @@ const FileFormatFilter = memo(function FileFormatFilter({ updateFilter }) {
         updateFilter('fileFormat', target.value);
     };
 
-    const fileFormats = awardDownloadOptions.fileFormats.map((fileFormat) => (
-        <div
-            className="radio"
-            key={fileFormat.name}>
-            <label
-                className={`radio-label ${fileFormat.disabled ? 'disabled' : ''}`}
-                htmlFor="fileFormat">
-                <input
-                    type="radio"
-                    aria-label={fileFormat.name}
-                    value={fileFormat.name}
-                    name="fileFormat"
-                    checked={currentFileFormat === fileFormat.name}
-                    onChange={onChange}
-                    disabled={fileFormat.disabled} />
-                {fileFormat.label}
-            </label>
-        </div>
+    const fileFormats = awardDownloadOptions.fileFormats.map(({ name, label, disabled }) => (
+        <BulkDownloadRadioButton
+            name="fileFormat"
+            value={name}
+            checked={currentFileFormat === name}
+            onChange={onChange}
+            label={label}
+            disabled={disabled}
+            key={name} />
     ));
 
     return (

--- a/src/js/components/bulkDownload/awards/filters/LocationFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/LocationFilter.jsx
@@ -9,6 +9,7 @@ import { useSelector } from "react-redux";
 import { awardDownloadOptions } from 'dataMapping/bulkDownload/bulkDownloadOptions';
 import FilterSectionTitle from 'components/bulkDownload/FilterSelectionTitle';
 import ComboBox from "components/sharedComponents/ComboBox";
+import BulkDownloadRadioButton from "../../../sharedComponents/BulkDownloadRadioButton";
 const countryOptions = [
     {
         value: 'all',
@@ -84,26 +85,15 @@ const LocationFilter = memo(function LocationFilter({ states, updateFilter }) {
         return tempArr.map(({ code, name }) => ({ value: code, text: name }));
     }, [states])
 
-    const locationTypesArray = locationTypes.map((type) => (
-        <div
-            className="radio"
-            key={type.name}>
-            <label className={"radio-label"} htmlFor={"locationType"}>
-                <input
-                    type="radio"
-                    aria-label={type.name}
-                    value={type.name}
-                    name="locationType"
-                    checked={locationType === type.name}
-                    onChange={onChange} />
-                <div className="radio-container">
-                    {type.label}
-                    <div className="radio-description">
-                        {type.description}
-                    </div>
-                </div>
-            </label>
-        </div>
+    const locationTypesArray = locationTypes.map(({ name, label, description }) => (
+        <BulkDownloadRadioButton
+            name="locationType"
+            value={name}
+            checked={locationType === name}
+            onChange={onChange}
+            label={label}
+            description={description}
+            key={name} />
     ));
 
     // set location to all on render

--- a/src/js/components/bulkDownload/awards/filters/dateRange/TimePeriodFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/dateRange/TimePeriodFilter.jsx
@@ -15,6 +15,7 @@ import {
 import { awardDownloadOptions } from 'dataMapping/bulkDownload/bulkDownloadOptions';
 
 import DownloadDateRange from './DownloadDateRange';
+import BulkDownloadRadioButton from "../../../../sharedComponents/BulkDownloadRadioButton";
 
 const dayjs = require('dayjs');
 const isSameOrAfter = require('dayjs/plugin/isSameOrAfter');
@@ -124,7 +125,7 @@ const TimePeriodFilter = ({
             else {
                 // already checked if end is valid above
                 // if start is not valid end must be.
-                const endValue = end.format('YYYY-MM-DD');       
+                const endValue = end.format('YYYY-MM-DD');
                 errorMessage = {
                     ...errorMessage,
                     type: 'start'
@@ -269,27 +270,18 @@ const TimePeriodFilter = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [startDateBulkUI, endDateBulkUI, validateDates]);
 
-    const timePeriodTypeList = awardDownloadOptions.timePeriodTypes.map((periodType) => (
-        <div
-            className="radio"
-            key={periodType.name}>
-            <label className="radio-label" htmlFor="periodType">
-                <input
-                    type="radio"
-                    aria-label={periodType.name}
-                    value={periodType.name}
-                    name="periodType"
-                    checked={currentTimeType === periodType.name}
-                    onChange={() => setCurrentTimeType(periodType.name)} />
-                <div className="radio-container">
-                    {periodType.label}
-                    <div className="radio-description">
-                        {periodType.description}
-                    </div>
-                </div>
-            </label>
-        </div>
-    ));
+    const timePeriodTypeList = awardDownloadOptions
+        .timePeriodTypes
+        .map(({ name, label, description }) => (
+            <BulkDownloadRadioButton
+                name="periodType"
+                value={name}
+                checked={currentTimeType === name}
+                onChange={() => setCurrentTimeType(name)}
+                label={label}
+                description={description}
+                key={name} />
+        ));
 
     return (
 

--- a/src/js/components/sharedComponents/BulkDownloadRadioButton.jsx
+++ b/src/js/components/sharedComponents/BulkDownloadRadioButton.jsx
@@ -1,0 +1,51 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const propTypes = {
+    name: PropTypes.string,
+    value: PropTypes.string,
+    checked: PropTypes.bool,
+    onChange: PropTypes.func,
+    label: PropTypes.string,
+    description: PropTypes.string
+}
+
+const BulkDownloadRadioButton = ({
+    name,
+    value,
+    checked,
+    onChange,
+    label,
+    description = false
+}) => {
+    // prevents submission on enter keydown
+    const onKeyDown = (e) => {
+        if (e.keyCode === 13) e.preventDefault();
+    };
+
+    return (
+        <div className="radio">
+            <label className="radio-label" htmlFor="periodType">
+                <input
+                    type="radio"
+                    aria-label={value}
+                    value={value}
+                    name={name}
+                    onKeyDown={onKeyDown}
+                    checked={checked}
+                    onChange={onChange}/>
+                <div className="radio-container">
+                    {label}
+                    {description &&
+                        <div className="radio-description">
+                            {description}
+                        </div>
+                    }
+                </div>
+            </label>
+        </div>
+    );
+};
+
+BulkDownloadRadioButton.propTypes = propTypes;
+export default BulkDownloadRadioButton;

--- a/src/js/components/sharedComponents/BulkDownloadRadioButton.jsx
+++ b/src/js/components/sharedComponents/BulkDownloadRadioButton.jsx
@@ -7,16 +7,18 @@ const propTypes = {
     checked: PropTypes.bool,
     onChange: PropTypes.func,
     label: PropTypes.string,
-    description: PropTypes.string
+    description: PropTypes.string,
+    disabled: PropTypes.bool
 }
 
 const BulkDownloadRadioButton = ({
     name,
     value,
     checked,
-    onChange,
+    onChange = () => {},
     label,
-    description = false
+    description = false,
+    disabled = false
 }) => {
     // prevents submission on enter keydown
     const onKeyDown = (e) => {
@@ -33,15 +35,17 @@ const BulkDownloadRadioButton = ({
                     name={name}
                     onKeyDown={onKeyDown}
                     checked={checked}
-                    onChange={onChange}/>
-                <div className="radio-container">
-                    {label}
-                    {description &&
+                    onChange={onChange}
+                    disabled={disabled} />
+                {description ?
+                    <div className="radio-container">
+                        {label}
                         <div className="radio-description">
                             {description}
                         </div>
-                    }
-                </div>
+                    </div> :
+                    label
+                }
             </label>
         </div>
     );

--- a/src/js/components/sharedComponents/BulkDownloadRadioButton.jsx
+++ b/src/js/components/sharedComponents/BulkDownloadRadioButton.jsx
@@ -25,7 +25,7 @@ const BulkDownloadRadioButton = ({
 
     return (
         <div className="radio">
-            <label className="radio-label" htmlFor="periodType">
+            <label className="radio-label" htmlFor={name}>
                 <input
                     type="radio"
                     aria-label={value}

--- a/src/js/components/sharedComponents/checkbox/CollapsedCheckboxType.jsx
+++ b/src/js/components/sharedComponents/checkbox/CollapsedCheckboxType.jsx
@@ -35,6 +35,14 @@ const CollapsedCheckboxType = ({
 
     if (ref.current) ref.current.indeterminate = indeterminate;
 
+    // prevents submission on enter keydown
+    const onKeyDown = (e) => {
+        if (e.keyCode === 13) {
+            e.preventDefault();
+            toggleChildren();
+        }
+    };
+
     return (
         <div className="primary-checkbox-type">
             <div className="checkbox-type-item-wrapper">
@@ -53,6 +61,7 @@ const CollapsedCheckboxType = ({
                         id={inputId}
                         value={name}
                         checked={selected}
+                        onKeyDown={onKeyDown}
                         onChange={toggleChildren}
                         ref={ref} />
                     <span className="checkbox-item-label">

--- a/src/js/components/sharedComponents/checkbox/PrimaryCheckboxType.jsx
+++ b/src/js/components/sharedComponents/checkbox/PrimaryCheckboxType.jsx
@@ -175,16 +175,18 @@ const PrimaryCheckboxType = ({
     }
 
     if (filters.length === 0) {
-        primaryTypes = (<SingleCheckboxType
-            name={name}
-            toggleCheckboxType={toggleCheckboxType}
-            filterType={filterType}
-            selectedCheckboxes={selectedCheckboxes}
-            enableAnalytics={enableAnalytics}
-            value={value}
-            code={value}
-            key={`${id} - ${value}`}
-            id={`primary-checkbox-${uniqueId()}`} />);
+        primaryTypes = (
+            <SingleCheckboxType
+                name={name}
+                toggleCheckboxType={toggleCheckboxType}
+                filterType={filterType}
+                selectedCheckboxes={selectedCheckboxes}
+                enableAnalytics={enableAnalytics}
+                value={value}
+                code={value}
+                key={`${id} - ${value}`}
+                id={`primary-checkbox-${uniqueId()}`} />
+        );
     }
 
     useEffect(() => {

--- a/src/js/components/sharedComponents/checkbox/SecondaryCheckboxType.jsx
+++ b/src/js/components/sharedComponents/checkbox/SecondaryCheckboxType.jsx
@@ -75,6 +75,14 @@ const SecondaryCheckboxType = ({
         }
     };
 
+    // prevents submission on enter keydown
+    const onKeyDown = (e) => {
+        if (e.keyCode === 13) {
+            e.preventDefault();
+            toggleFilter();
+        }
+    };
+
     return (
         <li key={id} className="secondary-checkbox-type">
             <label
@@ -85,6 +93,7 @@ const SecondaryCheckboxType = ({
                     id={elementId}
                     value={code}
                     checked={checked}
+                    onKeyDown={onKeyDown}
                     onChange={toggleFilter}
                     disabled={restrictChildren} />
                 <span className="checkbox-item-label">


### PR DESCRIPTION
**Description:**
Created new component to consolidate button code. Added a prevent default to the enter keydown action.

**JIRA Ticket:**
[DEV-15297](https://federal-spending-transparency.atlassian.net/browse/DEV-15297)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-15297]: https://federal-spending-transparency.atlassian.net/browse/DEV-15297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ