### PR TITLE
fix/DEV-15497 fixed page crash due to null period

### DIFF
--- a/src/js/components/bulkDownload/accounts/AccountUserSelections.jsx
+++ b/src/js/components/bulkDownload/accounts/AccountUserSelections.jsx
@@ -120,7 +120,7 @@ const AccountUserSelections = () => {
 
     const generateFyString = () => {
         const { fy, quarter, period } = accounts;
-        const timePeriodSelection = quarter ? `Q${quarter}` : `(P${period})`;
+        const timePeriodSelection = quarter ? `(Q${quarter})` : `(P${period})`;
         if (fy) {
             return (
                 <div className="selection__content">

--- a/src/js/components/bulkDownload/accounts/AccountUserSelections.jsx
+++ b/src/js/components/bulkDownload/accounts/AccountUserSelections.jsx
@@ -120,11 +120,11 @@ const AccountUserSelections = () => {
 
     const generateFyString = () => {
         const { fy, quarter, period } = accounts;
-        const timePeriodSelection = quarter ? `(Q${quarter})` : `(P${period})`;
+        const timePeriodSelection = quarter ? `Q${quarter}` : `(P${period})`;
         if (fy) {
             return (
                 <div className="selection__content">
-                    FY {fy} - {getPeriodTitle(period.toString())} {timePeriodSelection}
+                    FY {fy} - {getPeriodTitle(period?.toString())} {timePeriodSelection}
                 </div>
             );
         }


### PR DESCRIPTION
**Description:**
fixing the crashing on the bulk account downloads page when selecting a time period before 2020

**JIRA Ticket:**
[DEV-15497](https://federal-spending-transparency.atlassian.net/browse/DEV-15497)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-15497]: https://federal-spending-transparency.atlassian.net/browse/DEV-15497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ