### PR TITLE
Mod/dev 16367: Add First Time to Query trigger to Smart Assist

### DIFF
--- a/src/js/components/naturalLanguage/NLPreSearchButtonGroup.jsx
+++ b/src/js/components/naturalLanguage/NLPreSearchButtonGroup.jsx
@@ -15,7 +15,7 @@ import useFireQueryEvent from "../../hooks/useFireQueryEvent";
 
 const NLPreSearchButtonGroup = () => {
     const query = useQueryParams();
-    const test = useFireQueryEvent();
+    const fireQueryEvent = useFireQueryEvent();
 
     const getRandomOption = ({options}) => {
         // eslint-disable-next-line react-hooks/purity
@@ -26,7 +26,7 @@ const NLPreSearchButtonGroup = () => {
     const getQuestions = useMemo(() => preSearchOptions.map((type) => getRandomOption(type)), []);
 
     const fireSearchEvent = (filterValue) => {
-        test();
+        fireQueryEvent();
         let tempHash = generateUrlHash(filterValue);
         tempHash.promise
             .then((results) => {

--- a/src/js/components/naturalLanguage/NLPreSearchButtonGroup.jsx
+++ b/src/js/components/naturalLanguage/NLPreSearchButtonGroup.jsx
@@ -11,9 +11,11 @@ import { preSearchOptions } from "./NLData";
 import { generateUrlHash } from "../../helpers/searchHelper";
 import { combineQueryParams, getQueryParamString } from "../../helpers/queryParams";
 import useQueryParams from "../../hooks/useQueryParams";
+import useFireQueryEvent from "../../hooks/useFireQueryEvent";
 
 const NLPreSearchButtonGroup = () => {
     const query = useQueryParams();
+    const test = useFireQueryEvent();
 
     const getRandomOption = ({options}) => {
         // eslint-disable-next-line react-hooks/purity
@@ -24,6 +26,7 @@ const NLPreSearchButtonGroup = () => {
     const getQuestions = useMemo(() => preSearchOptions.map((type) => getRandomOption(type)), []);
 
     const fireSearchEvent = (filterValue) => {
+        test();
         let tempHash = generateUrlHash(filterValue);
         tempHash.promise
             .then((results) => {

--- a/src/js/components/search/SearchSidebarSubmit.jsx
+++ b/src/js/components/search/SearchSidebarSubmit.jsx
@@ -3,14 +3,10 @@
  * Created by Kevin Li 12/19/17
  */
 
-import React, { useEffect } from 'react';
-import { useLocation } from 'react-router';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'data-transparency-ui';
-import Cookies from 'js-cookie';
-
-import { getObjFromQueryParams } from "helpers/searchHelper";
-import Analytics from 'helpers/analytics/Analytics';
+import useFireQueryEvent from "../../hooks/useFireQueryEvent";
 
 const propTypes = {
     stagedFiltersAreEmpty: PropTypes.bool,
@@ -30,9 +26,9 @@ const SearchSidebarSubmit = ({
     applyStagedFilters,
     resetFilters
 }) => {
+    const fireSearchEvent = useFireQueryEvent();
     let disabled = false;
     let title = 'Click to submit your search.';
-    const { hash: urlHash } = getObjFromQueryParams(useLocation().search);
 
     if (stagedFiltersAreEmpty || !filtersChanged) {
         title = 'Add or update a filter to submit.';
@@ -42,56 +38,6 @@ const SearchSidebarSubmit = ({
         title = 'Add or update a filter to submit.';
         disabled = true;
     }
-
-    const fireSearchEvent = () => {
-        if (!urlHash) {
-            const now = new Date().getTime();
-            if (
-                Cookies.get("advanced_search_to_query_time") &&
-                !Cookies.get('has_logged_query_timer')
-            ) {
-                const timer = now - Cookies.get("advanced_search_to_query_time");
-                const timerInSeconds = Math.floor(timer / 1000);
-
-                if (timerInSeconds < 3600) {
-                    Analytics.event({
-                        category: 'Advanced Search - Time to First Query',
-                        action: 'query_submit',
-                        label: `${timerInSeconds} seconds`,
-                        time_to_query: timerInSeconds
-                    });
-                }
-
-                // clean up
-                Cookies.remove("advanced_search_to_query_time");
-            }
-
-            if (Cookies.get("homepage_to_query_time") && !Cookies.get('has_logged_query_timer')) {
-                const timerHomePage = now - Cookies.get("homepage_to_query_time");
-                const timerHomePageInSeconds = Math.floor(timerHomePage / 1000);
-
-                if (timerHomePageInSeconds < 3600) {
-                    Analytics.event({
-                        category: 'Homepage - Time to First Query',
-                        action: 'homepage_query_submit',
-                        label: `${timerHomePageInSeconds} seconds`,
-                        time_to_query: timerHomePageInSeconds
-                    });
-                }
-                // Cleanup
-                Cookies.remove("homepage_to_query_time");
-            }
-        }
-
-        // Sanity check
-        Cookies.set("has_logged_query_timer", true, { expires: 14 });
-    };
-
-    useEffect(() => {
-        // ok to rewrite with each page reload
-        // may need to check if timer already logged.
-        Cookies.set('advanced_search_to_query_time', new Date().getTime(), { expires: 14 });
-    }, []);
 
     return (
         <div

--- a/src/js/components/search/SearchSidebarSubmit.jsx
+++ b/src/js/components/search/SearchSidebarSubmit.jsx
@@ -26,7 +26,7 @@ const SearchSidebarSubmit = ({
     applyStagedFilters,
     resetFilters
 }) => {
-    const fireSearchEvent = useFireQueryEvent();
+    const fireQueryEvent = useFireQueryEvent();
     let disabled = false;
     let title = 'Click to submit your search.';
 
@@ -56,7 +56,7 @@ const SearchSidebarSubmit = ({
                     if (setShowMobileFilters) {
                         setShowMobileFilters();
                     }
-                    fireSearchEvent();
+                    fireQueryEvent();
                     applyStagedFilters();
                 }} />
             <Button

--- a/src/js/components/search/collapsibleSidebar/NLSearchButton.jsx
+++ b/src/js/components/search/collapsibleSidebar/NLSearchButton.jsx
@@ -5,19 +5,33 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import useFireQueryEvent from "../../../hooks/useFireQueryEvent";
+
 const DEFAULT_ICON_PATH = "../../../../img/magnifying-glass-white.svg";
+
 const propTypes = {
     loadingState: PropTypes.string,
     classname: PropTypes.string,
     icon: PropTypes.string,
-    text: PropTypes.string
-    /* ,onclick: PropTypes.func */
+    text: PropTypes.string,
+    onClick: PropTypes.func
 };
 
-const NLSearchButton = ({loadingState, classname="default-search", icon=DEFAULT_ICON_PATH, text = "Search"}) => {
+const NLSearchButton = ({
+    loadingState,
+    classname="default-search",
+    icon=DEFAULT_ICON_PATH,
+    text = "Search",
+    onClick = ()=> console.debug("clicked")
+}) => {
+    const fireSearchEvent = useFireQueryEvent();
 
+    const test = () => {
+        onClick();
+        fireSearchEvent();
+    }
     return (
-        <button className={`natural-language-submit ${classname}`} /* onClick={()=> console.debug("clicked")} */ >
+        <button className={`natural-language-submit ${classname}`} onClick={test} >
             {!loadingState && <img src={icon} alt="Icon for Search Button"/>}
             {loadingState && <FontAwesomeIcon icon={['far', 'wand-magic-sparkles']} />}
             {text}

--- a/src/js/hooks/useFireQueryEvent.jsx
+++ b/src/js/hooks/useFireQueryEvent.jsx
@@ -1,0 +1,65 @@
+/**
+ * useFireQueryEvent.jsx
+ * Created by Josue Aguilar, 9/10/2026
+ */
+import { useEffect } from "react";
+import Cookies from 'js-cookie';
+import { useLocation } from "react-router";
+import { getObjFromQueryParams } from "../helpers/searchHelper";
+import Analytics from "../helpers/analytics/Analytics";
+
+const useFireQueryEvent = () => {
+    const { hash: urlHash } = getObjFromQueryParams(useLocation().search);
+
+    useEffect(() => {
+        // ok to rewrite with each page reload
+        // may need to check if timer already logged.
+        Cookies.set('advanced_search_to_query_time', new Date().getTime(), { expires: 14 });
+    }, []);
+
+    return () => {
+        if (!urlHash) {
+            const now = new Date().getTime();
+            if (
+                Cookies.get("advanced_search_to_query_time") &&
+                !Cookies.get('has_logged_query_timer')
+            ) {
+                const timer = now - Cookies.get("advanced_search_to_query_time");
+                const timerInSeconds = Math.floor(timer / 1000);
+
+                if (timerInSeconds < 3600) {
+                    Analytics.event({
+                        category: 'Advanced Search - Time to First Query',
+                        action: 'query_submit',
+                        label: `${timerInSeconds} seconds`,
+                        time_to_query: timerInSeconds
+                    });
+                }
+
+                // clean up
+                Cookies.remove("advanced_search_to_query_time");
+            }
+
+            if (Cookies.get("homepage_to_query_time") && !Cookies.get('has_logged_query_timer')) {
+                const timerHomePage = now - Cookies.get("homepage_to_query_time");
+                const timerHomePageInSeconds = Math.floor(timerHomePage / 1000);
+
+                if (timerHomePageInSeconds < 3600) {
+                    Analytics.event({
+                        category: 'Homepage - Time to First Query',
+                        action: 'homepage_query_submit',
+                        label: `${timerHomePageInSeconds} seconds`,
+                        time_to_query: timerHomePageInSeconds
+                    });
+                }
+                // Cleanup
+                Cookies.remove("homepage_to_query_time");
+            }
+        }
+
+        // Sanity check
+        Cookies.set("has_logged_query_timer", true, { expires: 14 });
+    };
+}
+
+export default useFireQueryEvent;


### PR DESCRIPTION
**Description:**
Moved Analytics trigger into its own custom hook. Implemented it in the filters sidebar submit button, single click query buttons, and Smart Assist panel search button.

**JIRA Ticket:**
[DEV-16367](https://federal-spending-transparency.atlassian.net/browse/DEV-16367)

**Mockup:**
n/a

The following are ALL required for the PR to be merged:

Author:
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled and completed design review 
- [ ] Provided instructions for testing in JIRA ticket and PR `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension or Lighthouse report)
- [ ] Added Unit Tests for helper functions, reducers, models and Container/Component Interactivity Expectations `if applicable` [React Testing Library](react-testing-library.md)
- [ ] [API contract](https://github.com/fedspendingtransparency/usaspending-api/tree/dev/usaspending_api/api_contracts) updated `if applicable`



[DEV-16367]: https://federal-spending-transparency.atlassian.net/browse/DEV-16367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ