### PR TITLE
DEV - 16271:  508: Fix Mobile Navigation ul/ol immediate descendants must be li elements 

### DIFF
--- a/src/_scss/layouts/default/header/nav/mobile/_nav.scss
+++ b/src/_scss/layouts/default/header/nav/mobile/_nav.scss
@@ -2,7 +2,7 @@
   ul.mobile-nav-content__list {
     @include unstyled-list;
 
-    li.mobile-nav-content__list-item {
+    .mobile-nav-content__list-item {
       text-align: left;
       margin: rem(0) rem(16) rem(24) rem(16);
       @media (min-width: $tablet-screen) {

--- a/src/js/components/sharedComponents/megaMenu/mobile/MobileNav.jsx
+++ b/src/js/components/sharedComponents/megaMenu/mobile/MobileNav.jsx
@@ -135,9 +135,9 @@ const MobileNav = memo(function MobileNav(props) {
                     className="mobile-nav-content__list"
                     style={detailMobileNavIsHidden ? {} : { display: "none" }}>
                     {navbarConfig.map((n, index) => (
-                        <div key={`item: ${navbarConfig[index].title}`}>
+                        <li key={`item: ${navbarConfig[index].title}`}>
                             <hr className={`mobile-nav-content__divider ${detailMobileNavIsHidden ? " animation-enter" : " "}`} />
-                            <li className={`mobile-nav-content__list-item ${detailMobileNavIsHidden ? " animation-enter" : " "}`}>
+                            <div className={`mobile-nav-content__list-item ${detailMobileNavIsHidden ? " animation-enter" : " "}`}>
                                 <div className="mobile-dropdown">
                                     <button
                                         className="mobile-dropdown__parent"
@@ -153,8 +153,8 @@ const MobileNav = memo(function MobileNav(props) {
                                         </span>
                                     </button>
                                 </div>
-                            </li>
-                        </div>
+                            </div>
+                        </li>
                     ))}
                 </ul>
                 <ul


### PR DESCRIPTION
**Description:**
refactored so li is immediate descendant to unordered mobile navigation list.

**JIRA Ticket:**
[DEV-16271](https://federal-spending-transparency.atlassian.net/browse/DEV-16271)

The following are ALL required for the PR to be merged:

Author:
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-16271]: https://federal-spending-transparency.atlassian.net/browse/DEV-16271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ