### PR TITLE
FIX/DEV-15394 More Resources button borders should be clickable and include a hover effect

### DIFF
--- a/src/_scss/pages/search/naturalLanguage/_moreResources.scss
+++ b/src/_scss/pages/search/naturalLanguage/_moreResources.scss
@@ -24,6 +24,11 @@
     border: rem(1) solid $gray-10;
     background: $gray-5;
 
+    &:hover {
+      cursor: pointer;
+      background: $gray-10;
+    }
+
     @media (min-width: $large-screen) {
       flex: 1 1 0;
       flex-direction: column;

--- a/src/_scss/pages/search/naturalLanguage/_searchSuggestions.scss
+++ b/src/_scss/pages/search/naturalLanguage/_searchSuggestions.scss
@@ -9,38 +9,22 @@
   border: rem(1) solid $gray-10;
   margin-top: $global-spacing-unit * 5;
 
-  .button-icon-container {
-    border-radius: rem(4);
-    background: $blue-vivid-5v;
-    margin-left: rem(4);
-
-    &:hover {
-      background: $blue-70v;
-      color: $color-white;
-    }
-  }
-
-  .button-icon {
-    @include icon-styles;
-    margin-right: rem(5);
-  }
-
   .search-suggestions__row {
-    display: flex;
-    flex: 1 0 0;
-    align-items: flex-start;
-    justify-content: space-between;
+  display: flex;
+  flex: 1 0 0;
+  align-items: flex-start;
+  justify-content: space-between;
   }
 
   .search-suggestions__title {
-    color: $gray-80;
-    font-family: $font-sans;
-    font-size: $h3-font-size;
-    font-weight: $font-semibold;
-    line-height: $heading-line-height;
-    margin-bottom: $global-margin * 3;
-    display: flex;
-    flex-direction: column;
+  color: $gray-80;
+  font-family: $font-sans;
+  font-size: $h3-font-size;
+  font-weight: $font-semibold;
+  line-height: $heading-line-height;
+  margin-bottom: $global-margin * 3;
+  display: flex;
+  flex-direction: column;
    
   }
 
@@ -53,6 +37,25 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .button-icon-container {
+    width: rem(24);
+    height: rem(24);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: rem(4);
+    background: $blue-vivid-5v;
+
+    &:hover {
+      background: $blue-70v;
+      color: $color-white;
+    }
+
+    .button-icon {
+      @include icon-styles;
+    }
   }
 
   .search-suggestions__card-row {

--- a/src/_scss/pages/search/naturalLanguage/_searchSuggestions.scss
+++ b/src/_scss/pages/search/naturalLanguage/_searchSuggestions.scss
@@ -13,7 +13,13 @@
     border-radius: rem(4);
     background: $blue-vivid-5v;
     margin-left: rem(4);
+
+    &:hover {
+      background: $blue-70v;
+      color: $color-white;
+    }
   }
+
   .button-icon {
     @include icon-styles;
     margin-right: rem(5);

--- a/src/_scss/pages/search/resultsView/_dtuiOverrides.scss
+++ b/src/_scss/pages/search/resultsView/_dtuiOverrides.scss
@@ -45,7 +45,6 @@
   .button-type__text-right-icon-light svg {
     margin: 0;
   }
-
 }
 
 .more-resources__col {

--- a/src/_scss/pages/search/resultsView/_dtuiOverrides.scss
+++ b/src/_scss/pages/search/resultsView/_dtuiOverrides.scss
@@ -39,7 +39,13 @@
   .button__md {
     padding: 0;
     margin: 0;
+    gap: rem(8);
   }
+
+  .button-type__text-right-icon-light svg {
+    margin-left: rem(0);
+  }
+
 }
 
 .more-resources__col {

--- a/src/_scss/pages/search/resultsView/_dtuiOverrides.scss
+++ b/src/_scss/pages/search/resultsView/_dtuiOverrides.scss
@@ -43,7 +43,7 @@
   }
 
   .button-type__text-right-icon-light svg {
-    margin-left: rem(0);
+    margin: 0;
   }
 
 }

--- a/src/js/components/naturalLanguage/NLMoreResources.jsx
+++ b/src/js/components/naturalLanguage/NLMoreResources.jsx
@@ -20,13 +20,13 @@ const NLMoreResources = () => {
                 {moreResourcesBtnData.map((btn) => (
                     <FlexGridCol 
                         className="more-resources__col"
-                        key={`more-resources-${btn.id}`}  
+                        key={`more-resources-${btn.id}`} 
+                        onClick={() => btn.action(navigate)}
                         mobile={12}
                         tablet={6}
                         desktop={4}>
                         <Button
                             copy=""
-                            onClick={() => btn.action(navigate)}
                             buttonTitle=""
                             buttonSize="md"
                             buttonType="text"


### PR DESCRIPTION
More Resources grey button borders should be clickable and include a hover effect. Also the watch training videos arrow icon should have a hover effect.

**JIRA Ticket:**
[DEV-15394](https://federal-spending-transparency.atlassian.net/browse/DEV-15394)

https://figma-gov.com/design/f9KjGM5O8dagB6iC28nxfH/NL-Screens?node-id=630-13015&m=dev

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled and completed design review 
- [x] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [x] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [x] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-15394]: https://federal-spending-transparency.atlassian.net/browse/DEV-15394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ