### PR TITLE
[DEV-16252] Fix Obligated Amount sorting.

### DIFF
--- a/src/js/containers/explorer/detail/helpers/parseResults.js
+++ b/src/js/containers/explorer/detail/helpers/parseResults.js
@@ -8,7 +8,6 @@ const parseResults = (data, total, sort, goDeeper, goToUnreported) => {
         // Format obligated amount
         const obligatedAmount =
             formatMoneyWithPrecision(item.amount, 0);
-        const obligatedAmountNumeric = parseInt(obligatedAmount.replace(/[^\d]/g, ""), 10);
         // Convert from decimal value to percentage and round to 2 decimal places
         const formattedPercentage = ((item.amount / total) * 100).toFixed(2);
 
@@ -25,7 +24,7 @@ const parseResults = (data, total, sort, goDeeper, goToUnreported) => {
         const result = {
             Name: name,
             "Obligated Amount": obligatedAmount,
-            "Obligated Amount unformatted": obligatedAmountNumeric,
+            "Obligated Amount unformatted": item.amount,
             "Percent of Total": percent,
             link
         };

--- a/src/js/containers/explorer/detail/helpers/parseResults.js
+++ b/src/js/containers/explorer/detail/helpers/parseResults.js
@@ -8,7 +8,7 @@ const parseResults = (data, total, sort, goDeeper, goToUnreported) => {
         // Format obligated amount
         const obligatedAmount =
             formatMoneyWithPrecision(item.amount, 0);
-
+        const obligatedAmountNumeric = parseInt(obligatedAmount.replace(/[^\d]/g, ""), 10);
         // Convert from decimal value to percentage and round to 2 decimal places
         const formattedPercentage = ((item.amount / total) * 100).toFixed(2);
 
@@ -25,12 +25,19 @@ const parseResults = (data, total, sort, goDeeper, goToUnreported) => {
         const result = {
             Name: name,
             "Obligated Amount": obligatedAmount,
+            "Obligated Amount unformatted": obligatedAmountNumeric,
             "Percent of Total": percent,
             link
         };
         resultsArray.push(result);
     });
-
+    if (sort.field == 'Obligated Amount' ){
+        return orderBy(
+            resultsArray,
+            ['Obligated Amount unformatted'],
+            [sort.direction]
+        )
+    }  
     return orderBy(
         resultsArray,
         [sort.field],


### PR DESCRIPTION
**Description:**

Updated the parsed results to include another array column without the $ and commas and set as an Int to allow numeric sorting.

**JIRA Ticket:**
[DEV-16252](https://federal-spending-transparency.atlassian.net/browse/DEV-16252)


The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-16252]: https://federal-spending-transparency.atlassian.net/browse/DEV-16252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ