### PR TITLE
try to set the type manually so it forces the proper http header

### DIFF
--- a/src/js/components/bulkDownload/MetadataDownload.jsx
+++ b/src/js/components/bulkDownload/MetadataDownload.jsx
@@ -20,6 +20,7 @@ const MetadataDownload = () => (
             <a
                 rel="noreferrer"
                 href={downloadLocation}
+                type="binary/octet-stream"
                 aria-label="Dataset Metadata"
                 download>
                 <button


### PR DESCRIPTION
**Description:**
attempt to force the content type - note we have not had to do this in the many years since this functionality was first deployed