### PR TITLE
DEV - 15575: Strip bcc query string from share by email

### DIFF
--- a/src/js/components/trainingVideos/GenericErrorMessage.jsx
+++ b/src/js/components/trainingVideos/GenericErrorMessage.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from "prop-types";
+import { sanitizeMailUrl } from '../../helpers/url';
 
 const propTypes = {
     message: PropTypes.string,
@@ -17,7 +18,7 @@ const GeneralErrorMessage = ({ message, emailSubject }) => (
             <p className="error-message__paragraph-one">Something went wrong</p>
             <p className="error-message__paragraph-two">{message}</p>
             {/* eslint-disable-next-line no-return-assign */}
-            <button className="error-message__button" onClick={() => window.location = `mailto:usaspending.help@fiscal.treasury.gov?subject=${encodeURIComponent(emailSubject)}`}>Report this error</button>
+            <button className="error-message__button" onClick={() => window.location = sanitizeMailUrl(`mailto:usaspending.help@fiscal.treasury.gov?subject=${encodeURIComponent(emailSubject)}`)}>Report this error</button>
         </div>
     </div>
 );

--- a/src/js/helpers/socialShare.jsx
+++ b/src/js/helpers/socialShare.jsx
@@ -6,6 +6,7 @@ import {
     faLinkedin,
     faReddit
 } from '@fortawesome/free-brands-svg-icons';
+import { sanitizeMailUrl } from './url';
 
 export const socialUrls = {
     facebook: `https://www.facebook.com/sharer/sharer.php?u=`,
@@ -52,7 +53,7 @@ const handleShareClickReddit = (url, handleShareDispatch) => {
 
 const handleShareClickEmail = (subject, body) => {
     const finalUrl = `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
-    window.location.href = finalUrl;
+    window.location.href = sanitizeMailUrl(finalUrl);
     Analytics.event({
         event: 'Social Share Email', category: `${subject}`, action: 'share link click', label: 'email'
     });

--- a/src/js/helpers/url.js
+++ b/src/js/helpers/url.js
@@ -74,3 +74,27 @@ export const sanitizeUrl = (rawURL, blockRedirect = true) => {
 
     return encodeURI(parsed.toString());
 }
+
+
+export const sanitizeMailUrl = (rawURL) => {
+    let cleanMailto = rawURL;
+    const [prefix, queryString] = rawURL.split('?');
+
+    if (queryString) {
+        cleanMailto = prefix;
+
+        const params = new URLSearchParams(queryString);
+
+        // remove any unwanted copy emails
+        params.delete('cc');
+        params.delete('bcc');
+
+
+        if (params.toString() && params.toString() !== '' ) {
+            // add wanted params back
+            cleanMailto = `${prefix}?${params.toString()}`
+        }
+    }
+
+    return cleanMailto;
+}

--- a/tests/helpers/urlHelper-test.js
+++ b/tests/helpers/urlHelper-test.js
@@ -5,7 +5,7 @@
  * Created by JD House 7/7/2026
 */
 
-import { sanitizeUrl } from "../../src/js/helpers/url";
+import { sanitizeUrl, sanitizeMailUrl } from "../../src/js/helpers/url";
 
 
 describe('sanitizeUrl()', () => {
@@ -55,4 +55,18 @@ describe('sanitizeUrl()', () => {
         expect(sanitizeUrl("javascript:alert(1"))
             .toBeNull();
     })
+});
+
+describe('sanitizeMailUrl()', () => {
+    it('returns clean mailto url without hidden bcc', () => {
+        const encodedText = encodeURIComponent('Contact Us');
+        expect(sanitizeMailUrl(`mailto:usaspending.help@fiscal.treasury.gov?bcc=evil@evil.com&subject=${encodedText}&body=${encodedText}`))
+            .toBe('mailto:usaspending.help@fiscal.treasury.gov?subject=Contact+Us&body=Contact+Us');
+    });
+    it('returns clean mailto url without hidden bcc and cc', () => {
+        const encodedText = encodeURIComponent('Contact Us');
+        expect(sanitizeMailUrl(`mailto:usaspending.help@fiscal.treasury.gov?cc=evil@bad.com&bcc=evil@evil.com&subject=${encodedText}&body=${encodedText}`))
+            .toBe('mailto:usaspending.help@fiscal.treasury.gov?subject=Contact+Us&body=Contact+Us');
+    });
+        
 });


### PR DESCRIPTION
**Description:**

created new sanitizeMailUrl helper function with unit test.  Applied when subject and/or body are passed params to mailto link.

**JIRA Ticket:**
[DEV-15575](https://federal-spending-transparency.atlassian.net/browse/DEV-15575)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-15575]: https://federal-spending-transparency.atlassian.net/browse/DEV-15575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ