### PR TITLE
DEV-15324 the default/current FY is not displayed in the Fiscal Year field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14879,9 +14879,9 @@
       "integrity": "sha512-YMyxSlXpPjD8uWekCQGuN40lV4bnZagUwqa2m/uFv1z/tNImSk9fnXVMUI5qwME/zzI3MMQRvjZ+69zyfSSyew=="
     },
     "node_modules/postcss-svgo/node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {

--- a/src/js/components/sharedComponents/ComboBox.jsx
+++ b/src/js/components/sharedComponents/ComboBox.jsx
@@ -35,7 +35,7 @@ const ComboBox = memo(function ComboBox({
     className,
     filterInput = true
 }) {
-    const [inputValue, setInputValue] = useState('');
+    const [inputValue, setInputValue] = useState(defaultValue);
     const [openOptions, setOpenOptions] = useState(false);
     const comboRef = useRef(null)
 
@@ -97,10 +97,6 @@ const ComboBox = memo(function ComboBox({
         setOpenOptions(false);
         onClearSelect();
     }, []);
-
-    useEffect(() => {
-        if (disabled) onClickClear();
-    }, [disabled, onClickClear])
 
     const onClickToggle = () => setOpenOptions((prevState) => !prevState);
 

--- a/src/js/components/sharedComponents/QuarterPickerWithFY.jsx
+++ b/src/js/components/sharedComponents/QuarterPickerWithFY.jsx
@@ -50,11 +50,11 @@ const QuarterPickerWithFY = ({
         }
     }, [allPeriods, handlePickedYear]);
 
-    const onClearSelect = () => {
+    const onClearSelect = useCallback(() => {
         updateFilter('fy', '');
         updateFilter('period', null);
         updateFilter('quarter', null);
-    }
+    }, []);
 
     const periodsPerQuarter = useMemo(() =>
         getPeriodsPerQuarterByFy(parseInt(selectedFy, 10)),


### PR DESCRIPTION
**Description:**
Removed disabled/onClearSelect useEffect that was causing the default state to go blank.

**JIRA Ticket:**
[DEV-15324](https://federal-spending-transparency.atlassian.net/browse/DEV-15324)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-15324]: https://federal-spending-transparency.atlassian.net/browse/DEV-15324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ