### PR TITLE
Mod/dev 15558: For the Bulk Download pages, update the filter default selections

### DIFF
--- a/src/js/components/bulkDownload/FilterSelectionTitle.jsx
+++ b/src/js/components/bulkDownload/FilterSelectionTitle.jsx
@@ -37,7 +37,7 @@ const titleData = {
         preSpan: "Select a",
         span: "Location",
         postSpan: ".",
-        showRequired: false,
+        showRequired: true,
         background: '#fef2e4',
         fill: '#e66f0e',
         addClassName: "no-right-margin"
@@ -129,7 +129,7 @@ const titleData = {
             Period
         </span>.
         </>,
-        showRequired: false,
+        showRequired: true,
         background: '#E8F5FF',
         fill: '#0B4778',
         addClassName: "",

--- a/src/js/components/bulkDownload/accounts/filters/FiscalYearFilter.jsx
+++ b/src/js/components/bulkDownload/accounts/filters/FiscalYearFilter.jsx
@@ -10,6 +10,7 @@ import { useSelector } from "react-redux";
 import { handlePotentialStrings } from 'containers/explorer/detail/helpers/explorerQuarters';
 import QuarterPickerWithFY from 'components/sharedComponents/QuarterPickerWithFY';
 import FilterSectionTitle from 'components/bulkDownload/FilterSelectionTitle';
+import {useLatestAccountData} from "../../../../containers/account/WithLatestFy";
 
 const propTypes = { updateFilter: PropTypes.func };
 
@@ -17,6 +18,7 @@ const FiscalYearFilter = ({ updateFilter }) => {
     const fy = useSelector((state) => state.bulkDownload.accounts.fy);
     const period = useSelector((state) => state.bulkDownload.accounts.period);
     const quarter = useSelector((state) => state.bulkDownload.accounts.quarter);
+    const [, allPeriods, { year: latestFy }] = useLatestAccountData();
 
     /* eslint-disable max-len */
     const noteOne = (<>
@@ -76,6 +78,8 @@ const FiscalYearFilter = ({ updateFilter }) => {
                     handleQuarterPickerSelection={quarterPickerSelection}
                     latestSelectedTimeInterval={latestSelectedTimeInterval}
                     updateFilter={updateFilter}
+                    allPeriods={allPeriods}
+                    latestFy={latestFy}
                     newPicker />
                 <p className="download-filter__content-note">
                     <span className="download-filter__content-note_bold">Note: </span>

--- a/src/js/components/bulkDownload/awards/AwardDataContent.jsx
+++ b/src/js/components/bulkDownload/awards/AwardDataContent.jsx
@@ -43,7 +43,6 @@ const AwardDataContent = ({
 }) => {
     const { isMedium } = useContext(IsMobileContext);
     const [validDates, setValidDates] = useState(false);
-    const [validForm, setValidForm] = useState(false);
 
     const handleSubmit = (e) => {
         e.preventDefault();
@@ -64,23 +63,20 @@ const AwardDataContent = ({
         }
     };
 
-    const validateForm = useCallback((award, dates) => {
-        const primeAwards = award.awardTypes.primeAwards.size > 0;
-        const subAwards = award.awardTypes.subAwards.size > 0;
-        const form = (
-            (primeAwards || subAwards)
-            && dates && (award.dateType !== '')
-            && (award.agency.id !== '')
-            && (award.location !== '')
-            && (award.fileFormat !== '')
-        );
+    let validForm = false;
 
-        setValidForm(form);
-    }, []);
+    const primeAwards = awards.awardTypes.primeAwards.size > 0;
+    const subAwards = awards.awardTypes.subAwards.size > 0;
 
-    useEffect(() => {
-        validateForm(awards, validDates);
-    }, [awards, validDates, validateForm]);
+    const form = (
+        (primeAwards || subAwards)
+        && validDates && (awards.dateType !== '')
+        && (awards.agency.id !== '')
+        && (awards.location.country.code !== '')
+        && (awards.fileFormat !== '')
+    );
+
+    if (form) validForm = true;
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     useEffect(() => () => clearAwardFilters(), []);

--- a/src/js/components/bulkDownload/awards/AwardDataContent.jsx
+++ b/src/js/components/bulkDownload/awards/AwardDataContent.jsx
@@ -3,7 +3,7 @@
  * Created by Lizzie Salita 10/30/17
  */
 
-import React, { useCallback, useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import IsMobileContext from "context/IsMobileContext";

--- a/src/js/components/bulkDownload/awards/AwardsUserSelections.jsx
+++ b/src/js/components/bulkDownload/awards/AwardsUserSelections.jsx
@@ -74,7 +74,7 @@ const AwardsUserSelections = () => {
             );
         }
         return (
-            <div className="selection__content selection__content-required">required</div>
+            <div className="selection__content selection__content-required">Required</div>
         );
     };
 
@@ -125,11 +125,13 @@ const AwardsUserSelections = () => {
                 <div className="selection__content">{locationType}: {awards.location.country.name}</div>
             );
         }
-        
-        // default or if all is selected
-        return (
-            <div className="selection__content">{locationType}: All countries</div>
-        );
+        else if (awards.location?.country?.code === 'all') {
+            return (
+                <div className="selection__content">{locationType}: All countries</div>
+            );
+        }
+
+        return  <div className="selection__content selection__content-required">Required</div>;
     };
 
     const generateDateRangeString = () => {

--- a/src/js/components/bulkDownload/awards/filters/LocationFilter.jsx
+++ b/src/js/components/bulkDownload/awards/filters/LocationFilter.jsx
@@ -3,7 +3,7 @@
  * Created by Lizzie Salita 3/23/18
  */
 
-import React, { memo, useMemo, useEffect, useCallback } from 'react';
+import React, { memo, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from "react-redux";
 import { awardDownloadOptions } from 'dataMapping/bulkDownload/bulkDownloadOptions';
@@ -96,9 +96,6 @@ const LocationFilter = memo(function LocationFilter({ states, updateFilter }) {
             key={name} />
     ));
 
-    // set location to all on render
-    useEffect(() => updateCountry({ target: { value: 'all' } }), [updateCountry]);
-
     return (
         <div className="download-filter">
             <FilterSectionTitle type="location" />
@@ -112,7 +109,6 @@ const LocationFilter = memo(function LocationFilter({ states, updateFilter }) {
                         onSelect={updateCountry}
                         label={"Country"}
                         placeholder={"Select a Country"}
-                        defaultValue={'All Countries'}
                         onClearSelect={onCountryClearSelect} />
                     <ComboBox
                         optionsArray={stateOptions}

--- a/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
+++ b/src/js/components/explorer/detail/sidebar/ExplorerSidebar.jsx
@@ -3,7 +3,7 @@
  * Created by Kevin Li 8/16/17
  */
 
-import React from 'react';
+import React, {useCallback, useEffect, useRef} from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
@@ -11,6 +11,7 @@ import Analytics from 'helpers/analytics/Analytics';
 
 import { Home } from 'components/sharedComponents/icons/Icons';
 import QuarterPickerWithFY from 'components/sharedComponents/QuarterPickerWithFY';
+import { useLatestAccountData } from "../../../../containers/account/WithLatestFy";
 import VerticalTrail from './VerticalTrail';
 
 
@@ -23,122 +24,118 @@ const propTypes = {
     rewindToFilter: PropTypes.func
 };
 
-export default class ExplorerSidebar extends React.Component {
-    constructor(props) {
-        super(props);
+const ExplorerSidebar = ({
+    fy,
+    quarter,
+    period,
+    trail,
+    setExplorerPeriod,
+    rewindToFilter
+}) => {
+    const [, allPeriods, { year: latestFy, period: latestPeriod }] = useLatestAccountData();
+    const _queuedAnalyticEvent = useRef(null);
 
-        this.state = {
-            showFYMenu: false
-        };
-
-        this._queuedAnalyticEvent = null;
-
-        this.toggleFYMenu = this.toggleFYMenu.bind(this);
-        this.logTimePeriodEvent = this.logTimePeriodEvent.bind(this);
-        this.pickedYear = this.pickedYear.bind(this);
-        this.pickedQuarter = this.pickedQuarter.bind(this);
-    }
-
-    toggleFYMenu() {
-        this.setState({
-            showFYMenu: !this.state.showFYMenu
-        });
-    }
-
-    logTimePeriodEvent(quarter, fiscalYear) {
-    // discard any previously scheduled time period analytic events that haven't run yet
-        if (this._queuedAnalyticEvent) {
-            window.clearTimeout(this._queuedAnalyticEvent);
+    const logTimePeriodEvent = (quarter, fiscalYear) => {
+        // discard any previously scheduled time period analytic events that haven't run yet
+        if (_queuedAnalyticEvent.current) {
+            window.clearTimeout(_queuedAnalyticEvent.current);
         }
 
         // only log analytic event after 10 seconds
-        this._queuedAnalyticEvent = window.setTimeout(() => {
+        _queuedAnalyticEvent.current = window.setTimeout(() => {
             Analytics.event({
                 event: 'spending-explorer-time-period',
                 category: 'Spending Explorer - Time Period',
                 action: `Q${quarter} FY${fiscalYear}`
             });
         }, 10 * 1000);
-    }
+    };
 
-    pickedYear(year, period = null) {
+    const pickedYear = useCallback((year, period = null) => {
         if (year >= 2020) {
-            this.props.setExplorerPeriod({
+            setExplorerPeriod({
                 fy: `${year}`,
                 period: `${period}`,
                 quarter: null
             });
+
             // Log analytic event
-            this.logTimePeriodEvent(period, year);
+            logTimePeriodEvent(period, year);
         }
         else {
-            this.props.setExplorerPeriod({
+            setExplorerPeriod({
                 fy: `${year}`,
                 quarter: `4`,
                 period: null
             });
-            // Log analytic event
-            this.logTimePeriodEvent('4', year);
-        }
-        this.setState({
-            showFYMenu: false
-        });
-    }
 
-    pickedQuarter(input) {
+            // Log analytic event
+            logTimePeriodEvent('4', year);
+        }
+    }, []);
+
+    const pickedQuarter = (input) => {
         let quarter = input;
         if (typeof input !== 'string') {
             quarter = `${input}`;
         }
 
         // Log analytic event
-        this.logTimePeriodEvent(quarter, this.props.fy);
-        if (this.props.fy >= 2020) {
-            this.props.setExplorerPeriod({
+        logTimePeriodEvent(quarter, fy);
+        if (fy >= 2020) {
+            setExplorerPeriod({
                 period: quarter,
-                fy: this.props.fy,
+                fy: fy,
                 quarter: null
             });
         }
         else {
-            this.props.setExplorerPeriod({
+            setExplorerPeriod({
                 quarter,
-                fy: this.props.fy,
+                fy: fy,
                 period: null
             });
         }
-    }
+    };
 
-    render() {
-        return (
-            <div className="explorer-sidebar">
-                <div className="start-over">
-                    <Link
-                        className="start-over-button"
-                        to="/explorer">
-                        <div className="content">
-                            <div className="icon">
-                                <Home alt="Home" />
-                            </div>
-                            <div className="label">
-                                Start Over
-                            </div>
+    useEffect(() => {
+        // fetch periods on first render
+        if (latestFy && latestPeriod) {
+            pickedYear(`${latestFy}`, `${latestPeriod}`);
+        }
+    }, [latestFy, latestPeriod, pickedYear]);
+
+    return (
+        <div className="explorer-sidebar">
+            <div className="start-over">
+                <Link
+                    className="start-over-button"
+                    to="/explorer">
+                    <div className="content">
+                        <div className="icon">
+                            <Home alt="Home" />
                         </div>
-                    </Link>
-                </div>
-
-                <QuarterPickerWithFY
-                    selectedFy={this.props.fy}
-                    handleQuarterPickerSelection={this.pickedQuarter}
-                    handlePickedYear={this.pickedYear}
-                    latestSelectedTimeInterval={this.props.period == null ? this.props.quarter : this.props.period} />
-                <VerticalTrail
-                    trail={this.props.trail.toArray()}
-                    rewindToFilter={this.props.rewindToFilter} />
-
+                        <div className="label">
+                            Start Over
+                        </div>
+                    </div>
+                </Link>
             </div>
-        );
-    }
+
+            <QuarterPickerWithFY
+                selectedFy={fy}
+                handleQuarterPickerSelection={pickedQuarter}
+                handlePickedYear={pickedYear}
+                latestSelectedTimeInterval={period == null ? quarter : period}
+                allPeriods={allPeriods}
+                latestFy={latestFy} />
+            <VerticalTrail
+                trail={trail.toArray()}
+                rewindToFilter={rewindToFilter} />
+
+        </div>
+    );
 }
 
 ExplorerSidebar.propTypes = propTypes;
+export default ExplorerSidebar;

--- a/src/js/components/sharedComponents/QuarterPickerWithFY.jsx
+++ b/src/js/components/sharedComponents/QuarterPickerWithFY.jsx
@@ -3,12 +3,11 @@
  * Created by Max Kendall 10/25/2020
  **/
 
-import React, { useEffect, useMemo, useCallback } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import { allFiscalYears, currentFiscalYear, earliestExplorerYear } from 'helpers/fiscalYearHelper';
 import { getLatestSubmissionPeriodInFy } from 'helpers/downloadHelper';
-import { useLatestAccountData } from 'containers/account/WithLatestFy';
 import {
     periods,
     getPeriodsPerQuarterByFy
@@ -24,7 +23,9 @@ const propTypes = {
     selectedFy: PropTypes.string,
     latestSelectedTimeInterval: PropTypes.string,
     updateFilter: PropTypes.func,
-    newPicker: PropTypes.bool
+    newPicker: PropTypes.bool,
+    allPeriods: PropTypes.array,
+    latestFy: PropTypes.number
 };
 
 const QuarterPickerWithFY = ({
@@ -33,10 +34,10 @@ const QuarterPickerWithFY = ({
     handleQuarterPickerSelection,
     latestSelectedTimeInterval,
     updateFilter,
-    newPicker
+    newPicker,
+    allPeriods,
+    latestFy
 }) => {
-    const [, allPeriods, { year: latestFy, period: latestPeriod }] = useLatestAccountData();
-
     const onSelect = useCallback((e) => {
         const year = e.target.value;
 
@@ -73,13 +74,6 @@ const QuarterPickerWithFY = ({
         }
     }, [selectedFy, allPeriods])
 
-    useEffect(() => {
-        // fetch periods on first render
-        if (latestFy && latestPeriod) {
-            handlePickedYear(`${latestFy}`, `${latestPeriod}`);
-        }
-    }, [latestFy, latestPeriod, handlePickedYear]);
-
     const defaultFy = useMemo( () => latestFy || currentFiscalYear(), [latestFy]);
 
     const optionsArray = useMemo(() => {
@@ -95,10 +89,10 @@ const QuarterPickerWithFY = ({
             <ComboBox
                 optionsArray={optionsArray}
                 onSelect={onSelect}
-                defaultValue={`FY ${defaultFy}`}
                 label={"Fiscal Year"}
                 formName={"download-filter__fy"}
                 onClearSelect={onClearSelect}
+                placeholder="Select a FY"
                 disabled={!latestFy} />
             <NewQuarterPicker
                 showPeriods


### PR DESCRIPTION
**Description:**
The defaults for Bulk Awards Locations and Bulk Account FY/Q filters have been removed. Their headers now have the "Required" text added to them, as well as to their text in the summary cards when unselected.

**JIRA Ticket:**
[DEV-15558](https://federal-spending-transparency.atlassian.net/browse/DEV-15558)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-15558]: https://federal-spending-transparency.atlassian.net/browse/DEV-15558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ