### PR TITLE
removed attributes to ensure it won't open in a new tab

### DIFF
--- a/src/js/components/bulkDownload/MetadataDownload.jsx
+++ b/src/js/components/bulkDownload/MetadataDownload.jsx
@@ -18,6 +18,7 @@ const MetadataDownload = () => (
         </p>
         <div className="metadata-download-button">
             <a
+                rel="noreferrer"
                 href={downloadLocation}
                 aria-label="Dataset Metadata"
                 download>

--- a/src/js/components/bulkDownload/MetadataDownload.jsx
+++ b/src/js/components/bulkDownload/MetadataDownload.jsx
@@ -18,9 +18,7 @@ const MetadataDownload = () => (
         </p>
         <div className="metadata-download-button">
             <a
-                target="_blank"
                 href={downloadLocation}
-                rel="noopener noreferrer"
                 aria-label="Dataset Metadata"
                 download>
                 <button


### PR DESCRIPTION
**Description:**

target="_blank" overrides the download attribute and will open it in a new tab, so removed it