### PR TITLE
DEV-15672 Advanced Search - More Resources - About the Data panel is not opened while the Glossary panel is open

### DIFF
--- a/src/js/components/naturalLanguage/NLData.js
+++ b/src/js/components/naturalLanguage/NLData.js
@@ -6,7 +6,7 @@
 import React from "react";
 import NLSearchSuggestionsIcon from "./NLSearchSuggestionsIcon";
 import Analytics from "../../helpers/analytics/Analytics";
-import { closeOtherSlideOuts } from "../../helpers/slideoutHelper";
+import { closeOtherSlideouts } from "../../helpers/slideoutHelper";
 import storeSingleton from 'redux/storeSingleton';
 import * as glossaryActions from "../../redux/actions/glossary/glossaryActions"
 import * as aboutTheDataActions from "../../redux/actions/aboutTheDataSidebar/aboutTheDataActions"
@@ -99,7 +99,7 @@ export const moreResourcesBtnData = [
                 action: 'Link',
                 label: 'glossary button'
             });
-            closeOtherSlideOuts('glossary');
+            closeOtherSlideouts('glossary');
             dispatch(glossaryActions.toggleGlossary());
         },
         image: (
@@ -118,7 +118,7 @@ export const moreResourcesBtnData = [
                 action: 'Link',
                 label: 'about the data button'
             });
-            closeOtherSlideOuts('atd');
+            closeOtherSlideouts('atd');
             dispatch(aboutTheDataActions.toggleAboutTheData());
         },
         image: (
@@ -137,7 +137,7 @@ export const moreResourcesBtnData = [
                 action: 'Link',
                 label: 'data dictionary button'
             });
-            closeOtherSlideOuts();
+            closeOtherSlideouts();
             navigate("/data-dictionary");
         },
         image: (
@@ -156,7 +156,7 @@ export const moreResourcesBtnData = [
                 action: 'Link',
                 label: 'federal spending guide button'
             });
-            closeOtherSlideOuts();
+            closeOtherSlideouts();
             navigate("/federal-spending-guide");
         },
         image: (

--- a/src/js/components/naturalLanguage/NLData.js
+++ b/src/js/components/naturalLanguage/NLData.js
@@ -6,7 +6,7 @@
 import React from "react";
 import NLSearchSuggestionsIcon from "./NLSearchSuggestionsIcon";
 import Analytics from "../../helpers/analytics/Analytics";
-import { closeAllSlideouts } from "../../helpers/slideoutHelper";
+import { closeOtherSlideOuts } from "../../helpers/slideoutHelper";
 import storeSingleton from 'redux/storeSingleton';
 import * as glossaryActions from "../../redux/actions/glossary/glossaryActions"
 import * as aboutTheDataActions from "../../redux/actions/aboutTheDataSidebar/aboutTheDataActions"
@@ -99,6 +99,7 @@ export const moreResourcesBtnData = [
                 action: 'Link',
                 label: 'glossary button'
             });
+            closeOtherSlideOuts('glossary');
             dispatch(glossaryActions.toggleGlossary());
         },
         image: (
@@ -117,6 +118,7 @@ export const moreResourcesBtnData = [
                 action: 'Link',
                 label: 'about the data button'
             });
+            closeOtherSlideOuts('atd');
             dispatch(aboutTheDataActions.toggleAboutTheData());
         },
         image: (
@@ -135,7 +137,7 @@ export const moreResourcesBtnData = [
                 action: 'Link',
                 label: 'data dictionary button'
             });
-            closeAllSlideouts();
+            closeOtherSlideOuts();
             navigate("/data-dictionary");
         },
         image: (
@@ -154,7 +156,7 @@ export const moreResourcesBtnData = [
                 action: 'Link',
                 label: 'federal spending guide button'
             });
-            closeAllSlideouts();
+            closeOtherSlideOuts();
             navigate("/federal-spending-guide");
         },
         image: (

--- a/src/js/helpers/slideoutHelper.js
+++ b/src/js/helpers/slideoutHelper.js
@@ -73,7 +73,7 @@ export const showSlideout = (type, options = {}) => {
     return true;
 };
 
-const slideOutsLookup = {
+const slideoutsLookup = {
     glossary: () => glossaryActions.hideGlossary(),
     atd: () => aboutTheDataActions.hideAboutTheData()
 }
@@ -84,8 +84,8 @@ const slideOutsLookup = {
  * Can also be used to close all slideouts when called
  * with no arg
  */
-export const closeOtherSlideOuts = (currentType) => {
-    Object.entries(slideOutsLookup).forEach(([type, hideAction]) => {
+export const closeOtherSlideouts = (currentType) => {
+    Object.entries(slideoutsLookup).forEach(([type, hideAction]) => {
         if (type !== currentType) {
             storeSingleton.store.dispatch(hideAction());
         }

--- a/src/js/helpers/slideoutHelper.js
+++ b/src/js/helpers/slideoutHelper.js
@@ -84,7 +84,7 @@ const slideoutsLookup = {
  * Can also be used to close all slideouts when called
  * with no arg
  */
-export const closeOtherSlideouts = (currentType) => {
+export const closeOtherSlideouts = (currentType = '') => {
     Object.entries(slideoutsLookup).forEach(([type, hideAction]) => {
         if (type !== currentType) {
             storeSingleton.store.dispatch(hideAction());

--- a/src/js/helpers/slideoutHelper.js
+++ b/src/js/helpers/slideoutHelper.js
@@ -90,7 +90,7 @@ export const closeOtherSlideouts = (currentType) => {
             storeSingleton.store.dispatch(hideAction());
         }
     });
-    storeSingleton.store.dispatch(slideoutActions.setLastOpenedSlideout(''));
+    storeSingleton.store.dispatch(slideoutActions.setLastOpenedSlideout(currentType));
 }
 
 

--- a/src/js/helpers/slideoutHelper.js
+++ b/src/js/helpers/slideoutHelper.js
@@ -73,9 +73,26 @@ export const showSlideout = (type, options = {}) => {
     return true;
 };
 
-export const closeAllSlideouts = () => {
-    storeSingleton.store.dispatch(glossaryActions.hideGlossary());
-    storeSingleton.store.dispatch(aboutTheDataActions.hideAboutTheData());
+const slideOutsLookup = {
+    glossary: () => glossaryActions.hideGlossary(),
+    atd: () => aboutTheDataActions.hideAboutTheData()
+}
+
+/**
+ * 
+ * Closes all slideouts except the current. 
+ * Can also be used to close all slideouts when called
+ * with no arg
+ */
+export const closeOtherSlideOuts = (currentType) => {
+    Object.entries(slideOutsLookup).forEach(([type, hideAction]) => {
+        if (type !== currentType) {
+            storeSingleton.store.dispatch(hideAction());
+        }
+    });
     storeSingleton.store.dispatch(slideoutActions.setLastOpenedSlideout(''));
-};
+}
+
+
+
 

--- a/tests/helpers/slideoutHelper-test.js
+++ b/tests/helpers/slideoutHelper-test.js
@@ -125,8 +125,6 @@ describe('slideoutHelper', () => {
 
             closeOtherSlideouts('glossary');
 
-            console.log({getState: store.getState()});
-
             expect(mockDispatch).toHaveBeenCalledTimes(2);
             expect(mockHideATDAction).toHaveBeenCalledTimes(1);
             expect(mockSetLastAction).toHaveBeenCalledTimes(1);

--- a/tests/helpers/slideoutHelper-test.js
+++ b/tests/helpers/slideoutHelper-test.js
@@ -145,6 +145,8 @@ describe('slideoutHelper', () => {
             expect(mockHideATDAction).toHaveBeenCalledTimes(1);
             expect(mockHideGlossaryAction).toHaveBeenCalledTimes(1);
             expect(mockSetLastAction).toHaveBeenCalledTimes(1);
+            expect(mockSetLastAction).toBeCalledWith(undefined);
+
         });
     });
 });

--- a/tests/helpers/slideoutHelper-test.js
+++ b/tests/helpers/slideoutHelper-test.js
@@ -9,7 +9,7 @@ import { combineReducers, createStore } from 'redux';
 import storeSingleton from 'redux/storeSingleton';
 import { beforeEach, expect } from '@jest/globals';
 import { render, waitFor } from '../testResources/test-utils';
-import { showSlideout, closeAllSlideouts } from "../../src/js/helpers/slideoutHelper";
+import { showSlideout, closeOtherSlideOuts } from "../../src/js/helpers/slideoutHelper";
 import * as glossaryReducer from "../../src/js/redux/reducers/glossary/glossaryReducer";
 import * as atdReducer from "../../src/js/redux/reducers/aboutTheDataSidebar/aboutTheDataReducer";
 import * as slideoutReducer from "../../src/js/redux/reducers/slideouts/slideoutReducer";
@@ -31,8 +31,7 @@ const mockData = {
     }
 };
 
-const store = createStore(mockAPPReducer, mockData);
-storeSingleton.setStore(store);
+let store;
 
 const updateLastAction = (last) => {
     store.dispatch(slideoutActions.setLastOpenedSlideout(last));
@@ -43,6 +42,8 @@ describe('slideoutHelper', () => {
         let mockDispatch;
 
         beforeEach(() => {
+            store = createStore(mockAPPReducer, mockData);
+            storeSingleton.setStore(store);
             mockDispatch = jest.spyOn(store, 'dispatch').mockReturnValue(() => (fn) => fn()).mockClear();
         });
 
@@ -100,27 +101,53 @@ describe('slideoutHelper', () => {
             });
         });
     });
-    describe('closeAllSlideouts', () => {
+    describe('closeOtherSlideOuts', () => {
         let mockDispatch;
 
         beforeEach(() => {
+            store = createStore(mockAPPReducer, {
+                ...mockData,
+                slideouts: {
+                    ...mockData.slideouts,
+                    lastOpenedSlideout: ''
+                }
+            });
+            storeSingleton.setStore(store);
             mockDispatch = jest.spyOn(store, 'dispatch').mockReturnValue(() => (fn) => fn()).mockClear();
         });
 
-        it('should dispatch hideGlossary, hideAboutTheData, and setLastOpenSlideout when closeAllSlideouts helper function is called', () => {
+        it('should only dispatch hideAboutTheData and setLastOpenSlideout when closeOtherSlideOuts is called with glossary arg', () => {
+            render(<></>, { initialState: mockAPPReducer, store });
+
+            const mockHideATDAction = jest.spyOn(atdActions, 'hideAboutTheData').mockClear();
+            const mockSetLastAction = jest.spyOn(slideoutActions, 'setLastOpenedSlideout').mockClear();
+            const mockHideGlossaryAction = jest.spyOn(glossaryActions, 'hideGlossary').mockClear();
+
+            closeOtherSlideOuts('glossary');
+
+            console.log({getState: store.getState()});
+
+            expect(mockDispatch).toHaveBeenCalledTimes(2);
+            expect(mockHideATDAction).toHaveBeenCalledTimes(1);
+            expect(mockSetLastAction).toHaveBeenCalledTimes(1);
+            expect(mockHideGlossaryAction).toHaveBeenCalledTimes(0);
+
+        })
+
+        it('should dispatch hideGlossary, hideAboutTheData, and setLastOpenSlideout when closeOtherSlideOuts helper function is called with no args', () => {
             render(<></>, { initialState: mockAPPReducer, store });
 
             const mockHideATDAction = jest.spyOn(atdActions, 'hideAboutTheData').mockClear();
             const mockHideGlossaryAction = jest.spyOn(glossaryActions, 'hideGlossary').mockClear();
             const mockSetLastAction = jest.spyOn(slideoutActions, 'setLastOpenedSlideout').mockClear();
 
-            closeAllSlideouts();
+            closeOtherSlideOuts();
 
             expect(mockDispatch).toHaveBeenCalledTimes(3);
             expect(mockHideATDAction).toHaveBeenCalledTimes(1);
             expect(mockHideGlossaryAction).toHaveBeenCalledTimes(1);
             expect(mockSetLastAction).toHaveBeenCalledTimes(1);
-        })
-    })
+        });
+    });
 });
 

--- a/tests/helpers/slideoutHelper-test.js
+++ b/tests/helpers/slideoutHelper-test.js
@@ -146,7 +146,7 @@ describe('slideoutHelper', () => {
             expect(mockHideATDAction).toHaveBeenCalledTimes(1);
             expect(mockHideGlossaryAction).toHaveBeenCalledTimes(1);
             expect(mockSetLastAction).toHaveBeenCalledTimes(1);
-            expect(mockSetLastAction).toBeCalledWith(undefined);
+            expect(mockSetLastAction).toBeCalledWith('');
 
         });
     });

--- a/tests/helpers/slideoutHelper-test.js
+++ b/tests/helpers/slideoutHelper-test.js
@@ -9,7 +9,7 @@ import { combineReducers, createStore } from 'redux';
 import storeSingleton from 'redux/storeSingleton';
 import { beforeEach, expect } from '@jest/globals';
 import { render, waitFor } from '../testResources/test-utils';
-import { showSlideout, closeOtherSlideOuts } from "../../src/js/helpers/slideoutHelper";
+import { showSlideout, closeOtherSlideouts } from "../../src/js/helpers/slideoutHelper";
 import * as glossaryReducer from "../../src/js/redux/reducers/glossary/glossaryReducer";
 import * as atdReducer from "../../src/js/redux/reducers/aboutTheDataSidebar/aboutTheDataReducer";
 import * as slideoutReducer from "../../src/js/redux/reducers/slideouts/slideoutReducer";
@@ -101,7 +101,7 @@ describe('slideoutHelper', () => {
             });
         });
     });
-    describe('closeOtherSlideOuts', () => {
+    describe('closeOtherSlideouts', () => {
         let mockDispatch;
 
         beforeEach(() => {
@@ -116,14 +116,14 @@ describe('slideoutHelper', () => {
             mockDispatch = jest.spyOn(store, 'dispatch').mockReturnValue(() => (fn) => fn()).mockClear();
         });
 
-        it('should only dispatch hideAboutTheData and setLastOpenSlideout when closeOtherSlideOuts is called with glossary arg', () => {
+        it('should only dispatch hideAboutTheData and setLastOpenSlideout when closeOtherSlideouts is called with glossary arg', () => {
             render(<></>, { initialState: mockAPPReducer, store });
 
             const mockHideATDAction = jest.spyOn(atdActions, 'hideAboutTheData').mockClear();
             const mockSetLastAction = jest.spyOn(slideoutActions, 'setLastOpenedSlideout').mockClear();
             const mockHideGlossaryAction = jest.spyOn(glossaryActions, 'hideGlossary').mockClear();
 
-            closeOtherSlideOuts('glossary');
+            closeOtherSlideouts('glossary');
 
             console.log({getState: store.getState()});
 
@@ -134,14 +134,14 @@ describe('slideoutHelper', () => {
 
         })
 
-        it('should dispatch hideGlossary, hideAboutTheData, and setLastOpenSlideout when closeOtherSlideOuts helper function is called with no args', () => {
+        it('should dispatch hideGlossary, hideAboutTheData, and setLastOpenSlideout when closeOtherSlideouts helper function is called with no args', () => {
             render(<></>, { initialState: mockAPPReducer, store });
 
             const mockHideATDAction = jest.spyOn(atdActions, 'hideAboutTheData').mockClear();
             const mockHideGlossaryAction = jest.spyOn(glossaryActions, 'hideGlossary').mockClear();
             const mockSetLastAction = jest.spyOn(slideoutActions, 'setLastOpenedSlideout').mockClear();
 
-            closeOtherSlideOuts();
+            closeOtherSlideouts();
 
             expect(mockDispatch).toHaveBeenCalledTimes(3);
             expect(mockHideATDAction).toHaveBeenCalledTimes(1);

--- a/tests/helpers/slideoutHelper-test.js
+++ b/tests/helpers/slideoutHelper-test.js
@@ -128,6 +128,7 @@ describe('slideoutHelper', () => {
             expect(mockDispatch).toHaveBeenCalledTimes(2);
             expect(mockHideATDAction).toHaveBeenCalledTimes(1);
             expect(mockSetLastAction).toHaveBeenCalledTimes(1);
+            expect(mockSetLastAction).toBeCalledWith('glossary');
             expect(mockHideGlossaryAction).toHaveBeenCalledTimes(0);
 
         })


### PR DESCRIPTION
**Description:**
When a user clicks the Glossary button, then clicks the About the Data button, the Glossary section never closes so the About the Data section can open.

**JIRA Ticket:**
[DEV-15672](https://federal-spending-transparency.atlassian.net/browse/DEV-15672)

Steps to reproduce:

Navigate to the Advanced Search page:

https://qat.usaspending.gov/search

Click on Glossary

Glossary side panel is opened

Click on About the Data

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-15537]: https://federal-spending-transparency.atlassian.net/browse/DEV-15537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DEV-15672]: https://federal-spending-transparency.atlassian.net/browse/DEV-15672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ