### PR TITLE
HOTFIX DEV-16263: fix state pages with spaces in title

### DIFF
--- a/src/js/features/state/page/StatePageContainer.jsx
+++ b/src/js/features/state/page/StatePageContainer.jsx
@@ -29,7 +29,7 @@ require('pages/state/statePage.scss');
 
 const StatePageContainer = () => {
     const dispatch = useDispatch();
-    const { handleFyChange, state, stateId, fy } = useStateNavigation();
+    const { handleFyChange, stateId, fy } = useStateNavigation();
     const stateProfile = useSelector((s) => s.stateProfile);
     const [agencySlugs, , , slugsLoading, slugsError] = useAgencySlugs();
     const agencyData = { agencySlugs, slugsLoading, slugsError };
@@ -43,7 +43,7 @@ const StatePageContainer = () => {
         // Update the map center
         const center = stateCenterFromFips(stateId);
         dispatch(setStateCenter(center));
-    }, [state, stateProfile.fy, fy, stateId]);
+    }, [fy, stateId, dispatch]);
 
     let content = (
         <FlexGridRow className="state-content-wrapper">

--- a/src/js/features/state/useStateNavigation.jsx
+++ b/src/js/features/state/useStateNavigation.jsx
@@ -1,5 +1,5 @@
+import { useEffect, useCallback } from "react";
 import { useDispatch } from 'react-redux';
-import { useEffect } from "react";
 import { useMatch, useNavigate } from "react-router";
 import { parseStateDataFromUrl } from "./stateHelper";
 import { resetState, setStateFiscalYear } from "../../redux/actions/state/stateActions";
@@ -14,16 +14,16 @@ export const useStateNavigation = () => {
     const [wasInputStateName, stateName, stateId] = parseStateDataFromUrl(state);
     const fy = fyParam;
 
-    const handleFyChange = (newFy) => {
+    const handleFyChange = useCallback((newFy) => {
         navigate(`/state/${stateName}/${newFy}`);
         dispatch(setStateFiscalYear(newFy));
-    };
+    }, [dispatch, navigate, stateName]);
 
     useEffect(() => {
-        if (Object.keys(fipsIdByStateName).includes(stateName)) {
+        if (Object.keys(fipsIdByStateName).includes(stateName.replaceAll('-', ' '))) {
             if (!fy) {
-            // this may be an issue on the first day of 2026 fiscal year
-            // history(`/state/${stateName}/latest`, { replace: true });
+                // this may be an issue on the first day of 2026 fiscal year
+                // history(`/state/${stateName}/latest`, { replace: true });
                 navigate(`/state/${stateName}/2026`, { replace: true });
             }
             else if (!allFiscalYears().includes(parseInt(fyParam, 10))) {


### PR DESCRIPTION
hotfix for state profile pages not loading if they have spaces in the title